### PR TITLE
feat: lifestyle inflation detection insights — closes #118

### DIFF
--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,8 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.inflation import detect_lifestyle_inflation
+from ..services.cache import cache_get, cache_set
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +25,31 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/inflation")
+@jwt_required()
+def inflation_analysis():
+    """
+    Analyse lifestyle inflation over the past N months.
+
+    Query params:
+      months (int, 2-12, default 6) — lookback window
+    """
+    uid = int(get_jwt_identity())
+    try:
+        months = int(request.args.get("months", 6))
+        months = max(2, min(12, months))
+    except (ValueError, TypeError):
+        months = 6
+
+    cache_key = f"user:{uid}:inflation:{months}"
+    cached = cache_get(cache_key)
+    if cached:
+        return jsonify(cached)
+
+    from ..extensions import db
+    result = detect_lifestyle_inflation(uid, db.session, months=months)
+    cache_set(cache_key, result, ttl_seconds=600)
+    logger.info("Inflation analysis served user=%s months=%s", uid, months)
+    return jsonify(result)

--- a/packages/backend/app/services/inflation.py
+++ b/packages/backend/app/services/inflation.py
@@ -1,0 +1,271 @@
+"""
+inflation.py — Lifestyle inflation detection service.
+
+Analyses month-over-month spending trends to detect lifestyle inflation:
+consistent spending growth across categories, often without a matching
+income increase.
+
+Public API:
+    detect_lifestyle_inflation(uid, session, months, reference_date) -> dict
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from sqlalchemy import extract, func
+from sqlalchemy.orm import Session
+
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.inflation")
+
+_INFLATION_WARNING_THRESHOLD = 0.05   # 5%+ MoM growth = trending up
+_CONSISTENT_MONTHS = 2                # >= N consecutive up months = "inflating"
+
+
+def _ym_range(reference: date, months: int) -> list[str]:
+    """Return list of YYYY-MM strings for the `months` months ending before reference month."""
+    result = []
+    y, m = reference.year, reference.month
+    # Step back one month to exclude the current (partial) month
+    m -= 1
+    if m == 0:
+        m = 12
+        y -= 1
+    for _ in range(months):
+        result.append(f"{y}-{m:02d}")
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+    return list(reversed(result))   # oldest first
+
+
+def _monthly_category_spend(uid: int, session: Session, ym: str) -> dict[int | None, float]:
+    """Return {category_id: total_spend} for a given month (INCOME excluded)."""
+    year, month = map(int, ym.split("-"))
+    rows = (
+        session.query(Expense.category_id, func.sum(Expense.amount).label("total"))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+    return {r.category_id: float(r.total) for r in rows}
+
+
+def _monthly_totals(uid: int, session: Session, ym: str) -> tuple[float, float]:
+    """Return (total_income, total_spend) for a given month."""
+    year, month = map(int, ym.split("-"))
+    income = session.query(func.coalesce(func.sum(Expense.amount), 0)).filter(
+        Expense.user_id == uid,
+        extract("year", Expense.spent_at) == year,
+        extract("month", Expense.spent_at) == month,
+        Expense.expense_type == "INCOME",
+    ).scalar()
+    expenses = session.query(func.coalesce(func.sum(Expense.amount), 0)).filter(
+        Expense.user_id == uid,
+        extract("year", Expense.spent_at) == year,
+        extract("month", Expense.spent_at) == month,
+        Expense.expense_type != "INCOME",
+    ).scalar()
+    return float(income or 0), float(expenses or 0)
+
+
+def _pct_change(old: float, new: float) -> float | None:
+    if old == 0:
+        return None
+    return round((new - old) / old * 100, 1)
+
+
+def _consecutive_increases(values: list[float]) -> int:
+    """Count trailing consecutive month-over-month increases."""
+    count = 0
+    for i in range(len(values) - 1, 0, -1):
+        if values[i] > values[i - 1]:
+            count += 1
+        else:
+            break
+    return count
+
+
+def detect_lifestyle_inflation(
+    uid: int,
+    session: Session,
+    months: int = 6,
+    reference_date: date | None = None,
+) -> dict:
+    """
+    Detect lifestyle inflation by analysing spending trends over the past N months.
+
+    Returns:
+    {
+      "period_months": <int>,
+      "months_analysed": ["YYYY-MM", ...],
+      "inflation_score": <0-100>,        # 0=no inflation, 100=severe
+      "overall_trend": "UP"|"DOWN"|"FLAT"|"INSUFFICIENT_DATA",
+      "monthly_totals": [
+        {"month": "YYYY-MM", "income": <float>, "spend": <float>, "net": <float>}, ...
+      ],
+      "inflating_categories": [
+        {
+          "category_id": <int|null>,
+          "category_name": <str>,
+          "monthly_spend": [<float>, ...],
+          "consecutive_increases": <int>,
+          "total_growth_pct": <float|null>,
+          "status": "INFLATING"|"VOLATILE"|"STABLE"
+        }, ...
+      ],
+      "insights": ["<str>", ...]
+    }
+    """
+    ref = reference_date or date.today()
+    months = max(2, min(months, 12))  # clamp 2-12
+    period = _ym_range(ref, months)
+
+    if not period:
+        return {"error": "insufficient data period"}
+
+    # Gather category name map
+    cat_rows = session.query(Category.id, Category.name).filter_by(user_id=uid).all()
+    cat_names: dict[int | None, str] = {r.id: r.name for r in cat_rows}
+    cat_names[None] = "Uncategorised"
+
+    # Collect monthly totals and per-category spend
+    monthly_totals = []
+    all_category_spend: dict[int | None, list[float]] = {}
+
+    for ym in period:
+        income, spend = _monthly_totals(uid, session, ym)
+        monthly_totals.append({
+            "month": ym,
+            "income": round(income, 2),
+            "spend": round(spend, 2),
+            "net": round(income - spend, 2),
+        })
+        cat_spend = _monthly_category_spend(uid, session, ym)
+        # Ensure all known categories are represented (0 if no spend)
+        for cat_id in set(list(cat_spend.keys()) + list(all_category_spend.keys())):
+            if cat_id not in all_category_spend:
+                all_category_spend[cat_id] = [0.0] * len(period)
+            idx = period.index(ym)
+            all_category_spend[cat_id][idx] = cat_spend.get(cat_id, 0.0)
+
+    # Overall trend
+    spend_values = [m["spend"] for m in monthly_totals]
+    if len(spend_values) < 2 or all(v == 0 for v in spend_values):
+        overall_trend = "INSUFFICIENT_DATA"
+    else:
+        first_half = sum(spend_values[:len(spend_values)//2]) / (len(spend_values)//2)
+        second_half = sum(spend_values[len(spend_values)//2:]) / (len(spend_values) - len(spend_values)//2)
+        if second_half > first_half * 1.03:
+            overall_trend = "UP"
+        elif second_half < first_half * 0.97:
+            overall_trend = "DOWN"
+        else:
+            overall_trend = "FLAT"
+
+    # Analyse per-category inflation
+    inflating_categories = []
+    for cat_id, values in all_category_spend.items():
+        if all(v == 0 for v in values):
+            continue  # skip completely inactive categories
+        consec = _consecutive_increases(values)
+        first_nonzero = next((v for v in values if v > 0), 0)
+        last_val = values[-1]
+        total_growth = _pct_change(first_nonzero, last_val)
+
+        if consec >= _CONSISTENT_MONTHS:
+            status = "INFLATING"
+        elif total_growth is not None and total_growth > 20:
+            status = "VOLATILE"
+        else:
+            status = "STABLE"
+
+        inflating_categories.append({
+            "category_id": cat_id,
+            "category_name": cat_names.get(cat_id, f"Category {cat_id}"),
+            "monthly_spend": [round(v, 2) for v in values],
+            "consecutive_increases": consec,
+            "total_growth_pct": total_growth,
+            "status": status,
+        })
+
+    # Sort: INFLATING first, then by consecutive_increases desc
+    inflating_categories.sort(key=lambda c: (
+        -int(c["status"] == "INFLATING"),
+        -c["consecutive_increases"],
+    ))
+
+    # Inflation score (0-100)
+    n_inflating = sum(1 for c in inflating_categories if c["status"] == "INFLATING")
+    n_total = len(inflating_categories) or 1
+    base_score = min(100, int((n_inflating / n_total) * 60))
+    if overall_trend == "UP":
+        base_score = min(100, base_score + 25)
+    avg_growth = 0.0
+    growth_values = [
+        c["total_growth_pct"] for c in inflating_categories
+        if c["total_growth_pct"] is not None
+    ]
+    if growth_values:
+        avg_growth = sum(growth_values) / len(growth_values)
+        base_score = min(100, base_score + int(min(15, max(0, avg_growth / 10))))
+    inflation_score = base_score
+
+    # Plain-English insights
+    insights = []
+    if overall_trend == "UP":
+        first_spend = spend_values[0]
+        last_spend = spend_values[-1]
+        pct = _pct_change(first_spend, last_spend)
+        if pct is not None:
+            insights.append(
+                f"Total spending has increased {pct:+.1f}% over the past {months} months "
+                f"({monthly_totals[0]['month']} → {monthly_totals[-1]['month']})."
+            )
+    elif overall_trend == "DOWN":
+        insights.append(f"Overall spending is trending down — good discipline over {months} months.")
+    elif overall_trend == "FLAT":
+        insights.append(f"Spending is broadly stable over the past {months} months.")
+
+    inflating_names = [c["category_name"] for c in inflating_categories if c["status"] == "INFLATING"]
+    if inflating_names:
+        insights.append(
+            f"Lifestyle inflation detected in: {', '.join(inflating_names[:3])}."
+            + (" And more." if len(inflating_names) > 3 else "")
+        )
+
+    # Income vs spend divergence
+    income_values = [m["income"] for m in monthly_totals if m["income"] > 0]
+    if income_values and overall_trend == "UP":
+        avg_income = sum(income_values) / len(income_values)
+        avg_spend = sum(spend_values) / len(spend_values)
+        if avg_spend > avg_income * 0.9:
+            insights.append(
+                "Spending is close to or exceeding income on average — consider reviewing discretionary categories."
+            )
+
+    if not insights:
+        insights.append("No significant lifestyle inflation detected in this period.")
+
+    logger.info(
+        "Inflation analysis user=%s months=%s score=%d trend=%s inflating=%d",
+        uid, months, inflation_score, overall_trend, n_inflating,
+    )
+
+    return {
+        "period_months": months,
+        "months_analysed": period,
+        "inflation_score": inflation_score,
+        "overall_trend": overall_trend,
+        "monthly_totals": monthly_totals,
+        "inflating_categories": inflating_categories,
+        "insights": insights,
+    }

--- a/packages/backend/migrations/versions/add_inflation_analysis.py
+++ b/packages/backend/migrations/versions/add_inflation_analysis.py
@@ -1,0 +1,18 @@
+"""Lifestyle inflation detection service (no schema changes)
+
+Revision ID: d4e5f6a7b8c9
+Revises: 
+Create Date: 2026-02-24
+"""
+revision = 'd4e5f6a7b8c9'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass   # No schema changes — service layer only
+
+
+def downgrade():
+    pass

--- a/packages/backend/tests/test_inflation.py
+++ b/packages/backend/tests/test_inflation.py
@@ -1,0 +1,242 @@
+"""Tests for lifestyle inflation detection service."""
+import pytest
+from datetime import date
+from decimal import Decimal
+
+from flask_jwt_extended import create_access_token
+
+from app.extensions import db as _db
+from app.models import User, Category, Expense
+from app.services.inflation import (
+    detect_lifestyle_inflation,
+    _ym_range,
+    _consecutive_increases,
+    _pct_change,
+)
+
+
+# ── Helper unit tests ─────────────────────────────────────────────────────────
+
+class TestYmRange:
+    def test_returns_correct_count(self):
+        ref = date(2026, 3, 15)
+        result = _ym_range(ref, 3)
+        assert len(result) == 3
+
+    def test_excludes_current_month(self):
+        ref = date(2026, 3, 15)
+        result = _ym_range(ref, 3)
+        assert "2026-03" not in result
+
+    def test_oldest_first(self):
+        ref = date(2026, 3, 15)
+        result = _ym_range(ref, 3)
+        assert result == ["2025-12", "2026-01", "2026-02"]
+
+    def test_wraps_year_correctly(self):
+        ref = date(2026, 2, 1)
+        result = _ym_range(ref, 2)
+        assert "2025-12" in result
+        assert "2026-01" in result
+
+
+class TestConsecutiveIncreases:
+    def test_all_increasing(self):
+        assert _consecutive_increases([100, 200, 300, 400]) == 3
+
+    def test_no_increases(self):
+        assert _consecutive_increases([400, 300, 200, 100]) == 0
+
+    def test_trailing_increases_only(self):
+        assert _consecutive_increases([400, 100, 200, 300]) == 2
+
+    def test_single_value(self):
+        assert _consecutive_increases([100]) == 0
+
+
+class TestPctChange:
+    def test_positive_change(self):
+        assert _pct_change(100, 150) == pytest.approx(50.0)
+
+    def test_negative_change(self):
+        assert _pct_change(200, 100) == pytest.approx(-50.0)
+
+    def test_zero_base_returns_none(self):
+        assert _pct_change(0, 100) is None
+
+    def test_no_change(self):
+        assert _pct_change(100, 100) == pytest.approx(0.0)
+
+
+# ── Service integration tests ─────────────────────────────────────────────────
+
+class TestDetectLifestyleInflation:
+    def _seed_data(self, app_fixture):
+        """Create user + category + escalating expenses across 3 months."""
+        with app_fixture.app_context():
+            user = User(
+                email="inflation_test@example.com",
+                password_hash="x",
+                preferred_currency="INR",
+            )
+            _db.session.add(user)
+            _db.session.flush()
+            food = Category(user_id=user.id, name="Food")
+            _db.session.add(food)
+            _db.session.flush()
+
+            # Escalating food spend: Jan=1000, Feb=1300, Mar=1700 (inflating)
+            for ym, amount in [("2026-01", 1000), ("2026-02", 1300), ("2026-03", 1700)]:
+                y, m = map(int, ym.split("-"))
+                _db.session.add(Expense(
+                    user_id=user.id,
+                    category_id=food.id,
+                    amount=Decimal(str(amount)),
+                    currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date(y, m, 15),
+                ))
+            _db.session.commit()
+            return user.id, food.id
+
+    def test_detects_inflating_category(self, app_fixture):
+        uid, _ = self._seed_data(app_fixture)
+        with app_fixture.app_context():
+            result = detect_lifestyle_inflation(
+                uid, _db.session, months=3, reference_date=date(2026, 4, 1)
+            )
+            inflating = [c for c in result["inflating_categories"] if c["status"] == "INFLATING"]
+            assert len(inflating) >= 1
+            assert any(c["category_name"] == "Food" for c in inflating)
+
+    def test_result_shape(self, app_fixture):
+        uid, _ = self._seed_data(app_fixture)
+        with app_fixture.app_context():
+            result = detect_lifestyle_inflation(
+                uid, _db.session, months=3, reference_date=date(2026, 4, 1)
+            )
+            for key in [
+                "period_months", "months_analysed", "inflation_score",
+                "overall_trend", "monthly_totals", "inflating_categories", "insights",
+            ]:
+                assert key in result, f"missing key: {key}"
+
+    def test_inflation_score_range(self, app_fixture):
+        uid, _ = self._seed_data(app_fixture)
+        with app_fixture.app_context():
+            result = detect_lifestyle_inflation(
+                uid, _db.session, months=3, reference_date=date(2026, 4, 1)
+            )
+            assert 0 <= result["inflation_score"] <= 100
+
+    def test_no_data_returns_flat_or_insufficient(self, app_fixture):
+        with app_fixture.app_context():
+            user = User(
+                email="empty_inflation@example.com",
+                password_hash="x",
+                preferred_currency="INR",
+            )
+            _db.session.add(user)
+            _db.session.commit()
+            result = detect_lifestyle_inflation(
+                user.id, _db.session, months=3, reference_date=date(2026, 4, 1)
+            )
+            assert result["overall_trend"] in ("FLAT", "INSUFFICIENT_DATA")
+
+    def test_income_not_counted_as_spend(self, app_fixture):
+        uid, food_id = self._seed_data(app_fixture)
+        with app_fixture.app_context():
+            # Add large income entries — should NOT inflate spend totals
+            for ym in ["2026-01", "2026-02", "2026-03"]:
+                y, m = map(int, ym.split("-"))
+                _db.session.add(Expense(
+                    user_id=uid,
+                    category_id=food_id,
+                    amount=Decimal("50000"),
+                    currency="INR",
+                    expense_type="INCOME",
+                    spent_at=date(y, m, 15),
+                ))
+            _db.session.commit()
+            result = detect_lifestyle_inflation(
+                uid, _db.session, months=3, reference_date=date(2026, 4, 1)
+            )
+            # Food spend should still be 1000/1300/1700, not inflated by income
+            food_cat = next(
+                (c for c in result["inflating_categories"] if c["category_name"] == "Food"),
+                None,
+            )
+            assert food_cat is not None
+            assert max(food_cat["monthly_spend"]) < 10000
+
+    def test_insights_list_not_empty(self, app_fixture):
+        uid, _ = self._seed_data(app_fixture)
+        with app_fixture.app_context():
+            result = detect_lifestyle_inflation(
+                uid, _db.session, months=3, reference_date=date(2026, 4, 1)
+            )
+            assert isinstance(result["insights"], list)
+            assert len(result["insights"]) >= 1
+
+    def test_months_clamped(self, app_fixture):
+        uid, _ = self._seed_data(app_fixture)
+        with app_fixture.app_context():
+            result = detect_lifestyle_inflation(
+                uid, _db.session, months=99, reference_date=date(2026, 4, 1)
+            )
+            assert result["period_months"] == 12
+
+
+# ── Endpoint tests ─────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def jwt_auth_header(app_fixture):
+    """Return an Authorization header using a directly-created JWT (no Redis login)."""
+    with app_fixture.app_context():
+        # Create a test user
+        user = User(
+            email="jwt_test@example.com",
+            password_hash="x",
+            preferred_currency="INR",
+        )
+        _db.session.add(user)
+        _db.session.commit()
+        token = create_access_token(identity=str(user.id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestInflationEndpoint:
+    def test_endpoint_requires_auth(self, client):
+        resp = client.get("/insights/inflation")
+        assert resp.status_code in (401, 422)
+
+    def test_endpoint_exists(self, client):
+        resp = client.get("/insights/inflation")
+        assert resp.status_code != 404
+
+    def test_endpoint_returns_json_with_auth(self, client, jwt_auth_header, monkeypatch):
+        monkeypatch.setattr("app.routes.insights.cache_get", lambda k: None)
+        monkeypatch.setattr("app.routes.insights.cache_set", lambda k, v, **kw: None)
+        resp = client.get("/insights/inflation?months=3", headers=jwt_auth_header)
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert "inflation_score" in payload
+        assert "overall_trend" in payload
+        assert "inflating_categories" in payload
+        assert "insights" in payload
+
+    def test_endpoint_months_param(self, client, jwt_auth_header, monkeypatch):
+        monkeypatch.setattr("app.routes.insights.cache_get", lambda k: None)
+        monkeypatch.setattr("app.routes.insights.cache_set", lambda k, v, **kw: None)
+        resp = client.get("/insights/inflation?months=3", headers=jwt_auth_header)
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload["period_months"] == 3
+
+    def test_endpoint_clamps_months(self, client, jwt_auth_header, monkeypatch):
+        monkeypatch.setattr("app.routes.insights.cache_get", lambda k: None)
+        monkeypatch.setattr("app.routes.insights.cache_set", lambda k, v, **kw: None)
+        resp = client.get("/insights/inflation?months=99", headers=jwt_auth_header)
+        assert resp.status_code == 200
+        payload = resp.get_json()
+        assert payload["period_months"] == 12


### PR DESCRIPTION
## Summary

**Lifestyle inflation** is spending creep — when your monthly expenses grow consistently month-over-month, often without a corresponding income increase. Left unchecked, it silently erodes savings and financial resilience.

This PR adds a dedicated **Lifestyle Inflation Detection** service and API endpoint to FinMind, giving users actionable insight into their spending trends.

---

## New Files

| File | Description |
|------|-------------|
| `packages/backend/app/services/inflation.py` | Core detection service — computes MoM trends, inflation score, per-category analysis, and plain-English insights |
| `packages/backend/app/routes/insights.py` | Updated: adds `GET /insights/inflation` endpoint (JWT-protected, cached) |
| `packages/backend/tests/test_inflation.py` | 24 tests — unit tests for helpers + service integration + endpoint tests |
| `packages/backend/migrations/versions/add_inflation_analysis.py` | Migration stub (no schema changes — read-only service) |

---

## How It Works

1. **Data collection** — Fetches per-month totals and per-category spend for the last N months (excludes current partial month)
2. **Overall trend** — Compares first-half vs second-half average spend; classifies as UP / DOWN / FLAT / INSUFFICIENT_DATA
3. **Per-category analysis** — Tracks consecutive month-over-month increases; flags categories with ≥2 consecutive up months as **INFLATING**
4. **Inflation score** — 0–100 composite score based on: % inflating categories (60 pts), overall trend (+25 pts), average growth magnitude (+15 pts)
5. **Plain-English insights** — Human-readable strings describing spending trends, inflating categories, and income vs spend divergence (no LLM needed)

---

## API Reference

### `GET /insights/inflation?months=6`

**Auth:** JWT required (`Authorization: Bearer <token>`)  
**Query params:** `months` (int, 2–12, default 6)

#### Sample Response

```json
{
  "period_months": 6,
  "months_analysed": ["2025-09", "2025-10", "2025-11", "2025-12", "2026-01", "2026-02"],
  "inflation_score": 72,
  "overall_trend": "UP",
  "monthly_totals": [
    {"month": "2025-09", "income": 80000.0, "spend": 42000.0, "net": 38000.0},
    {"month": "2025-10", "income": 80000.0, "spend": 45500.0, "net": 34500.0},
    {"month": "2026-02", "income": 80000.0, "spend": 61000.0, "net": 19000.0}
  ],
  "inflating_categories": [
    {
      "category_id": 3,
      "category_name": "Dining Out",
      "monthly_spend": [4200.0, 5100.0, 6200.0, 7400.0, 8800.0, 9500.0],
      "consecutive_increases": 5,
      "total_growth_pct": 126.2,
      "status": "INFLATING"
    },
    {
      "category_id": 7,
      "category_name": "Entertainment",
      "monthly_spend": [2000.0, 2100.0, 2300.0, 2600.0, 3100.0, 3800.0],
      "consecutive_increases": 5,
      "total_growth_pct": 90.0,
      "status": "INFLATING"
    }
  ],
  "insights": [
    "Total spending has increased +45.2% over the past 6 months (2025-09 → 2026-02).",
    "Lifestyle inflation detected in: Dining Out, Entertainment.",
    "Spending is close to or exceeding income on average — consider reviewing discretionary categories."
  ]
}
```

---

## How to Test

```bash
cd packages/backend
pip install -r requirements.txt
PYTHONPATH=. pytest tests/test_inflation.py -v
```

All 24 tests pass (12 unit, 7 service integration, 5 endpoint).

---

## Demo

![Claw 🦾 — FinMind Lifestyle Inflation Detection #118](https://github.com/GoThundercats/FinMind/releases/download/demo-1771942347/demo_finmind_inflation.gif)

---

/claim #118