### PR TITLE
feat: locale-aware date, currency & number formatting — closes #131

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -15,6 +15,7 @@ class User(db.Model):
     email = db.Column(db.String(255), unique=True, nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
     preferred_currency = db.Column(db.String(10), default="INR", nullable=False)
+    preferred_locale = db.Column(db.String(20), default="en_IN", nullable=False)
     role = db.Column(db.String(20), default=Role.USER.value, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .locale import bp as locale_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(locale_bp, url_prefix="/locale")

--- a/packages/backend/app/routes/locale.py
+++ b/packages/backend/app/routes/locale.py
@@ -1,0 +1,96 @@
+"""
+locale.py — Locale formatting API endpoints.
+
+GET  /locale/supported          List supported locale codes
+GET  /locale/meta?locale=en_IN  Metadata for a locale
+POST /locale/format             Format values in bulk
+"""
+from flask import Blueprint, jsonify, request
+from ..services.locale_formatter import (
+    format_currency,
+    format_date,
+    format_datetime,
+    format_number,
+    locale_meta,
+    supported_locales,
+)
+
+bp = Blueprint("locale", __name__)
+
+
+@bp.get("/supported")
+def list_supported():
+    """Return list of supported locale codes."""
+    return jsonify({"locales": supported_locales()})
+
+
+@bp.get("/meta")
+def get_locale_meta():
+    """Return metadata for a given locale (defaults to en_IN)."""
+    locale = request.args.get("locale")
+    return jsonify(locale_meta(locale))
+
+
+@bp.post("/format")
+def format_values():
+    """
+    Bulk-format a set of values in a given locale.
+
+    Request body (JSON):
+    {
+      "locale": "de_DE",
+      "values": [
+        {"type": "currency", "amount": 1234.5, "currency": "EUR"},
+        {"type": "number",   "value": 9876543.21, "decimal_places": 2},
+        {"type": "date",     "value": "2026-02-24", "format": "long"},
+        {"type": "datetime", "value": "2026-02-24T13:00:00", "format": "medium"}
+      ]
+    }
+
+    Response:
+    {
+      "locale": "de_DE",
+      "results": ["1.234,50 €", "9.876.543,21", "24. Februar 2026", "24.02.2026, 13:00:00"]
+    }
+    """
+    body = request.get_json(silent=True) or {}
+    locale = body.get("locale")
+    values = body.get("values", [])
+
+    if not isinstance(values, list):
+        return jsonify(error="'values' must be a list"), 400
+
+    results = []
+    for item in values:
+        kind = item.get("type", "")
+        try:
+            if kind == "currency":
+                results.append(format_currency(
+                    item.get("amount", 0),
+                    item.get("currency", "INR"),
+                    locale,
+                ))
+            elif kind == "number":
+                results.append(format_number(
+                    item.get("value", 0),
+                    locale,
+                    item.get("decimal_places", 2),
+                ))
+            elif kind == "date":
+                results.append(format_date(
+                    item.get("value", ""),
+                    locale,
+                    item.get("format", "medium"),
+                ))
+            elif kind == "datetime":
+                results.append(format_datetime(
+                    item.get("value", ""),
+                    locale,
+                    item.get("format", "medium"),
+                ))
+            else:
+                results.append(None)
+        except Exception as exc:
+            results.append(f"error: {exc}")
+
+    return jsonify({"locale": locale, "results": results})

--- a/packages/backend/app/services/locale_formatter.py
+++ b/packages/backend/app/services/locale_formatter.py
@@ -1,0 +1,185 @@
+"""
+locale_formatter.py — Locale-aware formatting for dates, numbers, and currencies.
+
+Uses Babel for locale-specific output. Falls back to plain ISO / plain float
+if the requested locale is unknown or Babel is unavailable.
+
+Public API:
+    format_currency(amount, currency_code, locale) -> str
+    format_number(value, locale, decimal_places) -> str
+    format_date(d, locale, format) -> str
+    format_datetime(dt, locale, format) -> str
+    supported_locales() -> list[str]
+    locale_meta(locale) -> dict
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Union
+
+logger = logging.getLogger("finmind.locale")
+
+# ── Babel import (optional — graceful degradation if not installed) ────────────
+try:
+    from babel import Locale, UnknownLocaleError
+    from babel.dates import format_date as babel_format_date
+    from babel.dates import format_datetime as babel_format_datetime
+    from babel.numbers import format_currency as babel_format_currency
+    from babel.numbers import format_decimal as babel_format_decimal
+    _BABEL_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _BABEL_AVAILABLE = False
+    logger.warning("Babel not installed — locale formatting will fall back to plain output")
+
+# ── Supported locales (curated list matching FinMind's user base) ─────────────
+SUPPORTED_LOCALES: list[str] = [
+    "en_US", "en_GB", "en_IN", "en_AU", "en_CA",
+    "hi_IN", "ta_IN", "te_IN", "kn_IN", "mr_IN",
+    "de_DE", "fr_FR", "es_ES", "es_MX", "pt_BR",
+    "ja_JP", "zh_CN", "zh_TW", "ko_KR",
+    "ar_SA", "ar_AE",
+]
+
+_DEFAULT_LOCALE = "en_IN"  # FinMind default (INR-centric)
+
+
+def _resolve_locale(locale: str | None) -> str:
+    """Normalise locale string; return default if unrecognised."""
+    if not locale:
+        return _DEFAULT_LOCALE
+    # Accept both en-IN and en_IN forms
+    normalised = locale.replace("-", "_")
+    if normalised in SUPPORTED_LOCALES:
+        return normalised
+    # Try just the language part
+    lang = normalised.split("_")[0]
+    for sl in SUPPORTED_LOCALES:
+        if sl.startswith(lang + "_"):
+            return sl
+    logger.debug("Unknown locale '%s', falling back to %s", locale, _DEFAULT_LOCALE)
+    return _DEFAULT_LOCALE
+
+
+def format_currency(
+    amount: Union[float, Decimal, int],
+    currency_code: str = "INR",
+    locale: str | None = None,
+) -> str:
+    """
+    Format an amount as a locale-aware currency string.
+
+    Examples:
+        format_currency(1234.5, "INR", "en_IN")  -> "₹1,234.50"
+        format_currency(1234.5, "USD", "en_US")  -> "$1,234.50"
+        format_currency(1234.5, "EUR", "de_DE")  -> "1.234,50 €"
+    """
+    loc = _resolve_locale(locale)
+    if not _BABEL_AVAILABLE:
+        return f"{currency_code} {float(amount):.2f}"
+    try:
+        return babel_format_currency(float(amount), currency_code.upper(), locale=loc)
+    except Exception as exc:
+        logger.warning("format_currency failed (locale=%s): %s", loc, exc)
+        return f"{currency_code} {float(amount):.2f}"
+
+
+def format_number(
+    value: Union[float, Decimal, int],
+    locale: str | None = None,
+    decimal_places: int = 2,
+) -> str:
+    """
+    Format a number with locale-appropriate grouping and decimal separators.
+
+    Examples:
+        format_number(1234567.89, "en_US") -> "1,234,567.89"
+        format_number(1234567.89, "de_DE") -> "1.234.567,89"
+        format_number(1234567.89, "en_IN") -> "12,34,567.89"
+    """
+    loc = _resolve_locale(locale)
+    if not _BABEL_AVAILABLE:
+        return f"{float(value):.{decimal_places}f}"
+    fmt = f"#,##0.{'0' * decimal_places}" if decimal_places > 0 else "#,##0"
+    try:
+        return babel_format_decimal(float(value), format=fmt, locale=loc)
+    except Exception as exc:
+        logger.warning("format_number failed (locale=%s): %s", loc, exc)
+        return f"{float(value):.{decimal_places}f}"
+
+
+def format_date(
+    d: Union[date, str],
+    locale: str | None = None,
+    fmt: str = "medium",
+) -> str:
+    """
+    Format a date in a locale-aware style.
+
+    fmt: 'full' | 'long' | 'medium' | 'short'
+
+    Examples:
+        format_date(date(2026, 2, 24), "en_US", "medium") -> "Feb 24, 2026"
+        format_date(date(2026, 2, 24), "de_DE", "medium") -> "24.02.2026"
+        format_date(date(2026, 2, 24), "en_IN", "long")   -> "24 February 2026"
+    """
+    loc = _resolve_locale(locale)
+    if isinstance(d, str):
+        try:
+            d = date.fromisoformat(d)
+        except ValueError:
+            return d  # return as-is if unparseable
+    if not _BABEL_AVAILABLE:
+        return d.isoformat()
+    try:
+        return babel_format_date(d, format=fmt, locale=loc)
+    except Exception as exc:
+        logger.warning("format_date failed (locale=%s): %s", loc, exc)
+        return d.isoformat()
+
+
+def format_datetime(
+    dt: Union[datetime, str],
+    locale: str | None = None,
+    fmt: str = "medium",
+) -> str:
+    """Format a datetime in a locale-aware style."""
+    loc = _resolve_locale(locale)
+    if isinstance(dt, str):
+        try:
+            dt = datetime.fromisoformat(dt)
+        except ValueError:
+            return dt
+    if not _BABEL_AVAILABLE:
+        return dt.isoformat()
+    try:
+        return babel_format_datetime(dt, format=fmt, locale=loc)
+    except Exception as exc:
+        logger.warning("format_datetime failed (locale=%s): %s", loc, exc)
+        return dt.isoformat()
+
+
+def supported_locales() -> list[str]:
+    """Return the list of supported locale codes."""
+    return list(SUPPORTED_LOCALES)
+
+
+def locale_meta(locale: str | None = None) -> dict:
+    """
+    Return metadata about a locale: display name, currency, date/number format examples.
+    """
+    loc = _resolve_locale(locale)
+    meta: dict = {"locale": loc, "babel_available": _BABEL_AVAILABLE}
+    if _BABEL_AVAILABLE:
+        try:
+            bl = Locale.parse(loc)
+            meta["display_name"] = bl.get_display_name("en")
+            meta["language"] = bl.language_name
+            meta["territory"] = bl.territory_name
+            meta["currency"] = str(bl.currency_symbols.get(loc, ""))
+            meta["decimal_symbol"] = bl.number_symbols.get("decimal", ".")
+            meta["grouping_symbol"] = bl.number_symbols.get("group", ",")
+        except Exception:
+            pass
+    return meta

--- a/packages/backend/migrations/versions/add_locale_support.py
+++ b/packages/backend/migrations/versions/add_locale_support.py
@@ -1,0 +1,23 @@
+"""Add locale formatting support: preferred_locale column + locale service
+
+Revision ID: b2c3d4e5f6a7
+Revises: None
+Create Date: 2026-02-24
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'b2c3d4e5f6a7'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users',
+        sa.Column('preferred_locale', sa.String(20), nullable=False,
+                  server_default='en_IN'))
+
+
+def downgrade():
+    op.drop_column('users', 'preferred_locale')

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -19,3 +19,4 @@ black==24.8.0
 flake8==7.0.0
 bandit==1.7.9
 
+babel==2.14.0

--- a/packages/backend/tests/test_locale.py
+++ b/packages/backend/tests/test_locale.py
@@ -1,0 +1,183 @@
+"""Tests for locale-aware formatting service and API endpoints."""
+import pytest
+from app import create_app
+from app.config import Settings
+from app.services.locale_formatter import (
+    format_currency,
+    format_date,
+    format_datetime,
+    format_number,
+    locale_meta,
+    supported_locales,
+    _resolve_locale,
+)
+from datetime import date, datetime
+
+
+@pytest.fixture
+def app():
+    settings = Settings(
+        database_url="sqlite:///:memory:",
+        redis_url="redis://localhost:6379/0",
+        jwt_secret="test-secret",
+    )
+    application = create_app(settings)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ── locale_formatter unit tests ───────────────────────────────────────────────
+
+class TestFormatCurrency:
+    def test_inr_en_in(self):
+        result = format_currency(1234.50, "INR", "en_IN")
+        assert "1,234" in result or "1234" in result
+        assert "₹" in result or "INR" in result
+
+    def test_usd_en_us(self):
+        result = format_currency(9876.54, "USD", "en_US")
+        assert "9,876" in result or "9876" in result
+
+    def test_eur_de_de(self):
+        result = format_currency(1000.0, "EUR", "de_DE")
+        assert "€" in result or "EUR" in result
+
+    def test_zero_amount(self):
+        result = format_currency(0, "INR", "en_IN")
+        assert result is not None and isinstance(result, str)
+
+    def test_fallback_unknown_locale(self):
+        # Unknown locale should not raise, just fall back
+        result = format_currency(500.0, "INR", "xx_XX")
+        assert isinstance(result, str)
+
+
+class TestFormatNumber:
+    def test_en_us_grouping(self):
+        result = format_number(1234567.89, "en_US")
+        assert "1,234,567" in result
+
+    def test_de_de_grouping(self):
+        result = format_number(1234567.89, "de_DE")
+        # German uses dot as thousands separator
+        assert isinstance(result, str) and len(result) > 0
+
+    def test_decimal_places(self):
+        result = format_number(3.14159, "en_US", decimal_places=3)
+        assert "3.142" in result or "3.14" in result
+
+    def test_zero_decimal_places(self):
+        result = format_number(42.7, "en_US", decimal_places=0)
+        assert isinstance(result, str)
+
+
+class TestFormatDate:
+    def test_date_object(self):
+        result = format_date(date(2026, 2, 24), "en_US", "medium")
+        assert "2026" in result
+
+    def test_date_string(self):
+        result = format_date("2026-02-24", "en_IN", "long")
+        assert "2026" in result
+
+    def test_invalid_string_passthrough(self):
+        result = format_date("not-a-date", "en_US")
+        assert result == "not-a-date"
+
+    def test_short_format(self):
+        result = format_date(date(2026, 2, 24), "en_US", "short")
+        assert isinstance(result, str) and len(result) > 0
+
+
+class TestFormatDatetime:
+    def test_datetime_object(self):
+        result = format_datetime(datetime(2026, 2, 24, 13, 0, 0), "en_US", "medium")
+        assert "2026" in result
+
+    def test_datetime_string(self):
+        result = format_datetime("2026-02-24T13:00:00", "en_IN")
+        assert isinstance(result, str)
+
+
+class TestSupportedLocales:
+    def test_returns_list(self):
+        locales = supported_locales()
+        assert isinstance(locales, list)
+        assert len(locales) >= 10
+
+    def test_contains_en_in(self):
+        assert "en_IN" in supported_locales()
+
+    def test_contains_en_us(self):
+        assert "en_US" in supported_locales()
+
+
+class TestLocaleMeta:
+    def test_returns_dict(self):
+        meta = locale_meta("en_US")
+        assert isinstance(meta, dict)
+        assert meta["locale"] == "en_US"
+
+    def test_default_locale(self):
+        meta = locale_meta(None)
+        assert meta["locale"] == "en_IN"
+
+
+class TestResolveLocale:
+    def test_hyphen_normalisation(self):
+        assert _resolve_locale("en-IN") == "en_IN"
+
+    def test_unknown_returns_default(self):
+        assert _resolve_locale("xx_XX") == "en_IN"
+
+    def test_none_returns_default(self):
+        assert _resolve_locale(None) == "en_IN"
+
+
+# ── API endpoint tests ────────────────────────────────────────────────────────
+
+class TestLocaleAPI:
+    def test_supported_endpoint(self, client):
+        resp = client.get("/locale/supported")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "locales" in data
+        assert isinstance(data["locales"], list)
+
+    def test_meta_endpoint(self, client):
+        resp = client.get("/locale/meta?locale=en_US")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["locale"] == "en_US"
+
+    def test_format_endpoint_currency(self, client):
+        resp = client.post("/locale/format", json={
+            "locale": "en_US",
+            "values": [{"type": "currency", "amount": 1234.5, "currency": "USD"}]
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["results"]) == 1
+        assert isinstance(data["results"][0], str)
+
+    def test_format_endpoint_mixed(self, client):
+        resp = client.post("/locale/format", json={
+            "locale": "en_IN",
+            "values": [
+                {"type": "currency", "amount": 5000.0, "currency": "INR"},
+                {"type": "number",   "value": 42.5, "decimal_places": 1},
+                {"type": "date",     "value": "2026-02-24", "format": "medium"},
+            ]
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert len(data["results"]) == 3
+
+    def test_format_endpoint_invalid_values(self, client):
+        resp = client.post("/locale/format", json={"locale": "en_US", "values": "bad"})
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Implements locale-aware formatting for dates, numbers, and currencies using [Babel](https://babel.pocoo.org/), with graceful fallback if Babel is unavailable. Adds a new `/locale` API, a reusable service module, `preferred_locale` on the User model, a DB migration, and 28 tests.

---

## New Files

| File | Purpose |
|------|---------|
| `app/services/locale_formatter.py` | Core Babel-backed formatting service |
| `app/routes/locale.py` | `/locale` Blueprint — 3 REST endpoints |
| `migrations/versions/add_locale_support.py` | Alembic migration: adds `preferred_locale` column |
| `tests/test_locale.py` | 28 unit + integration tests |

**Modified:**
- `app/routes/__init__.py` — registers locale blueprint
- `app/models.py` — adds `preferred_locale` field to User
- `requirements.txt` — adds `babel==2.14.0`

---

## API Reference

### `GET /locale/supported`
Returns all supported locale codes.

```json
{locales: [en_US, en_GB, en_IN, hi_IN, de_DE, ...]}
```

### `GET /locale/meta?locale=en_IN`
Returns metadata for the given locale (display name, currency symbol, decimal/grouping separators).

```json
{
  "locale": "en_IN",
  "babel_available": true,
  "display_name": "English (India)",
  "language": "English",
  "territory": "India",
  "decimal_symbol": ".",
  "grouping_symbol": ","
}
```

### `POST /locale/format`
Bulk-format currencies, numbers, dates, and datetimes in one request.

**Request:**
```json
{
  "locale": "de_DE",
  "values": [
    {"type": "currency", "amount": 1234.5, "currency": "EUR"},
    {"type": "number",   "value": 9876543.21, "decimal_places": 2},
    {"type": "date",     "value": "2026-02-24", "format": "long"},
    {"type": "datetime", "value": "2026-02-24T13:00:00", "format": "medium"}
  ]
}
```

**Response:**
```json
{
  "locale": "de_DE",
  "results": [
    "1.234,50 €",
    "9.876.543,21",
    "24. Februar 2026",
    "24.02.2026, 13:00:00"
  ]
}
```

---

## How to Test

```bash
pip install babel==2.14.0
cd packages/backend
PYTHONPATH=. pytest tests/test_locale.py -v
# 28 passed in 0.09s
```

---

## Demo

![Demo](https://github.com/GoThundercats/FinMind/releases/download/demo-1771941514/demo_finmind_locale.gif)

---

/claim #131