### PR TITLE
feat: notification priority & grouping system — closes #122

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, Index
 from .extensions import db
 
 
@@ -66,6 +66,19 @@ class RecurringExpense(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class NotificationPriority(str, Enum):
+    LOW    = "LOW"
+    NORMAL = "NORMAL"
+    HIGH   = "HIGH"
+    URGENT = "URGENT"
+
+
+class NotificationType(str, Enum):
+    BILL_REMINDER = "BILL_REMINDER"
+    CUSTOM        = "CUSTOM"
+    SYSTEM        = "SYSTEM"
+
+
 class BillCadence(str, Enum):
     MONTHLY = "MONTHLY"
     WEEKLY = "WEEKLY"
@@ -91,6 +104,11 @@ class Bill(db.Model):
 
 class Reminder(db.Model):
     __tablename__ = "reminders"
+    __table_args__ = (
+        Index("ix_reminder_priority", "user_id", "priority"),
+        Index("ix_reminder_type",     "user_id", "notification_type"),
+        Index("ix_reminder_pending",  "user_id", "sent", "send_at"),
+    )
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     bill_id = db.Column(db.Integer, db.ForeignKey("bills.id"), nullable=True)
@@ -98,6 +116,8 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    priority = db.Column(db.String(10), default=NotificationPriority.NORMAL.value, nullable=False)
+    notification_type = db.Column(db.String(20), default=NotificationType.CUSTOM.value, nullable=False)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .notifications import bp_notifications
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(bp_notifications, url_prefix="/notifications")

--- a/packages/backend/app/routes/notifications.py
+++ b/packages/backend/app/routes/notifications.py
@@ -1,0 +1,79 @@
+"""
+notifications.py — Notification priority management endpoints.
+
+GET  /notifications/grouped              — grouped view (by priority + type)
+POST /notifications/<id>/priority        — update priority on a reminder
+POST /notifications/bulk-prioritise      — auto-assign priorities for all pending
+"""
+import logging
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import NotificationPriority, Reminder
+from ..services.notification_grouping import auto_priority, get_grouped_notifications
+
+bp_notifications = Blueprint("notifications", __name__)
+logger = logging.getLogger("finmind.notification_routes")
+
+_VALID_PRIORITIES = {p.value for p in NotificationPriority}
+
+
+@bp_notifications.get("/grouped")
+@jwt_required()
+def grouped_notifications():
+    """Return pending notifications grouped by priority and type."""
+    uid = int(get_jwt_identity())
+    include_sent = request.args.get("include_sent", "false").lower() == "true"
+    result = get_grouped_notifications(uid, db.session, include_sent=include_sent)
+    return jsonify(result)
+
+
+@bp_notifications.post("/<int:reminder_id>/priority")
+@jwt_required()
+def set_priority(reminder_id: int):
+    """
+    Manually set the priority of a notification.
+    Body: {"priority": "URGENT"|"HIGH"|"NORMAL"|"LOW"}
+    """
+    uid = int(get_jwt_identity())
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder or reminder.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    priority = (data.get("priority") or "").upper()
+    if priority not in _VALID_PRIORITIES:
+        return jsonify(error=f"priority must be one of {sorted(_VALID_PRIORITIES)}"), 400
+
+    reminder.priority = priority
+    db.session.commit()
+    logger.info("Set priority reminder=%s user=%s priority=%s", reminder_id, uid, priority)
+    return jsonify({"reminder_id": reminder_id, "priority": priority})
+
+
+@bp_notifications.post("/bulk-prioritise")
+@jwt_required()
+def bulk_prioritise():
+    """
+    Auto-assign priorities to all pending notifications based on context
+    (bill due date proximity for BILL_REMINDERs, NORMAL for others).
+
+    Returns count of updated notifications.
+    """
+    uid = int(get_jwt_identity())
+    pending = (
+        db.session.query(Reminder)
+        .filter(Reminder.user_id == uid, Reminder.sent == False)  # noqa: E712
+        .all()
+    )
+    updated = 0
+    for r in pending:
+        new_prio = auto_priority(r, db.session)
+        if r.priority != new_prio:
+            r.priority = new_prio
+            updated += 1
+    db.session.commit()
+    logger.info("Bulk-prioritised user=%s updated=%d", uid, updated)
+    return jsonify({"updated": updated, "total_pending": len(pending)})

--- a/packages/backend/app/services/notification_grouping.py
+++ b/packages/backend/app/services/notification_grouping.py
@@ -1,0 +1,143 @@
+"""
+notification_grouping.py — Notification priority and grouping service.
+
+Provides:
+  - auto_priority(reminder, session) -> str   Priority inference from context
+  - get_grouped_notifications(uid, session, include_sent=False) -> dict
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from ..models import Bill, NotificationPriority, NotificationType, Reminder
+
+logger = logging.getLogger("finmind.notifications")
+
+# Days-to-due thresholds for auto-priority
+_URGENT_DAYS = 1
+_HIGH_DAYS   = 3
+_NORMAL_DAYS = 7
+
+
+def auto_priority(reminder: Reminder, session: Session) -> str:
+    """
+    Infer notification priority from context.
+
+    Rules (in priority order):
+    1. BILL_REMINDER with bill due in <= 1 day  → URGENT
+    2. BILL_REMINDER with bill due in <= 3 days → HIGH
+    3. BILL_REMINDER with bill due in <= 7 days → NORMAL
+    4. BILL_REMINDER due > 7 days away          → LOW
+    5. CUSTOM / SYSTEM                          → NORMAL
+    """
+    if reminder.notification_type == NotificationType.BILL_REMINDER.value and reminder.bill_id:
+        bill = session.get(Bill, reminder.bill_id)
+        if bill:
+            days_left = (bill.next_due_date - date.today()).days
+            if days_left <= _URGENT_DAYS:
+                return NotificationPriority.URGENT.value
+            if days_left <= _HIGH_DAYS:
+                return NotificationPriority.HIGH.value
+            if days_left <= _NORMAL_DAYS:
+                return NotificationPriority.NORMAL.value
+            return NotificationPriority.LOW.value
+    return NotificationPriority.NORMAL.value
+
+
+def get_grouped_notifications(
+    uid: int,
+    session: Session,
+    include_sent: bool = False,
+) -> dict:
+    """
+    Return notifications grouped by priority, then by notification_type.
+
+    Returns:
+    {
+      "total": <int>,
+      "by_priority": {
+        "URGENT": {"count": <int>, "items": [<notification>, ...]},
+        "HIGH":   {"count": <int>, "items": [...]},
+        "NORMAL": {"count": <int>, "items": [...]},
+        "LOW":    {"count": <int>, "items": [...]},
+      },
+      "by_type": {
+        "BILL_REMINDER": {"count": <int>, "items": [...]},
+        "CUSTOM":        {"count": <int>, "items": [...]},
+        "SYSTEM":        {"count": <int>, "items": [...]},
+      },
+      "summary": {
+        "urgent_count": <int>,
+        "overdue_count": <int>,   # send_at < now and not sent
+        "upcoming_24h": <int>,    # due within next 24 hours
+      }
+    }
+    """
+    q = session.query(Reminder).filter(Reminder.user_id == uid)
+    if not include_sent:
+        q = q.filter(Reminder.sent == False)  # noqa: E712
+    reminders = q.order_by(Reminder.send_at.asc()).all()
+
+    now = datetime.utcnow()
+
+    def serialise(r: Reminder) -> dict:
+        return {
+            "id":                r.id,
+            "message":           r.message,
+            "send_at":           r.send_at.isoformat(),
+            "sent":              r.sent,
+            "channel":           r.channel,
+            "priority":          r.priority,
+            "notification_type": r.notification_type,
+            "bill_id":           r.bill_id,
+            "overdue":           r.send_at < now and not r.sent,
+        }
+
+    by_priority: dict[str, dict] = {
+        p.value: {"count": 0, "items": []}
+        for p in NotificationPriority
+    }
+    by_type: dict[str, dict] = {
+        t.value: {"count": 0, "items": []}
+        for t in NotificationType
+    }
+
+    overdue_count = 0
+    upcoming_24h  = 0
+    cutoff_24h    = now + timedelta(hours=24)
+
+    for r in reminders:
+        item = serialise(r)
+        prio  = r.priority          or NotificationPriority.NORMAL.value
+        ntype = r.notification_type or NotificationType.CUSTOM.value
+
+        if prio in by_priority:
+            by_priority[prio]["count"] += 1
+            by_priority[prio]["items"].append(item)
+        if ntype in by_type:
+            by_type[ntype]["count"] += 1
+            by_type[ntype]["items"].append(item)
+
+        if item["overdue"]:
+            overdue_count += 1
+        if not r.sent and now <= r.send_at <= cutoff_24h:
+            upcoming_24h += 1
+
+    logger.info(
+        "Grouped notifications user=%s total=%d urgent=%d overdue=%d",
+        uid, len(reminders), by_priority["URGENT"]["count"], overdue_count,
+    )
+
+    return {
+        "total": len(reminders),
+        "by_priority": by_priority,
+        "by_type": by_type,
+        "summary": {
+            "urgent_count":  by_priority["URGENT"]["count"],
+            "overdue_count": overdue_count,
+            "upcoming_24h":  upcoming_24h,
+        },
+    }

--- a/packages/backend/migrations/versions/add_notification_priority.py
+++ b/packages/backend/migrations/versions/add_notification_priority.py
@@ -1,0 +1,29 @@
+"""Add priority and notification_type columns to reminders
+
+Revision ID: g7h8i9j0k1l2
+Revises: None
+Create Date: 2026-02-24
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'g7h8i9j0k1l2'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reminders', sa.Column('priority',          sa.String(10), nullable=False, server_default='NORMAL'))
+    op.add_column('reminders', sa.Column('notification_type', sa.String(20), nullable=False, server_default='CUSTOM'))
+    op.create_index('ix_reminder_priority', 'reminders', ['user_id', 'priority'])
+    op.create_index('ix_reminder_type',     'reminders', ['user_id', 'notification_type'])
+    op.create_index('ix_reminder_pending',  'reminders', ['user_id', 'sent', 'send_at'])
+
+
+def downgrade():
+    op.drop_index('ix_reminder_pending',  table_name='reminders')
+    op.drop_index('ix_reminder_type',     table_name='reminders')
+    op.drop_index('ix_reminder_priority', table_name='reminders')
+    op.drop_column('reminders', 'notification_type')
+    op.drop_column('reminders', 'priority')

--- a/packages/backend/tests/test_notification_priority.py
+++ b/packages/backend/tests/test_notification_priority.py
@@ -1,0 +1,194 @@
+"""Tests for notification priority and grouping system."""
+import pytest
+from datetime import datetime, timedelta, date
+
+from app import create_app
+from app.config import Settings
+from app.extensions import db as _db
+from app.models import (
+    User, Bill, Reminder, BillCadence,
+    NotificationPriority, NotificationType,
+)
+from app.services.notification_grouping import auto_priority, get_grouped_notifications
+
+
+@pytest.fixture
+def app():
+    settings = Settings(
+        database_url="sqlite:///:memory:",
+        redis_url="redis://localhost:6379/0",
+        jwt_secret="test-secret",
+    )
+    application = create_app(settings)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture
+def db(app):
+    with app.app_context():
+        _db.create_all()
+        yield _db
+        _db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _make_user(email="u@x.com"):
+    return User(email=email, password_hash="x", preferred_currency="INR")
+
+
+def _make_bill(user_id, days_until_due=5, name="Electric"):
+    return Bill(
+        user_id=user_id, name=name, amount=500,
+        currency="INR",
+        next_due_date=date.today() + timedelta(days=days_until_due),
+        cadence=BillCadence.MONTHLY,
+    )
+
+
+def _make_reminder(user_id, bill_id=None, priority="NORMAL",
+                   ntype="CUSTOM", hours_from_now=1, sent=False):
+    return Reminder(
+        user_id=user_id,
+        bill_id=bill_id,
+        message="Test notification",
+        send_at=datetime.utcnow() + timedelta(hours=hours_from_now),
+        sent=sent,
+        channel="email",
+        priority=priority,
+        notification_type=ntype,
+    )
+
+
+class TestAutoPriority:
+    def test_urgent_for_bill_due_today(self, app, db):
+        with app.app_context():
+            user = _make_user("ap1@x.com")
+            _db.session.add(user)
+            _db.session.flush()
+            bill = _make_bill(user.id, days_until_due=0)
+            _db.session.add(bill)
+            _db.session.flush()
+            r = _make_reminder(user.id, bill_id=bill.id, ntype="BILL_REMINDER")
+            _db.session.add(r)
+            _db.session.commit()
+            prio = auto_priority(r, _db.session)
+            assert prio == NotificationPriority.URGENT.value
+
+    def test_high_for_bill_due_in_2_days(self, app, db):
+        with app.app_context():
+            user = _make_user("ap2@x.com")
+            _db.session.add(user)
+            _db.session.flush()
+            bill = _make_bill(user.id, days_until_due=2)
+            _db.session.add(bill)
+            _db.session.flush()
+            r = _make_reminder(user.id, bill_id=bill.id, ntype="BILL_REMINDER")
+            _db.session.add(r)
+            _db.session.commit()
+            prio = auto_priority(r, _db.session)
+            assert prio == NotificationPriority.HIGH.value
+
+    def test_low_for_bill_due_in_14_days(self, app, db):
+        with app.app_context():
+            user = _make_user("ap3@x.com")
+            _db.session.add(user)
+            _db.session.flush()
+            bill = _make_bill(user.id, days_until_due=14)
+            _db.session.add(bill)
+            _db.session.flush()
+            r = _make_reminder(user.id, bill_id=bill.id, ntype="BILL_REMINDER")
+            _db.session.add(r)
+            _db.session.commit()
+            prio = auto_priority(r, _db.session)
+            assert prio == NotificationPriority.LOW.value
+
+    def test_normal_for_custom_notification(self, app, db):
+        with app.app_context():
+            user = _make_user("ap4@x.com")
+            _db.session.add(user)
+            _db.session.flush()
+            r = _make_reminder(user.id, ntype="CUSTOM")
+            _db.session.add(r)
+            _db.session.commit()
+            prio = auto_priority(r, _db.session)
+            assert prio == NotificationPriority.NORMAL.value
+
+
+class TestGetGroupedNotifications:
+    def _seed(self, app, db, email="g@x.com"):
+        with app.app_context():
+            user = _make_user(email)
+            _db.session.add(user)
+            _db.session.flush()
+            r_urgent = _make_reminder(user.id, priority="URGENT", ntype="BILL_REMINDER")
+            r_high   = _make_reminder(user.id, priority="HIGH",   ntype="BILL_REMINDER")
+            r_normal = _make_reminder(user.id, priority="NORMAL", ntype="CUSTOM")
+            r_sent   = _make_reminder(user.id, priority="NORMAL", ntype="CUSTOM", sent=True)
+            _db.session.add_all([r_urgent, r_high, r_normal, r_sent])
+            _db.session.commit()
+            return user.id
+
+    def test_excludes_sent_by_default(self, app, db):
+        uid = self._seed(app, db)
+        with app.app_context():
+            result = get_grouped_notifications(uid, _db.session, include_sent=False)
+            assert result["total"] == 3  # sent one excluded
+
+    def test_includes_sent_when_flagged(self, app, db):
+        uid = self._seed(app, db, email="g2@x.com")
+        with app.app_context():
+            result = get_grouped_notifications(uid, _db.session, include_sent=True)
+            assert result["total"] == 4
+
+    def test_urgent_bucket_populated(self, app, db):
+        uid = self._seed(app, db, email="g3@x.com")
+        with app.app_context():
+            result = get_grouped_notifications(uid, _db.session)
+            assert result["by_priority"]["URGENT"]["count"] == 1
+
+    def test_by_type_buckets_present(self, app, db):
+        uid = self._seed(app, db, email="g4@x.com")
+        with app.app_context():
+            result = get_grouped_notifications(uid, _db.session)
+            assert "BILL_REMINDER" in result["by_type"]
+            assert "CUSTOM" in result["by_type"]
+
+    def test_summary_keys_present(self, app, db):
+        uid = self._seed(app, db, email="g5@x.com")
+        with app.app_context():
+            result = get_grouped_notifications(uid, _db.session)
+            for k in ["urgent_count", "overdue_count", "upcoming_24h"]:
+                assert k in result["summary"]
+
+    def test_empty_user_returns_zero(self, app, db):
+        with app.app_context():
+            _db.create_all()
+            user = _make_user("empty@x.com")
+            _db.session.add(user)
+            _db.session.commit()
+            result = get_grouped_notifications(user.id, _db.session)
+            assert result["total"] == 0
+            assert result["summary"]["urgent_count"] == 0
+
+
+class TestNotificationEndpoints:
+    def test_grouped_requires_auth(self, client):
+        resp = client.get("/notifications/grouped")
+        assert resp.status_code in (401, 422)
+
+    def test_grouped_endpoint_exists(self, client):
+        resp = client.get("/notifications/grouped")
+        assert resp.status_code != 404
+
+    def test_set_priority_requires_auth(self, client):
+        resp = client.post("/notifications/1/priority", json={"priority": "HIGH"})
+        assert resp.status_code in (401, 404, 422)
+
+    def test_bulk_prioritise_requires_auth(self, client):
+        resp = client.post("/notifications/bulk-prioritise")
+        assert resp.status_code in (401, 422)


### PR DESCRIPTION
## Summary

Implements a full notification priority and grouping system for FinMind reminders. Adds `priority` (LOW/NORMAL/HIGH/URGENT) and `notification_type` (BILL_REMINDER/CUSTOM/SYSTEM) fields to the `Reminder` model, smart auto-priority inference based on bill due date proximity, and three new REST endpoints for grouped views and priority management.

## Files Changed

| File | Change |
|------|--------|
| `app/models.py` | Added `NotificationPriority` + `NotificationType` enums; new columns + indexes on `Reminder` |
| `app/services/notification_grouping.py` | New: `auto_priority()` + `get_grouped_notifications()` |
| `app/routes/notifications.py` | New: 3 endpoints (grouped, set priority, bulk-prioritise) |
| `app/routes/__init__.py` | Register `bp_notifications` at `/notifications` |
| `migrations/versions/add_notification_priority.py` | Alembic migration: add columns + indexes |
| `tests/test_notification_priority.py` | 14 passing tests |

## API Reference

### `GET /notifications/grouped`
Returns pending notifications grouped by priority and type.

**Query params:** `include_sent=true` to include already-sent notifications.

**Sample response:**
```json
{
  "total": 3,
  "by_priority": {
    "URGENT": {"count": 1, "items": [{"id": 5, "message": "Bill due today!", "priority": "URGENT", "notification_type": "BILL_REMINDER", ...}]},
    "HIGH":   {"count": 1, "items": [...]},
    "NORMAL": {"count": 1, "items": [...]},
    "LOW":    {"count": 0, "items": []}
  },
  "by_type": {
    "BILL_REMINDER": {"count": 2, "items": [...]},
    "CUSTOM":        {"count": 1, "items": [...]},
    "SYSTEM":        {"count": 0, "items": []}
  },
  "summary": {
    "urgent_count": 1,
    "overdue_count": 0,
    "upcoming_24h": 2
  }
}
```

### `POST /notifications/<id>/priority`
Manually override the priority of a single notification.
```json
{ "priority": "URGENT" }
```

### `POST /notifications/bulk-prioritise`
Auto-assigns priorities to all pending notifications based on context (bill due date proximity for BILL_REMINDERs, NORMAL for others).
```json
{ "updated": 5, "total_pending": 8 }
```

## Auto-Priority Logic

| Days until bill due | Priority |
|---------------------|----------|
| ≤ 1 day             | URGENT   |
| ≤ 3 days            | HIGH     |
| ≤ 7 days            | NORMAL   |
| > 7 days            | LOW      |
| CUSTOM / SYSTEM     | NORMAL   |

## How to Test

```bash
cd packages/backend
PYTHONPATH=. /tmp/finmind_venv/bin/pytest tests/test_notification_priority.py -v
# 14 passed in 0.19s
```

## Demo

![Claw 🦾 — FinMind Notification Priority & Grouping #122](https://github.com/GoThundercats/FinMind/releases/download/demo-1771943700/demo_finmind_notifications.gif)

/claim #122