### PR TITLE
feat: Smart digest with weekly financial summary

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import WeeklyDigest from "./pages/WeeklyDigest";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="digest"
+              element={
+                <ProtectedRoute>
+                  <WeeklyDigest />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/digest.ts
+++ b/app/src/api/digest.ts
@@ -1,0 +1,30 @@
+import { api } from './client';
+
+export type WeeklyDigest = {
+  period: { start: string; end: string };
+  totals: {
+    income: number;
+    expenses: number;
+    net: number;
+  };
+  comparison: {
+    previous_week_expenses: number;
+    change: number;
+    change_percent: number | null;
+  };
+  category_breakdown: Array<{
+    category: string;
+    total: number;
+    count: number;
+  }>;
+  daily_spending: Array<{
+    date: string;
+    amount: number;
+  }>;
+  highlights: string[];
+};
+
+export async function fetchWeeklyDigest(date?: string): Promise<WeeklyDigest> {
+  const params = date ? `?date=${date}` : '';
+  return api<WeeklyDigest>(`/digest/weekly${params}`);
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Digest', href: '/digest' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/WeeklyDigest.tsx
+++ b/app/src/pages/WeeklyDigest.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+import { fetchWeeklyDigest, type WeeklyDigest } from '../api/digest';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardDescription,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '../components/ui/financial-card';
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount);
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export default function WeeklyDigestPage() {
+  const [digest, setDigest] = useState<WeeklyDigest | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchWeeklyDigest()
+      .then(setDigest)
+      .catch((err) => setError(err.message ?? 'Failed to load digest'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <p className="text-muted-foreground">Loading weekly digest...</p>
+      </div>
+    );
+  }
+
+  if (error || !digest) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <p className="text-destructive">{error ?? 'No data available'}</p>
+      </div>
+    );
+  }
+
+  const { period, totals, comparison, category_breakdown, daily_spending, highlights } = digest;
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Weekly Digest</h1>
+        <p className="text-muted-foreground">
+          {formatDate(period.start)} — {formatDate(period.end)}
+        </p>
+      </div>
+
+      {/* Highlights */}
+      {highlights.length > 0 && (
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle>Highlights</FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <ul className="space-y-2">
+              {highlights.map((h, i) => (
+                <li key={i} className="text-sm">
+                  {h}
+                </li>
+              ))}
+            </ul>
+          </FinancialCardContent>
+        </FinancialCard>
+      )}
+
+      {/* Summary Cards */}
+      <div className="grid gap-4 md:grid-cols-3">
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardDescription>Income</FinancialCardDescription>
+            <FinancialCardTitle className="text-green-600">
+              {formatCurrency(totals.income)}
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+        </FinancialCard>
+
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardDescription>Expenses</FinancialCardDescription>
+            <FinancialCardTitle className="text-red-600">
+              {formatCurrency(totals.expenses)}
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+        </FinancialCard>
+
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardDescription>Net</FinancialCardDescription>
+            <FinancialCardTitle className={totals.net >= 0 ? 'text-green-600' : 'text-red-600'}>
+              {formatCurrency(totals.net)}
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+        </FinancialCard>
+      </div>
+
+      {/* Week-over-week comparison */}
+      {comparison.change_percent !== null && (
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle>vs Previous Week</FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="flex items-center gap-4">
+              <div>
+                <p className="text-sm text-muted-foreground">Previous week</p>
+                <p className="font-medium">{formatCurrency(comparison.previous_week_expenses)}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Change</p>
+                <p
+                  className={`font-medium ${comparison.change <= 0 ? 'text-green-600' : 'text-red-600'}`}
+                >
+                  {comparison.change > 0 ? '+' : ''}
+                  {formatCurrency(comparison.change)} ({comparison.change_percent > 0 ? '+' : ''}
+                  {comparison.change_percent}%)
+                </p>
+              </div>
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+      )}
+
+      {/* Category breakdown */}
+      {category_breakdown.length > 0 && (
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle>Spending by Category</FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="space-y-3">
+              {category_breakdown.map((cat) => (
+                <div key={cat.category} className="flex items-center justify-between">
+                  <div>
+                    <p className="font-medium">{cat.category}</p>
+                    <p className="text-xs text-muted-foreground">{cat.count} transactions</p>
+                  </div>
+                  <p className="font-medium">{formatCurrency(cat.total)}</p>
+                </div>
+              ))}
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+      )}
+
+      {/* Daily spending */}
+      {daily_spending.length > 0 && (
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle>Daily Spending</FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="space-y-2">
+              {daily_spending.map((day) => (
+                <div key={day.date} className="flex items-center justify-between">
+                  <p className="text-sm">{formatDate(day.date)}</p>
+                  <p className="font-medium">{formatCurrency(day.amount)}</p>
+                </div>
+              ))}
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,28 @@
+"""Weekly digest API routes."""
+
+from datetime import date
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.digest import weekly_digest
+import logging
+
+bp = Blueprint("digest", __name__)
+logger = logging.getLogger("finmind.digest")
+
+
+@bp.get("/weekly")
+@jwt_required()
+def get_weekly_digest():
+    """Return the weekly financial digest for the authenticated user.
+
+    Query params:
+        date (optional): ISO date string (YYYY-MM-DD) to get the digest for
+                         the week containing that date. Defaults to current week.
+    """
+    uid = int(get_jwt_identity())
+    date_str = request.args.get("date")
+    target_date = date.fromisoformat(date_str) if date_str else None
+
+    digest = weekly_digest(uid, target_date)
+    logger.info("Weekly digest served user=%s period=%s", uid, digest["period"])
+    return jsonify(digest)

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,180 @@
+"""Weekly financial digest service.
+
+Generates weekly summaries highlighting spending trends and insights.
+"""
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from sqlalchemy import func, extract
+
+from ..extensions import db
+from ..models import Expense, Category
+
+
+def _week_range(target_date: date | None = None) -> tuple[date, date]:
+    """Return (start, end) of the ISO week containing *target_date*."""
+    d = target_date or date.today()
+    start = d - timedelta(days=d.weekday())  # Monday
+    end = start + timedelta(days=6)  # Sunday
+    return start, end
+
+
+def _previous_week_range(target_date: date | None = None) -> tuple[date, date]:
+    """Return (start, end) of the week before the one containing *target_date*."""
+    d = target_date or date.today()
+    start = d - timedelta(days=d.weekday() + 7)
+    end = start + timedelta(days=6)
+    return start, end
+
+
+def _query_totals(uid: int, start: date, end: date) -> dict:
+    """Query income and expense totals for a date range."""
+    rows = (
+        db.session.query(
+            Expense.expense_type,
+            func.coalesce(func.sum(Expense.amount), 0),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .group_by(Expense.expense_type)
+        .all()
+    )
+    totals = {"INCOME": Decimal("0"), "EXPENSE": Decimal("0")}
+    for expense_type, amount in rows:
+        totals[expense_type] = Decimal(str(amount))
+    return totals
+
+
+def _query_category_breakdown(uid: int, start: date, end: date) -> list[dict]:
+    """Return per-category expense breakdown sorted by amount descending."""
+    rows = (
+        db.session.query(
+            Category.name,
+            func.sum(Expense.amount).label("total"),
+            func.count(Expense.id).label("count"),
+        )
+        .outerjoin(Category, Expense.category_id == Category.id)
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "EXPENSE",
+        )
+        .group_by(Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .all()
+    )
+    return [
+        {
+            "category": name or "Uncategorized",
+            "total": float(total),
+            "count": count,
+        }
+        for name, total, count in rows
+    ]
+
+
+def _query_daily_spending(uid: int, start: date, end: date) -> list[dict]:
+    """Return daily spending totals for the date range."""
+    rows = (
+        db.session.query(
+            Expense.spent_at,
+            func.sum(Expense.amount),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "EXPENSE",
+        )
+        .group_by(Expense.spent_at)
+        .order_by(Expense.spent_at)
+        .all()
+    )
+    return [
+        {"date": str(d), "amount": float(amount)}
+        for d, amount in rows
+    ]
+
+
+def weekly_digest(uid: int, target_date: date | None = None) -> dict:
+    """Generate a weekly financial digest for the given user.
+
+    Returns a dict containing:
+    - period: start/end dates
+    - totals: income, expenses, net
+    - category_breakdown: per-category spending
+    - daily_spending: day-by-day expenses
+    - comparison: vs previous week (amount change & percentage)
+    - highlights: notable observations
+    """
+    start, end = _week_range(target_date)
+    prev_start, prev_end = _previous_week_range(target_date)
+
+    totals = _query_totals(uid, start, end)
+    prev_totals = _query_totals(uid, prev_start, prev_end)
+
+    income = float(totals["INCOME"])
+    expenses = float(totals["EXPENSE"])
+    net = income - expenses
+
+    prev_expenses = float(prev_totals["EXPENSE"])
+    expense_change = expenses - prev_expenses
+    expense_change_pct = (
+        round((expense_change / prev_expenses) * 100, 1) if prev_expenses else None
+    )
+
+    categories = _query_category_breakdown(uid, start, end)
+    daily = _query_daily_spending(uid, start, end)
+
+    # Generate highlights
+    highlights = []
+    if expense_change_pct is not None:
+        if expense_change_pct > 20:
+            highlights.append(
+                f"⚠️ Spending increased by {expense_change_pct}% compared to last week."
+            )
+        elif expense_change_pct < -20:
+            highlights.append(
+                f"🎉 Spending decreased by {abs(expense_change_pct)}% compared to last week!"
+            )
+        else:
+            highlights.append(
+                f"📊 Spending is roughly stable vs last week ({expense_change_pct:+.1f}%)."
+            )
+
+    if categories:
+        top = categories[0]
+        highlights.append(
+            f"💰 Top spending category: {top['category']} ({top['total']:.2f})"
+        )
+
+    if net < 0:
+        highlights.append("🔴 You spent more than you earned this week.")
+    elif income > 0:
+        savings_rate = round((net / income) * 100, 1)
+        highlights.append(f"💚 Savings rate: {savings_rate}%")
+
+    return {
+        "period": {
+            "start": str(start),
+            "end": str(end),
+        },
+        "totals": {
+            "income": income,
+            "expenses": expenses,
+            "net": net,
+        },
+        "comparison": {
+            "previous_week_expenses": prev_expenses,
+            "change": expense_change,
+            "change_percent": expense_change_pct,
+        },
+        "category_breakdown": categories,
+        "daily_spending": daily,
+        "highlights": highlights,
+    }

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,106 @@
+"""Tests for the weekly digest feature."""
+
+from datetime import date, timedelta
+
+
+def _create_category(client, auth_header, name="General"):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code in (201, 409)
+    r = client.get("/categories", headers=auth_header)
+    assert r.status_code == 200
+    cats = [c for c in r.get_json() if c["name"] == name]
+    return cats[0]["id"]
+
+
+def _add_expense(client, auth_header, amount, category_id, expense_date, expense_type="EXPENSE"):
+    payload = {
+        "amount": amount,
+        "currency": "USD",
+        "category_id": category_id,
+        "description": f"Test {expense_type}",
+        "date": str(expense_date),
+    }
+    if expense_type == "INCOME":
+        payload["expense_type"] = "INCOME"
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201, f"Failed to create expense: {r.get_json()}"
+    return r.get_json()
+
+
+def test_weekly_digest_empty(client, auth_header):
+    """Digest with no expenses returns zero totals."""
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "period" in data
+    assert "totals" in data
+    assert "highlights" in data
+    assert data["totals"]["income"] == 0
+    assert data["totals"]["expenses"] == 0
+    assert data["totals"]["net"] == 0
+    assert data["category_breakdown"] == []
+    assert data["daily_spending"] == []
+
+
+def test_weekly_digest_with_expenses(client, auth_header):
+    """Digest correctly summarizes expenses for the current week."""
+    cat_id = _create_category(client, auth_header, "Food")
+
+    # Add expenses for today (current week)
+    today = date.today()
+    _add_expense(client, auth_header, 25.50, cat_id, today)
+    _add_expense(client, auth_header, 15.00, cat_id, today)
+
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+
+    assert data["totals"]["expenses"] == 40.50
+    assert len(data["category_breakdown"]) == 1
+    assert data["category_breakdown"][0]["category"] == "Food"
+    assert data["category_breakdown"][0]["total"] == 40.50
+    assert data["category_breakdown"][0]["count"] == 2
+
+
+def test_weekly_digest_with_date_param(client, auth_header):
+    """Digest respects the date query parameter."""
+    cat_id = _create_category(client, auth_header, "Transport")
+
+    # Add expense for a specific past date
+    past_date = date(2026, 1, 15)  # a Wednesday
+    _add_expense(client, auth_header, 100.00, cat_id, past_date)
+
+    r = client.get(f"/digest/weekly?date={past_date}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+
+    assert data["totals"]["expenses"] == 100.00
+    assert data["period"]["start"] == "2026-01-12"  # Monday of that week
+    assert data["period"]["end"] == "2026-01-18"  # Sunday
+
+
+def test_weekly_digest_comparison(client, auth_header):
+    """Digest includes comparison with previous week."""
+    cat_id = _create_category(client, auth_header, "Shopping")
+
+    today = date.today()
+    week_ago = today - timedelta(days=7)
+
+    # Previous week expense
+    _add_expense(client, auth_header, 200.00, cat_id, week_ago)
+    # Current week expense
+    _add_expense(client, auth_header, 50.00, cat_id, today)
+
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+
+    assert data["comparison"]["previous_week_expenses"] == 200.00
+    assert data["comparison"]["change"] == -150.00
+    assert data["comparison"]["change_percent"] is not None
+
+
+def test_weekly_digest_unauthorized(client):
+    """Digest endpoint requires authentication."""
+    r = client.get("/digest/weekly")
+    assert r.status_code in (401, 422)


### PR DESCRIPTION
## Summary

Implements the weekly financial digest feature (#121) that generates smart summaries highlighting spending trends and insights.

### Backend
- New `/digest/weekly` endpoint (GET, JWT-protected)
- Computes: income/expense totals, category breakdown, daily spending
- Week-over-week comparison with percentage change
- Auto-generated highlights (spending trends, top category, savings rate)
- Optional `?date=YYYY-MM-DD` parameter to view any week's digest

### Frontend
- New `/digest` page with summary cards, highlights, and breakdowns
- Navigation link added to navbar

### Tests
- `test_digest.py`: empty state, with expenses, date param, week comparison, auth check

Closes #121

/claim #121