### PR TITLE
perf: composite DB indexes for financial query optimization — closes #128

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, Index
 from .extensions import db
 
 
@@ -26,6 +26,10 @@ class Category(db.Model):
     name = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
+    __table_args__ = (
+        Index('ix_category_user', 'user_id'),
+    )
+
 
 class Expense(db.Model):
     __tablename__ = "expenses"
@@ -41,6 +45,14 @@ class Expense(db.Model):
         db.Integer, db.ForeignKey("recurring_expenses.id"), nullable=True
     )
     created_at = db.Column(db.DateTime, default=datetime.now, nullable=False)
+
+    __table_args__ = (
+        Index('ix_expense_user_date', 'user_id', 'spent_at'),
+        Index('ix_expense_user_currency', 'user_id', 'currency'),
+        Index('ix_expense_user_category', 'user_id', 'category_id'),
+        Index('ix_expense_user_type', 'user_id', 'expense_type'),
+        Index('ix_expense_created', 'created_at'),
+    )
 
 
 class RecurringCadence(str, Enum):
@@ -65,6 +77,11 @@ class RecurringExpense(db.Model):
     active = db.Column(db.Boolean, default=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
+    __table_args__ = (
+        Index('ix_recurring_user_active', 'user_id', 'active'),
+        Index('ix_recurring_user_dates', 'user_id', 'start_date', 'end_date'),
+    )
+
 
 class BillCadence(str, Enum):
     MONTHLY = "MONTHLY"
@@ -88,6 +105,11 @@ class Bill(db.Model):
     active = db.Column(db.Boolean, default=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
+    __table_args__ = (
+        Index('ix_bill_user_due', 'user_id', 'next_due_date'),
+        Index('ix_bill_user_active', 'user_id', 'active'),
+    )
+
 
 class Reminder(db.Model):
     __tablename__ = "reminders"
@@ -99,6 +121,11 @@ class Reminder(db.Model):
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
 
+    __table_args__ = (
+        Index('ix_reminder_user_send_at', 'user_id', 'send_at'),
+        Index('ix_reminder_unsent', 'user_id', 'sent', 'send_at'),
+    )
+
 
 class AdImpression(db.Model):
     __tablename__ = "ad_impressions"
@@ -106,6 +133,10 @@ class AdImpression(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     placement = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index('ix_ad_user_created', 'user_id', 'created_at'),
+    )
 
 
 class SubscriptionPlan(db.Model):
@@ -126,6 +157,10 @@ class UserSubscription(db.Model):
     active = db.Column(db.Boolean, default=False, nullable=False)
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
+    __table_args__ = (
+        Index('ix_subscription_user_active', 'user_id', 'active'),
+    )
+
 
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
@@ -133,3 +168,7 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index('ix_audit_user_created', 'user_id', 'created_at'),
+    )

--- a/packages/backend/migrations/versions/add_performance_indexes.py
+++ b/packages/backend/migrations/versions/add_performance_indexes.py
@@ -1,0 +1,82 @@
+"""Add composite performance indexes for financial queries
+
+Revision ID: a1b2c3d4e5f6
+Revises: None
+Create Date: 2026-02-24
+
+This migration adds composite indexes targeting all high-frequency query
+patterns in FinMind. Zero application-logic changes — purely additive
+performance improvement.
+"""
+from alembic import op
+
+revision = 'a1b2c3d4e5f6'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # --- expenses ---
+    op.create_index('ix_expense_user_date', 'expenses', ['user_id', 'spent_at'])
+    op.create_index('ix_expense_user_currency', 'expenses', ['user_id', 'currency'])
+    op.create_index('ix_expense_user_category', 'expenses', ['user_id', 'category_id'])
+    op.create_index('ix_expense_user_type', 'expenses', ['user_id', 'expense_type'])
+    op.create_index('ix_expense_created', 'expenses', ['created_at'])
+
+    # --- recurring_expenses ---
+    op.create_index('ix_recurring_user_active', 'recurring_expenses', ['user_id', 'active'])
+    op.create_index('ix_recurring_user_dates', 'recurring_expenses', ['user_id', 'start_date', 'end_date'])
+
+    # --- bills ---
+    op.create_index('ix_bill_user_due', 'bills', ['user_id', 'next_due_date'])
+    op.create_index('ix_bill_user_active', 'bills', ['user_id', 'active'])
+
+    # --- reminders ---
+    op.create_index('ix_reminder_user_send_at', 'reminders', ['user_id', 'send_at'])
+    op.create_index('ix_reminder_unsent', 'reminders', ['user_id', 'sent', 'send_at'])
+
+    # --- categories ---
+    op.create_index('ix_category_user', 'categories', ['user_id'])
+
+    # --- audit_logs ---
+    op.create_index('ix_audit_user_created', 'audit_logs', ['user_id', 'created_at'])
+
+    # --- ad_impressions ---
+    op.create_index('ix_ad_user_created', 'ad_impressions', ['user_id', 'created_at'])
+
+    # --- user_subscriptions ---
+    op.create_index('ix_subscription_user_active', 'user_subscriptions', ['user_id', 'active'])
+
+
+def downgrade():
+    # --- user_subscriptions ---
+    op.drop_index('ix_subscription_user_active', table_name='user_subscriptions')
+
+    # --- ad_impressions ---
+    op.drop_index('ix_ad_user_created', table_name='ad_impressions')
+
+    # --- audit_logs ---
+    op.drop_index('ix_audit_user_created', table_name='audit_logs')
+
+    # --- categories ---
+    op.drop_index('ix_category_user', table_name='categories')
+
+    # --- reminders ---
+    op.drop_index('ix_reminder_unsent', table_name='reminders')
+    op.drop_index('ix_reminder_user_send_at', table_name='reminders')
+
+    # --- bills ---
+    op.drop_index('ix_bill_user_active', table_name='bills')
+    op.drop_index('ix_bill_user_due', table_name='bills')
+
+    # --- recurring_expenses ---
+    op.drop_index('ix_recurring_user_dates', table_name='recurring_expenses')
+    op.drop_index('ix_recurring_user_active', table_name='recurring_expenses')
+
+    # --- expenses ---
+    op.drop_index('ix_expense_created', table_name='expenses')
+    op.drop_index('ix_expense_user_type', table_name='expenses')
+    op.drop_index('ix_expense_user_category', table_name='expenses')
+    op.drop_index('ix_expense_user_currency', table_name='expenses')
+    op.drop_index('ix_expense_user_date', table_name='expenses')

--- a/packages/backend/tests/test_indexes.py
+++ b/packages/backend/tests/test_indexes.py
@@ -1,0 +1,132 @@
+"""Tests to verify composite DB indexes are defined on all relevant models."""
+import pytest
+from sqlalchemy import create_engine, inspect
+from app import models  # noqa: F401 — registers all models
+from app.extensions import db
+
+
+def _get_index_names(inspector, table_name):
+    """Return a set of index names for a given table."""
+    return {idx['name'] for idx in inspector.get_indexes(table_name)}
+
+
+@pytest.fixture(scope="module")
+def sqlite_engine():
+    """Create an in-memory SQLite engine with all tables."""
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    db.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+def test_expense_user_date_index(sqlite_engine):
+    """ix_expense_user_date — most critical index for dashboard queries."""
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'expenses')
+    assert 'ix_expense_user_date' in names, f"Missing ix_expense_user_date; found: {names}"
+
+
+def test_expense_user_currency_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'expenses')
+    assert 'ix_expense_user_currency' in names, f"Missing ix_expense_user_currency; found: {names}"
+
+
+def test_expense_user_category_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'expenses')
+    assert 'ix_expense_user_category' in names, f"Missing ix_expense_user_category; found: {names}"
+
+
+def test_expense_user_type_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'expenses')
+    assert 'ix_expense_user_type' in names, f"Missing ix_expense_user_type; found: {names}"
+
+
+def test_expense_created_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'expenses')
+    assert 'ix_expense_created' in names, f"Missing ix_expense_created; found: {names}"
+
+
+def test_recurring_user_active_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'recurring_expenses')
+    assert 'ix_recurring_user_active' in names, f"Missing ix_recurring_user_active; found: {names}"
+
+
+def test_recurring_user_dates_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'recurring_expenses')
+    assert 'ix_recurring_user_dates' in names, f"Missing ix_recurring_user_dates; found: {names}"
+
+
+def test_bill_user_due_index(sqlite_engine):
+    """ix_bill_user_due — critical for due-soon queries."""
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'bills')
+    assert 'ix_bill_user_due' in names, f"Missing ix_bill_user_due; found: {names}"
+
+
+def test_bill_user_active_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'bills')
+    assert 'ix_bill_user_active' in names, f"Missing ix_bill_user_active; found: {names}"
+
+
+def test_reminder_user_send_at_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'reminders')
+    assert 'ix_reminder_user_send_at' in names, f"Missing ix_reminder_user_send_at; found: {names}"
+
+
+def test_reminder_unsent_index(sqlite_engine):
+    """ix_reminder_unsent — exact pattern used by scheduler to find pending reminders."""
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'reminders')
+    assert 'ix_reminder_unsent' in names, f"Missing ix_reminder_unsent; found: {names}"
+
+
+def test_category_user_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'categories')
+    assert 'ix_category_user' in names, f"Missing ix_category_user; found: {names}"
+
+
+def test_audit_user_created_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'audit_logs')
+    assert 'ix_audit_user_created' in names, f"Missing ix_audit_user_created; found: {names}"
+
+
+def test_ad_user_created_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'ad_impressions')
+    assert 'ix_ad_user_created' in names, f"Missing ix_ad_user_created; found: {names}"
+
+
+def test_subscription_user_active_index(sqlite_engine):
+    inspector = inspect(sqlite_engine)
+    names = _get_index_names(inspector, 'user_subscriptions')
+    assert 'ix_subscription_user_active' in names, f"Missing ix_subscription_user_active; found: {names}"
+
+
+def test_all_expense_indexes_columns(sqlite_engine):
+    """Verify ix_expense_user_date covers the right columns (user_id, spent_at)."""
+    inspector = inspect(sqlite_engine)
+    indexes = {idx['name']: idx for idx in inspector.get_indexes('expenses')}
+    idx = indexes.get('ix_expense_user_date', {})
+    cols = idx.get('column_names', [])
+    assert 'user_id' in cols and 'spent_at' in cols, \
+        f"ix_expense_user_date should cover user_id+spent_at, got: {cols}"
+
+
+def test_reminder_unsent_columns(sqlite_engine):
+    """Verify ix_reminder_unsent covers user_id, sent, send_at."""
+    inspector = inspect(sqlite_engine)
+    indexes = {idx['name']: idx for idx in inspector.get_indexes('reminders')}
+    idx = indexes.get('ix_reminder_unsent', {})
+    cols = idx.get('column_names', [])
+    assert 'user_id' in cols and 'sent' in cols and 'send_at' in cols, \
+        f"ix_reminder_unsent should cover user_id+sent+send_at, got: {cols}"


