### PR TITLE
feat: Bank Sync Connector Architecture

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -8,6 +8,8 @@ from .observability import (
     finalize_request,
     init_request_context,
 )
+from .connectors.registry import registry as connector_registry
+from .connectors.mock import MockBankConnector
 from flask_cors import CORS
 import click
 import os
@@ -49,6 +51,9 @@ def create_app(settings: Settings | None = None) -> Flask:
     CORS(app, resources={r"*": {"origins": "*"}}, supports_credentials=True)
 
     # Redis (already global)
+    # Bank-sync connectors
+    connector_registry.register("mock", MockBankConnector)
+
     # Blueprint routes
     register_routes(app)
 

--- a/packages/backend/app/connectors/__init__.py
+++ b/packages/backend/app/connectors/__init__.py
@@ -1,0 +1,11 @@
+from .base import BankConnector, BankAccount, BankTransaction, SyncResult
+from .registry import ConnectorRegistry, registry
+
+__all__ = [
+    "BankConnector",
+    "BankAccount",
+    "BankTransaction",
+    "SyncResult",
+    "ConnectorRegistry",
+    "registry",
+]

--- a/packages/backend/app/connectors/base.py
+++ b/packages/backend/app/connectors/base.py
@@ -1,0 +1,133 @@
+"""Abstract base class for bank sync connectors.
+
+Every bank integration (mock, Setu AA, direct bank API, etc.) must
+implement :class:`BankConnector`.  The interface is deliberately small so
+that adding a new provider is a single-file job.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+
+# ------------------------------------------------------------------
+# Value objects
+# ------------------------------------------------------------------
+
+
+class AccountType(str, Enum):
+    SAVINGS = "SAVINGS"
+    CURRENT = "CURRENT"
+    CREDIT_CARD = "CREDIT_CARD"
+    LOAN = "LOAN"
+    OTHER = "OTHER"
+
+
+class TransactionStatus(str, Enum):
+    POSTED = "POSTED"
+    PENDING = "PENDING"
+
+
+class SyncStatus(str, Enum):
+    SUCCESS = "SUCCESS"
+    PARTIAL = "PARTIAL"
+    FAILED = "FAILED"
+
+
+@dataclass
+class BankAccount:
+    """Normalised representation of a bank account."""
+
+    external_id: str
+    name: str
+    account_type: AccountType = AccountType.SAVINGS
+    balance: Decimal = Decimal("0.00")
+    currency: str = "INR"
+    masked_number: str = ""
+
+
+@dataclass
+class BankTransaction:
+    """Normalised representation of a single transaction."""
+
+    external_id: str
+    date: date
+    amount: Decimal
+    description: str
+    currency: str = "INR"
+    category_hint: str | None = None
+    status: TransactionStatus = TransactionStatus.POSTED
+    reference: str = ""
+
+
+@dataclass
+class SyncResult:
+    """Value returned by import/refresh operations."""
+
+    status: SyncStatus = SyncStatus.SUCCESS
+    accounts: list[BankAccount] = field(default_factory=list)
+    transactions: list[BankTransaction] = field(default_factory=list)
+    cursor: str | None = None
+    error: str | None = None
+    synced_at: datetime = field(default_factory=datetime.utcnow)
+
+    @property
+    def transaction_count(self) -> int:
+        return len(self.transactions)
+
+
+# ------------------------------------------------------------------
+# Abstract connector
+# ------------------------------------------------------------------
+
+
+class BankConnector(ABC):
+    """Interface that every bank connector must implement.
+
+    Lifecycle::
+
+        connector = SomeConnector(config)
+        connector.authenticate(credentials)
+        result = connector.import_transactions(account_id, start, end)
+
+        # later …
+        result = connector.refresh(account_id, cursor)
+    """
+
+    @abstractmethod
+    def authenticate(self, credentials: dict[str, Any]) -> bool:
+        """Validate / exchange credentials.  Return True on success."""
+
+    @abstractmethod
+    def get_accounts(self) -> list[BankAccount]:
+        """Return the list of accounts available after authentication."""
+
+    @abstractmethod
+    def import_transactions(
+        self,
+        account_id: str,
+        start_date: date,
+        end_date: date,
+    ) -> SyncResult:
+        """Full import of transactions for the given date window."""
+
+    @abstractmethod
+    def refresh(
+        self,
+        account_id: str,
+        cursor: str | None = None,
+    ) -> SyncResult:
+        """Incremental refresh since *cursor*.
+
+        If *cursor* is ``None`` the connector should fall back to a
+        sensible default (e.g. last 30 days).
+        """
+
+    # Optional hook — connectors may override for cleanup.
+    def disconnect(self) -> None:  # pragma: no cover
+        """Release any resources held by the connector."""

--- a/packages/backend/app/connectors/mock.py
+++ b/packages/backend/app/connectors/mock.py
@@ -1,0 +1,196 @@
+"""Mock bank connector for development and CI testing.
+
+Generates realistic-looking Indian bank transactions (INR, UPI, NEFT,
+IMPS, etc.) without any external dependencies.  The data is
+deterministic for a given ``seed`` so tests stay reproducible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+
+from .base import (
+    AccountType,
+    BankAccount,
+    BankConnector,
+    BankTransaction,
+    SyncResult,
+    SyncStatus,
+    TransactionStatus,
+)
+
+logger = logging.getLogger("finmind.connectors.mock")
+
+# Realistic Indian-style payees / descriptions
+_PAYEES: list[tuple[str, str]] = [
+    ("UPI-Swiggy-Food", "EXPENSE"),
+    ("UPI-Zomato", "EXPENSE"),
+    ("NEFT-RENT-APR", "EXPENSE"),
+    ("UPI-Amazon Pay", "EXPENSE"),
+    ("UPI-Flipkart", "EXPENSE"),
+    ("IMPS-ElectricityBill", "EXPENSE"),
+    ("UPI-JioCinema", "EXPENSE"),
+    ("NEFT-SALARY-ACME", "INCOME"),
+    ("UPI-PhonePe-Refund", "INCOME"),
+    ("IMPS-FreelancePay", "INCOME"),
+    ("ATM-CASH-WITHDRAWAL", "EXPENSE"),
+    ("UPI-BigBasket", "EXPENSE"),
+    ("UPI-Uber", "EXPENSE"),
+    ("NEFT-MutualFund-SIP", "EXPENSE"),
+    ("UPI-Ola", "EXPENSE"),
+]
+
+_MOCK_ACCOUNTS: list[dict[str, Any]] = [
+    {
+        "external_id": "mock-sav-001",
+        "name": "HDFC Savings ****1234",
+        "account_type": AccountType.SAVINGS,
+        "balance": Decimal("84367.50"),
+        "currency": "INR",
+        "masked_number": "XXXX1234",
+    },
+    {
+        "external_id": "mock-cc-001",
+        "name": "ICICI Credit Card ****5678",
+        "account_type": AccountType.CREDIT_CARD,
+        "balance": Decimal("-12450.00"),
+        "currency": "INR",
+        "masked_number": "XXXX5678",
+    },
+]
+
+
+class MockBankConnector(BankConnector):
+    """Generates deterministic mock data.  Useful for local dev + CI.
+
+    Config keys:
+        - ``seed`` (str): seed for deterministic generation (default "mock").
+        - ``transaction_count`` (int): how many transactions to generate
+          per import call (default 30).
+        - ``fail_auth`` (bool): if True, ``authenticate`` always fails.
+    """
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        cfg = config or {}
+        self._seed: str = str(cfg.get("seed", "mock"))
+        self._tx_count: int = int(cfg.get("transaction_count", 30))
+        self._fail_auth: bool = bool(cfg.get("fail_auth", False))
+        self._authenticated: bool = False
+
+    # ------------------------------------------------------------------
+    # BankConnector implementation
+    # ------------------------------------------------------------------
+
+    def authenticate(self, credentials: dict[str, Any]) -> bool:
+        if self._fail_auth:
+            logger.info("MockBankConnector: auth forced to fail")
+            return False
+        self._authenticated = True
+        logger.info("MockBankConnector: authenticated")
+        return True
+
+    def get_accounts(self) -> list[BankAccount]:
+        self._require_auth()
+        return [BankAccount(**acct) for acct in _MOCK_ACCOUNTS]
+
+    def import_transactions(
+        self,
+        account_id: str,
+        start_date: date,
+        end_date: date,
+    ) -> SyncResult:
+        self._require_auth()
+        txns = self._generate(account_id, start_date, end_date)
+        cursor = end_date.isoformat()
+        logger.info(
+            "MockBankConnector: imported %d txns for %s (%s – %s)",
+            len(txns),
+            account_id,
+            start_date,
+            end_date,
+        )
+        return SyncResult(
+            status=SyncStatus.SUCCESS,
+            transactions=txns,
+            cursor=cursor,
+        )
+
+    def refresh(
+        self,
+        account_id: str,
+        cursor: str | None = None,
+    ) -> SyncResult:
+        self._require_auth()
+        if cursor:
+            start = date.fromisoformat(cursor)
+        else:
+            start = date.today() - timedelta(days=30)
+        end = date.today()
+        txns = self._generate(account_id, start, end)
+        logger.info(
+            "MockBankConnector: refreshed %d txns for %s (cursor=%s)",
+            len(txns),
+            account_id,
+            cursor,
+        )
+        return SyncResult(
+            status=SyncStatus.SUCCESS,
+            transactions=txns,
+            cursor=end.isoformat(),
+        )
+
+    def disconnect(self) -> None:
+        self._authenticated = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _require_auth(self) -> None:
+        if not self._authenticated:
+            raise RuntimeError("MockBankConnector: not authenticated")
+
+    def _generate(
+        self,
+        account_id: str,
+        start_date: date,
+        end_date: date,
+    ) -> list[BankTransaction]:
+        """Build a deterministic list of mock transactions."""
+        days = max(1, (end_date - start_date).days)
+        count = min(self._tx_count, days * 3)
+        txns: list[BankTransaction] = []
+        for i in range(count):
+            digest = hashlib.md5(  # noqa: S324  # nosec B324
+                f"{self._seed}:{account_id}:{i}".encode(),
+                usedforsecurity=False,
+            ).hexdigest()
+            idx = int(digest[:4], 16) % len(_PAYEES)
+            payee, txn_type = _PAYEES[idx]
+
+            day_offset = int(digest[4:8], 16) % days
+            txn_date = start_date + timedelta(days=day_offset)
+
+            raw_amount = (int(digest[8:12], 16) % 9000 + 100) / 100
+            amount = Decimal(str(raw_amount)).quantize(Decimal("0.01"))
+            if txn_type == "INCOME":
+                amount = amount * 10  # incomes tend to be larger
+
+            txns.append(
+                BankTransaction(
+                    external_id=f"mock-tx-{digest[:12]}",
+                    date=txn_date,
+                    amount=amount,
+                    description=payee,
+                    currency="INR",
+                    category_hint=txn_type,
+                    status=TransactionStatus.POSTED,
+                    reference=f"REF{digest[:8].upper()}",
+                )
+            )
+        txns.sort(key=lambda t: t.date)
+        return txns

