### PR TITLE
feat: category overspend early warning system — closes #117

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, Index
 from .extensions import db
 
 
@@ -133,3 +133,18 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class CategoryBudget(db.Model):
+    __tablename__ = "category_budgets"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=False)
+    monthly_limit = db.Column(db.Numeric(12, 2), nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "category_id", name="uq_budget_user_category"),
+        Index("ix_budget_user", "user_id"),
+    )

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .alerts import bp_alerts, bp_budgets
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,5 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(bp_alerts, url_prefix="/alerts")
+    app.register_blueprint(bp_budgets, url_prefix="/budgets")

--- a/packages/backend/app/routes/alerts.py
+++ b/packages/backend/app/routes/alerts.py
@@ -1,0 +1,119 @@
+"""
+alerts.py — Category budget management and overspend alert endpoints.
+
+Endpoints:
+    GET  /alerts/overspend              — current-month overspend warnings
+    GET  /budgets                       — list all category budgets
+    POST /budgets/<int:category_id>     — set/update monthly limit
+    DELETE /budgets/<int:category_id>   — remove a budget
+"""
+import logging
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import Category, CategoryBudget
+from ..services.overspend import budget_to_dict, check_category_warnings
+
+bp_alerts = Blueprint("alerts", __name__)
+bp_budgets = Blueprint("budgets", __name__)
+logger = logging.getLogger("finmind.alerts")
+
+
+# ── Overspend alerts ──────────────────────────────────────────────────────────
+
+@bp_alerts.get("/overspend")
+@jwt_required()
+def get_overspend_alerts():
+    """Return current-month categories that are at or near their budget limit."""
+    uid = int(get_jwt_identity())
+    warnings = check_category_warnings(uid, db.session)
+    return jsonify({
+        "count": len(warnings),
+        "warnings": warnings,
+    })
+
+
+# ── Budget management ─────────────────────────────────────────────────────────
+
+@bp_budgets.get("")
+@jwt_required()
+def list_budgets():
+    """List all category budgets for the current user."""
+    uid = int(get_jwt_identity())
+    rows = (
+        db.session.query(CategoryBudget, Category.name)
+        .join(Category, CategoryBudget.category_id == Category.id)
+        .filter(CategoryBudget.user_id == uid)
+        .order_by(Category.name)
+        .all()
+    )
+    return jsonify([budget_to_dict(b, name) for b, name in rows])
+
+
+@bp_budgets.post("/<int:category_id>")
+@jwt_required()
+def set_budget(category_id: int):
+    """
+    Set or update a monthly budget limit for a category.
+
+    Body: { "monthly_limit": 5000.0, "currency": "INR" }
+    """
+    uid = int(get_jwt_identity())
+    cat = db.session.get(Category, category_id)
+    if not cat or cat.user_id != uid:
+        return jsonify(error="category not found"), 404
+
+    data = request.get_json() or {}
+    try:
+        limit = float(data["monthly_limit"])
+    except (KeyError, TypeError, ValueError):
+        return jsonify(error="monthly_limit (number) required"), 400
+    if limit <= 0:
+        return jsonify(error="monthly_limit must be positive"), 400
+
+    currency = str(data.get("currency") or "INR").upper()[:10]
+
+    existing = (
+        db.session.query(CategoryBudget)
+        .filter_by(user_id=uid, category_id=category_id)
+        .first()
+    )
+    if existing:
+        existing.monthly_limit = limit
+        existing.currency = currency
+        existing.updated_at = datetime.utcnow()
+        db.session.commit()
+        logger.info("Updated budget cat=%s user=%s limit=%.2f", category_id, uid, limit)
+        return jsonify(budget_to_dict(existing, cat.name))
+    else:
+        budget = CategoryBudget(
+            user_id=uid,
+            category_id=category_id,
+            monthly_limit=limit,
+            currency=currency,
+        )
+        db.session.add(budget)
+        db.session.commit()
+        logger.info("Created budget cat=%s user=%s limit=%.2f", category_id, uid, limit)
+        return jsonify(budget_to_dict(budget, cat.name)), 201
+
+
+@bp_budgets.delete("/<int:category_id>")
+@jwt_required()
+def delete_budget(category_id: int):
+    """Remove a category budget."""
+    uid = int(get_jwt_identity())
+    budget = (
+        db.session.query(CategoryBudget)
+        .filter_by(user_id=uid, category_id=category_id)
+        .first()
+    )
+    if not budget:
+        return jsonify(error="not found"), 404
+    db.session.delete(budget)
+    db.session.commit()
+    logger.info("Deleted budget cat=%s user=%s", category_id, uid)
+    return jsonify(message="deleted")

