### PR TITLE
feat: Smart Digest - Weekly Financial Summary (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Digest: `/digest/weekly?week=YYYY-WNN` — weekly spending summary with category breakdown, week-over-week trends, and smart insights
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.
@@ -75,6 +76,7 @@ OpenAPI: `backend/app/openapi.yaml`
   - AI budget suggestion card.
 - Expenses page: add expense (amount, category, notes, date), list & filter.
 - Bills page: create bill (name, amount, cadence, due date, channel), toggle WhatsApp/email.
+- **Digest page**: weekly summary with total spent, category breakdown bars, week-over-week change badges, trends, and AI insights. Navigate between weeks.
 - Settings: profile, categories, reminders default channel, export (premium).
 
 ## Monetization Plan

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Digest from "./pages/Digest";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="digest"
+              element={
+                <ProtectedRoute>
+                  <Digest />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/digest.ts
+++ b/app/src/api/digest.ts
@@ -1,0 +1,23 @@
+import { api } from './client';
+
+export interface WeekOverWeekEntry {
+  current: number;
+  previous: number;
+  change: number;
+  change_pct: number;
+}
+
+export interface WeeklyDigest {
+  week: string;
+  period: { start: string; end: string };
+  total_spent: number;
+  category_breakdown: Record<string, number>;
+  week_over_week_change: Record<string, WeekOverWeekEntry>;
+  trends: string[];
+  insights: string[];
+}
+
+export async function fetchWeeklyDigest(week?: string): Promise<WeeklyDigest> {
+  const params = week ? `?week=${week}` : '';
+  return api<WeeklyDigest>(`/digest/weekly${params}`);
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Digest', href: '/digest' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/Digest.tsx
+++ b/app/src/pages/Digest.tsx
@@ -1,0 +1,175 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchWeeklyDigest, type WeeklyDigest } from '@/api/digest';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+  FinancialCardDescription,
+} from '@/components/ui/financial-card';
+import { Badge } from '@/components/ui/badge';
+import { TrendingUp, TrendingDown, DollarSign, BarChart3, Lightbulb, Calendar } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function Digest() {
+  const [week, setWeek] = useState<string | undefined>(undefined);
+
+  const { data, isLoading, error } = useQuery<WeeklyDigest>({
+    queryKey: ['weekly-digest', week],
+    queryFn: () => fetchWeeklyDigest(week),
+  });
+
+  const navigateWeek = (direction: -1 | 1) => {
+    const current = data?.week;
+    if (!current) return;
+    const match = current.match(/^(\d{4})-W(\d{2})$/);
+    if (!match) return;
+    let y = parseInt(match[1]);
+    let w = parseInt(match[2]) + direction;
+    if (w < 1) { y--; w = 52; }
+    if (w > 52) { y++; w = 1; }
+    setWeek(`${y}-W${String(w).padStart(2, '0')}`);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="container-financial py-8">
+        <div className="flex items-center justify-center h-64 text-muted-foreground">Loading digest…</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container-financial py-8">
+        <div className="flex items-center justify-center h-64 text-destructive">Failed to load digest.</div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const categories = Object.entries(data.category_breakdown);
+  const totalSpent = data.total_spent;
+  const maxCat = categories.length > 0 ? Math.max(...categories.map(([, v]) => v)) : 1;
+
+  return (
+    <div className="container-financial py-8 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Weekly Digest</h1>
+          <p className="text-sm text-muted-foreground">
+            {data.period.start} — {data.period.end}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => navigateWeek(-1)}>← Prev</Button>
+          <Badge variant="secondary" className="text-sm font-mono">{data.week}</Badge>
+          <Button variant="outline" size="sm" onClick={() => navigateWeek(1)}>Next →</Button>
+        </div>
+      </div>
+
+      {/* Total Spent Card */}
+      <FinancialCard>
+        <FinancialCardHeader>
+          <FinancialCardTitle className="flex items-center gap-2">
+            <DollarSign className="h-5 w-5 text-primary" />
+            Total Spent
+          </FinancialCardTitle>
+        </FinancialCardHeader>
+        <FinancialCardContent>
+          <p className="text-3xl font-bold">{totalSpent.toFixed(2)}</p>
+        </FinancialCardContent>
+      </FinancialCard>
+
+      {/* Category Breakdown */}
+      <FinancialCard>
+        <FinancialCardHeader>
+          <FinancialCardTitle className="flex items-center gap-2">
+            <BarChart3 className="h-5 w-5 text-primary" />
+            Category Breakdown
+          </FinancialCardTitle>
+        </FinancialCardHeader>
+        <FinancialCardContent>
+          {categories.length === 0 ? (
+            <p className="text-muted-foreground text-sm">No expenses this week.</p>
+          ) : (
+            <div className="space-y-3">
+              {categories
+                .sort((a, b) => b[1] - a[1])
+                .map(([name, amount]) => {
+                  const pct = totalSpent > 0 ? ((amount / totalSpent) * 100).toFixed(1) : '0';
+                  const wow = data.week_over_week_change[name];
+                  return (
+                    <div key={name} className="space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-medium">{name}</span>
+                        <div className="flex items-center gap-2">
+                          <span>{amount.toFixed(2)} ({pct}%)</span>
+                          {wow && wow.change !== 0 && (
+                            <Badge variant={wow.change > 0 ? 'destructive' : 'default'} className="text-xs">
+                              {wow.change > 0 ? <TrendingUp className="h-3 w-3 mr-1" /> : <TrendingDown className="h-3 w-3 mr-1" />}
+                              {wow.change > 0 ? '+' : ''}{wow.change_pct}%
+                            </Badge>
+                          )}
+                        </div>
+                      </div>
+                      <div className="h-2 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-primary transition-all"
+                          style={{ width: `${(amount / maxCat) * 100}%` }}
+                        />
+                      </div>
+                    </div>
+                  );
+                })}
+            </div>
+          )}
+        </FinancialCardContent>
+      </FinancialCard>
+
+      {/* Trends */}
+      {data.trends.length > 0 && (
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle className="flex items-center gap-2">
+              <TrendingUp className="h-5 w-5 text-primary" />
+              Trends
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <ul className="space-y-2">
+              {data.trends.map((t, i) => (
+                <li key={i} className="text-sm text-muted-foreground flex items-start gap-2">
+                  <Calendar className="h-4 w-4 mt-0.5 text-primary shrink-0" />
+                  {t}
+                </li>
+              ))}
+            </ul>
+          </FinancialCardContent>
+        </FinancialCard>
+      )}
+
+      {/* Insights */}
+      {data.insights.length > 0 && (
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle className="flex items-center gap-2">
+              <Lightbulb className="h-5 w-5 text-warning" />
+              Insights
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <ul className="space-y-2">
+              {data.insights.map((insight, i) => (
+                <li key={i} className="text-sm text-muted-foreground">{insight}</li>
+              ))}
+            </ul>
+          </FinancialCardContent>
+        </FinancialCard>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,35 @@
+"""Weekly digest route."""
+
+import re
+from datetime import date
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.digest import weekly_digest
+import logging
+
+bp = Blueprint("digest", __name__)
+logger = logging.getLogger("finmind.digest")
+
+_WEEK_RE = re.compile(r"^(\d{4})-W(\d{2})$")
+
+
+@bp.get("/weekly")
+@jwt_required()
+def weekly():
+    uid = int(get_jwt_identity())
+    week_param = request.args.get("week")
+
+    if week_param:
+        m = _WEEK_RE.match(week_param)
+        if not m:
+            return jsonify(error="Invalid week format. Use YYYY-WNN."), 400
+        year, week_num = int(m.group(1)), int(m.group(2))
+        if week_num < 1 or week_num > 53:
+            return jsonify(error="Week number must be between 01 and 53."), 400
+    else:
+        today = date.today()
+        year, week_num, _ = today.isocalendar()
+
+    result = weekly_digest(uid, year, week_num)
+    logger.info("Weekly digest served user=%s week=%s-W%02d", uid, year, week_num)
+    return jsonify(result)

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,99 @@
+"""Weekly digest service – aggregates expenses into a weekly summary."""
+
+from datetime import date, timedelta
+from decimal import Decimal
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Expense, Category
+
+
+def _week_bounds(year: int, week: int) -> tuple[date, date]:
+    """Return (monday, sunday) for ISO year/week."""
+    jan4 = date(year, 1, 4)
+    start_of_week1 = jan4 - timedelta(days=jan4.isoweekday() - 1)
+    monday = start_of_week1 + timedelta(weeks=week - 1)
+    sunday = monday + timedelta(days=6)
+    return monday, sunday
+
+
+def _aggregate_by_category(user_id: int, start: date, end: date) -> dict:
+    """Return {category_name: total} for the given date range."""
+    rows = (
+        db.session.query(
+            func.coalesce(Category.name, "Uncategorized").label("cat_name"),
+            func.sum(Expense.amount).label("total"),
+        )
+        .outerjoin(Category, Expense.category_id == Category.id)
+        .filter(Expense.user_id == user_id)
+        .filter(Expense.spent_at >= start)
+        .filter(Expense.spent_at <= end)
+        .group_by("cat_name")
+        .all()
+    )
+    return {row.cat_name: float(row.total) for row in rows}
+
+
+def weekly_digest(user_id: int, year: int, week: int) -> dict:
+    """Build weekly digest for *user_id* and ISO *year*/*week*."""
+    start, end = _week_bounds(year, week)
+    prev_start, prev_end = _week_bounds(year if week > 1 else year - 1, week - 1 if week > 1 else 52)
+
+    current = _aggregate_by_category(user_id, start, end)
+    previous = _aggregate_by_category(user_id, prev_start, prev_end)
+
+    total_spent = round(sum(current.values()), 2)
+    prev_total = round(sum(previous.values()), 2)
+
+    # Week-over-week by category
+    all_cats = sorted(set(list(current.keys()) + list(previous.keys())))
+    wow = {}
+    for cat in all_cats:
+        cur = current.get(cat, 0.0)
+        prev = previous.get(cat, 0.0)
+        change = round(cur - prev, 2)
+        pct = round((change / prev) * 100, 1) if prev else (100.0 if cur > 0 else 0.0)
+        wow[cat] = {"current": cur, "previous": prev, "change": change, "change_pct": pct}
+
+    # Trends
+    trends = []
+    if current:
+        top_cat = max(current, key=current.get)
+        trends.append(f"Top spending category: {top_cat} ({current[top_cat]:.2f})")
+
+    if wow:
+        biggest_inc = max(wow, key=lambda c: wow[c]["change"])
+        biggest_dec = min(wow, key=lambda c: wow[c]["change"])
+        if wow[biggest_inc]["change"] > 0:
+            trends.append(
+                f"Biggest increase: {biggest_inc} (+{wow[biggest_inc]['change']:.2f}, "
+                f"+{wow[biggest_inc]['change_pct']}%)"
+            )
+        if wow[biggest_dec]["change"] < 0:
+            trends.append(
+                f"Biggest decrease: {biggest_dec} ({wow[biggest_dec]['change']:.2f}, "
+                f"{wow[biggest_dec]['change_pct']}%)"
+            )
+
+    # Insights
+    insights = []
+    if prev_total > 0:
+        overall_pct = round(((total_spent - prev_total) / prev_total) * 100, 1)
+        direction = "more" if overall_pct > 0 else "less"
+        insights.append(
+            f"You spent {abs(overall_pct)}% {direction} this week compared to last week."
+        )
+    elif total_spent > 0:
+        insights.append("This is your first tracked week – keep logging expenses!")
+
+    if total_spent == 0:
+        insights.append("No expenses recorded this week.")
+
+    return {
+        "week": f"{year}-W{week:02d}",
+        "period": {"start": start.isoformat(), "end": end.isoformat()},
+        "total_spent": total_spent,
+        "category_breakdown": current,
+        "week_over_week_change": wow,
+        "trends": trends,
+        "insights": insights,
+    }

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,95 @@
+"""Tests for the weekly digest endpoint."""
+
+
+def _create_category(client, auth_header, name="Food"):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code in (201, 409)
+    r = client.get("/categories", headers=auth_header)
+    cats = r.get_json()
+    return next(c["id"] for c in cats if c["name"] == name)
+
+
+def _create_expense(client, auth_header, amount, category_id, date_str):
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": amount,
+            "currency": "INR",
+            "category_id": category_id,
+            "description": "test",
+            "date": date_str,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+
+def test_weekly_digest_empty(client, auth_header):
+    """Digest with no expenses returns zero totals."""
+    r = client.get("/digest/weekly?week=2026-W08", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_spent"] == 0
+    assert data["category_breakdown"] == {}
+    assert data["week"] == "2026-W08"
+    assert isinstance(data["trends"], list)
+    assert isinstance(data["insights"], list)
+
+
+def test_weekly_digest_with_expenses(client, auth_header):
+    """Digest correctly aggregates expenses by category."""
+    cat_id = _create_category(client, auth_header, "Food")
+    cat_id2 = _create_category(client, auth_header, "Transport")
+
+    # Week 8 of 2026: 2026-02-16 (Mon) to 2026-02-22 (Sun)
+    _create_expense(client, auth_header, 100.0, cat_id, "2026-02-16")
+    _create_expense(client, auth_header, 50.0, cat_id, "2026-02-18")
+    _create_expense(client, auth_header, 200.0, cat_id2, "2026-02-17")
+
+    r = client.get("/digest/weekly?week=2026-W08", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_spent"] == 350.0
+    assert data["category_breakdown"]["Food"] == 150.0
+    assert data["category_breakdown"]["Transport"] == 200.0
+    assert len(data["trends"]) > 0
+
+
+def test_weekly_digest_week_over_week(client, auth_header):
+    """Digest computes week-over-week changes."""
+    cat_id = _create_category(client, auth_header, "Food")
+
+    # Week 7: 2026-02-09 to 2026-02-15
+    _create_expense(client, auth_header, 100.0, cat_id, "2026-02-09")
+    # Week 8: 2026-02-16 to 2026-02-22
+    _create_expense(client, auth_header, 150.0, cat_id, "2026-02-16")
+
+    r = client.get("/digest/weekly?week=2026-W08", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    wow = data["week_over_week_change"]
+    assert "Food" in wow
+    assert wow["Food"]["current"] == 150.0
+    assert wow["Food"]["previous"] == 100.0
+    assert wow["Food"]["change"] == 50.0
+
+
+def test_weekly_digest_invalid_week(client, auth_header):
+    """Invalid week format returns 400."""
+    r = client.get("/digest/weekly?week=invalid", headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_weekly_digest_requires_auth(client):
+    """Endpoint requires JWT."""
+    r = client.get("/digest/weekly")
+    assert r.status_code == 401
+
+
+def test_weekly_digest_default_week(client, auth_header):
+    """Calling without week param returns current week."""
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "week" in data
+    assert data["period"]["start"] is not None


### PR DESCRIPTION
/claim #121

## Summary

Implements the **Smart Digest** feature — weekly financial summaries highlighting spending trends and insights.

### What's New

**Backend** (`packages/backend/`):
- `GET /digest/weekly?week=YYYY-WNN` — new endpoint returning weekly spending summary
- `app/services/digest.py` — business logic: category aggregation, week-over-week comparison, trend detection
- `app/routes/digest.py` — route with input validation and JWT auth
- Blueprint registered in `app/routes/__init__.py`

**Frontend** (`app/`):
- `pages/Digest.tsx` — card-based weekly summary page
  - Total spent card
  - Category breakdown with progress bars
  - Week-over-week change badges (red for increase, default for decrease)
  - Trends and insights sections
  - Week navigation (prev/next)
- API client `api/digest.ts` with TypeScript types
- Route added in `App.tsx`, nav link in `Navbar.tsx`

**Tests** (`packages/backend/tests/test_digest.py`):
- Empty digest, populated digest, week-over-week comparison
- Invalid week format (400), auth required (401), default week

**Docs:**
- README updated with digest endpoint and UI description

### API Response Shape
```json
{
  "week": "2026-W08",
  "period": {"start": "2026-02-16", "end": "2026-02-22"},
  "total_spent": 350.0,
  "category_breakdown": {"Food": 150.0, "Transport": 200.0},
  "week_over_week_change": {
    "Food": {"current": 150.0, "previous": 100.0, "change": 50.0, "change_pct": 50.0}
  },
  "trends": ["Top spending category: Transport (200.00)"],
  "insights": ["You spent 75.0% more this week compared to last week."]
}
```

Closes #121