--- a/packages/backend/app/connectors/registry.py
+++ b/packages/backend/app/connectors/registry.py
@@ -1,0 +1,66 @@
+"""Connector registry — maps provider names to connector classes.
+
+Usage::
+
+    from app.connectors.registry import registry
+
+    registry.register("mock", MockBankConnector)
+
+    cls = registry.get("mock")
+    connector = cls(config)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Type
+
+from .base import BankConnector
+
+logger = logging.getLogger("finmind.connectors.registry")
+
+
+class ConnectorRegistry:
+    """Simple dictionary-backed registry for bank connectors."""
+
+    def __init__(self) -> None:
+        self._providers: dict[str, Type[BankConnector]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def register(self, name: str, cls: Type[BankConnector]) -> None:
+        """Register *cls* under *name* (case-insensitive)."""
+        key = name.strip().lower()
+        if key in self._providers:
+            logger.warning("Overwriting connector %r", key)
+        self._providers[key] = cls
+        logger.info("Registered bank connector: %s", key)
+
+    def get(self, name: str) -> Type[BankConnector]:
+        """Return the connector class for *name*.
+
+        Raises ``KeyError`` when the provider is unknown.
+        """
+        key = name.strip().lower()
+        if key not in self._providers:
+            raise KeyError(
+                f"Unknown bank connector {name!r}. "
+                f"Available: {', '.join(sorted(self._providers))}"
+            )
+        return self._providers[key]
+
+    def available(self) -> list[str]:
+        """Return sorted list of registered provider names."""
+        return sorted(self._providers)
+
+    def __contains__(self, name: str) -> bool:
+        return name.strip().lower() in self._providers
+
+    def __len__(self) -> int:
+        return len(self._providers)
+
+
+# Module-level singleton used across the app.
+registry = ConnectorRegistry()

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,35 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Bank Sync
+CREATE TABLE IF NOT EXISTS bank_connections (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider VARCHAR(50) NOT NULL,
+  external_account_id VARCHAR(255) NOT NULL,
+  account_name VARCHAR(255) NOT NULL,
+  account_type VARCHAR(50) NOT NULL DEFAULT 'SAVINGS',
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+  last_sync_at TIMESTAMP,
+  sync_cursor VARCHAR(500),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_bank_connections_user
+  ON bank_connections(user_id);
+
+CREATE TABLE IF NOT EXISTS sync_logs (
+  id SERIAL PRIMARY KEY,
+  connection_id INT NOT NULL REFERENCES bank_connections(id) ON DELETE CASCADE,
+  sync_type VARCHAR(20) NOT NULL,
+  status VARCHAR(20) NOT NULL,
+  records_imported INT NOT NULL DEFAULT 0,
+  duplicates_skipped INT NOT NULL DEFAULT 0,
+  error_message VARCHAR(500),
+  started_at TIMESTAMP NOT NULL,
+  completed_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_sync_logs_connection
+  ON sync_logs(connection_id, created_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,55 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+# ------------------------------------------------------------------
+# Bank Sync
+# ------------------------------------------------------------------
+
+
+class ConnectionStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    DISCONNECTED = "DISCONNECTED"
+    ERROR = "ERROR"
+
+
+class BankConnection(db.Model):
+    """Tracks a user's linked bank account via a specific connector."""
+
+    __tablename__ = "bank_connections"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    provider = db.Column(db.String(50), nullable=False)
+    external_account_id = db.Column(db.String(255), nullable=False)
+    account_name = db.Column(db.String(255), nullable=False)
+    account_type = db.Column(db.String(50), default="SAVINGS", nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    status = db.Column(
+        db.String(20), default=ConnectionStatus.ACTIVE.value, nullable=False
+    )
+    last_sync_at = db.Column(db.DateTime, nullable=True)
+    sync_cursor = db.Column(db.String(500), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    sync_logs = db.relationship(
+        "SyncLog", backref="connection", lazy="dynamic", cascade="all, delete-orphan"
+    )
+
+
+class SyncLog(db.Model):
+    """Audit trail for every sync attempt against a bank connection."""
+
+    __tablename__ = "sync_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    connection_id = db.Column(
+        db.Integer, db.ForeignKey("bank_connections.id"), nullable=False
+    )
+    sync_type = db.Column(db.String(20), nullable=False)  # "import" or "refresh"
+    status = db.Column(db.String(20), nullable=False)
+    records_imported = db.Column(db.Integer, default=0, nullable=False)
+    duplicates_skipped = db.Column(db.Integer, default=0, nullable=False)
+    error_message = db.Column(db.String(500), nullable=True)
+    started_at = db.Column(db.DateTime, nullable=False)
+    completed_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .bank_sync import bp as bank_sync_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(bank_sync_bp, url_prefix="/bank-sync")

--- a/packages/backend/app/routes/bank_sync.py
+++ b/packages/backend/app/routes/bank_sync.py
@@ -1,0 +1,178 @@
+"""Bank-sync API endpoints.
+
+Provides CRUD for bank connections and trigger endpoints for import /
+refresh operations.  The actual sync logic lives in
+:mod:`app.services.bank_sync`.
+"""
+
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import logging
+
+from ..connectors.registry import registry
+from ..extensions import db
+from ..models import BankConnection, SyncLog
+from ..services import bank_sync as sync_service
+
+bp = Blueprint("bank_sync", __name__)
+logger = logging.getLogger("finmind.routes.bank_sync")
+
+
+@bp.get("/providers")
+@jwt_required()
+def list_providers():
+    """Return the list of registered connector provider names."""
+    return jsonify(providers=registry.available())
+
+
+@bp.post("/connect")
+@jwt_required()
+def connect():
+    """Authenticate with a bank provider and create a connection."""
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    provider = (data.get("provider") or "").strip().lower()
+    credentials = data.get("credentials") or {}
+    config = data.get("config") or {}
+
+    if not provider:
+        return jsonify(error="provider required"), 400
+    if provider not in registry:
+        return jsonify(error=f"unknown provider: {provider}"), 400
+
+    cls = registry.get(provider)
+    connector = cls(config)
+    connection = sync_service.connect_account(
+        user_id=uid,
+        provider=provider,
+        connector=connector,
+        credentials=credentials,
+    )
+    if connection is None:
+        return jsonify(error="authentication failed"), 401
+    return (
+        jsonify(_connection_to_dict(connection)),
+        201,
+    )
+
+
+@bp.get("/connections")
+@jwt_required()
+def list_connections():
+    """List all bank connections for the current user."""
+    uid = int(get_jwt_identity())
+    items = (
+        db.session.query(BankConnection)
+        .filter_by(user_id=uid)
+        .order_by(BankConnection.created_at.desc())
+        .all()
+    )
+    return jsonify([_connection_to_dict(c) for c in items])
+
+
+@bp.post("/connections/<int:conn_id>/import")
+@jwt_required()
+def trigger_import(conn_id: int):
+    """Full import of transactions for a date range."""
+    uid = int(get_jwt_identity())
+    connection = db.session.get(BankConnection, conn_id)
+    if not connection or connection.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    try:
+        start = date.fromisoformat(data.get("start_date", ""))
+        end = date.fromisoformat(data.get("end_date", ""))
+    except (ValueError, TypeError):
+        return jsonify(error="start_date and end_date required (YYYY-MM-DD)"), 400
+
+    cls = registry.get(connection.provider)
+    connector = cls(data.get("config") or {})
+    connector.authenticate(data.get("credentials") or {})
+
+    result = sync_service.import_transactions(connection, connector, start, end)
+    return jsonify(result), 200
+
+
+@bp.post("/connections/<int:conn_id>/refresh")
+@jwt_required()
+def trigger_refresh(conn_id: int):
+    """Incremental refresh using the stored cursor."""
+    uid = int(get_jwt_identity())
+    connection = db.session.get(BankConnection, conn_id)
+    if not connection or connection.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    cls = registry.get(connection.provider)
+    connector = cls(data.get("config") or {})
+    connector.authenticate(data.get("credentials") or {})
+
+    result = sync_service.refresh_transactions(connection, connector)
+    return jsonify(result), 200
+
+
+@bp.get("/connections/<int:conn_id>/logs")
+@jwt_required()
+def sync_logs(conn_id: int):
+    """Return sync history for a connection."""
+    uid = int(get_jwt_identity())
+    connection = db.session.get(BankConnection, conn_id)
+    if not connection or connection.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    logs = (
+        db.session.query(SyncLog)
+        .filter_by(connection_id=conn_id)
+        .order_by(SyncLog.created_at.desc())
+        .limit(50)
+        .all()
+    )
+    return jsonify([_log_to_dict(lg) for lg in logs])
+
+
+@bp.delete("/connections/<int:conn_id>")
+@jwt_required()
+def disconnect(conn_id: int):
+    """Disconnect (soft-delete) a bank connection."""
+    uid = int(get_jwt_identity())
+    connection = db.session.get(BankConnection, conn_id)
+    if not connection or connection.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    sync_service.disconnect_account(connection)
+    return jsonify(message="disconnected"), 200
+
+
+# ------------------------------------------------------------------
+# Serialisers
+# ------------------------------------------------------------------
+
+
+def _connection_to_dict(c: BankConnection) -> dict:
+    return {
+        "id": c.id,
+        "provider": c.provider,
+        "external_account_id": c.external_account_id,
+        "account_name": c.account_name,
+        "account_type": c.account_type,
+        "currency": c.currency,
+        "status": c.status,
+        "last_sync_at": c.last_sync_at.isoformat() if c.last_sync_at else None,
+        "created_at": c.created_at.isoformat() if c.created_at else None,
+    }
+
+
+def _log_to_dict(lg: SyncLog) -> dict:
+    return {
+        "id": lg.id,
+        "sync_type": lg.sync_type,
+        "status": lg.status,
+        "records_imported": lg.records_imported,
+        "duplicates_skipped": lg.duplicates_skipped,
+        "error_message": lg.error_message,
+        "started_at": lg.started_at.isoformat() if lg.started_at else None,
+        "completed_at": lg.completed_at.isoformat() if lg.completed_at else None,
+    }

--- a/packages/backend/app/services/bank_sync.py
+++ b/packages/backend/app/services/bank_sync.py
@@ -1,0 +1,230 @@
+"""Service layer for bank-sync operations.
+
+Bridges the pluggable :class:`BankConnector` interface with FinMind's
+SQLAlchemy models, handling deduplication, cursor tracking, and
+audit logging.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from decimal import Decimal
+
+from ..connectors import BankConnector, SyncResult
+from ..connectors.base import SyncStatus
+from ..extensions import db
+from ..models import (
+    BankConnection,
+    ConnectionStatus,
+    Expense,
+    SyncLog,
+    User,
+)
+
+logger = logging.getLogger("finmind.services.bank_sync")
+
+
+def connect_account(
+    user_id: int,
+    provider: str,
+    connector: BankConnector,
+    credentials: dict,
+) -> BankConnection | None:
+    """Authenticate and persist a new bank connection.
+
+    Returns the :class:`BankConnection` on success or ``None`` when
+    authentication fails.
+    """
+    if not connector.authenticate(credentials):
+        return None
+
+    accounts = connector.get_accounts()
+    if not accounts:
+        return None
+
+    # Use the first account returned by the connector.
+    acct = accounts[0]
+    connection = BankConnection(
+        user_id=user_id,
+        provider=provider,
+        external_account_id=acct.external_id,
+        account_name=acct.name,
+        account_type=acct.account_type.value,
+        currency=acct.currency,
+        status=ConnectionStatus.ACTIVE.value,
+    )
+    db.session.add(connection)
+    db.session.commit()
+    logger.info(
+        "Bank connection created id=%s user=%s provider=%s",
+        connection.id,
+        user_id,
+        provider,
+    )
+    return connection
+
+
+def import_transactions(
+    connection: BankConnection,
+    connector: BankConnector,
+    start_date: date,
+    end_date: date,
+) -> dict:
+    """Full import of transactions for *connection*.
+
+    Returns a summary dict ``{inserted, duplicates, status, error}``.
+    """
+    log = SyncLog(
+        connection_id=connection.id,
+        sync_type="import",
+        status="RUNNING",
+        started_at=datetime.utcnow(),
+    )
+    db.session.add(log)
+    db.session.flush()
+
+    try:
+        result = connector.import_transactions(
+            connection.external_account_id, start_date, end_date
+        )
+        inserted, duplicates = _persist_transactions(connection, result)
+        log.status = result.status.value
+        log.records_imported = inserted
+        log.duplicates_skipped = duplicates
+        log.completed_at = datetime.utcnow()
+
+        connection.last_sync_at = datetime.utcnow()
+        if result.cursor:
+            connection.sync_cursor = result.cursor
+        db.session.commit()
+        return {
+            "inserted": inserted,
+            "duplicates": duplicates,
+            "status": result.status.value,
+            "error": result.error,
+        }
+    except Exception as exc:
+        logger.exception("Import failed connection=%s: %s", connection.id, exc)
+        log.status = SyncStatus.FAILED.value
+        log.error_message = str(exc)[:500]
+        log.completed_at = datetime.utcnow()
+        connection.status = ConnectionStatus.ERROR.value
+        db.session.commit()
+        return {
+            "inserted": 0,
+            "duplicates": 0,
+            "status": SyncStatus.FAILED.value,
+            "error": str(exc),
+        }
+
+
+def refresh_transactions(
+    connection: BankConnection,
+    connector: BankConnector,
+) -> dict:
+    """Incremental refresh using the stored cursor.
+
+    Returns the same summary dict as :func:`import_transactions`.
+    """
+    log = SyncLog(
+        connection_id=connection.id,
+        sync_type="refresh",
+        status="RUNNING",
+        started_at=datetime.utcnow(),
+    )
+    db.session.add(log)
+    db.session.flush()
+
+    try:
+        result = connector.refresh(
+            connection.external_account_id,
+            cursor=connection.sync_cursor,
+        )
+        inserted, duplicates = _persist_transactions(connection, result)
+        log.status = result.status.value
+        log.records_imported = inserted
+        log.duplicates_skipped = duplicates
+        log.completed_at = datetime.utcnow()
+
+        connection.last_sync_at = datetime.utcnow()
+        if result.cursor:
+            connection.sync_cursor = result.cursor
+        connection.status = ConnectionStatus.ACTIVE.value
+        db.session.commit()
+        return {
+            "inserted": inserted,
+            "duplicates": duplicates,
+            "status": result.status.value,
+            "error": result.error,
+        }
+    except Exception as exc:
+        logger.exception("Refresh failed connection=%s: %s", connection.id, exc)
+        log.status = SyncStatus.FAILED.value
+        log.error_message = str(exc)[:500]
+        log.completed_at = datetime.utcnow()
+        connection.status = ConnectionStatus.ERROR.value
+        db.session.commit()
+        return {
+            "inserted": 0,
+            "duplicates": 0,
+            "status": SyncStatus.FAILED.value,
+            "error": str(exc),
+        }
+
+
+def disconnect_account(connection: BankConnection) -> None:
+    """Mark a connection as disconnected."""
+    connection.status = ConnectionStatus.DISCONNECTED.value
+    db.session.commit()
+
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+
+def _persist_transactions(
+    connection: BankConnection,
+    result: SyncResult,
+) -> tuple[int, int]:
+    """Write :class:`BankTransaction` items to the expenses table.
+
+    Returns ``(inserted, duplicates_skipped)``.
+    """
+    user = db.session.get(User, connection.user_id)
+    preferred_currency = user.preferred_currency if user else "INR"
+    inserted = 0
+    duplicates = 0
+
+    for txn in result.transactions:
+        amount = Decimal(str(txn.amount)).quantize(Decimal("0.01"))
+        expense_type = "INCOME" if txn.category_hint == "INCOME" else "EXPENSE"
+
+        exists = (
+            db.session.query(Expense)
+            .filter_by(
+                user_id=connection.user_id,
+                spent_at=txn.date,
+                amount=amount,
+                notes=txn.description,
+            )
+            .first()
+        )
+        if exists:
+            duplicates += 1
+            continue
+
+        expense = Expense(
+            user_id=connection.user_id,
+            amount=amount,
+            currency=txn.currency or preferred_currency,
+            expense_type=expense_type,
+            notes=txn.description,
+            spent_at=txn.date,
+        )
+        db.session.add(expense)
+        inserted += 1
+
+    db.session.flush()
+    return inserted, duplicates

--- a/packages/backend/tests/test_bank_sync.py
+++ b/packages/backend/tests/test_bank_sync.py
@@ -1,0 +1,391 @@
+"""Tests for the bank-sync connector architecture.
+
+Covers:
+- Connector interface / mock connector
+- Connector registry
+- Bank-sync service layer (import, refresh, dedup, disconnect)
+- Bank-sync API endpoints
+"""
+
+from datetime import date
+
+from app.connectors.base import (
+    BankAccount,
+    BankTransaction,
+    SyncStatus,
+)
+from app.connectors.mock import MockBankConnector
+from app.connectors.registry import ConnectorRegistry
+
+
+# ======================================================================
+# Unit: Connector interface & mock connector
+# ======================================================================
+
+
+class TestMockConnector:
+    def test_authenticate_success(self):
+        conn = MockBankConnector()
+        assert conn.authenticate({}) is True
+
+    def test_authenticate_fail(self):
+        conn = MockBankConnector({"fail_auth": True})
+        assert conn.authenticate({}) is False
+
+    def test_get_accounts_returns_list(self):
+        conn = MockBankConnector()
+        conn.authenticate({})
+        accounts = conn.get_accounts()
+        assert len(accounts) >= 1
+        assert isinstance(accounts[0], BankAccount)
+        assert accounts[0].external_id
+        assert accounts[0].currency == "INR"
+
+    def test_get_accounts_requires_auth(self):
+        conn = MockBankConnector()
+        try:
+            conn.get_accounts()
+            assert False, "Expected RuntimeError"
+        except RuntimeError:
+            pass
+
+    def test_import_transactions(self):
+        conn = MockBankConnector({"transaction_count": 10, "seed": "test"})
+        conn.authenticate({})
+        result = conn.import_transactions(
+            "mock-sav-001",
+            date(2026, 1, 1),
+            date(2026, 1, 31),
+        )
+        assert result.status == SyncStatus.SUCCESS
+        assert result.transaction_count > 0
+        assert result.cursor == "2026-01-31"
+        for txn in result.transactions:
+            assert isinstance(txn, BankTransaction)
+            assert txn.external_id
+            assert txn.currency == "INR"
+
+    def test_import_deterministic(self):
+        """Same seed + params should produce identical transactions."""
+        conn1 = MockBankConnector({"seed": "stable", "transaction_count": 5})
+        conn1.authenticate({})
+        r1 = conn1.import_transactions(
+            "mock-sav-001", date(2026, 2, 1), date(2026, 2, 15)
+        )
+
+        conn2 = MockBankConnector({"seed": "stable", "transaction_count": 5})
+        conn2.authenticate({})
+        r2 = conn2.import_transactions(
+            "mock-sav-001", date(2026, 2, 1), date(2026, 2, 15)
+        )
+
+        ids1 = [t.external_id for t in r1.transactions]
+        ids2 = [t.external_id for t in r2.transactions]
+        assert ids1 == ids2
+
+    def test_refresh_without_cursor(self):
+        conn = MockBankConnector({"transaction_count": 5})
+        conn.authenticate({})
+        result = conn.refresh("mock-sav-001", cursor=None)
+        assert result.status == SyncStatus.SUCCESS
+        assert result.transaction_count > 0
+        assert result.cursor == date.today().isoformat()
+
+    def test_refresh_with_cursor(self):
+        conn = MockBankConnector({"transaction_count": 5})
+        conn.authenticate({})
+        result = conn.refresh("mock-sav-001", cursor="2026-02-01")
+        assert result.status == SyncStatus.SUCCESS
+
+    def test_disconnect(self):
+        conn = MockBankConnector()
+        conn.authenticate({})
+        conn.disconnect()
+        try:
+            conn.get_accounts()
+            assert False, "Expected RuntimeError after disconnect"
+        except RuntimeError:
+            pass
+
+
+# ======================================================================
+# Unit: Connector registry
+# ======================================================================
+
+
+class TestConnectorRegistry:
+    def test_register_and_get(self):
+        reg = ConnectorRegistry()
+        reg.register("mock", MockBankConnector)
+        cls = reg.get("mock")
+        assert cls is MockBankConnector
+
+    def test_case_insensitive(self):
+        reg = ConnectorRegistry()
+        reg.register("Mock", MockBankConnector)
+        assert reg.get("MOCK") is MockBankConnector
+        assert "mock" in reg
+
+    def test_unknown_raises_key_error(self):
+        reg = ConnectorRegistry()
+        try:
+            reg.get("nonexistent")
+            assert False, "Expected KeyError"
+        except KeyError:
+            pass
+
+    def test_available_sorted(self):
+        reg = ConnectorRegistry()
+        reg.register("beta", MockBankConnector)
+        reg.register("alpha", MockBankConnector)
+        assert reg.available() == ["alpha", "beta"]
+
+    def test_len(self):
+        reg = ConnectorRegistry()
+        assert len(reg) == 0
+        reg.register("x", MockBankConnector)
+        assert len(reg) == 1
+
+
+# ======================================================================
+# Integration: API endpoints
+# ======================================================================
+
+
+def test_list_providers(client, auth_header):
+    r = client.get("/bank-sync/providers", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "mock" in data["providers"]
+
+
+def test_connect_creates_connection(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={"provider": "mock", "credentials": {}},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["provider"] == "mock"
+    assert data["status"] == "ACTIVE"
+    assert data["account_name"]
+    assert data["id"]
+
+
+def test_connect_unknown_provider(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={"provider": "nonexistent", "credentials": {}},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_connect_auth_failure(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={
+            "provider": "mock",
+            "credentials": {},
+            "config": {"fail_auth": True},
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 401
+
+
+def test_list_connections(client, auth_header):
+    client.post(
+        "/bank-sync/connect",
+        json={"provider": "mock", "credentials": {}},
+        headers=auth_header,
+    )
+    r = client.get("/bank-sync/connections", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data) >= 1
+
+
+def test_import_transactions(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={"provider": "mock", "credentials": {}},
+        headers=auth_header,
+    )
+    conn_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/bank-sync/connections/{conn_id}/import",
+        json={
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-31",
+            "credentials": {},
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["status"] == "SUCCESS"
+    assert data["inserted"] > 0
+    assert data["duplicates"] == 0
+
+
+def test_import_prevents_duplicates(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={
+            "provider": "mock",
+            "credentials": {},
+            "config": {"seed": "dedup", "transaction_count": 5},
+        },
+        headers=auth_header,
+    )
+    conn_id = r.get_json()["id"]
+    payload = {
+        "start_date": "2026-02-01",
+        "end_date": "2026-02-15",
+        "credentials": {},
+        "config": {"seed": "dedup", "transaction_count": 5},
+    }
+
+    r1 = client.post(
+        f"/bank-sync/connections/{conn_id}/import",
+        json=payload,
+        headers=auth_header,
+    )
+    assert r1.status_code == 200
+    first = r1.get_json()
+    assert first["inserted"] > 0
+
+    r2 = client.post(
+        f"/bank-sync/connections/{conn_id}/import",
+        json=payload,
+        headers=auth_header,
+    )
+    assert r2.status_code == 200
+    second = r2.get_json()
+    assert second["duplicates"] == first["inserted"]
+    assert second["inserted"] == 0
+
+
+def test_refresh_transactions(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={"provider": "mock", "credentials": {}},
+        headers=auth_header,
+    )
+    conn_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/bank-sync/connections/{conn_id}/refresh",
+        json={"credentials": {}},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["status"] == "SUCCESS"
+    assert data["inserted"] >= 0
+
+
+def test_sync_logs(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={"provider": "mock", "credentials": {}},
+        headers=auth_header,
+    )
+    conn_id = r.get_json()["id"]
+
+    client.post(
+        f"/bank-sync/connections/{conn_id}/import",
+        json={
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-31",
+            "credentials": {},
+        },
+        headers=auth_header,
+    )
+
+    r = client.get(
+        f"/bank-sync/connections/{conn_id}/logs",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    logs = r.get_json()
+    assert len(logs) >= 1
+    assert logs[0]["sync_type"] == "import"
+    assert logs[0]["status"] == "SUCCESS"
+
+
+def test_disconnect(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={"provider": "mock", "credentials": {}},
+        headers=auth_header,
+    )
+    conn_id = r.get_json()["id"]
+
+    r = client.delete(
+        f"/bank-sync/connections/{conn_id}",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+
+    r = client.get("/bank-sync/connections", headers=auth_header)
+    conns = r.get_json()
+    matching = [c for c in conns if c["id"] == conn_id]
+    assert matching[0]["status"] == "DISCONNECTED"
+
+
+def test_import_missing_dates(client, auth_header):
+    r = client.post(
+        "/bank-sync/connect",
+        json={"provider": "mock", "credentials": {}},
+        headers=auth_header,
+    )
+    conn_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/bank-sync/connections/{conn_id}/import",
+        json={"credentials": {}},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_connection_not_found(client, auth_header):
+    r = client.post(
+        "/bank-sync/connections/99999/import",
+        json={
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-31",
+            "credentials": {},
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+def test_refresh_not_found(client, auth_header):
+    r = client.post(
+        "/bank-sync/connections/99999/refresh",
+        json={"credentials": {}},
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+def test_disconnect_not_found(client, auth_header):
+    r = client.delete(
+        "/bank-sync/connections/99999",
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+def test_logs_not_found(client, auth_header):
+    r = client.get(
+        "/bank-sync/connections/99999/logs",
+        headers=auth_header,
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
Closes #75

## Summary
- Pluggable `BankConnector` abstract base class that every bank integration must implement (`authenticate`, `get_accounts`, `import_transactions`, `refresh`)
- `ConnectorRegistry` for dynamic provider discovery — adding a new bank is a single-file job
- `MockBankConnector` generating deterministic Indian bank transactions (UPI, NEFT, IMPS in INR) for development and CI
- `BankConnection` and `SyncLog` SQLAlchemy models with cursor-based sync tracking
- Service layer handling deduplication against existing expenses, error recovery, and audit logging
- REST API under `/bank-sync` with endpoints for connecting, importing, refreshing, viewing logs, and disconnecting
- Database schema extensions for `bank_connections` and `sync_logs` tables

## Architecture

```
app/connectors/
  base.py       — BankConnector ABC + value objects (BankAccount, BankTransaction, SyncResult)
  registry.py   — ConnectorRegistry singleton
  mock.py       — MockBankConnector (dev/CI)
  __init__.py

app/services/bank_sync.py  — orchestrates connector ↔ DB (import, refresh, dedup, disconnect)
app/routes/bank_sync.py    — Flask Blueprint with JWT-protected endpoints
app/models.py              — BankConnection + SyncLog models (added)
app/db/schema.sql          — PostgreSQL DDL for new tables (added)
```

### Adding a new provider
1. Create `app/connectors/your_provider.py` implementing `BankConnector`
2. Register it in `app/__init__.py`: `connector_registry.register("your_provider", YourProviderConnector)`
3. Done — all existing endpoints work automatically

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/bank-sync/providers` | List registered connector names |
| POST | `/bank-sync/connect` | Authenticate & create connection |
| GET | `/bank-sync/connections` | List user's connections |
| POST | `/bank-sync/connections/{id}/import` | Full import for date range |
| POST | `/bank-sync/connections/{id}/refresh` | Incremental sync via cursor |
| GET | `/bank-sync/connections/{id}/logs` | Sync audit history |
| DELETE | `/bank-sync/connections/{id}` | Disconnect |

## Testing
- 29 tests total: 14 unit tests (connector + registry) + 15 integration tests (API endpoints)
- Unit tests run without any external dependencies
- Integration tests use the existing `conftest.py` fixtures (Flask test client + SQLite in-memory + Redis)
- All linters pass: `black --check`, `flake8`, `bandit -r app -ll`

## Validation
- [x] Backend lint: `black --check .` and `flake8 .`
- [x] Backend tests: `python -m pytest -q` (unit tests pass; integration tests require Redis as per existing CI setup)
- [x] Security scan: `bandit -r app -ll`
- [x] No secrets added
- [x] No unrelated files changed

## Security and Ownership
- [x] PR opened from a fork (not direct push to `main`)
- [x] CODEOWNERS review requested