### PR TITLE
feat: Auto-detect subscriptions from recurring charges (fixes #109)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .subscriptions import bp as subscriptions_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(subscriptions_bp, url_prefix="/subscriptions")

--- a/packages/backend/app/routes/subscriptions.py
+++ b/packages/backend/app/routes/subscriptions.py
@@ -1,0 +1,26 @@
+import logging
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.subscription_detect import detect_subscriptions
+
+bp = Blueprint("subscriptions", __name__)
+logger = logging.getLogger("finmind.subscriptions")
+
+
+@bp.get("/detect")
+@jwt_required()
+def detect():
+    """Return auto-detected subscriptions from the user's expense history."""
+    uid = int(get_jwt_identity())
+
+    try:
+        min_occ = int(request.args.get("min_occurrences", "3"))
+        tolerance = int(request.args.get("tolerance_days", "5"))
+    except ValueError:
+        return jsonify(error="invalid query parameters"), 400
+
+    results = detect_subscriptions(uid, min_occurrences=min_occ, tolerance_days=tolerance)
+    logger.info("Subscription detect user=%s found=%s", uid, len(results))
+    return jsonify(results)

--- a/packages/backend/app/services/subscription_detect.py
+++ b/packages/backend/app/services/subscription_detect.py
@@ -1,0 +1,117 @@
+"""Auto-detect subscriptions from recurring charges in expense history.
+
+Scans a user's expenses looking for repeated (merchant, amount) pairs that
+recur on a roughly monthly cadence.  A charge is considered a likely
+subscription when it appears at least ``min_occurrences`` times with
+consecutive gaps within ``tolerance_days`` of 30 days.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from typing import List
+
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Expense
+
+
+def detect_subscriptions(
+    user_id: int,
+    *,
+    min_occurrences: int = 3,
+    tolerance_days: int = 5,
+) -> List[dict]:
+    """Return a list of detected subscription-like charges.
+
+    Each entry contains:
+        merchant   – the expense description (notes)
+        amount     – the recurring amount
+        currency   – currency code
+        occurrences – how many times the charge appeared
+        first_seen – earliest date
+        last_seen  – latest date
+        cadence    – estimated cadence label (e.g. "MONTHLY")
+    """
+
+    # Group expenses by (notes, amount, currency) with at least min_occurrences
+    groups = (
+        db.session.query(
+            Expense.notes,
+            Expense.amount,
+            Expense.currency,
+            func.count(Expense.id).label("cnt"),
+            func.min(Expense.spent_at).label("first_seen"),
+            func.max(Expense.spent_at).label("last_seen"),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            Expense.notes.isnot(None),
+            Expense.notes != "",
+        )
+        .group_by(Expense.notes, Expense.amount, Expense.currency)
+        .having(func.count(Expense.id) >= min_occurrences)
+        .all()
+    )
+
+    results: List[dict] = []
+
+    for notes, amount, currency, cnt, first_seen, last_seen in groups:
+        # Fetch individual dates to verify cadence
+        dates = [
+            row[0]
+            for row in db.session.query(Expense.spent_at)
+            .filter(
+                Expense.user_id == user_id,
+                Expense.notes == notes,
+                Expense.amount == amount,
+                Expense.currency == currency,
+            )
+            .order_by(Expense.spent_at)
+            .all()
+        ]
+
+        cadence = _estimate_cadence(dates, tolerance_days)
+        if cadence is None:
+            continue
+
+        results.append(
+            {
+                "merchant": notes,
+                "amount": float(amount),
+                "currency": currency,
+                "occurrences": cnt,
+                "first_seen": first_seen.isoformat() if isinstance(first_seen, date) else str(first_seen),
+                "last_seen": last_seen.isoformat() if isinstance(last_seen, date) else str(last_seen),
+                "cadence": cadence,
+            }
+        )
+
+    return results
+
+
+def _estimate_cadence(dates: list[date], tolerance: int) -> str | None:
+    """Return a cadence label if consecutive gaps are consistent, else None."""
+    if len(dates) < 2:
+        return None
+
+    gaps = [(dates[i + 1] - dates[i]).days for i in range(len(dates) - 1)]
+    avg_gap = sum(gaps) / len(gaps)
+
+    cadence_map = [
+        ("WEEKLY", 7),
+        ("MONTHLY", 30),
+        ("YEARLY", 365),
+    ]
+
+    for label, expected in cadence_map:
+        if all(abs(g - expected) <= tolerance for g in gaps):
+            return label
+
+    # Fallback: check if average gap is close to monthly
+    if abs(avg_gap - 30) <= tolerance:
+        return "MONTHLY"
+
+    return None

--- a/packages/backend/tests/test_subscription_detect.py
+++ b/packages/backend/tests/test_subscription_detect.py
@@ -1,0 +1,73 @@
+from datetime import date, timedelta
+
+
+def _create_expense(client, auth_header, description, amount, spent_at):
+    return client.post(
+        "/expenses",
+        json={
+            "description": description,
+            "amount": amount,
+            "date": spent_at.isoformat(),
+        },
+        headers=auth_header,
+    )
+
+
+def test_detect_subscriptions_finds_monthly_pattern(client, auth_header):
+    """Three identical charges ~30 days apart should be detected."""
+    base = date(2025, 1, 15)
+    for i in range(3):
+        r = _create_expense(
+            client, auth_header, "Netflix", 15.99, base + timedelta(days=30 * i)
+        )
+        assert r.status_code == 201
+
+    r = client.get("/subscriptions/detect", headers=auth_header)
+    assert r.status_code == 200
+    subs = r.get_json()
+    assert len(subs) == 1
+    assert subs[0]["merchant"] == "Netflix"
+    assert subs[0]["amount"] == 15.99
+    assert subs[0]["cadence"] == "MONTHLY"
+    assert subs[0]["occurrences"] == 3
+
+
+def test_detect_subscriptions_ignores_irregular(client, auth_header):
+    """Charges with irregular gaps should not be detected."""
+    dates = [date(2025, 1, 1), date(2025, 2, 1), date(2025, 5, 20)]
+    for d in dates:
+        r = _create_expense(client, auth_header, "RandomShop", 25.00, d)
+        assert r.status_code == 201
+
+    r = client.get("/subscriptions/detect", headers=auth_header)
+    assert r.status_code == 200
+    subs = r.get_json()
+    merchants = [s["merchant"] for s in subs]
+    assert "RandomShop" not in merchants
+
+
+def test_detect_subscriptions_empty(client, auth_header):
+    """No expenses should return empty list."""
+    r = client.get("/subscriptions/detect", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_detect_subscriptions_weekly(client, auth_header):
+    """Weekly recurring charges should be detected."""
+    base = date(2025, 3, 1)
+    for i in range(4):
+        r = _create_expense(
+            client, auth_header, "Gym", 10.00, base + timedelta(weeks=i)
+        )
+        assert r.status_code == 201
+
+    r = client.get(
+        "/subscriptions/detect?min_occurrences=3&tolerance_days=2",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    subs = r.get_json()
+    gym = [s for s in subs if s["merchant"] == "Gym"]
+    assert len(gym) == 1
+    assert gym[0]["cadence"] == "WEEKLY"


### PR DESCRIPTION
## Summary
Auto-detect subscriptions by analyzing expense history for recurring (merchant, amount) patterns.

### Changes
- **New service** `subscription_detect.py`: Scans expenses for repeated charges with consistent cadence (weekly/monthly/yearly)
- **New endpoint** `GET /subscriptions/detect`: Returns detected subscriptions with configurable `min_occurrences` and `tolerance_days` query params
- **Tests**: Covers monthly, weekly, irregular, and empty cases

### How it works
1. Groups expenses by (description, amount, currency)
2. Filters groups with >= min_occurrences
3. Validates that consecutive gaps match a known cadence within tolerance
4. Returns merchant, amount, cadence, occurrence count, and date range

Fixes #109