### PR TITLE
fix: Docker healthcheck cascade — service_started → service_healthy

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -11,4 +11,8 @@ FROM nginx:alpine
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 80
+
+HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
+  CMD wget -q --spider http://localhost/ || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,11 @@ services:
     image: redis:7
     ports: ["6379:6379"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   backend:
     build: ./packages/backend
@@ -27,7 +32,7 @@ services:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_started
+        condition: service_healthy
     ports: ["8000:8000"]
     volumes:
       - ./packages/backend/app:/app/app
@@ -36,14 +41,27 @@ services:
       - ./.flake8:/app/.flake8:ro
       - ./.bandit:/app/.bandit:ro
     command: sh -c "python -m flask --app wsgi:app init-db && export PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus_multiproc && rm -rf $$PROMETHEUS_MULTIPROC_DIR && mkdir -p $$PROMETHEUS_MULTIPROC_DIR && gunicorn --reload --workers=2 --threads=4 --bind 0.0.0.0:8000 wsgi:app"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:8000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 30s
     restart: unless-stopped
 
   nginx:
     image: nginx:1.27-alpine
-    depends_on: [backend]
+    depends_on:
+      backend:
+        condition: service_healthy
     ports: ["8080:80"]
     volumes:
       - ./monitoring/nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost/nginx_status || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
     restart: unless-stopped
 
   frontend-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,8 +76,16 @@ services:
       - ./app:/app
       - /app/node_modules
     ports: ["5173:5173"]
-    depends_on: [backend]
+    depends_on:
+      backend:
+        condition: service_healthy
     command: sh -c "npm install && npm run dev -- --host 0.0.0.0 --port 5173"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:5173 || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
     restart: unless-stopped
 
   prometheus:
@@ -146,7 +154,9 @@ services:
     image: oliver006/redis_exporter:v1.63.0
     environment:
       REDIS_ADDR: redis://redis:6379
-    depends_on: [redis]
+    depends_on:
+      redis:
+        condition: service_healthy
     restart: unless-stopped
 
   nginx-exporter:

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
+    curl \
   && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /app/requirements.txt
@@ -21,4 +22,8 @@ COPY app /app/app
 COPY wsgi.py /app/wsgi.py
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=6 \
+  CMD curl -fs http://localhost:8000/health || exit 1
+
 CMD ["gunicorn", "-w", "2", "-k", "gthread", "-b", "0.0.0.0:8000", "wsgi:app"]


### PR DESCRIPTION
## Summary

Fixes the cold-start 502 race condition identified during a Docker audit.
Only `postgres` had a healthcheck; `redis`, `backend`, and `nginx` were
all using `service_started`, meaning containers started before dependencies
were actually ready to serve traffic.

## Problems Fixed

| Service | Was | Fix |
|---------|-----|-----|
| `redis` | No healthcheck | Added `redis-cli ping` healthcheck |
| `backend` | Depended on redis via `service_started` | Now `service_healthy` + own healthcheck added |
| `nginx` | Depended on backend via shorthand `[backend]` | Now `condition: service_healthy` |
| `packages/backend/Dockerfile` | No `HEALTHCHECK` instruction | Added `HEALTHCHECK` pointing at `/health` |
| `app/Dockerfile` | No `HEALTHCHECK` instruction | Added `HEALTHCHECK` via `wget` (Alpine-compatible) |

## Changes

- **`docker-compose.yml`** — redis healthcheck block; backend healthcheck block with `start_period: 30s` (covers `flask init-db` time); nginx `depends_on` upgraded to `condition: service_healthy`; nginx healthcheck via `/nginx_status`
- **`packages/backend/Dockerfile`** — added `curl` to apt deps; added `HEALTHCHECK` instruction
- **`app/Dockerfile`** — added `HEALTHCHECK` via `wget --spider` (BusyBox-compatible)

## Health Chain After Fix

```
postgres (healthy) → redis (healthy) → backend (healthy) → nginx (starts)
```

The `/health` endpoint (`GET → {"status": "ok"}`) already exists in
`packages/backend/app/__init__.py` — no application code changes needed.

## Testing

```bash
docker compose up --build
docker compose ps   # all services should reach 'healthy' state
```