### PR TITLE
feat: Webhook Event System with HMAC Signatures and Retries

### DIFF
--- a/packages/backend/WEBHOOKS.md
+++ b/packages/backend/WEBHOOKS.md
@@ -1,0 +1,38 @@
+# FinMind Webhooks Documentation
+
+FinMind supports outgoing webhooks to notify external systems of key events.
+
+## Signature Verification
+
+Each webhook request includes a `X-FinMind-Signature` header. This is a HMAC SHA-256 hex digest of the JSON payload, signed with your subscription secret.
+
+Example (Node.js):
+```javascript
+const crypto = require('crypto');
+const signature = crypto
+  .createHmac('sha256', secret)
+  .update(JSON.stringify(payload))
+  .digest('hex');
+```
+
+## Retry Logic
+
+If a delivery attempt fails (status code outside 200-299), FinMind will retry up to 3 times with exponential backoff (2^n seconds).
+
+## Event Types
+
+### `expense.created`
+Triggered when a new expense is added.
+Payload: Same as Expense object.
+
+### `expense.updated`
+Triggered when an existing expense is modified.
+Payload: Same as Expense object.
+
+### `expense.deleted`
+Triggered when an expense is deleted.
+Payload: Same as Expense object (before deletion).
+
+## Registration
+
+Use the `POST /webhooks/subscribe` endpoint with your target URL. It will return a unique `secret`.

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -44,6 +44,8 @@ def create_app(settings: Settings | None = None) -> Flask:
     # Extensions
     db.init_app(app)
     jwt.init_app(app)
+    if not scheduler.running:
+        scheduler.start()
     app.extensions["observability"] = Observability()
     # CORS for local dev frontend
     CORS(app, resources={r"*": {"origins": "*"}}, supports_credentials=True)

--- a/packages/backend/app/extensions.py
+++ b/packages/backend/app/extensions.py
@@ -1,11 +1,13 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
 import redis
+from apscheduler.schedulers.background import BackgroundScheduler
 from .config import Settings
 
 
 db = SQLAlchemy()
 jwt = JWTManager()
+scheduler = BackgroundScheduler()
 
 _settings = Settings()
 redis_client = redis.Redis.from_url(_settings.redis_url, decode_responses=True)

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,13 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WebhookSubscription(db.Model):
+    __tablename__ = "webhook_subscriptions"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    url = db.Column(db.String(500), nullable=False)
+    secret = db.Column(db.String(100), nullable=False)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .webhooks import bp as webhooks_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(webhooks_bp, url_prefix="/webhooks")

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -8,6 +8,7 @@ from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
+from ..services.webhooks import WebhookService
 import logging
 
 bp = Blueprint("expenses", __name__)
@@ -77,6 +78,8 @@ def create_expense():
     db.session.add(e)
     db.session.commit()
     logger.info("Created expense id=%s user=%s amount=%s", e.id, uid, e.amount)
