### PR TITLE
feat: reminder reliability tracking & delivery metrics

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, Index
 from .extensions import db
 
 
@@ -133,3 +133,24 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ReminderDeliveryLog(db.Model):
+    """Records each delivery attempt for a reminder, enabling reliability metrics."""
+    __tablename__ = "reminder_delivery_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    reminder_id = db.Column(
+        db.Integer,
+        db.ForeignKey("reminders.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    channel = db.Column(db.String(20), nullable=False)
+    attempted_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    success = db.Column(db.Boolean, nullable=False)
+    error_message = db.Column(db.String(500), nullable=True)
+    latency_seconds = db.Column(db.Integer, nullable=True)
+    __table_args__ = (
+        Index("ix_delivery_log_reminder", "reminder_id"),
+        Index("ix_delivery_log_attempted", "attempted_at"),
+        Index("ix_delivery_log_success", "success"),
+    )

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -221,3 +221,23 @@ def _create_reminder_if_missing(
         )
     )
     return True
+
+
+from ..services.reminder_metrics import get_reminder_metrics  # noqa: E402
+
+
+@bp.get("/metrics")
+@jwt_required()
+def reminder_metrics():
+    """
+    Return delivery reliability metrics for the current user's reminders.
+    Query params: days (int, 1-365, default 30)
+    """
+    uid = int(get_jwt_identity())
+    try:
+        days = int(request.args.get("days", 30))
+        days = max(1, min(365, days))
+    except (ValueError, TypeError):
+        days = 30
+    result = get_reminder_metrics(uid, db.session, days=days)
+    return jsonify(result)

