### PR TITLE
feat: essential vs discretionary spending breakdown (closes #120)

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, Index
 from .extensions import db
 
 
@@ -133,3 +133,27 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SpendingType(str, Enum):
+    ESSENTIAL     = "ESSENTIAL"
+    DISCRETIONARY = "DISCRETIONARY"
+    UNCATEGORISED = "UNCATEGORISED"
+
+
+class CategoryClassification(db.Model):
+    """User-defined override of essential/discretionary for a category."""
+    __tablename__ = "category_classifications"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=False)
+    classification = db.Column(
+        db.String(20),
+        nullable=False,
+        default=SpendingType.UNCATEGORISED.value,
+    )
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "category_id", name="uq_classification_user_category"),
+        Index("ix_classification_user", "user_id"),
+    )

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .breakdown import bp_breakdown
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(bp_breakdown, url_prefix="/breakdown")

--- a/packages/backend/app/routes/breakdown.py
+++ b/packages/backend/app/routes/breakdown.py
@@ -1,0 +1,86 @@
+"""
+breakdown.py — Essential vs discretionary spending breakdown endpoints.
+
+GET  /breakdown/classifications                   — list user overrides
+POST /breakdown/classifications/<category_id>     — set override
+DELETE /breakdown/classifications/<category_id>   — remove override
+"""
+import logging
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import Category, CategoryClassification
+
+bp_breakdown = Blueprint("breakdown", __name__)
+logger = logging.getLogger("finmind.breakdown_routes")
+
+_VALID_TYPES = {"ESSENTIAL", "DISCRETIONARY", "UNCATEGORISED"}
+
+
+@bp_breakdown.get("/classifications")
+@jwt_required()
+def list_classifications():
+    """List all user-defined category classifications."""
+    uid = int(get_jwt_identity())
+    rows = (
+        db.session.query(CategoryClassification, Category.name)
+        .join(Category, CategoryClassification.category_id == Category.id)
+        .filter(CategoryClassification.user_id == uid)
+        .all()
+    )
+    return jsonify([
+        {
+            "category_id": c.category_id,
+            "category_name": name,
+            "classification": c.classification,
+        }
+        for c, name in rows
+    ])
+
+
+@bp_breakdown.post("/classifications/<int:category_id>")
+@jwt_required()
+def set_classification(category_id: int):
+    """Set or update the essential/discretionary classification for a category."""
+    uid = int(get_jwt_identity())
+    cat = db.session.get(Category, category_id)
+    if not cat or cat.user_id != uid:
+        return jsonify(error="category not found"), 404
+
+    data = request.get_json() or {}
+    cls = (data.get("classification") or "").upper()
+    if cls not in _VALID_TYPES:
+        return jsonify(error=f"classification must be one of {sorted(_VALID_TYPES)}"), 400
+
+    existing = (
+        db.session.query(CategoryClassification)
+        .filter_by(user_id=uid, category_id=category_id)
+        .first()
+    )
+    if existing:
+        existing.classification = cls
+    else:
+        db.session.add(CategoryClassification(
+            user_id=uid, category_id=category_id, classification=cls
+        ))
+    db.session.commit()
+    return jsonify({"category_id": category_id, "classification": cls})
+
+
+@bp_breakdown.delete("/classifications/<int:category_id>")
+@jwt_required()
+def delete_classification(category_id: int):
+    """Remove a user-defined classification override."""
+    uid = int(get_jwt_identity())
+    obj = (
+        db.session.query(CategoryClassification)
+        .filter_by(user_id=uid, category_id=category_id)
+        .first()
+    )
+    if not obj:
+        return jsonify(error="not found"), 404
+    db.session.delete(obj)
+    db.session.commit()
+    return jsonify(message="deleted")

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,9 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.spending_breakdown import get_spending_breakdown as _get_breakdown
+from ..services.cache import cache_get, cache_set
+from ..extensions import db
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +26,22 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/spending-breakdown")
+@jwt_required()
+def spending_breakdown():
+    """
+    Essential vs discretionary spending breakdown for a given month.
+    Query params: month=YYYY-MM (default: current month)
+    """
+    uid = int(get_jwt_identity())
+    ym = request.args.get("month") or date.today().strftime("%Y-%m")
+    cache_key = f"user:{uid}:breakdown:{ym}"
+    cached = cache_get(cache_key)
+    if cached:
+        return jsonify(cached)
+    result = _get_breakdown(uid, db.session, ym=ym)
+    cache_set(cache_key, result, ttl_seconds=600)
+    logger.info("Spending breakdown served user=%s month=%s", uid, ym)
+    return jsonify(result)