+    # Emit Webhook
+    WebhookService.emit(uid, "expense.created", _expense_to_dict(e))
     # Invalidate caches
     cache_delete_patterns(
         [
@@ -231,6 +234,7 @@ def update_expense(expense_id: int):
         e.spent_at = date.fromisoformat(raw_date)
     db.session.commit()
     _invalidate_expense_cache(uid, e.spent_at.isoformat())
+    WebhookService.emit(uid, "expense.updated", _expense_to_dict(e))
     return jsonify(_expense_to_dict(e))
 
 
@@ -242,9 +246,11 @@ def delete_expense(expense_id: int):
     if not e or e.user_id != uid:
         return jsonify(error="not found"), 404
     spent_at = e.spent_at.isoformat()
+    expense_data = _expense_to_dict(e)
     db.session.delete(e)
     db.session.commit()
     _invalidate_expense_cache(uid, spent_at)
+    WebhookService.emit(uid, "expense.deleted", expense_data)
     return jsonify(message="deleted")
 
 

--- a/packages/backend/app/routes/webhooks.py
+++ b/packages/backend/app/routes/webhooks.py
@@ -1,0 +1,55 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import secrets
+from ..models import WebhookSubscription, db
+
+bp = Blueprint("webhooks", __name__, url_prefix="/webhooks")
+
+@bp.post("/subscribe")
+@jwt_required()
+def subscribe():
+    user_id = get_jwt_identity()
+    data = request.get_json()
+    
+    url = data.get("url")
+    if not url:
+        return jsonify(error="url is required"), 400
+        
+    # Generate a secret for the user to verify signatures
+    secret = secrets.token_hex(32)
+    
+    sub = WebhookSubscription(
+        user_id=user_id,
+        url=url,
+        secret=secret
+    )
+    db.session.add(sub)
+    db.session.commit()
+    
+    return jsonify({
+        "id": sub.id,
+        "url": sub.url,
+        "secret": sub.secret,
+        "msg": "Store this secret securely to verify webhook signatures."
+    }), 201
+
+@bp.get("/")
+@jwt_required()
+def list_subscriptions():
+    user_id = get_jwt_identity()
+    subs = WebhookSubscription.query.filter_by(user_id=user_id).all()
+    return jsonify([{
+        "id": s.id,
+        "url": s.url,
+        "is_active": s.is_active,
+        "created_at": s.created_at.isoformat()
+    } for s in subs]), 200
+
+@bp.delete("/<int:sub_id>")
+@jwt_required()
+def unsubscribe(sub_id):
+    user_id = get_jwt_identity()
+    sub = WebhookSubscription.query.filter_by(id=sub_id, user_id=user_id).first_or_404()
+    db.session.delete(sub)
+    db.session.commit()
+    return jsonify(status="deleted"), 200

--- a/packages/backend/app/services/webhooks.py
+++ b/packages/backend/app/services/webhooks.py
@@ -1,0 +1,68 @@
+import hmac
+import hashlib
+import json
+import requests
+import time
+import logging
+from typing import Any, Dict
+from ..models import WebhookSubscription, db
+from ..extensions import scheduler
+
+logger = logging.getLogger("finmind.webhooks")
+
+class WebhookService:
+    @staticmethod
+    def emit(user_id: int, event_type: str, payload: Dict[str, Any]):
+        """Emit a webhook event for a specific user."""
+        subscriptions = WebhookSubscription.query.filter_by(
+            user_id=user_id, is_active=True
+        ).all()
+        
+        for sub in subscriptions:
+            full_payload = {
+                "event": event_type,
+                "timestamp": int(time.time()),
+                "data": payload
+            }
+            # Offload delivery to background scheduler
+            scheduler.add_job(
+                WebhookService._deliver_with_retry,
+                args=[sub.url, sub.secret, full_payload],
+                id=f"webhook_{sub.id}_{int(time.time())}",
+                misfire_grace_time=10
+            )
+
+    @staticmethod
+    def _deliver_with_retry(url: str, secret: str, payload: Dict[str, Any], retries: int = 3):
+        """Deliver webhook with exponential backoff retry logic."""
+        payload_bytes = json.dumps(payload).encode('utf-8')
+        signature = hmac.new(
+            secret.encode('utf-8'), 
+            payload_bytes, 
+            hashlib.sha256
+        ).hexdigest()
+        
+        headers = {
+            "Content-Type": "application/json",
+            "X-FinMind-Signature": signature,
+            "X-FinMind-Event": payload.get("event", "unknown"),
+            "User-Agent": "FinMind-Webhook-Bot/1.0"
+        }
+        
+        for i in range(retries):
+            try:
+                logger.info(f"Attempting webhook delivery to {url} (Attempt {i+1})")
+                response = requests.post(url, data=payload_bytes, headers=headers, timeout=5)
+                if 200 <= response.status_code < 300:
+                    logger.info(f"Successfully delivered webhook to {url}")
+                    return True
+                logger.warning(f"Webhook delivery failed with status {response.status_code}")
+            except requests.RequestException as e:
+                logger.error(f"Webhook delivery error to {url}: {e}")
+            
+            if i < retries - 1:
+                wait_time = 2 ** i
+                time.sleep(wait_time)
+        
+        logger.error(f"Failed to deliver webhook to {url} after {retries} attempts")
+        return False


### PR DESCRIPTION
This PR implements the requested Webhook Event System ($50 Bounty).

### Changes:
- **WebhookSubscription Model**: New model to store user URLs and secrets.
- **WebhookService**: Handles event emission, payload signing (HMAC SHA-256), and delivery with exponential backoff retries (using APScheduler).
- **Webhooks Blueprint**: API endpoints for users to manage their subscriptions (`/webhooks/subscribe`, `/webhooks/list`, etc.).
- **Expense Hooks**: Automatically emit events on `expense.created`, `expense.updated`, and `expense.deleted`.
- **Documentation**: Added `WEBHOOKS.md` with integration guide and event types.

Closes #77