### PR TITLE
feat: Reminder reliability tracking & delivery metrics (fixes #123)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .delivery_metrics import bp as delivery_metrics_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(delivery_metrics_bp, url_prefix="/delivery")

--- a/packages/backend/app/routes/delivery_metrics.py
+++ b/packages/backend/app/routes/delivery_metrics.py
@@ -1,0 +1,59 @@
+"""API routes for reminder delivery metrics (#123)."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.delivery_metrics import (
+    log_delivery, get_delivery_metrics, get_delivery_history,
+)
+
+bp = Blueprint("delivery_metrics", __name__)
+
+
+def _serialize(entry):
+    return {
+        "id": entry.id,
+        "reminder_id": entry.reminder_id,
+        "channel": entry.channel,
+        "status": entry.status,
+        "error_message": entry.error_message,
+        "sent_at": entry.sent_at.isoformat(),
+        "delivered_at": entry.delivered_at.isoformat() if entry.delivered_at else None,
+        "latency_ms": entry.latency_ms,
+    }
+
+
+@bp.get("/metrics")
+@jwt_required()
+def metrics():
+    uid = int(get_jwt_identity())
+    days = request.args.get("days", 30, type=int)
+    return jsonify(get_delivery_metrics(uid, days=days))
+
+
+@bp.get("/history")
+@jwt_required()
+def history():
+    uid = int(get_jwt_identity())
+    reminder_id = request.args.get("reminder_id", type=int)
+    limit = request.args.get("limit", 50, type=int)
+    items = get_delivery_history(uid, reminder_id=reminder_id, limit=limit)
+    return jsonify([_serialize(e) for e in items])
+
+
+@bp.post("/log")
+@jwt_required()
+def create_log():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    reminder_id = data.get("reminder_id")
+    if not reminder_id:
+        return jsonify(error="reminder_id required"), 400
+    entry = log_delivery(
+        user_id=uid,
+        reminder_id=reminder_id,
+        channel=data.get("channel", "in_app"),
+        status=data.get("status", "SENT"),
+        error=data.get("error"),
+        latency_ms=data.get("latency_ms"),
+    )
+    return jsonify(_serialize(entry)), 201

--- a/packages/backend/app/services/delivery_metrics.py
+++ b/packages/backend/app/services/delivery_metrics.py
@@ -1,0 +1,108 @@
+"""Reminder reliability tracking & delivery metrics (#123).
+
+Tracks reminder delivery success/failure rates and provides
+metrics for monitoring reminder system health.
+"""
+
+import logging
+from datetime import datetime, date, timedelta
+
+from ..extensions import db
+
+logger = logging.getLogger("finmind.delivery_metrics")
+
+
+class DeliveryLog(db.Model):
+    __tablename__ = "delivery_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    reminder_id = db.Column(db.Integer, nullable=False)
+    channel = db.Column(db.String(50), default="in_app", nullable=False)  # in_app, email, push
+    status = db.Column(db.String(20), nullable=False)  # SENT, DELIVERED, FAILED, SKIPPED
+    error_message = db.Column(db.String(500))
+    sent_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    delivered_at = db.Column(db.DateTime)
+    latency_ms = db.Column(db.Integer)  # delivery latency in milliseconds
+
+
+def log_delivery(user_id, reminder_id, channel="in_app", status="SENT", error=None, latency_ms=None):
+    """Log a reminder delivery attempt."""
+    entry = DeliveryLog(
+        user_id=user_id,
+        reminder_id=reminder_id,
+        channel=channel,
+        status=status,
+        error_message=error[:500] if error else None,
+        delivered_at=datetime.utcnow() if status == "DELIVERED" else None,
+        latency_ms=latency_ms,
+    )
+    db.session.add(entry)
+    db.session.commit()
+    logger.info("Delivery log: reminder=%s channel=%s status=%s", reminder_id, channel, status)
+    return entry
+
+
+def get_delivery_metrics(user_id, days=30):
+    """Get delivery reliability metrics for the past N days."""
+    from sqlalchemy import func
+
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    base = DeliveryLog.query.filter(
+        DeliveryLog.user_id == user_id,
+        DeliveryLog.sent_at >= cutoff,
+    )
+
+    total = base.count()
+    if total == 0:
+        return {
+            "period_days": days,
+            "total_deliveries": 0,
+            "success_rate": 0.0,
+            "by_status": {},
+            "by_channel": {},
+            "avg_latency_ms": None,
+        }
+
+    # By status
+    status_counts = (
+        base.with_entities(DeliveryLog.status, func.count(DeliveryLog.id))
+        .group_by(DeliveryLog.status)
+        .all()
+    )
+    by_status = {s: c for s, c in status_counts}
+
+    # By channel
+    channel_counts = (
+        base.with_entities(DeliveryLog.channel, func.count(DeliveryLog.id))
+        .group_by(DeliveryLog.channel)
+        .all()
+    )
+    by_channel = {ch: c for ch, c in channel_counts}
+
+    # Success rate
+    delivered = by_status.get("DELIVERED", 0) + by_status.get("SENT", 0)
+    success_rate = round(delivered / total * 100, 1)
+
+    # Average latency
+    avg_lat = (
+        base.with_entities(func.avg(DeliveryLog.latency_ms))
+        .filter(DeliveryLog.latency_ms.isnot(None))
+        .scalar()
+    )
+
+    return {
+        "period_days": days,
+        "total_deliveries": total,
+        "success_rate": success_rate,
+        "by_status": by_status,
+        "by_channel": by_channel,
+        "avg_latency_ms": round(float(avg_lat)) if avg_lat else None,
+    }
+
+
+def get_delivery_history(user_id, reminder_id=None, limit=50):
+    """Get delivery history, optionally filtered by reminder."""
+    q = DeliveryLog.query.filter_by(user_id=user_id)
+    if reminder_id:
+        q = q.filter_by(reminder_id=reminder_id)
+    return q.order_by(DeliveryLog.sent_at.desc()).limit(limit).all()

--- a/packages/backend/tests/test_delivery_metrics.py
+++ b/packages/backend/tests/test_delivery_metrics.py
@@ -1,0 +1,70 @@
+"""Tests for reminder reliability tracking & delivery metrics (#123)."""
+
+
+def _log(client, auth_header, reminder_id, channel="in_app", status="SENT", latency_ms=None):
+    r = client.post("/delivery/log", json={
+        "reminder_id": reminder_id, "channel": channel,
+        "status": status, "latency_ms": latency_ms,
+    }, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+class TestDeliveryLog:
+    def test_create_log(self, client, auth_header):
+        entry = _log(client, auth_header, 1, "email", "DELIVERED", 120)
+        assert entry["reminder_id"] == 1
+        assert entry["channel"] == "email"
+        assert entry["status"] == "DELIVERED"
+        assert entry["latency_ms"] == 120
+
+    def test_missing_reminder_id(self, client, auth_header):
+        r = client.post("/delivery/log", json={"channel": "email"}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_log_with_error(self, client, auth_header):
+        entry = _log(client, auth_header, 2, "push", "FAILED")
+        assert entry["status"] == "FAILED"
+
+
+class TestMetrics:
+    def test_empty_metrics(self, client, auth_header):
+        r = client.get("/delivery/metrics", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["total_deliveries"] == 0
+        assert data["success_rate"] == 0.0
+
+    def test_metrics_with_data(self, client, auth_header):
+        _log(client, auth_header, 10, "in_app", "DELIVERED", 50)
+        _log(client, auth_header, 11, "email", "DELIVERED", 200)
+        _log(client, auth_header, 12, "push", "FAILED")
+
+        r = client.get("/delivery/metrics", headers=auth_header)
+        data = r.get_json()
+        assert data["total_deliveries"] == 3
+        assert data["by_status"]["DELIVERED"] == 2
+        assert data["by_status"]["FAILED"] == 1
+        assert data["success_rate"] > 60
+
+    def test_metrics_custom_days(self, client, auth_header):
+        r = client.get("/delivery/metrics?days=7", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["period_days"] == 7
+
+
+class TestHistory:
+    def test_history(self, client, auth_header):
+        _log(client, auth_header, 20, "in_app", "SENT")
+        _log(client, auth_header, 20, "in_app", "DELIVERED", 100)
+
+        r = client.get("/delivery/history?reminder_id=20", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert len(data) == 2
+
+    def test_history_all(self, client, auth_header):
+        _log(client, auth_header, 30, "email", "SENT")
+        r = client.get("/delivery/history", headers=auth_header)
+        assert r.status_code == 200
+        assert len(r.get_json()) >= 1


### PR DESCRIPTION
## Summary
Tracks reminder delivery success/failure rates with detailed metrics for monitoring system health.

## Changes
- DeliveryLog model (channel, status, latency, error tracking)
- Metrics endpoint: success rate, breakdown by status/channel, avg latency
- Delivery history with optional reminder filter
- API: GET /delivery/metrics, GET /delivery/history, POST /delivery/log
- Full test suite

Fixes #123