--- a/packages/backend/app/services/reminder_metrics.py
+++ b/packages/backend/app/services/reminder_metrics.py
@@ -1,0 +1,182 @@
+"""
+reminder_metrics.py — Reminder reliability tracking and delivery metrics.
+
+Aggregates delivery log data to surface success rates, failure patterns,
+channel performance, and latency statistics.
+
+Public API:
+    get_reminder_metrics(uid, session, days=30) -> dict
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from ..models import Reminder, ReminderDeliveryLog
+
+logger = logging.getLogger("finmind.reminder_metrics")
+
+
+def get_reminder_metrics(
+    uid: int,
+    session: Session,
+    days: int = 30,
+) -> dict:
+    """
+    Return delivery reliability metrics for a user's reminders.
+
+    Returns:
+    {
+      "period_days": <int>,
+      "total_reminders_scheduled": <int>,
+      "total_attempts": <int>,
+      "total_sent": <int>,
+      "total_failed": <int>,
+      "success_rate": <float 0.0-1.0>,
+      "by_channel": {
+        "email":     {"attempts": <int>, "sent": <int>, "failed": <int>, "success_rate": <float>},
+        "whatsapp":  { ... },
+        ...
+      },
+      "avg_latency_seconds": <float|null>,
+      "recent_failures": [
+        {"reminder_id": <int>, "channel": <str>, "attempted_at": "<ISO>", "error_message": <str|null>},
+        ...  (last 5)
+      ],
+      "pending_reminders": <int>,
+    }
+    """
+    days = max(1, min(days, 365))
+    since = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=days)
+
+    # Only look at delivery logs for this user's reminders
+    user_reminder_ids = [
+        r.id for r in session.query(Reminder.id).filter_by(user_id=uid).all()
+    ]
+
+    if not user_reminder_ids:
+        # Still compute pending/scheduled counts even with no logs
+        total_scheduled = session.query(func.count(Reminder.id)).filter(
+            Reminder.user_id == uid,
+        ).scalar() or 0
+        pending = session.query(func.count(Reminder.id)).filter(
+            Reminder.user_id == uid,
+            Reminder.sent == False,  # noqa: E712
+        ).scalar() or 0
+        result = _empty_metrics(days)
+        result["total_reminders_scheduled"] = total_scheduled
+        result["pending_reminders"] = pending
+        return result
+
+    # Base query for delivery logs in period
+    logs_q = session.query(ReminderDeliveryLog).filter(
+        ReminderDeliveryLog.reminder_id.in_(user_reminder_ids),
+        ReminderDeliveryLog.attempted_at >= since,
+    )
+
+    all_logs = logs_q.all()
+    total_attempts = len(all_logs)
+    total_sent = sum(1 for log in all_logs if log.success)
+    total_failed = total_attempts - total_sent
+    success_rate = round(total_sent / total_attempts, 4) if total_attempts else 0.0
+
+    # Per-channel breakdown
+    channels: dict[str, dict] = {}
+    for log in all_logs:
+        ch = log.channel or "unknown"
+        if ch not in channels:
+            channels[ch] = {"attempts": 0, "sent": 0, "failed": 0}
+        channels[ch]["attempts"] += 1
+        if log.success:
+            channels[ch]["sent"] += 1
+        else:
+            channels[ch]["failed"] += 1
+    for ch_data in channels.values():
+        ch_data["success_rate"] = (
+            round(ch_data["sent"] / ch_data["attempts"], 4)
+            if ch_data["attempts"]
+            else 0.0
+        )
+
+    # Average latency (only for successful sends with latency data)
+    latencies = [
+        log.latency_seconds
+        for log in all_logs
+        if log.success and log.latency_seconds is not None
+    ]
+    avg_latency = round(sum(latencies) / len(latencies), 1) if latencies else None
+
+    # Recent failures (last 5)
+    failures = sorted(
+        [log for log in all_logs if not log.success],
+        key=lambda log: log.attempted_at,
+        reverse=True,
+    )[:5]
+    recent_failures = [
+        {
+            "reminder_id": f.reminder_id,
+            "channel": f.channel,
+            "attempted_at": f.attempted_at.isoformat(),
+            "error_message": f.error_message,
+        }
+        for f in failures
+    ]
+
+    # Pending (scheduled but not yet sent)
+    pending = (
+        session.query(func.count(Reminder.id))
+        .filter(
+            Reminder.user_id == uid,
+            Reminder.sent == False,  # noqa: E712
+        )
+        .scalar()
+        or 0
+    )
+
+    total_scheduled = (
+        session.query(func.count(Reminder.id))
+        .filter(
+            Reminder.user_id == uid,
+        )
+        .scalar()
+        or 0
+    )
+
+    logger.info(
+        "Reminder metrics user=%s days=%d attempts=%d success_rate=%.2f",
+        uid,
+        days,
+        total_attempts,
+        success_rate,
+    )
+
+    return {
+        "period_days": days,
+        "total_reminders_scheduled": total_scheduled,
+        "total_attempts": total_attempts,
+        "total_sent": total_sent,
+        "total_failed": total_failed,
+        "success_rate": success_rate,
+        "by_channel": channels,
+        "avg_latency_seconds": avg_latency,
+        "recent_failures": recent_failures,
+        "pending_reminders": pending,
+    }
+
+
+def _empty_metrics(days: int) -> dict:
+    return {
+        "period_days": days,
+        "total_reminders_scheduled": 0,
+        "total_attempts": 0,
+        "total_sent": 0,
+        "total_failed": 0,
+        "success_rate": 0.0,
+        "by_channel": {},
+        "avg_latency_seconds": None,
+        "recent_failures": [],
+        "pending_reminders": 0,
+    }

--- a/packages/backend/app/services/reminders.py
+++ b/packages/backend/app/services/reminders.py
@@ -1,7 +1,7 @@
 import smtplib
 from email.message import EmailMessage
 from ..config import Settings
-from ..models import Reminder
+from ..models import Reminder, ReminderDeliveryLog
 
 try:
     from twilio.rest import Client as TwilioClient
@@ -56,7 +56,8 @@ def send_whatsapp(to_number: str, body: str):
         return False
 
 
-def send_reminder(r: Reminder):
+def _do_send(r: Reminder) -> bool:
+    """Core send logic — email or whatsapp dispatch (no logging here)."""
     # Channel holds 'email' or 'whatsapp:<number>'
     if r.channel == "whatsapp":
         return False
@@ -69,3 +70,38 @@ def send_reminder(r: Reminder):
         to = r.channel if "@" in r.channel else (_settings.email_from or "")
         subject = "Bill Reminder"
         return send_email(to, subject, r.message)
+
+
+def send_reminder(r: Reminder) -> bool:
+    """Send a reminder and log the delivery attempt to ReminderDeliveryLog."""
+    from datetime import datetime as _dt
+
+    attempt_time = _dt.utcnow()
+    success = False
+    error_msg = None
+    try:
+        success = _do_send(r)
+    except Exception as exc:
+        error_msg = str(exc)[:500]
+        success = False
+    finally:
+        try:
+            from ..extensions import db as _db
+
+            latency = None
+            if hasattr(r, "send_at") and r.send_at:
+                delta = attempt_time - r.send_at
+                latency = int(delta.total_seconds())
+            log = ReminderDeliveryLog(
+                reminder_id=r.id,
+                channel=r.channel or "email",
+                attempted_at=attempt_time,
+                success=success,
+                error_message=error_msg,
+                latency_seconds=latency,
+            )
+            _db.session.add(log)
+            _db.session.commit()
+        except Exception:
+            pass  # never let logging break the scheduler
+    return success

--- a/packages/backend/migrations/versions/add_reminder_delivery_log.py
+++ b/packages/backend/migrations/versions/add_reminder_delivery_log.py
@@ -1,0 +1,48 @@
+"""Add reminder_delivery_logs table for reliability tracking
+
+Revision ID: f6a7b8c9d0e1
+Revises: None
+Create Date: 2026-02-24
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "f6a7b8c9d0e1"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "reminder_delivery_logs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "reminder_id",
+            sa.Integer(),
+            sa.ForeignKey("reminders.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("channel", sa.String(20), nullable=False),
+        sa.Column("attempted_at", sa.DateTime(), nullable=False),
+        sa.Column("success", sa.Boolean(), nullable=False),
+        sa.Column("error_message", sa.String(500), nullable=True),
+        sa.Column("latency_seconds", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_delivery_log_reminder", "reminder_delivery_logs", ["reminder_id"]
+    )
+    op.create_index(
+        "ix_delivery_log_attempted", "reminder_delivery_logs", ["attempted_at"]
+    )
+    op.create_index(
+        "ix_delivery_log_success", "reminder_delivery_logs", ["success"]
+    )
+
+
+def downgrade():
+    op.drop_index("ix_delivery_log_success", table_name="reminder_delivery_logs")
+    op.drop_index("ix_delivery_log_attempted", table_name="reminder_delivery_logs")
+    op.drop_index("ix_delivery_log_reminder", table_name="reminder_delivery_logs")
+    op.drop_table("reminder_delivery_logs")

--- a/packages/backend/tests/test_reminder_metrics.py
+++ b/packages/backend/tests/test_reminder_metrics.py
@@ -1,0 +1,198 @@
+"""Tests for reminder reliability tracking and delivery metrics."""
+import pytest
+from datetime import datetime, timedelta
+from app.extensions import db as _db
+from app.models import User, Reminder, ReminderDeliveryLog
+from app.services.reminder_metrics import get_reminder_metrics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_user(db_session, email="test@x.com"):
+    u = User(email=email, password_hash="x", preferred_currency="INR")
+    db_session.add(u)
+    db_session.flush()
+    return u
+
+
+def _make_reminder(db_session, user_id, channel="email", sent=False, offset_hours=-1):
+    r = Reminder(
+        user_id=user_id,
+        message="Test reminder",
+        send_at=datetime.utcnow() + timedelta(hours=offset_hours),
+        sent=sent,
+        channel=channel,
+    )
+    db_session.add(r)
+    db_session.flush()
+    return r
+
+
+def _make_log(db_session, reminder_id, channel="email", success=True, hours_ago=1, latency=30):
+    log = ReminderDeliveryLog(
+        reminder_id=reminder_id,
+        channel=channel,
+        attempted_at=datetime.utcnow() - timedelta(hours=hours_ago),
+        success=success,
+        error_message=None if success else "SMTP connection failed",
+        latency_seconds=latency if success else None,
+    )
+    db_session.add(log)
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Service-level tests
+# ---------------------------------------------------------------------------
+
+class TestGetReminderMetrics:
+    def test_empty_returns_zeros(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session)
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session)
+            assert result["total_attempts"] == 0
+            assert result["success_rate"] == 0.0
+
+    def test_counts_successes_and_failures(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session, "counts@x.com")
+            r = _make_reminder(_db.session, user.id)
+            _make_log(_db.session, r.id, success=True)
+            _make_log(_db.session, r.id, success=True)
+            _make_log(_db.session, r.id, success=False)
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session)
+            assert result["total_sent"] == 2
+            assert result["total_failed"] == 1
+            assert result["success_rate"] == pytest.approx(2 / 3, abs=0.01)
+
+    def test_by_channel_breakdown(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session, "chan@x.com")
+            r_email = _make_reminder(_db.session, user.id, channel="email")
+            r_wa = _make_reminder(_db.session, user.id, channel="whatsapp")
+            _make_log(_db.session, r_email.id, channel="email", success=True)
+            _make_log(_db.session, r_wa.id, channel="whatsapp", success=False)
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session)
+            assert "email" in result["by_channel"]
+            assert "whatsapp" in result["by_channel"]
+            assert result["by_channel"]["email"]["sent"] == 1
+            assert result["by_channel"]["whatsapp"]["failed"] == 1
+
+    def test_avg_latency_calculated(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session, "lat@x.com")
+            r = _make_reminder(_db.session, user.id)
+            _make_log(_db.session, r.id, success=True, latency=60)
+            _make_log(_db.session, r.id, success=True, latency=120)
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session)
+            assert result["avg_latency_seconds"] == pytest.approx(90.0)
+
+    def test_recent_failures_populated(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session, "fail@x.com")
+            r = _make_reminder(_db.session, user.id)
+            for i in range(3):
+                _make_log(_db.session, r.id, success=False, hours_ago=i + 1)
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session)
+            assert len(result["recent_failures"]) == 3
+            assert all("reminder_id" in f for f in result["recent_failures"])
+            assert all("error_message" in f for f in result["recent_failures"])
+
+    def test_pending_reminders_counted(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session, "pend@x.com")
+            _make_reminder(_db.session, user.id, sent=False, offset_hours=1)
+            _make_reminder(_db.session, user.id, sent=False, offset_hours=2)
+            _make_reminder(_db.session, user.id, sent=True, offset_hours=-1)
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session)
+            assert result["pending_reminders"] == 2
+
+    def test_response_shape(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session, "shape@x.com")
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session)
+            for key in [
+                "period_days",
+                "total_reminders_scheduled",
+                "total_attempts",
+                "total_sent",
+                "total_failed",
+                "success_rate",
+                "by_channel",
+                "avg_latency_seconds",
+                "recent_failures",
+                "pending_reminders",
+            ]:
+                assert key in result
+
+    def test_days_period_filter(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user(_db.session, "filter@x.com")
+            r = _make_reminder(_db.session, user.id)
+            # Log from 60 days ago — should NOT appear in 30-day window
+            old_log = ReminderDeliveryLog(
+                reminder_id=r.id,
+                channel="email",
+                attempted_at=datetime.utcnow() - timedelta(days=60),
+                success=True,
+                latency_seconds=30,
+            )
+            _db.session.add(old_log)
+            # Recent log — should appear
+            _make_log(_db.session, r.id, success=True, hours_ago=1)
+            _db.session.commit()
+            result = get_reminder_metrics(user.id, _db.session, days=30)
+            assert result["total_attempts"] == 1  # only the recent one
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests
+# ---------------------------------------------------------------------------
+
+class TestMetricsEndpoint:
+    def test_requires_auth(self, client):
+        resp = client.get("/reminders/metrics")
+        assert resp.status_code in (401, 422)
+
+    def test_endpoint_exists(self, client):
+        resp = client.get("/reminders/metrics")
+        assert resp.status_code != 404
+
+    def test_days_param_accepted(self, client):
+        resp = client.get("/reminders/metrics?days=7")
+        assert resp.status_code in (200, 401, 422)
+
+    # NOTE: tests below require Redis (for JWT refresh token storage via auth_header).
+    # They are marked xfail in environments without Redis, matching the existing test
+    # suite behaviour (see test_reminders.py — same pattern).
+    @pytest.mark.xfail(reason="requires Redis for auth_header fixture", strict=False)
+    def test_authenticated_returns_200(self, client, auth_header):
+        resp = client.get("/reminders/metrics", headers=auth_header)
+        assert resp.status_code == 200
+
+    @pytest.mark.xfail(reason="requires Redis for auth_header fixture", strict=False)
+    def test_authenticated_returns_valid_shape(self, client, auth_header):
+        resp = client.get("/reminders/metrics", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data["period_days"], int)
+        assert isinstance(data["success_rate"], float)
+        assert isinstance(data["by_channel"], dict)
+        assert isinstance(data["recent_failures"], list)
+        assert isinstance(data["pending_reminders"], int)
+
+    @pytest.mark.xfail(reason="requires Redis for auth_header fixture", strict=False)
+    def test_days_param_changes_period(self, client, auth_header):
+        resp = client.get("/reminders/metrics?days=7", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["period_days"] == 7


### PR DESCRIPTION
## Summary

Implements **reminder delivery reliability tracking** for issue #123. This PR adds end-to-end observability for reminder dispatch: every send attempt is logged, and a new metrics endpoint aggregates success rates, failure counts, channel breakdown, and scheduling latency.

---

## Files Changed

| File | Change |
|------|--------|
| `app/models.py` | ➕ `ReminderDeliveryLog` model with indexed FK→reminders |
| `app/services/reminders.py` | 🔧 `send_reminder()` wrapped with delivery logging |
| `app/services/reminder_metrics.py` | ➕ New service — `get_reminder_metrics(uid, session, days)` |
| `app/routes/reminders.py` | ➕ `GET /reminders/metrics?days=30` endpoint |
| `migrations/versions/add_reminder_delivery_log.py` | ➕ Alembic migration |
| `tests/test_reminder_metrics.py` | ➕ 14 tests (11 pass, 3 xfail — pre-existing Redis constraint) |

---

## New Model: `ReminderDeliveryLog`

```python
class ReminderDeliveryLog(db.Model):
    __tablename__ = "reminder_delivery_logs"
    id              = Integer PK
    reminder_id     = FK → reminders.id (CASCADE DELETE)
    channel         = String(20)          # "email" | "whatsapp:+.."
    attempted_at    = DateTime            # when the send was attempted
    success         = Boolean             # True = delivered
    error_message   = String(500)         # populated on failure
    latency_seconds = Integer nullable    # attempted_at − send_at
    # Indexes: ix_delivery_log_reminder, ix_delivery_log_attempted, ix_delivery_log_success
```

---

## API Reference: `GET /reminders/metrics?days=30`

| Param | Type | Default | Description |
|-------|------|---------|-------------|
| `days` | int | 30 | Look-back window (1–365) |

**Auth:** JWT bearer required.

### Sample Response

```json
{
  "period_days": 30,
  "total_reminders_scheduled": 12,
  "total_attempts": 10,
  "total_sent": 8,
  "total_failed": 2,
  "success_rate": 0.8,
  "by_channel": {
    "email": {"attempts": 7, "sent": 6, "failed": 1, "success_rate": 0.8571},
    "whatsapp": {"attempts": 3, "sent": 2, "failed": 1, "success_rate": 0.6667}
  },
  "avg_latency_seconds": 42.5,
  "recent_failures": [
    {"reminder_id": 9, "channel": "email", "attempted_at": "2026-02-24T09:01:00", "error_message": "SMTP connection refused"}
  ],
  "pending_reminders": 2
}
```

---

## How to Test

```bash
cd packages/backend
PYTHONPATH=. pytest tests/test_reminder_metrics.py -v --tb=short
# 11 passed, 3 xfailed (Redis not required for core logic tests)
```

---

## Demo

![Claw 🦾 — FinMind Reminder Reliability Tracking #123](https://github.com/GoThundercats/FinMind/releases/download/demo-1771943379/demo_finmind_reminder_metrics.gif)

---

/claim #123