### PR TITLE
feat: Resilient background job retry & monitoring (fixes #130)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .jobs import bp as jobs_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(jobs_bp, url_prefix="/jobs")

--- a/packages/backend/app/routes/jobs.py
+++ b/packages/backend/app/routes/jobs.py
@@ -1,0 +1,64 @@
+"""API routes for background job monitoring (#130)."""
+
+import logging
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.job_queue import (
+    BackgroundJob, JobStatus, enqueue, process_pending, get_job_stats,
+)
+from ..extensions import db
+
+bp = Blueprint("jobs", __name__)
+logger = logging.getLogger("finmind.jobs")
+
+
+@bp.get("")
+@jwt_required()
+def list_jobs():
+    """List jobs with optional status filter."""
+    status = request.args.get("status")
+    q = BackgroundJob.query.order_by(BackgroundJob.created_at.desc())
+    if status:
+        q = q.filter_by(status=status.upper())
+    jobs = q.limit(100).all()
+    return jsonify([_serialize(j) for j in jobs])
+
+
+@bp.get("/stats")
+@jwt_required()
+def job_stats():
+    """Return job queue statistics."""
+    return jsonify(get_job_stats())
+
+
+@bp.get("/<int:job_id>")
+@jwt_required()
+def get_job(job_id: int):
+    job = db.session.get(BackgroundJob, job_id)
+    if not job:
+        return jsonify(error="not found"), 404
+    return jsonify(_serialize(job))
+
+
+@bp.post("/process")
+@jwt_required()
+def trigger_processing():
+    """Manually trigger processing of pending jobs."""
+    count = process_pending()
+    return jsonify(processed=count)
+
+
+def _serialize(job: BackgroundJob) -> dict:
+    return {
+        "id": job.id,
+        "name": job.name,
+        "payload": job.payload,
+        "status": job.status,
+        "attempts": job.attempts,
+        "max_retries": job.max_retries,
+        "last_error": job.last_error,
+        "next_retry_at": job.next_retry_at.isoformat() if job.next_retry_at else None,
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+        "created_at": job.created_at.isoformat(),
+    }

--- a/packages/backend/app/services/job_queue.py
+++ b/packages/backend/app/services/job_queue.py
@@ -1,0 +1,139 @@
+"""Resilient background job queue with retry logic and monitoring (#130).
+
+Provides a simple in-process job queue backed by SQLAlchemy for persistence.
+Jobs support configurable max retries with exponential backoff.
+"""
+
+import logging
+import traceback
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Callable, Dict, Optional
+
+from ..extensions import db
+
+logger = logging.getLogger("finmind.job_queue")
+
+
+class JobStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    RETRYING = "RETRYING"
+
+
+class BackgroundJob(db.Model):
+    __tablename__ = "background_jobs"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    payload = db.Column(db.JSON, nullable=True)
+    status = db.Column(db.String(20), default=JobStatus.PENDING.value, nullable=False)
+    attempts = db.Column(db.Integer, default=0, nullable=False)
+    max_retries = db.Column(db.Integer, default=3, nullable=False)
+    last_error = db.Column(db.Text, nullable=True)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    started_at = db.Column(db.DateTime, nullable=True)
+    completed_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+# Registry of job handlers
+_handlers: Dict[str, Callable] = {}
+
+
+def register_handler(name: str, handler: Callable) -> None:
+    """Register a named job handler function."""
+    _handlers[name] = handler
+
+
+def enqueue(name: str, payload: dict = None, max_retries: int = 3) -> BackgroundJob:
+    """Create a new background job."""
+    if name not in _handlers:
+        raise ValueError(f"No handler registered for job '{name}'")
+    job = BackgroundJob(name=name, payload=payload or {}, max_retries=max_retries)
+    db.session.add(job)
+    db.session.commit()
+    logger.info("Enqueued job id=%s name=%s", job.id, name)
+    return job
+
+
+def process_pending() -> int:
+    """Process all pending/retrying jobs. Returns count of jobs processed."""
+    now = datetime.utcnow()
+    jobs = (
+        BackgroundJob.query
+        .filter(
+            BackgroundJob.status.in_([JobStatus.PENDING.value, JobStatus.RETRYING.value]),
+            db.or_(
+                BackgroundJob.next_retry_at.is_(None),
+                BackgroundJob.next_retry_at <= now,
+            ),
+        )
+        .order_by(BackgroundJob.created_at)
+        .all()
+    )
+
+    processed = 0
+    for job in jobs:
+        _execute_job(job)
+        processed += 1
+
+    return processed
+
+
+def _execute_job(job: BackgroundJob) -> None:
+    """Execute a single job with error handling and retry logic."""
+    handler = _handlers.get(job.name)
+    if not handler:
+        job.status = JobStatus.FAILED.value
+        job.last_error = f"No handler for '{job.name}'"
+        db.session.commit()
+        return
+
+    job.status = JobStatus.RUNNING.value
+    job.started_at = datetime.utcnow()
+    job.attempts += 1
+    db.session.commit()
+
+    try:
+        handler(job.payload)
+        job.status = JobStatus.COMPLETED.value
+        job.completed_at = datetime.utcnow()
+        job.last_error = None
+        logger.info("Job id=%s completed (attempt %s)", job.id, job.attempts)
+    except Exception as exc:
+        error_msg = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+        job.last_error = error_msg[:2000]
+
+        if job.attempts < job.max_retries:
+            backoff = min(2 ** job.attempts * 30, 3600)  # 30s, 60s, 120s... max 1h
+            job.status = JobStatus.RETRYING.value
+            job.next_retry_at = datetime.utcnow() + timedelta(seconds=backoff)
+            logger.warning(
+                "Job id=%s failed (attempt %s/%s), retry in %ss: %s",
+                job.id, job.attempts, job.max_retries, backoff, exc,
+            )
+        else:
+            job.status = JobStatus.FAILED.value
+            logger.error(
+                "Job id=%s permanently failed after %s attempts: %s",
+                job.id, job.attempts, exc,
+            )
+
+    db.session.commit()
+
+
+def get_job_stats() -> dict:
+    """Return job queue statistics."""
+    from sqlalchemy import func
+    rows = (
+        db.session.query(BackgroundJob.status, func.count(BackgroundJob.id))
+        .group_by(BackgroundJob.status)
+        .all()
+    )
+    stats = {s.value: 0 for s in JobStatus}
+    for status, count in rows:
+        stats[status] = count
+    stats["total"] = sum(stats.values())
+    return stats

--- a/packages/backend/tests/test_job_queue.py
+++ b/packages/backend/tests/test_job_queue.py
@@ -1,0 +1,150 @@
+"""Tests for resilient background job retry & monitoring (#130)."""
+
+import pytest
+from app.services.job_queue import (
+    BackgroundJob, JobStatus, register_handler, enqueue, process_pending, get_job_stats,
+)
+from app.extensions import db
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def _success_handler(payload):
+    """A handler that always succeeds."""
+    pass
+
+
+def _fail_handler(payload):
+    """A handler that always fails."""
+    raise RuntimeError("intentional failure")
+
+
+_call_count = 0
+
+def _fail_then_succeed(payload):
+    """Fails on first call, succeeds on second."""
+    global _call_count
+    _call_count += 1
+    if _call_count <= payload.get("fail_times", 1):
+        raise RuntimeError(f"fail #{_call_count}")
+
+
+@pytest.fixture(autouse=True)
+def _register_handlers(app):
+    register_handler("test_success", _success_handler)
+    register_handler("test_fail", _fail_handler)
+    register_handler("test_retry", _fail_then_succeed)
+    global _call_count
+    _call_count = 0
+    yield
+
+
+# ── Unit tests ───────────────────────────────────────────────────────
+
+class TestEnqueue:
+    def test_creates_pending_job(self, app):
+        with app.app_context():
+            job = enqueue("test_success", {"key": "val"})
+            assert job.id is not None
+            assert job.status == JobStatus.PENDING.value
+            assert job.attempts == 0
+            assert job.payload == {"key": "val"}
+
+    def test_unknown_handler_raises(self, app):
+        with app.app_context():
+            with pytest.raises(ValueError, match="No handler"):
+                enqueue("nonexistent")
+
+
+class TestProcessing:
+    def test_success_job(self, app):
+        with app.app_context():
+            job = enqueue("test_success")
+            count = process_pending()
+            assert count == 1
+            db.session.refresh(job)
+            assert job.status == JobStatus.COMPLETED.value
+            assert job.attempts == 1
+            assert job.completed_at is not None
+            assert job.last_error is None
+
+    def test_failed_job_retries(self, app):
+        with app.app_context():
+            job = enqueue("test_fail", max_retries=3)
+            process_pending()
+            db.session.refresh(job)
+            assert job.status == JobStatus.RETRYING.value
+            assert job.attempts == 1
+            assert job.next_retry_at is not None
+            assert "intentional failure" in job.last_error
+
+    def test_permanent_failure_after_max_retries(self, app):
+        with app.app_context():
+            job = enqueue("test_fail", max_retries=1)
+            # First attempt
+            process_pending()
+            db.session.refresh(job)
+            assert job.status == JobStatus.FAILED.value
+            assert job.attempts == 1
+
+    def test_retry_then_succeed(self, app):
+        with app.app_context():
+            job = enqueue("test_retry", {"fail_times": 1}, max_retries=3)
+            # First attempt - fails
+            process_pending()
+            db.session.refresh(job)
+            assert job.status == JobStatus.RETRYING.value
+            # Force next_retry_at to now so it gets picked up
+            job.next_retry_at = None
+            db.session.commit()
+            # Second attempt - succeeds
+            process_pending()
+            db.session.refresh(job)
+            assert job.status == JobStatus.COMPLETED.value
+            assert job.attempts == 2
+
+    def test_no_pending_jobs(self, app):
+        with app.app_context():
+            count = process_pending()
+            assert count == 0
+
+
+class TestStats:
+    def test_empty_stats(self, app):
+        with app.app_context():
+            stats = get_job_stats()
+            assert stats["total"] == 0
+
+    def test_stats_after_jobs(self, app):
+        with app.app_context():
+            enqueue("test_success")
+            enqueue("test_fail", max_retries=1)
+            process_pending()
+            stats = get_job_stats()
+            assert stats[JobStatus.COMPLETED.value] == 1
+            assert stats[JobStatus.FAILED.value] == 1
+            assert stats["total"] == 2
+
+
+# ── API tests ────────────────────────────────────────────────────────
+
+class TestJobsAPI:
+    def test_list_empty(self, client, auth_header):
+        r = client.get("/jobs", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json() == []
+
+    def test_stats_endpoint(self, client, auth_header):
+        r = client.get("/jobs/stats", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "total" in data
+
+    def test_get_nonexistent(self, client, auth_header):
+        r = client.get("/jobs/99999", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_trigger_processing(self, client, auth_header):
+        r = client.post("/jobs/process", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["processed"] == 0


### PR DESCRIPTION
## Summary
Improves reliability of async job execution with a persistent job queue, configurable retries, and monitoring endpoints.

## Changes
### Backend
- `BackgroundJob` model with status tracking (PENDING/RUNNING/COMPLETED/FAILED/RETRYING)
- Job handler registry pattern (`register_handler`, `enqueue`, `process_pending`)
- Exponential backoff retry: 30s → 60s → 120s... (max 1 hour)
- Error capture with stack traces (truncated to 2000 chars)
- Queue statistics aggregation

### API Endpoints
- `GET /jobs` — list jobs with optional status filter
- `GET /jobs/stats` — queue statistics by status
- `GET /jobs/:id` — single job details
- `POST /jobs/process` — manually trigger pending job processing

### Tests
- Enqueue and handler registration
- Success, failure, and retry-then-succeed scenarios
- Permanent failure after max retries
- Stats aggregation
- All API endpoints

Fixes #130