--- a/packages/backend/app/services/spending_breakdown.py
+++ b/packages/backend/app/services/spending_breakdown.py
@@ -1,0 +1,200 @@
+"""
+spending_breakdown.py — Essential vs discretionary spending classification.
+
+Classifies each expense category as ESSENTIAL or DISCRETIONARY using keyword
+matching, with user-override support via CategoryClassification model.
+
+Public API:
+    classify_category(name, user_overrides) -> str
+    get_spending_breakdown(uid, session, ym, reference_date) -> dict
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from sqlalchemy import extract, func
+from sqlalchemy.orm import Session
+
+from ..models import Category, CategoryClassification, Expense
+
+logger = logging.getLogger("finmind.breakdown")
+
+# ── Keyword classification rules ──────────────────────────────────────────────
+_ESSENTIAL_KEYWORDS = {
+    "rent", "mortgage", "housing", "utilities", "electric", "electricity",
+    "water", "gas", "internet", "broadband", "phone", "mobile", "grocery",
+    "groceries", "supermarket", "food", "transport", "commute", "fuel",
+    "petrol", "diesel", "bus", "train", "metro", "healthcare", "medical",
+    "doctor", "hospital", "pharmacy", "medicine", "insurance", "health",
+    "education", "school", "tuition", "childcare", "tax", "emi", "loan",
+}
+
+_DISCRETIONARY_KEYWORDS = {
+    "dining", "restaurant", "cafe", "coffee", "takeaway", "takeout",
+    "entertainment", "movie", "cinema", "concert", "streaming", "netflix",
+    "spotify", "amazon", "subscription", "shopping", "clothes", "fashion",
+    "electronics", "gadget", "travel", "holiday", "vacation", "hotel",
+    "flight", "uber", "ola", "cab", "taxi", "bar", "pub", "alcohol",
+    "gym", "fitness", "beauty", "salon", "spa", "hobby", "game", "gaming",
+    "gift", "donation", "luxury", "jewellery", "jewelry",
+}
+
+
+def classify_category(
+    name: str,
+    user_overrides: dict[int, str] | None = None,
+    category_id: int | None = None,
+) -> str:
+    """
+    Return "ESSENTIAL", "DISCRETIONARY", or "UNCATEGORISED" for a category name.
+
+    user_overrides: {category_id: "ESSENTIAL"|"DISCRETIONARY"}
+    """
+    if user_overrides and category_id is not None:
+        override = user_overrides.get(category_id)
+        if override:
+            return override
+
+    words = set(name.lower().replace("-", " ").replace("_", " ").split())
+    if words & _ESSENTIAL_KEYWORDS:
+        return "ESSENTIAL"
+    if words & _DISCRETIONARY_KEYWORDS:
+        return "DISCRETIONARY"
+    return "UNCATEGORISED"
+
+
+def get_spending_breakdown(
+    uid: int,
+    session: Session,
+    ym: str | None = None,
+    reference_date: date | None = None,
+) -> dict:
+    """
+    Return essential vs discretionary breakdown for a given month.
+
+    Returns:
+    {
+      "month": "YYYY-MM",
+      "total_spend": <float>,
+      "essential": {
+        "total": <float>,
+        "pct_of_total_spend": <float>,
+        "categories": [{"category_id", "category_name", "amount", "pct_of_type",
+                         "pct_of_total", "classification", "user_override"}, ...]
+      },
+      "discretionary": { <same shape> },
+      "uncategorised": { <same shape> },
+      "insights": ["<str>", ...]
+    }
+    """
+    ref = reference_date or date.today()
+    if ym:
+        try:
+            year, month = map(int, ym.split("-"))
+        except ValueError:
+            year, month = ref.year, ref.month
+    else:
+        year, month = ref.year, ref.month
+
+    month_str = f"{year}-{month:02d}"
+
+    # Fetch user overrides
+    overrides_rows = (
+        session.query(CategoryClassification.category_id, CategoryClassification.classification)
+        .filter_by(user_id=uid)
+        .all()
+    )
+    overrides: dict[int, str] = {r.category_id: r.classification for r in overrides_rows}
+
+    # Fetch category names
+    cat_rows = session.query(Category.id, Category.name).filter_by(user_id=uid).all()
+    cat_names: dict[int | None, str] = {r.id: r.name for r in cat_rows}
+    cat_names[None] = "Uncategorised"
+
+    # Fetch this month's spend per category
+    rows = (
+        session.query(Expense.category_id, func.sum(Expense.amount).label("total"))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+
+    total_spend = sum(float(r.total) for r in rows)
+
+    buckets: dict[str, list[dict]] = {
+        "ESSENTIAL": [],
+        "DISCRETIONARY": [],
+        "UNCATEGORISED": [],
+    }
+
+    for r in rows:
+        cat_id = r.category_id
+        cat_name = cat_names.get(cat_id, f"Category {cat_id}")
+        amount = float(r.total)
+        cls = classify_category(cat_name, overrides, cat_id)
+        buckets[cls].append({
+            "category_id": cat_id,
+            "category_name": cat_name,
+            "amount": round(amount, 2),
+            "pct_of_total": round(amount / total_spend * 100, 1) if total_spend else 0.0,
+            "classification": cls,
+            "user_override": cat_id in overrides,
+        })
+
+    def bucket_summary(items: list[dict]) -> dict:
+        total = sum(i["amount"] for i in items)
+        # sort by amount desc, compute pct_of_type
+        for item in items:
+            item["pct_of_type"] = round(item["amount"] / total * 100, 1) if total else 0.0
+        items_sorted = sorted(items, key=lambda x: -x["amount"])
+        return {
+            "total": round(total, 2),
+            "pct_of_total_spend": round(total / total_spend * 100, 1) if total_spend else 0.0,
+            "categories": items_sorted,
+        }
+
+    essential     = bucket_summary(buckets["ESSENTIAL"])
+    discretionary = bucket_summary(buckets["DISCRETIONARY"])
+    uncategorised  = bucket_summary(buckets["UNCATEGORISED"])
+
+    # Insights
+    insights = []
+    if total_spend == 0:
+        insights.append(f"No spending recorded for {month_str}.")
+    else:
+        e_pct = essential["pct_of_total_spend"]
+        d_pct = discretionary["pct_of_total_spend"]
+        insights.append(
+            f"Essential spending: {e_pct:.1f}% of total. "
+            f"Discretionary: {d_pct:.1f}%."
+        )
+        if d_pct > 40:
+            insights.append(
+                f"Discretionary spending is high ({d_pct:.1f}%). "
+                "Reviewing non-essential categories could free up budget."
+            )
+        if uncategorised["pct_of_total_spend"] > 20:
+            insights.append(
+                f"{uncategorised['pct_of_total_spend']:.1f}% of spend is uncategorised. "
+                "Assigning categories will improve tracking accuracy."
+            )
+
+    logger.info(
+        "Spending breakdown user=%s month=%s essential=%.1f%% discretionary=%.1f%%",
+        uid, month_str, essential["pct_of_total_spend"], discretionary["pct_of_total_spend"],
+    )
+
+    return {
+        "month": month_str,
+        "total_spend": round(total_spend, 2),
+        "essential": essential,
+        "discretionary": discretionary,
+        "uncategorised": uncategorised,
+        "insights": insights,
+    }

--- a/packages/backend/tests/test_spending_breakdown.py
+++ b/packages/backend/tests/test_spending_breakdown.py
@@ -1,0 +1,168 @@
+"""Tests for essential vs discretionary spending breakdown."""
+import pytest
+from datetime import date
+from decimal import Decimal
+
+from app.extensions import db as _db
+from app.models import User, Category, CategoryClassification, Expense
+from app.services.spending_breakdown import classify_category, get_spending_breakdown
+
+
+# ── Pure unit tests — no DB needed ────────────────────────────────────────────
+
+class TestClassifyCategory:
+    def test_essential_food(self):
+        assert classify_category("Food") == "ESSENTIAL"
+
+    def test_essential_transport(self):
+        assert classify_category("Transport") == "ESSENTIAL"
+
+    def test_essential_healthcare(self):
+        assert classify_category("Healthcare") == "ESSENTIAL"
+
+    def test_discretionary_entertainment(self):
+        assert classify_category("Entertainment") == "DISCRETIONARY"
+
+    def test_discretionary_shopping(self):
+        assert classify_category("Shopping") == "DISCRETIONARY"
+
+    def test_discretionary_dining(self):
+        assert classify_category("Dining Out") == "DISCRETIONARY"
+
+    def test_unknown_returns_uncategorised(self):
+        assert classify_category("Miscellaneous") == "UNCATEGORISED"
+
+    def test_user_override_takes_precedence(self):
+        result = classify_category("Entertainment", user_overrides={5: "ESSENTIAL"}, category_id=5)
+        assert result == "ESSENTIAL"
+
+    def test_no_override_for_other_category(self):
+        result = classify_category("Entertainment", user_overrides={99: "ESSENTIAL"}, category_id=5)
+        assert result == "DISCRETIONARY"
+
+    def test_case_insensitive(self):
+        assert classify_category("FOOD") == "ESSENTIAL"
+        assert classify_category("food") == "ESSENTIAL"
+
+
+# ── DB-backed tests ────────────────────────────────────────────────────────────
+
+def _seed(app_fixture):
+    """Seed test data and return (user_id, food_id, entertain_id, misc_id)."""
+    with app_fixture.app_context():
+        user = User(email="breakdown_test@example.com", password_hash="x", preferred_currency="INR")
+        _db.session.add(user)
+        _db.session.flush()
+
+        food = Category(user_id=user.id, name="Food")           # ESSENTIAL
+        entertain = Category(user_id=user.id, name="Entertainment")  # DISCRETIONARY
+        misc = Category(user_id=user.id, name="Misc")           # UNCATEGORISED
+        _db.session.add_all([food, entertain, misc])
+        _db.session.flush()
+
+        for cat, amt in [(food, 3000), (entertain, 1500), (misc, 500)]:
+            _db.session.add(Expense(
+                user_id=user.id,
+                category_id=cat.id,
+                amount=Decimal(str(amt)),
+                currency="INR",
+                expense_type="EXPENSE",
+                spent_at=date(2026, 2, 15),
+            ))
+        _db.session.commit()
+        return user.id, food.id, entertain.id, misc.id
+
+
+class TestGetSpendingBreakdown:
+    def test_totals_correct(self, app_fixture):
+        uid, *_ = _seed(app_fixture)
+        with app_fixture.app_context():
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            assert result["total_spend"] == pytest.approx(5000.0)
+
+    def test_essential_bucket_has_food(self, app_fixture):
+        uid, *_ = _seed(app_fixture)
+        with app_fixture.app_context():
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            names = [c["category_name"] for c in result["essential"]["categories"]]
+            assert "Food" in names
+
+    def test_discretionary_bucket_has_entertainment(self, app_fixture):
+        uid, *_ = _seed(app_fixture)
+        with app_fixture.app_context():
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            names = [c["category_name"] for c in result["discretionary"]["categories"]]
+            assert "Entertainment" in names
+
+    def test_percentages_sum_to_100(self, app_fixture):
+        uid, *_ = _seed(app_fixture)
+        with app_fixture.app_context():
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            total_pct = (
+                result["essential"]["pct_of_total_spend"]
+                + result["discretionary"]["pct_of_total_spend"]
+                + result["uncategorised"]["pct_of_total_spend"]
+            )
+            assert total_pct == pytest.approx(100.0, abs=0.5)
+
+    def test_user_override_applied(self, app_fixture):
+        uid, food_id, entertain_id, misc_id = _seed(app_fixture)
+        with app_fixture.app_context():
+            # Override Entertainment → ESSENTIAL
+            _db.session.add(CategoryClassification(
+                user_id=uid, category_id=entertain_id, classification="ESSENTIAL"
+            ))
+            _db.session.commit()
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            essential_names = [c["category_name"] for c in result["essential"]["categories"]]
+            assert "Entertainment" in essential_names
+            disc_names = [c["category_name"] for c in result["discretionary"]["categories"]]
+            assert "Entertainment" not in disc_names
+
+    def test_income_excluded(self, app_fixture):
+        uid, food_id, *_ = _seed(app_fixture)
+        with app_fixture.app_context():
+            _db.session.add(Expense(
+                user_id=uid,
+                category_id=food_id,
+                amount=Decimal("100000"),
+                currency="INR",
+                expense_type="INCOME",
+                spent_at=date(2026, 2, 15),
+            ))
+            _db.session.commit()
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            assert result["total_spend"] == pytest.approx(5000.0)
+
+    def test_response_shape(self, app_fixture):
+        uid, *_ = _seed(app_fixture)
+        with app_fixture.app_context():
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            for key in ["month", "total_spend", "essential", "discretionary", "uncategorised", "insights"]:
+                assert key in result
+
+    def test_insights_not_empty(self, app_fixture):
+        uid, *_ = _seed(app_fixture)
+        with app_fixture.app_context():
+            result = get_spending_breakdown(uid, _db.session, ym="2026-02")
+            assert len(result["insights"]) >= 1
+
+
+class TestBreakdownEndpoints:
+    def test_breakdown_requires_auth(self, client):
+        resp = client.get("/insights/spending-breakdown")
+        assert resp.status_code in (401, 422)
+
+    def test_breakdown_endpoint_exists(self, client):
+        resp = client.get("/insights/spending-breakdown")
+        assert resp.status_code != 404
+
+    def test_classifications_requires_auth(self, client):
+        resp = client.get("/breakdown/classifications")
+        assert resp.status_code in (401, 422)
+
+    def test_set_classification_requires_auth(self, client):
+        resp = client.post("/breakdown/classifications/1", json={"classification": "ESSENTIAL"})
+        assert resp.status_code in (401, 404, 422)
+
+


### PR DESCRIPTION
## Summary

Implements essential vs discretionary spending breakdown for FinMind. Automatically classifies expense categories using keyword matching, supports user-defined overrides, and provides a monthly breakdown with percentages and actionable insights.

**Key features:**
- 🔑 Keyword-based auto-classification (ESSENTIAL / DISCRETIONARY / UNCATEGORISED)
- 👤 Per-user category override support via `CategoryClassification` model
- 📊 Monthly breakdown with totals, percentages, and sorted category lists
- 💡 Automatic insights (high discretionary %, uncategorised spend alerts)
- ⚡ Response cached for 10 min via existing Redis cache layer

---

## Files Changed

| File | Change |
|------|--------|
| `app/models.py` | + `SpendingType` enum + `CategoryClassification` model |
| `app/services/spending_breakdown.py` | New — classification engine + breakdown service |
| `app/routes/breakdown.py` | New — classification CRUD endpoints (Blueprint) |
| `app/routes/insights.py` | + `GET /insights/spending-breakdown` endpoint |
| `app/routes/__init__.py` | Register `bp_breakdown` at `/breakdown` |
| `tests/test_spending_breakdown.py` | 22 tests, all passing ✅ |

---

## API Reference

### `GET /insights/spending-breakdown?month=YYYY-MM`
Returns monthly essential vs discretionary breakdown.

**Query params:**
- `month` — `YYYY-MM` format (default: current month)

**Sample response:**
```json
{
  "month": "2026-02",
  "total_spend": 5000.0,
  "essential": {
    "total": 3000.0,
    "pct_of_total_spend": 60.0,
    "categories": [
      {"category_id": 1, "category_name": "Food", "amount": 3000.0,
       "pct_of_total": 60.0, "pct_of_type": 100.0,
       "classification": "ESSENTIAL", "user_override": false}
    ]
  },
  "discretionary": {
    "total": 1500.0,
    "pct_of_total_spend": 30.0,
    "categories": [...]
  },
  "uncategorised": {
    "total": 500.0,
    "pct_of_total_spend": 10.0,
    "categories": [...]
  },
  "insights": [
    "Essential spending: 60.0% of total. Discretionary: 30.0%."
  ]
}
```

### `GET /breakdown/classifications`
List all user-defined category classification overrides.

### `POST /breakdown/classifications/<category_id>`
Set or update classification for a category.

**Body:** `{"classification": "ESSENTIAL" | "DISCRETIONARY" | "UNCATEGORISED"}`

### `DELETE /breakdown/classifications/<category_id>`
Remove a classification override (reverts to keyword auto-classification).

---

## Classification Logic

**Essential keywords:** rent, mortgage, housing, utilities, electricity, water, gas, internet, phone, grocery, food, transport, fuel, healthcare, medical, insurance, education, school, loan, tax, ...

**Discretionary keywords:** dining, restaurant, cafe, entertainment, movie, streaming, shopping, clothes, travel, hotel, uber, cab, bar, gym, beauty, hobby, gaming, gift, luxury, ...

Categories not matching either set are **UNCATEGORISED**. User overrides always take precedence.

---

## How to Test

```bash
cd packages/backend
PYTHONPATH=. pytest tests/test_spending_breakdown.py -v
# 22 passed in 0.21s ✅
```

---

## Demo

![Claw 🦾 — FinMind Essential vs Discretionary Breakdown #120](https://github.com/GoThundercats/FinMind/releases/download/demo-1771942973/demo_finmind_breakdown.gif)

---

/claim #120