### PR TITLE
feat: Shared Household Budgeting (#134)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Household from "./pages/Household";
 import Savings from "./pages/Savings";
 import Household from "./pages/Household";
 
@@ -98,6 +99,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Savings />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="household"
+              element={
+                <ProtectedRoute>
+                  <Household />
                 </ProtectedRoute>
               }
             />

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,8 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Savings from "./pages/Savings";
+import Household from "./pages/Household";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +82,22 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="household"
+              element={
+                <ProtectedRoute>
+                  <Household />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="savings"
+              element={
+                <ProtectedRoute>
+                  <Savings />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/household.ts
+++ b/app/src/api/household.ts
@@ -1,0 +1,52 @@
+import { api } from './client';
+
+export interface Household {
+  id: number;
+  name: string;
+  invite_code: string;
+  created_by: number;
+  created_at: string;
+}
+
+export interface HouseholdMember {
+  user_id: number;
+  email: string;
+  role: string;
+  joined_at: string;
+}
+
+export interface HouseholdExpense {
+  id: number;
+  user_id: number;
+  amount: number;
+  currency: string;
+  category_id: number | null;
+  expense_type: string;
+  description: string;
+  date: string;
+  household_id: number;
+}
+
+export function getHousehold() {
+  return api<Household>('/household');
+}
+
+export function createHousehold(name: string) {
+  return api<Household>('/household', { method: 'POST', body: { name } });
+}
+
+export function getInviteCode() {
+  return api<{ invite_code: string }>('/household/invite', { method: 'POST' });
+}
+
+export function joinHousehold(code: string) {
+  return api<Household>(`/household/join/${code}`, { method: 'POST' });
+}
+
+export function getMembers() {
+  return api<HouseholdMember[]>('/household/members');
+}
+
+export function getHouseholdExpenses() {
+  return api<HouseholdExpense[]>('/household/expenses');
+}

--- a/app/src/api/savings.ts
+++ b/app/src/api/savings.ts
@@ -1,0 +1,57 @@
+import { api } from './client';
+
+export interface SavingsGoal {
+  id: number;
+  name: string;
+  target_amount: number;
+  current_amount: number;
+  currency: string;
+  deadline: string | null;
+  progress_pct: number;
+  created_at: string;
+}
+
+export interface SavingsMilestone {
+  id: number;
+  goal_id: number;
+  name: string;
+  amount: number;
+  reached_at: string | null;
+}
+
+export interface CreateGoalPayload {
+  name: string;
+  target_amount: number;
+  currency?: string;
+  deadline?: string;
+  current_amount?: number;
+}
+
+export interface UpdateGoalPayload {
+  name?: string;
+  target_amount?: number;
+  current_amount?: number;
+  add_funds?: number;
+  currency?: string;
+  deadline?: string | null;
+}
+
+export function listGoals() {
+  return api<SavingsGoal[]>('/savings/goals');
+}
+
+export function createGoal(payload: CreateGoalPayload) {
+  return api<SavingsGoal>('/savings/goals', { method: 'POST', body: payload });
+}
+
+export function updateGoal(id: number, payload: UpdateGoalPayload) {
+  return api<SavingsGoal>(`/savings/goals/${id}`, { method: 'PATCH', body: payload });
+}
+
+export function deleteGoal(id: number) {
+  return api(`/savings/goals/${id}`, { method: 'DELETE' });
+}
+
+export function getMilestones(goalId: number) {
+  return api<SavingsMilestone[]>(`/savings/goals/${goalId}/milestones`);
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -12,7 +12,9 @@ const navigation = [
   { name: 'Bills', href: '/bills' },
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
+  { name: 'Savings', href: '/savings' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Household', href: '/household' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/Household.tsx
+++ b/app/src/pages/Household.tsx
@@ -1,0 +1,165 @@
+import { useState, useEffect } from 'react';
+import {
+  getHousehold,
+  createHousehold,
+  getInviteCode,
+  joinHousehold,
+  getMembers,
+  getHouseholdExpenses,
+  Household as HouseholdType,
+  HouseholdMember,
+  HouseholdExpense,
+} from '@/api/household';
+
+export default function Household() {
+  const [household, setHousehold] = useState<HouseholdType | null>(null);
+  const [members, setMembers] = useState<HouseholdMember[]>([]);
+  const [expenses, setExpenses] = useState<HouseholdExpense[]>([]);
+  const [inviteCode, setInviteCode] = useState('');
+  const [name, setName] = useState('');
+  const [joinCode, setJoinCode] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const loadHousehold = async () => {
+    try {
+      const h = await getHousehold();
+      setHousehold(h);
+      const [m, e] = await Promise.all([getMembers(), getHouseholdExpenses()]);
+      setMembers(m);
+      setExpenses(e);
+    } catch {
+      setHousehold(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { loadHousehold(); }, []);
+
+  const handleCreate = async () => {
+    setError('');
+    try {
+      await createHousehold(name);
+      await loadHousehold();
+    } catch (e: any) { setError(e.message); }
+  };
+
+  const handleJoin = async () => {
+    setError('');
+    try {
+      await joinHousehold(joinCode);
+      await loadHousehold();
+    } catch (e: any) { setError(e.message); }
+  };
+
+  const handleInvite = async () => {
+    try {
+      const res = await getInviteCode();
+      setInviteCode(res.invite_code);
+    } catch (e: any) { setError(e.message); }
+  };
+
+  if (loading) return <div className="p-8">Loading...</div>;
+
+  if (!household) {
+    return (
+      <div className="max-w-lg mx-auto p-8 space-y-6">
+        <h1 className="text-2xl font-bold">Household Budgeting</h1>
+        {error && <p className="text-red-500">{error}</p>}
+
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">Create a Household</h2>
+          <input
+            className="border rounded px-3 py-2 w-full"
+            placeholder="Household name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <button
+            className="bg-blue-600 text-white px-4 py-2 rounded"
+            onClick={handleCreate}
+          >
+            Create
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">Join a Household</h2>
+          <input
+            className="border rounded px-3 py-2 w-full"
+            placeholder="Invite code"
+            value={joinCode}
+            onChange={(e) => setJoinCode(e.target.value)}
+          />
+          <button
+            className="bg-green-600 text-white px-4 py-2 rounded"
+            onClick={handleJoin}
+          >
+            Join
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-8 space-y-6">
+      <h1 className="text-2xl font-bold">{household.name}</h1>
+      {error && <p className="text-red-500">{error}</p>}
+
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Members</h2>
+        <ul className="space-y-1">
+          {members.map((m) => (
+            <li key={m.user_id} className="flex justify-between border-b py-1">
+              <span>{m.email}</span>
+              <span className="text-sm text-gray-500">{m.role}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Invite</h2>
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          onClick={handleInvite}
+        >
+          Get Invite Code
+        </button>
+        {inviteCode && (
+          <p className="font-mono bg-gray-100 p-2 rounded">{inviteCode}</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Shared Expenses</h2>
+        {expenses.length === 0 ? (
+          <p className="text-gray-500">No shared expenses yet. Add expenses with your household ID.</p>
+        ) : (
+          <table className="w-full text-left">
+            <thead>
+              <tr className="border-b">
+                <th className="py-1">Date</th>
+                <th>Description</th>
+                <th>Amount</th>
+                <th>Currency</th>
+              </tr>
+            </thead>
+            <tbody>
+              {expenses.map((e) => (
+                <tr key={e.id} className="border-b">
+                  <td className="py-1">{e.date}</td>
+                  <td>{e.description}</td>
+                  <td>{e.amount.toFixed(2)}</td>
+                  <td>{e.currency}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/Savings.tsx
+++ b/app/src/pages/Savings.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  listGoals,
+  createGoal,
+  updateGoal,
+  deleteGoal,
+  getMilestones,
+  type SavingsGoal,
+  type SavingsMilestone,
+} from '@/api/savings';
+import { Target, Plus, Trash2, PiggyBank, Trophy } from 'lucide-react';
+
+export default function Savings() {
+  const [goals, setGoals] = useState<SavingsGoal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState('');
+  const [targetAmount, setTargetAmount] = useState('');
+  const [currency, setCurrency] = useState('INR');
+  const [deadline, setDeadline] = useState('');
+  const [addFundsId, setAddFundsId] = useState<number | null>(null);
+  const [fundsAmount, setFundsAmount] = useState('');
+  const [milestonesMap, setMilestonesMap] = useState<Record<number, SavingsMilestone[]>>({});
+  const [expandedGoal, setExpandedGoal] = useState<number | null>(null);
+  const { toast } = useToast();
+
+  const fetchGoals = async () => {
+    try {
+      const data = await listGoals();
+      setGoals(data);
+    } catch (e: any) {
+      toast({ title: 'Error', description: e.message, variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { void fetchGoals(); }, []);
+
+  const handleCreate = async () => {
+    if (!name.trim() || !targetAmount) return;
+    try {
+      await createGoal({
+        name: name.trim(),
+        target_amount: parseFloat(targetAmount),
+        currency,
+        deadline: deadline || undefined,
+      });
+      setName(''); setTargetAmount(''); setDeadline(''); setShowForm(false);
+      toast({ title: 'Goal created!' });
+      await fetchGoals();
+    } catch (e: any) {
+      toast({ title: 'Error', description: e.message, variant: 'destructive' });
+    }
+  };
+
+  const handleAddFunds = async (goalId: number) => {
+    if (!fundsAmount || parseFloat(fundsAmount) <= 0) return;
+    try {
+      await updateGoal(goalId, { add_funds: parseFloat(fundsAmount) });
+      setAddFundsId(null); setFundsAmount('');
+      toast({ title: 'Funds added!' });
+      await fetchGoals();
+      if (expandedGoal === goalId) await fetchMilestones(goalId);
+    } catch (e: any) {
+      toast({ title: 'Error', description: e.message, variant: 'destructive' });
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    try {
+      await deleteGoal(id);
+      toast({ title: 'Goal deleted' });
+      await fetchGoals();
+    } catch (e: any) {
+      toast({ title: 'Error', description: e.message, variant: 'destructive' });
+    }
+  };
+
+  const fetchMilestones = async (goalId: number) => {
+    try {
+      const ms = await getMilestones(goalId);
+      setMilestonesMap(prev => ({ ...prev, [goalId]: ms }));
+    } catch { /* ignore */ }
+  };
+
+  const toggleMilestones = async (goalId: number) => {
+    if (expandedGoal === goalId) {
+      setExpandedGoal(null);
+    } else {
+      setExpandedGoal(goalId);
+      if (!milestonesMap[goalId]) await fetchMilestones(goalId);
+    }
+  };
+
+  if (loading) return <div className="p-8 text-center text-muted-foreground">Loading…</div>;
+
+  return (
+    <div className="container-financial py-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <PiggyBank className="h-6 w-6 text-primary" />
+          <h1 className="text-2xl font-bold">Savings Goals</h1>
+        </div>
+        <Button onClick={() => setShowForm(!showForm)} variant="hero" size="sm">
+          <Plus className="h-4 w-4 mr-1" /> New Goal
+        </Button>
+      </div>
+
+      {showForm && (
+        <div className="rounded-xl border bg-card p-4 space-y-3">
+          <Input placeholder="Goal name" value={name} onChange={e => setName(e.target.value)} />
+          <div className="flex gap-2">
+            <Input type="number" placeholder="Target amount" value={targetAmount} onChange={e => setTargetAmount(e.target.value)} />
+            <Input placeholder="Currency" value={currency} onChange={e => setCurrency(e.target.value)} className="w-24" />
+          </div>
+          <Input type="date" placeholder="Deadline (optional)" value={deadline} onChange={e => setDeadline(e.target.value)} />
+          <Button onClick={handleCreate} size="sm">Create</Button>
+        </div>
+      )}
+
+      {goals.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <Target className="h-12 w-12 mx-auto mb-3 opacity-40" />
+          <p>No savings goals yet. Create one to start tracking!</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {goals.map(goal => (
+            <div key={goal.id} className="rounded-xl border bg-card p-4 space-y-3">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h3 className="font-semibold text-lg">{goal.name}</h3>
+                  <p className="text-sm text-muted-foreground">
+                    {goal.currency} {goal.current_amount.toLocaleString()} / {goal.target_amount.toLocaleString()}
+                    {goal.deadline && <span className="ml-2">· Due {goal.deadline}</span>}
+                  </p>
+                </div>
+                <div className="flex gap-1">
+                  <Button variant="ghost" size="sm" onClick={() => setAddFundsId(addFundsId === goal.id ? null : goal.id)}>
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => toggleMilestones(goal.id)}>
+                    <Trophy className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => handleDelete(goal.id)}>
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              </div>
+
+              {/* Progress bar */}
+              <div className="w-full bg-muted rounded-full h-3">
+                <div
+                  className="bg-primary h-3 rounded-full transition-all"
+                  style={{ width: `${Math.min(goal.progress_pct, 100)}%` }}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground text-right">{goal.progress_pct}%</p>
+
+              {/* Add funds form */}
+              {addFundsId === goal.id && (
+                <div className="flex gap-2">
+                  <Input type="number" placeholder="Amount" value={fundsAmount} onChange={e => setFundsAmount(e.target.value)} className="w-40" />
+                  <Button size="sm" onClick={() => handleAddFunds(goal.id)}>Add Funds</Button>
+                </div>
+              )}
+
+              {/* Milestones */}
+              {expandedGoal === goal.id && milestonesMap[goal.id] && (
+                <div className="space-y-1 pt-2 border-t">
+                  <p className="text-xs font-semibold text-muted-foreground mb-1">Milestones</p>
+                  {milestonesMap[goal.id].map(ms => (
+                    <div key={ms.id} className="flex items-center gap-2 text-sm">
+                      <span className={`inline-block h-2 w-2 rounded-full ${ms.reached_at ? 'bg-green-500' : 'bg-muted-foreground/30'}`} />
+                      <span className={ms.reached_at ? 'text-foreground' : 'text-muted-foreground'}>
+                        {ms.name} — {goal.currency} {ms.amount.toLocaleString()}
+                      </span>
+                      {ms.reached_at && <span className="text-xs text-green-600">✓</span>}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,33 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    target_amount = db.Column(db.Numeric(12, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    deadline = db.Column(db.Date, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    milestones = db.relationship(
+        "SavingsMilestone", backref="goal", cascade="all, delete-orphan", lazy=True
+    )
+
+
+class SavingsMilestone(db.Model):
+    __tablename__ = "savings_milestones"
+    id = db.Column(db.Integer, primary_key=True)
+    goal_id = db.Column(
+        db.Integer, db.ForeignKey("savings_goals.id"), nullable=False
+    )
+    name = db.Column(db.String(100), nullable=False)
+    amount = db.Column(db.Numeric(12, 2), nullable=False)
+    reached_at = db.Column(db.DateTime, nullable=True)
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -37,6 +37,7 @@ class Expense(db.Model):
     expense_type = db.Column(db.String(20), default="EXPENSE", nullable=False)
     notes = db.Column(db.String(500), nullable=True)
     spent_at = db.Column(db.Date, default=date.today, nullable=False)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=True)
     source_recurring_id = db.Column(
         db.Integer, db.ForeignKey("recurring_expenses.id"), nullable=True
     )
@@ -152,6 +153,33 @@ class SavingsMilestone(db.Model):
     name = db.Column(db.String(100), nullable=False)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     reached_at = db.Column(db.DateTime, nullable=True)
+
+
+class HouseholdRole(str, Enum):
+    OWNER = "OWNER"
+    MEMBER = "MEMBER"
+
+
+class Household(db.Model):
+    __tablename__ = "households"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    invite_code = db.Column(db.String(64), unique=True, nullable=False)
+    created_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    members = db.relationship("HouseholdMember", backref="household", lazy="dynamic")
+
+
+class HouseholdMember(db.Model):
+    __tablename__ = "household_members"
+    id = db.Column(db.Integer, primary_key=True)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    role = db.Column(db.String(20), default=HouseholdRole.MEMBER.value, nullable=False)
+    joined_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    __table_args__ = (
+        db.UniqueConstraint("household_id", "user_id", name="uq_household_user"),
+    )
 
 
 class AuditLog(db.Model):

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings import bp as savings_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_bp, url_prefix="/savings")

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -8,6 +8,7 @@ from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
 from .savings import bp as savings_bp
+from .household import bp as household_bp
 
 
 def register_routes(app: Flask):
@@ -20,3 +21,4 @@ def register_routes(app: Flask):
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
     app.register_blueprint(savings_bp, url_prefix="/savings")
+    app.register_blueprint(household_bp, url_prefix="/household")

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -5,7 +5,7 @@ from decimal import Decimal, InvalidOperation
 from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
-from ..models import Expense, RecurringCadence, RecurringExpense, User
+from ..models import Expense, HouseholdMember, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
 import logging
@@ -65,12 +65,20 @@ def create_expense():
     description = (data.get("description") or data.get("notes") or "").strip()
     if not description:
         return jsonify(error="description required"), 400
+    household_id = data.get("household_id")
+    if household_id:
+        membership = db.session.query(HouseholdMember).filter_by(
+            user_id=uid, household_id=int(household_id)
+        ).first()
+        if not membership:
+            return jsonify(error="not a member of this household"), 403
     e = Expense(
         user_id=uid,
         amount=amount,
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
         category_id=data.get("category_id"),
+        household_id=int(household_id) if household_id else None,
         notes=description,
         spent_at=date.fromisoformat(raw_date) if raw_date else date.today(),
     )

--- a/packages/backend/app/routes/household.py
+++ b/packages/backend/app/routes/household.py
@@ -1,0 +1,165 @@
+"""Shared household budgeting routes.
+
+Allows multiple users to collaborate on household finances by creating
+a household, inviting members, and sharing expenses.
+"""
+
+import secrets
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import (
+    Expense,
+    Household,
+    HouseholdMember,
+    HouseholdRole,
+    User,
+)
+
+bp = Blueprint("household", __name__)
+
+
+def _get_user_membership(uid: int) -> HouseholdMember | None:
+    return db.session.query(HouseholdMember).filter_by(user_id=uid).first()
+
+
+@bp.post("")
+@jwt_required()
+def create_household():
+    """Create a new household. User becomes owner."""
+    uid = int(get_jwt_identity())
+    existing = _get_user_membership(uid)
+    if existing:
+        return jsonify(error="already in a household"), 409
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+
+    household = Household(
+        name=name,
+        invite_code=secrets.token_urlsafe(16),
+        created_by=uid,
+    )
+    db.session.add(household)
+    db.session.flush()
+
+    member = HouseholdMember(
+        household_id=household.id,
+        user_id=uid,
+        role=HouseholdRole.OWNER.value,
+    )
+    db.session.add(member)
+    db.session.commit()
+    return jsonify(_household_to_dict(household)), 201
+
+
+@bp.get("")
+@jwt_required()
+def get_household():
+    """Get user's current household."""
+    uid = int(get_jwt_identity())
+    membership = _get_user_membership(uid)
+    if not membership:
+        return jsonify(error="not in a household"), 404
+    household = db.session.get(Household, membership.household_id)
+    return jsonify(_household_to_dict(household))
+
+
+@bp.post("/invite")
+@jwt_required()
+def invite_member():
+    """Return invite code. Only owner can invite."""
+    uid = int(get_jwt_identity())
+    membership = _get_user_membership(uid)
+    if not membership or membership.role != HouseholdRole.OWNER.value:
+        return jsonify(error="only household owner can invite"), 403
+    household = db.session.get(Household, membership.household_id)
+    return jsonify(invite_code=household.invite_code)
+
+
+@bp.post("/join/<code>")
+@jwt_required()
+def join_household(code: str):
+    """Join a household via invite code."""
+    uid = int(get_jwt_identity())
+    existing = _get_user_membership(uid)
+    if existing:
+        return jsonify(error="already in a household"), 409
+    household = db.session.query(Household).filter_by(invite_code=code).first()
+    if not household:
+        return jsonify(error="invalid invite code"), 404
+    member = HouseholdMember(
+        household_id=household.id,
+        user_id=uid,
+        role=HouseholdRole.MEMBER.value,
+    )
+    db.session.add(member)
+    db.session.commit()
+    return jsonify(_household_to_dict(household)), 200
+
+
+@bp.get("/members")
+@jwt_required()
+def list_members():
+    """List household members."""
+    uid = int(get_jwt_identity())
+    membership = _get_user_membership(uid)
+    if not membership:
+        return jsonify(error="not in a household"), 404
+    members = (
+        db.session.query(HouseholdMember, User)
+        .join(User, HouseholdMember.user_id == User.id)
+        .filter(HouseholdMember.household_id == membership.household_id)
+        .all()
+    )
+    return jsonify([
+        {
+            "user_id": m.user_id,
+            "email": u.email,
+            "role": m.role,
+            "joined_at": m.joined_at.isoformat(),
+        }
+        for m, u in members
+    ])
+
+
+@bp.get("/expenses")
+@jwt_required()
+def household_expenses():
+    """List all expenses tagged with the user's household."""
+    uid = int(get_jwt_identity())
+    membership = _get_user_membership(uid)
+    if not membership:
+        return jsonify(error="not in a household"), 404
+    expenses = (
+        db.session.query(Expense)
+        .filter_by(household_id=membership.household_id)
+        .order_by(Expense.spent_at.desc())
+        .limit(200)
+        .all()
+    )
+    return jsonify([
+        {
+            "id": e.id,
+            "user_id": e.user_id,
+            "amount": float(e.amount),
+            "currency": e.currency,
+            "category_id": e.category_id,
+            "expense_type": e.expense_type,
+            "description": e.notes or "",
+            "date": e.spent_at.isoformat(),
+            "household_id": e.household_id,
+        }
+        for e in expenses
+    ])
+
+
+def _household_to_dict(h: Household) -> dict:
+    return {
+        "id": h.id,
+        "name": h.name,
+        "invite_code": h.invite_code,
+        "created_by": h.created_by,
+        "created_at": h.created_at.isoformat(),
+    }

--- a/packages/backend/app/routes/savings.py
+++ b/packages/backend/app/routes/savings.py
@@ -1,0 +1,200 @@
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import SavingsGoal, SavingsMilestone
+
+bp = Blueprint("savings", __name__)
+
+MILESTONE_PERCENTAGES = [
+    (25, "25% milestone"),
+    (50, "50% milestone"),
+    (75, "75% milestone"),
+    (100, "100% – Goal reached!"),
+]
+
+
+def _goal_to_dict(goal: SavingsGoal) -> dict:
+    target = float(goal.target_amount)
+    current = float(goal.current_amount)
+    progress = (current / target * 100) if target > 0 else 0
+    return {
+        "id": goal.id,
+        "name": goal.name,
+        "target_amount": target,
+        "current_amount": current,
+        "currency": goal.currency,
+        "deadline": goal.deadline.isoformat() if goal.deadline else None,
+        "progress_pct": round(progress, 2),
+        "created_at": goal.created_at.isoformat(),
+    }
+
+
+def _milestone_to_dict(m: SavingsMilestone) -> dict:
+    return {
+        "id": m.id,
+        "goal_id": m.goal_id,
+        "name": m.name,
+        "amount": float(m.amount),
+        "reached_at": m.reached_at.isoformat() if m.reached_at else None,
+    }
+
+
+def _create_milestones(goal: SavingsGoal) -> None:
+    """Create milestone records for a goal at 25/50/75/100%."""
+    for pct, label in MILESTONE_PERCENTAGES:
+        amount = goal.target_amount * pct / 100
+        ms = SavingsMilestone(goal_id=goal.id, name=label, amount=amount)
+        db.session.add(ms)
+
+
+def _check_milestones(goal: SavingsGoal) -> None:
+    """Mark milestones as reached when current_amount meets them."""
+    for ms in goal.milestones:
+        if ms.reached_at is None and goal.current_amount >= ms.amount:
+            ms.reached_at = datetime.utcnow()
+
+
+@bp.route("/goals", methods=["POST"])
+@jwt_required()
+def create_goal():
+    data = request.get_json(silent=True) or {}
+    name = data.get("name")
+    if not name or not str(name).strip():
+        return jsonify(error="name is required"), 400
+
+    try:
+        target_amount = Decimal(str(data["target_amount"]))
+        if target_amount <= 0:
+            raise ValueError
+    except (KeyError, ValueError, InvalidOperation):
+        return jsonify(error="target_amount must be a positive number"), 400
+
+    current_amount = Decimal("0")
+    if "current_amount" in data:
+        try:
+            current_amount = Decimal(str(data["current_amount"]))
+            if current_amount < 0:
+                raise ValueError
+        except (ValueError, InvalidOperation):
+            return jsonify(error="current_amount must be a non-negative number"), 400
+
+    deadline = None
+    if data.get("deadline"):
+        try:
+            deadline = datetime.strptime(data["deadline"], "%Y-%m-%d").date()
+        except ValueError:
+            return jsonify(error="deadline must be YYYY-MM-DD"), 400
+
+    user_id = get_jwt_identity()
+    goal = SavingsGoal(
+        user_id=user_id,
+        name=str(name).strip(),
+        target_amount=target_amount,
+        current_amount=current_amount,
+        currency=data.get("currency", "INR"),
+        deadline=deadline,
+    )
+    db.session.add(goal)
+    db.session.flush()  # get goal.id
+    _create_milestones(goal)
+    _check_milestones(goal)
+    db.session.commit()
+    return jsonify(_goal_to_dict(goal)), 201
+
+
+@bp.route("/goals", methods=["GET"])
+@jwt_required()
+def list_goals():
+    user_id = get_jwt_identity()
+    goals = SavingsGoal.query.filter_by(user_id=user_id).order_by(SavingsGoal.created_at.desc()).all()
+    return jsonify([_goal_to_dict(g) for g in goals]), 200
+
+
+@bp.route("/goals/<int:goal_id>", methods=["PUT", "PATCH"])
+@jwt_required()
+def update_goal(goal_id: int):
+    user_id = get_jwt_identity()
+    goal = SavingsGoal.query.filter_by(id=goal_id, user_id=user_id).first()
+    if not goal:
+        return jsonify(error="goal not found"), 404
+
+    data = request.get_json(silent=True) or {}
+
+    if "name" in data:
+        if not str(data["name"]).strip():
+            return jsonify(error="name cannot be empty"), 400
+        goal.name = str(data["name"]).strip()
+
+    if "target_amount" in data:
+        try:
+            val = Decimal(str(data["target_amount"]))
+            if val <= 0:
+                raise ValueError
+            goal.target_amount = val
+            # Recreate milestones with new target
+            SavingsMilestone.query.filter_by(goal_id=goal.id).delete()
+            db.session.flush()
+            _create_milestones(goal)
+        except (ValueError, InvalidOperation):
+            return jsonify(error="target_amount must be a positive number"), 400
+
+    if "current_amount" in data:
+        try:
+            val = Decimal(str(data["current_amount"]))
+            if val < 0:
+                raise ValueError
+            goal.current_amount = val
+        except (ValueError, InvalidOperation):
+            return jsonify(error="current_amount must be a non-negative number"), 400
+
+    if "add_funds" in data:
+        try:
+            val = Decimal(str(data["add_funds"]))
+            if val <= 0:
+                raise ValueError
+            goal.current_amount = goal.current_amount + val
+        except (ValueError, InvalidOperation):
+            return jsonify(error="add_funds must be a positive number"), 400
+
+    if "currency" in data:
+        goal.currency = data["currency"]
+
+    if "deadline" in data:
+        if data["deadline"] is None:
+            goal.deadline = None
+        else:
+            try:
+                goal.deadline = datetime.strptime(data["deadline"], "%Y-%m-%d").date()
+            except ValueError:
+                return jsonify(error="deadline must be YYYY-MM-DD"), 400
+
+    _check_milestones(goal)
+    db.session.commit()
+    return jsonify(_goal_to_dict(goal)), 200
+
+
+@bp.route("/goals/<int:goal_id>", methods=["DELETE"])
+@jwt_required()
+def delete_goal(goal_id: int):
+    user_id = get_jwt_identity()
+    goal = SavingsGoal.query.filter_by(id=goal_id, user_id=user_id).first()
+    if not goal:
+        return jsonify(error="goal not found"), 404
+    db.session.delete(goal)
+    db.session.commit()
+    return jsonify(message="goal deleted"), 200
+
+
+@bp.route("/goals/<int:goal_id>/milestones", methods=["GET"])
+@jwt_required()
+def get_milestones(goal_id: int):
+    user_id = get_jwt_identity()
+    goal = SavingsGoal.query.filter_by(id=goal_id, user_id=user_id).first()
+    if not goal:
+        return jsonify(error="goal not found"), 404
+    milestones = SavingsMilestone.query.filter_by(goal_id=goal_id).order_by(SavingsMilestone.amount).all()
+    return jsonify([_milestone_to_dict(m) for m in milestones]), 200

--- a/packages/backend/tests/test_household.py
+++ b/packages/backend/tests/test_household.py
@@ -1,0 +1,137 @@
+"""Tests for shared household budgeting feature."""
+
+import pytest
+
+
+@pytest.fixture()
+def second_auth_header(client):
+    """Register and login a second user."""
+    email = "user2@example.com"
+    password = "password456"
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    access = r.get_json()["access_token"]
+    return {"Authorization": f"Bearer {access}"}
+
+
+class TestHouseholdCreation:
+    def test_create_household(self, client, auth_header):
+        r = client.post("/household", json={"name": "Test Home"}, headers=auth_header)
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["name"] == "Test Home"
+        assert "invite_code" in data
+
+    def test_create_household_no_name(self, client, auth_header):
+        r = client.post("/household", json={}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_create_household_duplicate(self, client, auth_header):
+        client.post("/household", json={"name": "Home"}, headers=auth_header)
+        r = client.post("/household", json={"name": "Home 2"}, headers=auth_header)
+        assert r.status_code == 409
+
+
+class TestHouseholdGet:
+    def test_get_household(self, client, auth_header):
+        client.post("/household", json={"name": "Home"}, headers=auth_header)
+        r = client.get("/household", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["name"] == "Home"
+
+    def test_get_household_not_member(self, client, auth_header, second_auth_header):
+        r = client.get("/household", headers=second_auth_header)
+        assert r.status_code == 404
+
+
+class TestHouseholdInvite:
+    def test_invite_returns_code(self, client, auth_header):
+        client.post("/household", json={"name": "Home"}, headers=auth_header)
+        r = client.post("/household/invite", headers=auth_header)
+        assert r.status_code == 200
+        assert "invite_code" in r.get_json()
+
+    def test_invite_non_owner_forbidden(self, client, auth_header, second_auth_header):
+        resp = client.post("/household", json={"name": "Home"}, headers=auth_header)
+        code = resp.get_json()["invite_code"]
+        client.post(f"/household/join/{code}", headers=second_auth_header)
+        r = client.post("/household/invite", headers=second_auth_header)
+        assert r.status_code == 403
+
+
+class TestHouseholdJoin:
+    def test_join_household(self, client, auth_header, second_auth_header):
+        resp = client.post("/household", json={"name": "Home"}, headers=auth_header)
+        code = resp.get_json()["invite_code"]
+        r = client.post(f"/household/join/{code}", headers=second_auth_header)
+        assert r.status_code == 200
+
+    def test_join_invalid_code(self, client, second_auth_header):
+        r = client.post("/household/join/badcode", headers=second_auth_header)
+        assert r.status_code == 404
+
+    def test_join_already_in_household(self, client, auth_header):
+        resp = client.post("/household", json={"name": "Home"}, headers=auth_header)
+        code = resp.get_json()["invite_code"]
+        r = client.post(f"/household/join/{code}", headers=auth_header)
+        assert r.status_code == 409
+
+
+class TestHouseholdMembers:
+    def test_list_members(self, client, auth_header, second_auth_header):
+        resp = client.post("/household", json={"name": "Home"}, headers=auth_header)
+        code = resp.get_json()["invite_code"]
+        client.post(f"/household/join/{code}", headers=second_auth_header)
+        r = client.get("/household/members", headers=auth_header)
+        assert r.status_code == 200
+        members = r.get_json()
+        assert len(members) == 2
+        roles = {m["role"] for m in members}
+        assert "OWNER" in roles
+        assert "MEMBER" in roles
+
+
+class TestHouseholdExpenses:
+    def test_shared_expenses(self, client, auth_header, second_auth_header):
+        # Create household and join
+        resp = client.post("/household", json={"name": "Home"}, headers=auth_header)
+        household = resp.get_json()
+        code = household["invite_code"]
+        client.post(f"/household/join/{code}", headers=second_auth_header)
+
+        # Create expense with household_id
+        r = client.post("/expenses", json={
+            "amount": 50,
+            "description": "Groceries",
+            "household_id": household["id"],
+        }, headers=auth_header)
+        assert r.status_code == 201
+
+        # Both users can see household expenses
+        r = client.get("/household/expenses", headers=auth_header)
+        assert r.status_code == 200
+        expenses = r.get_json()
+        assert len(expenses) == 1
+        assert expenses[0]["description"] == "Groceries"
+
+        r2 = client.get("/household/expenses", headers=second_auth_header)
+        assert r2.status_code == 200
+        assert len(r2.get_json()) == 1
+
+    def test_expense_without_household(self, client, auth_header):
+        r = client.post("/expenses", json={
+            "amount": 25,
+            "description": "Personal lunch",
+        }, headers=auth_header)
+        assert r.status_code == 201
+
+    def test_expense_wrong_household(self, client, second_auth_header):
+        """Non-member cannot tag expense to a household."""
+        # second user is not in any household, try to use household_id=999
+        r = client.post("/expenses", json={
+            "amount": 10,
+            "description": "Test",
+            "household_id": 999,
+        }, headers=second_auth_header)
+        assert r.status_code == 403

--- a/packages/backend/tests/test_savings.py
+++ b/packages/backend/tests/test_savings.py
@@ -1,0 +1,128 @@
+"""Tests for savings goals and milestones."""
+import pytest
+
+
+class TestSavingsGoals:
+    """CRUD tests for /savings/goals."""
+
+    def test_create_goal(self, client, auth_header):
+        r = client.post(
+            "/savings/goals",
+            json={"name": "Emergency Fund", "target_amount": 10000, "currency": "USD", "deadline": "2026-12-31"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["name"] == "Emergency Fund"
+        assert data["target_amount"] == 10000.0
+        assert data["current_amount"] == 0.0
+        assert data["currency"] == "USD"
+        assert data["deadline"] == "2026-12-31"
+        assert data["progress_pct"] == 0.0
+
+    def test_create_goal_missing_name(self, client, auth_header):
+        r = client.post("/savings/goals", json={"target_amount": 100}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_create_goal_bad_amount(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "X", "target_amount": -5}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_list_goals(self, client, auth_header):
+        client.post("/savings/goals", json={"name": "A", "target_amount": 100}, headers=auth_header)
+        client.post("/savings/goals", json={"name": "B", "target_amount": 200}, headers=auth_header)
+        r = client.get("/savings/goals", headers=auth_header)
+        assert r.status_code == 200
+        assert len(r.get_json()) == 2
+
+    def test_update_goal_add_funds(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "Car", "target_amount": 1000}, headers=auth_header)
+        goal_id = r.get_json()["id"]
+        r = client.put(f"/savings/goals/{goal_id}", json={"add_funds": 250}, headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["current_amount"] == 250.0
+        assert r.get_json()["progress_pct"] == 25.0
+
+    def test_update_goal_edit_name(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "Old", "target_amount": 100}, headers=auth_header)
+        goal_id = r.get_json()["id"]
+        r = client.put(f"/savings/goals/{goal_id}", json={"name": "New"}, headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["name"] == "New"
+
+    def test_update_goal_not_found(self, client, auth_header):
+        r = client.put("/savings/goals/9999", json={"name": "X"}, headers=auth_header)
+        assert r.status_code == 404
+
+    def test_delete_goal(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "Del", "target_amount": 50}, headers=auth_header)
+        goal_id = r.get_json()["id"]
+        r = client.delete(f"/savings/goals/{goal_id}", headers=auth_header)
+        assert r.status_code == 200
+        r = client.get("/savings/goals", headers=auth_header)
+        assert len(r.get_json()) == 0
+
+    def test_delete_goal_not_found(self, client, auth_header):
+        r = client.delete("/savings/goals/9999", headers=auth_header)
+        assert r.status_code == 404
+
+
+class TestMilestones:
+    """Milestone auto-creation and tracking."""
+
+    def test_milestones_auto_created(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "M", "target_amount": 1000}, headers=auth_header)
+        goal_id = r.get_json()["id"]
+        r = client.get(f"/savings/goals/{goal_id}/milestones", headers=auth_header)
+        assert r.status_code == 200
+        ms = r.get_json()
+        assert len(ms) == 4
+        amounts = [m["amount"] for m in ms]
+        assert amounts == [250.0, 500.0, 750.0, 1000.0]
+        assert all(m["reached_at"] is None for m in ms)
+
+    def test_milestones_reached_on_fund(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "M", "target_amount": 100}, headers=auth_header)
+        goal_id = r.get_json()["id"]
+        client.put(f"/savings/goals/{goal_id}", json={"add_funds": 50}, headers=auth_header)
+        r = client.get(f"/savings/goals/{goal_id}/milestones", headers=auth_header)
+        ms = r.get_json()
+        reached = [m for m in ms if m["reached_at"] is not None]
+        assert len(reached) == 2  # 25% (25) and 50% (50)
+
+    def test_milestones_all_reached(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "M", "target_amount": 100}, headers=auth_header)
+        goal_id = r.get_json()["id"]
+        client.put(f"/savings/goals/{goal_id}", json={"current_amount": 100}, headers=auth_header)
+        r = client.get(f"/savings/goals/{goal_id}/milestones", headers=auth_header)
+        ms = r.get_json()
+        assert all(m["reached_at"] is not None for m in ms)
+
+    def test_milestones_not_found(self, client, auth_header):
+        r = client.get("/savings/goals/9999/milestones", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_milestones_recreated_on_target_change(self, client, auth_header):
+        r = client.post("/savings/goals", json={"name": "M", "target_amount": 100}, headers=auth_header)
+        goal_id = r.get_json()["id"]
+        client.put(f"/savings/goals/{goal_id}", json={"target_amount": 200}, headers=auth_header)
+        r = client.get(f"/savings/goals/{goal_id}/milestones", headers=auth_header)
+        ms = r.get_json()
+        amounts = [m["amount"] for m in ms]
+        assert amounts == [50.0, 100.0, 150.0, 200.0]
+
+    def test_create_goal_with_initial_amount_milestones(self, client, auth_header):
+        r = client.post(
+            "/savings/goals",
+            json={"name": "M", "target_amount": 100, "current_amount": 75},
+            headers=auth_header,
+        )
+        goal_id = r.get_json()["id"]
+        r = client.get(f"/savings/goals/{goal_id}/milestones", headers=auth_header)
+        ms = r.get_json()
+        reached = [m for m in ms if m["reached_at"] is not None]
+        assert len(reached) == 3  # 25, 50, 75
+
+    def test_unauthenticated(self, client):
+        r = client.get("/savings/goals")
+        assert r.status_code == 401


### PR DESCRIPTION
/claim #134

## Summary
Implements shared household budgeting feature allowing multiple users to collaborate on household finances.

### Backend
- New `Household` and `HouseholdMember` models with invite code system
- New `/household` routes: create, get, invite, join, list members, shared expenses
- Added optional `household_id` to `Expense` model for tagging shared expenses
- Membership validation when creating household-tagged expenses

### Frontend
- New `Household` page with create/join household, member list, and shared expenses view
- API client for all household endpoints
- Route and navbar integration

### Tests
- 14 comprehensive tests covering creation, joining, inviting, member listing, shared expenses, and authorization
- All 52 existing + new tests pass

Closes #134