### PR DESCRIPTION
## Summary

Adds **composite SQLAlchemy indexes** targeting all high-frequency query patterns in FinMind. Zero application-logic changes — purely additive performance improvement.

## Indexes Added

| Table | Index Name | Columns | Covers |
|-------|-----------|---------|--------|
| expenses | ix_expense_user_date | user_id, spent_at | Dashboard & digest date-range queries |
| expenses | ix_expense_user_currency | user_id, currency | Multi-currency filter (digest, insights) |
| expenses | ix_expense_user_category | user_id, category_id | Per-category breakdowns |
| expenses | ix_expense_user_type | user_id, expense_type | EXPENSE vs INCOME splits |
| expenses | ix_expense_created | created_at | Admin/audit queries |
| recurring_expenses | ix_recurring_user_active | user_id, active | Active recurring schedule lookups |
| recurring_expenses | ix_recurring_user_dates | user_id, start_date, end_date | Date-range overlap checks |
| bills | ix_bill_user_due | user_id, next_due_date | Due-soon queries |
| bills | ix_bill_user_active | user_id, active | Active bill filter |
| reminders | ix_reminder_user_send_at | user_id, send_at | Reminder schedule lookups |
| reminders | ix_reminder_unsent | user_id, sent, send_at | Scheduler: find unsent upcoming reminders |
| categories | ix_category_user | user_id | Category list by user |
| audit_logs | ix_audit_user_created | user_id, created_at | Per-user audit trail queries |
| ad_impressions | ix_ad_user_created | user_id, created_at | Per-user impression history |
| user_subscriptions | ix_subscription_user_active | user_id, active | Active subscription check |

## Why These Indexes

- **`expenses`** is queried on every page load (dashboard, insights, digest). Without `(user_id, spent_at)` the DB scans all rows for a user to filter by date.
- **`bills`** `(user_id, next_due_date)` enables the due-soon query to skip all inactive/past bills instantly.
- **`reminders`** `(user_id, sent, send_at)` is the exact pattern the scheduler uses to find pending reminders — without it, every scheduler tick is a full table scan.

## How to Test

```bash
cd packages/backend
PYTHONPATH=. pytest tests/test_indexes.py -v
```

## Migration

An Alembic migration is included. Apply with:
```bash
flask db upgrade
```

## Demo

![Demo](https://github.com/GoThundercats/FinMind/releases/download/demo-1771940995/demo_finmind_indexes.gif)

/claim #128