--- a/packages/backend/app/services/overspend.py
+++ b/packages/backend/app/services/overspend.py
@@ -1,0 +1,137 @@
+"""
+overspend.py — Category overspend early warning service.
+
+Checks the current month's spending against per-category budget limits
+and returns structured warnings at 70% (WARNING) and 100% (EXCEEDED) thresholds.
+
+Public API:
+    check_category_warnings(uid, session, reference_date=None) -> list[dict]
+    budget_to_dict(budget, category_name) -> dict
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy import extract, func
+from sqlalchemy.orm import Session
+
+from ..models import CategoryBudget, Category, Expense
+
+logger = logging.getLogger("finmind.overspend")
+
+WARNING_THRESHOLD = 0.70   # 70% → WARNING
+EXCEEDED_THRESHOLD = 1.00  # 100% → EXCEEDED
+
+
+def check_category_warnings(
+    uid: int,
+    session: Session,
+    reference_date: date | None = None,
+) -> list[dict]:
+    """
+    Return a list of overspend warnings for the current month.
+
+    Each entry represents a category where the user has set a monthly_limit
+    and spending has reached at least WARNING_THRESHOLD.
+
+    Returns:
+        [
+          {
+            "category_id": <int>,
+            "category_name": <str>,
+            "monthly_limit": <float>,
+            "currency": <str>,
+            "spent": <float>,
+            "pct_used": <float>,      # 0.0–1.0+ (can exceed 1.0)
+            "remaining": <float>,     # negative if exceeded
+            "status": "WARNING" | "EXCEEDED",
+            "month": "YYYY-MM",
+          },
+          ...
+        ]
+    """
+    today = reference_date or date.today()
+    year, month = today.year, today.month
+    ym = f"{year}-{month:02d}"
+
+    # Fetch all budgets for this user
+    budgets = (
+        session.query(CategoryBudget, Category.name)
+        .join(Category, CategoryBudget.category_id == Category.id)
+        .filter(CategoryBudget.user_id == uid)
+        .all()
+    )
+
+    if not budgets:
+        return []
+
+    # Fetch this month's spend per category in one query
+    rows = (
+        session.query(
+            Expense.category_id,
+            Expense.currency,
+            func.sum(Expense.amount).label("total"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id, Expense.currency)
+        .all()
+    )
+
+    # Build spend lookup: {(category_id, currency): total}
+    spend_map: dict[tuple, Decimal] = {}
+    for row in rows:
+        key = (row.category_id, row.currency)
+        spend_map[key] = spend_map.get(key, Decimal(0)) + Decimal(str(row.total))
+
+    warnings = []
+    for budget, cat_name in budgets:
+        # Use budget currency to look up spend
+        spent = float(spend_map.get((budget.category_id, budget.currency), Decimal(0)))
+        limit = float(budget.monthly_limit)
+
+        if limit <= 0:
+            continue
+
+        pct_used = spent / limit
+
+        if pct_used < WARNING_THRESHOLD:
+            continue
+
+        status = "EXCEEDED" if pct_used >= EXCEEDED_THRESHOLD else "WARNING"
+
+        warnings.append({
+            "category_id": budget.category_id,
+            "category_name": cat_name,
+            "monthly_limit": limit,
+            "currency": budget.currency,
+            "spent": round(spent, 2),
+            "pct_used": round(pct_used, 4),
+            "remaining": round(limit - spent, 2),
+            "status": status,
+            "month": ym,
+        })
+
+    # Sort: EXCEEDED first, then by pct_used descending
+    warnings.sort(key=lambda w: (-int(w["status"] == "EXCEEDED"), -w["pct_used"]))
+    logger.info("Overspend check user=%s month=%s warnings=%d", uid, ym, len(warnings))
+    return warnings
+
+
+def budget_to_dict(budget: CategoryBudget, category_name: str = "") -> dict:
+    """Serialise a CategoryBudget to a plain dict."""
+    return {
+        "id": budget.id,
+        "category_id": budget.category_id,
+        "category_name": category_name,
+        "monthly_limit": float(budget.monthly_limit),
+        "currency": budget.currency,
+        "created_at": budget.created_at.isoformat(),
+        "updated_at": budget.updated_at.isoformat(),
+    }

--- a/packages/backend/migrations/versions/add_category_budgets.py
+++ b/packages/backend/migrations/versions/add_category_budgets.py
@@ -1,0 +1,34 @@
+"""Add category_budgets table for overspend early warning
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-02-24
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'c3d4e5f6a7b8'
+down_revision = 'b2c3d4e5f6a7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'category_budgets',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('category_id', sa.Integer(), sa.ForeignKey('categories.id'), nullable=False),
+        sa.Column('monthly_limit', sa.Numeric(12, 2), nullable=False),
+        sa.Column('currency', sa.String(10), nullable=False, server_default='INR'),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'category_id', name='uq_budget_user_category'),
+    )
+    op.create_index('ix_budget_user', 'category_budgets', ['user_id'])
+
+
+def downgrade():
+    op.drop_index('ix_budget_user', table_name='category_budgets')
+    op.drop_table('category_budgets')

--- a/packages/backend/tests/test_overspend.py
+++ b/packages/backend/tests/test_overspend.py
@@ -1,0 +1,306 @@
+"""Tests for category overspend early warning system."""
+import pytest
+import fakeredis
+from unittest.mock import patch
+from datetime import date
+from decimal import Decimal
+
+from app.extensions import db as _db
+from app.models import User, Category, CategoryBudget, Expense
+from app.services.overspend import check_category_warnings
+
+
+# ── Redis mock (no real Redis in CI) ─────────────────────────────────────────
+
+@pytest.fixture(autouse=True)
+def mock_redis():
+    """Replace the global redis_client with fakeredis for all tests."""
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    with (
+        patch("app.extensions.redis_client", fake),
+        patch("app.routes.auth.redis_client", fake),
+        patch("app.services.cache.redis_client", fake),
+    ):
+        yield fake
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def sample_data(app_fixture):
+    """Create a user, categories, budgets, and expenses for overspend tests."""
+    with app_fixture.app_context():
+        user = User(
+            email="overspend@example.com",
+            password_hash="hashed",
+            preferred_currency="INR",
+        )
+        _db.session.add(user)
+        _db.session.flush()
+
+        food = Category(user_id=user.id, name="Food")
+        shopping = Category(user_id=user.id, name="Shopping")
+        transport = Category(user_id=user.id, name="Transport")
+        _db.session.add_all([food, shopping, transport])
+        _db.session.flush()
+
+        # Budgets: Food=5000, Shopping=3000, Transport=2000
+        _db.session.add(CategoryBudget(
+            user_id=user.id, category_id=food.id,
+            monthly_limit=Decimal("5000"), currency="INR"
+        ))
+        _db.session.add(CategoryBudget(
+            user_id=user.id, category_id=shopping.id,
+            monthly_limit=Decimal("3000"), currency="INR"
+        ))
+        _db.session.add(CategoryBudget(
+            user_id=user.id, category_id=transport.id,
+            monthly_limit=Decimal("2000"), currency="INR"
+        ))
+
+        today = date.today()
+        # Food: 4200 spent (84% — WARNING)
+        _db.session.add(Expense(
+            user_id=user.id, category_id=food.id,
+            amount=Decimal("4200"), currency="INR",
+            expense_type="EXPENSE", spent_at=today
+        ))
+        # Shopping: 3100 spent (103% — EXCEEDED)
+        _db.session.add(Expense(
+            user_id=user.id, category_id=shopping.id,
+            amount=Decimal("3100"), currency="INR",
+            expense_type="EXPENSE", spent_at=today
+        ))
+        # Transport: 500 spent (25% — no warning)
+        _db.session.add(Expense(
+            user_id=user.id, category_id=transport.id,
+            amount=Decimal("500"), currency="INR",
+            expense_type="EXPENSE", spent_at=today
+        ))
+
+        _db.session.commit()
+        return {
+            "user_id": user.id,
+            "food_id": food.id,
+            "shopping_id": shopping.id,
+            "transport_id": transport.id,
+        }
+
+
+# ── Unit tests: check_category_warnings ───────────────────────────────────────
+
+class TestCheckCategoryWarnings:
+    def test_returns_only_threshold_categories(self, app_fixture, sample_data):
+        with app_fixture.app_context():
+            warnings = check_category_warnings(sample_data["user_id"], _db.session)
+            category_names = [w["category_name"] for w in warnings]
+            assert "Shopping" in category_names   # EXCEEDED
+            assert "Food" in category_names        # WARNING
+            assert "Transport" not in category_names  # under 70%
+
+    def test_exceeded_sorted_first(self, app_fixture, sample_data):
+        with app_fixture.app_context():
+            warnings = check_category_warnings(sample_data["user_id"], _db.session)
+            assert warnings[0]["status"] == "EXCEEDED"
+
+    def test_warning_status_at_70_percent(self, app_fixture, sample_data):
+        with app_fixture.app_context():
+            warnings = check_category_warnings(sample_data["user_id"], _db.session)
+            food_w = next(w for w in warnings if w["category_name"] == "Food")
+            assert food_w["status"] == "WARNING"
+            assert food_w["pct_used"] >= 0.70
+
+    def test_exceeded_status_at_100_percent(self, app_fixture, sample_data):
+        with app_fixture.app_context():
+            warnings = check_category_warnings(sample_data["user_id"], _db.session)
+            shopping_w = next(w for w in warnings if w["category_name"] == "Shopping")
+            assert shopping_w["status"] == "EXCEEDED"
+            assert shopping_w["pct_used"] >= 1.0
+            assert shopping_w["remaining"] < 0
+
+    def test_income_excluded_from_spend(self, app_fixture, sample_data):
+        with app_fixture.app_context():
+            # Add income entry for food — should NOT count toward spend
+            _db.session.add(Expense(
+                user_id=sample_data["user_id"],
+                category_id=sample_data["food_id"],
+                amount=Decimal("10000"),
+                currency="INR",
+                expense_type="INCOME",
+                spent_at=date.today(),
+            ))
+            _db.session.commit()
+            warnings = check_category_warnings(sample_data["user_id"], _db.session)
+            food_w = next(w for w in warnings if w["category_name"] == "Food")
+            # Spend should still be 4200, not 14200
+            assert food_w["spent"] == pytest.approx(4200.0, abs=0.01)
+
+    def test_no_budgets_returns_empty(self, app_fixture):
+        with app_fixture.app_context():
+            user = User(
+                email="nobudget@example.com",
+                password_hash="x",
+                preferred_currency="INR",
+            )
+            _db.session.add(user)
+            _db.session.commit()
+            warnings = check_category_warnings(user.id, _db.session)
+            assert warnings == []
+
+    def test_warning_fields_present(self, app_fixture, sample_data):
+        with app_fixture.app_context():
+            warnings = check_category_warnings(sample_data["user_id"], _db.session)
+            assert len(warnings) > 0
+            w = warnings[0]
+            for field in [
+                "category_id", "category_name", "monthly_limit", "currency",
+                "spent", "pct_used", "remaining", "status", "month",
+            ]:
+                assert field in w, f"missing field: {field}"
+
+    def test_under_threshold_not_included(self, app_fixture, sample_data):
+        """Transport at 25% should not appear in warnings."""
+        with app_fixture.app_context():
+            warnings = check_category_warnings(sample_data["user_id"], _db.session)
+            statuses = [w["category_name"] for w in warnings]
+            assert "Transport" not in statuses
+
+
+# ── API tests: /alerts and /budgets endpoints ─────────────────────────────────
+
+class TestBudgetAPI:
+    def test_alerts_endpoint_requires_auth(self, client):
+        resp = client.get("/alerts/overspend")
+        assert resp.status_code in (401, 422)
+
+    def test_budgets_list_requires_auth(self, client):
+        resp = client.get("/budgets")
+        assert resp.status_code in (401, 422)
+
+    def test_set_budget_requires_auth(self, client):
+        resp = client.post("/budgets/1", json={"monthly_limit": 5000})
+        assert resp.status_code in (401, 404, 422)
+
+    def test_delete_budget_requires_auth(self, client):
+        resp = client.delete("/budgets/1")
+        assert resp.status_code in (401, 404, 422)
+
+    def test_alerts_authenticated(self, client, auth_header):
+        """Authenticated user gets empty warnings list with no budgets set."""
+        resp = client.get("/alerts/overspend", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "count" in data
+        assert "warnings" in data
+        assert data["count"] == 0
+        assert data["warnings"] == []
+
+    def test_budgets_list_authenticated_empty(self, client, auth_header):
+        """Authenticated user gets empty budget list initially."""
+        resp = client.get("/budgets", headers=auth_header)
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+
+    def test_set_and_list_budget(self, client, auth_header):
+        """Create a category then set a budget on it."""
+        # Create category
+        r = client.post("/categories", json={"name": "TestCat"}, headers=auth_header)
+        assert r.status_code == 201
+        cat_id = r.get_json()["id"]
+
+        # Set budget
+        r = client.post(
+            f"/budgets/{cat_id}",
+            json={"monthly_limit": 5000, "currency": "INR"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["monthly_limit"] == 5000.0
+        assert data["currency"] == "INR"
+        assert data["category_id"] == cat_id
+
+        # List budgets
+        r = client.get("/budgets", headers=auth_header)
+        assert r.status_code == 200
+        budgets = r.get_json()
+        assert len(budgets) == 1
+        assert budgets[0]["category_id"] == cat_id
+
+    def test_update_budget(self, client, auth_header):
+        """Update an existing budget."""
+        r = client.post("/categories", json={"name": "UpdateCat"}, headers=auth_header)
+        cat_id = r.get_json()["id"]
+
+        client.post(f"/budgets/{cat_id}", json={"monthly_limit": 1000}, headers=auth_header)
+        r = client.post(f"/budgets/{cat_id}", json={"monthly_limit": 2000}, headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["monthly_limit"] == 2000.0
+
+    def test_delete_budget(self, client, auth_header):
+        """Delete a budget."""
+        r = client.post("/categories", json={"name": "DelCat"}, headers=auth_header)
+        cat_id = r.get_json()["id"]
+
+        client.post(f"/budgets/{cat_id}", json={"monthly_limit": 1000}, headers=auth_header)
+
+        r = client.delete(f"/budgets/{cat_id}", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["message"] == "deleted"
+
+        # Should be gone
+        r = client.get("/budgets", headers=auth_header)
+        assert r.get_json() == []
+
+    def test_alerts_shows_overspend(self, client, auth_header):
+        """Set a tiny budget, add an expense exceeding it, check alerts."""
+        # Create category
+        r = client.post("/categories", json={"name": "AlertCat"}, headers=auth_header)
+        cat_id = r.get_json()["id"]
+
+        # Set budget of 100 INR
+        client.post(
+            f"/budgets/{cat_id}",
+            json={"monthly_limit": 100, "currency": "INR"},
+            headers=auth_header,
+        )
+
+        # Add an expense of 90 (90% — WARNING)
+        client.post(
+            "/expenses",
+            json={
+                "amount": 90,
+                "currency": "INR",
+                "category_id": cat_id,
+                "expense_type": "EXPENSE",
+                "description": "test expense",
+                "spent_at": date.today().isoformat(),
+            },
+            headers=auth_header,
+        )
+
+        r = client.get("/alerts/overspend", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["count"] >= 1
+        names = [w["category_name"] for w in data["warnings"]]
+        assert "AlertCat" in names
+
+    def test_set_budget_invalid_limit(self, client, auth_header):
+        """Reject non-positive monthly_limit."""
+        r = client.post("/categories", json={"name": "BadLimitCat"}, headers=auth_header)
+        cat_id = r.get_json()["id"]
+        r = client.post(f"/budgets/{cat_id}", json={"monthly_limit": -100}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_set_budget_missing_limit(self, client, auth_header):
+        """Reject missing monthly_limit."""
+        r = client.post("/categories", json={"name": "NoLimitCat"}, headers=auth_header)
+        cat_id = r.get_json()["id"]
+        r = client.post(f"/budgets/{cat_id}", json={}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_delete_nonexistent_budget(self, client, auth_header):
+        """Delete non-existent budget returns 404."""
+        r = client.delete("/budgets/999999", headers=auth_header)
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary

Implements a **category overspend early warning system** for FinMind, closing #117.

Users can set per-category monthly budget limits and receive structured warnings when spending reaches 70% (WARNING) or 100% (EXCEEDED) of their limit.

### What's new

| File | Purpose |
|---|---|
| `app/models.py` | `CategoryBudget` model — stores per-category monthly limits |
| `app/services/overspend.py` | Core warning engine — queries spend vs limit, returns structured dicts |
| `app/routes/alerts.py` | 4 REST endpoints for alerts + budget management |
| `migrations/versions/add_category_budgets.py` | Alembic migration — creates `category_budgets` table |
| `tests/test_overspend.py` | 21 tests covering service logic and all API endpoints |

---

## New Model: `CategoryBudget`

```python
class CategoryBudget(db.Model):
    __tablename__ = "category_budgets"
    id, user_id, category_id  # FK→users, FK→categories
    monthly_limit  # Numeric(12, 2)
    currency       # String(10), default "INR"
    created_at, updated_at
    # UNIQUE(user_id, category_id)
```

---

## API Reference

### `GET /alerts/overspend`
Returns current-month categories at or near their budget limit (≥ 70%).

**Response:**
```json
{
  "count": 2,
  "warnings": [
    {
      "category_id": 3,
      "category_name": "Shopping",
      "monthly_limit": 3000.0,
      "currency": "INR",
      "spent": 3100.0,
      "pct_used": 1.0333,
      "remaining": -100.0,
      "status": "EXCEEDED",
      "month": "2026-02"
    },
    {
      "category_id": 1,
      "category_name": "Food",
      "monthly_limit": 5000.0,
      "currency": "INR",
      "spent": 4200.0,
      "pct_used": 0.84,
      "remaining": 800.0,
      "status": "WARNING",
      "month": "2026-02"
    }
  ]
}
```

### `GET /budgets`
List all category budgets for the authenticated user.

### `POST /budgets/<category_id>`
Set or update a monthly budget for a category.
```json
{ "monthly_limit": 5000.0, "currency": "INR" }
```

### `DELETE /budgets/<category_id>`
Remove a budget.

---

## Warning Thresholds

| Threshold | Status |
|---|---|
| ≥ 70% and < 100% | `WARNING` |
| ≥ 100% | `EXCEEDED` |

- EXCEEDED warnings sorted before WARNINGs
- INCOME expense_type is excluded from spend totals
- Spend is matched by category + currency

---

## How to Test

```bash
cd packages/backend
pip install -r requirements.txt
PYTHONPATH=. pytest tests/test_overspend.py -v
# 21 passed ✓
```

To apply the migration:
```bash
flask db upgrade
```

---

## Demo

![Claw 🦾 — FinMind Category Overspend Alerts #117](https://github.com/GoThundercats/FinMind/releases/download/demo-1771941970/demo_finmind_overspend.gif)

---

/claim #117