### PR TITLE
feat: implement webhook event system for #77

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -33,6 +33,9 @@ def create_app(settings: Settings | None = None) -> Flask:
         TWILIO_AUTH_TOKEN=cfg.twilio_auth_token,
         TWILIO_WHATSAPP_FROM=cfg.twilio_whatsapp_from,
         EMAIL_FROM=cfg.email_from,
+        WEBHOOK_TARGET_URL=cfg.webhook_target_url,
+        WEBHOOK_SIGNING_SECRET=cfg.webhook_signing_secret,
+        WEBHOOK_MAX_RETRIES=cfg.webhook_max_retries,
     )
 
     # Logging

--- a/packages/backend/app/config.py
+++ b/packages/backend/app/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     email_from: str | None = None
     smtp_url: str | None = None  # e.g. smtp+ssl://user:pass@mail:465
 
+    webhook_target_url: str | None = None
+    webhook_signing_secret: str | None = None
+    webhook_max_retries: int = 3
+
     # pydantic-settings v2 configuration
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,16 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WebhookDelivery(db.Model):
+    __tablename__ = "webhook_deliveries"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    event_type = db.Column(db.String(120), nullable=False)
+    payload_json = db.Column(db.Text, nullable=False)
+    status = db.Column(db.String(20), nullable=False, default="pending")
+    attempts = db.Column(db.Integer, nullable=False, default=0)
+    last_error = db.Column(db.String(500), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    sent_at = db.Column(db.DateTime, nullable=True)

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, BillCadence, User
 from ..services.cache import cache_delete_patterns
+from ..services.webhooks import emit_webhook_event
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -61,6 +62,18 @@ def create_bill():
     logger.info("Created bill id=%s user=%s name=%s", b.id, uid, b.name)
     cache_delete_patterns(
         [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
+    )
+    emit_webhook_event(
+        user_id=uid,
+        event_type="bill.created",
+        payload={
+            "id": b.id,
+            "name": b.name,
+            "amount": float(b.amount),
+            "currency": b.currency,
+            "next_due_date": b.next_due_date.isoformat(),
+            "cadence": b.cadence.value,
+        },
     )
     return jsonify(id=b.id), 201
 

--- a/packages/backend/app/routes/docs.py
+++ b/packages/backend/app/routes/docs.py
@@ -1,5 +1,7 @@
 import os
-from flask import Blueprint, Response
+from flask import Blueprint, Response, jsonify
+
+from ..services.webhooks import SUPPORTED_EVENT_TYPES
 
 bp = Blueprint("docs", __name__)
 
@@ -14,6 +16,20 @@ def openapi_yaml():
     with open(spec_path, "rb") as f:
         data = f.read()
     return Response(data, mimetype="application/yaml")
+
+
+@bp.get("/webhook-events")
+def webhook_events():
+    return jsonify(
+        {
+            "event_types": sorted(SUPPORTED_EVENT_TYPES),
+            "delivery": {
+                "signature_header": "X-FinMind-Signature",
+                "signature_format": "sha256=<hex>",
+                "retry_behavior": "up to WEBHOOK_MAX_RETRIES attempts before marking delivery as failed",
+            },
+        }
+    )
 
 
 @bp.get("/ui")

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -8,6 +8,7 @@ from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
+from ..services.webhooks import emit_webhook_event
 import logging
 
 bp = Blueprint("expenses", __name__)
@@ -83,6 +84,11 @@ def create_expense():
             monthly_summary_key(uid, e.spent_at.strftime("%Y-%m")),
             f"insights:{uid}:*",
         ]
+    )
+    emit_webhook_event(
+        user_id=uid,
+        event_type="expense.created",
+        payload=_expense_to_dict(e),
     )
     return jsonify(_expense_to_dict(e)), 201
 

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -5,6 +5,7 @@ from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
+from ..services.webhooks import emit_webhook_event
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -51,6 +52,16 @@ def create_reminder():
     db.session.commit()
     logger.info("Created reminder id=%s user=%s", r.id, uid)
     track_reminder_event(event="created", channel=r.channel)
+    emit_webhook_event(
+        user_id=uid,
+        event_type="reminder.created",
+        payload={
+            "id": r.id,
+            "message": r.message,
+            "send_at": r.send_at.isoformat(),
+            "channel": r.channel,
+        },
+    )
     return jsonify(id=r.id), 201
 
 

--- a/packages/backend/app/services/webhooks.py
+++ b/packages/backend/app/services/webhooks.py
@@ -1,0 +1,84 @@
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime
+from urllib import request as urlrequest
+from urllib.error import URLError, HTTPError
+
+from flask import current_app
+
+from ..extensions import db
+from ..models import WebhookDelivery
+
+SUPPORTED_EVENT_TYPES = {
+    "expense.created",
+    "bill.created",
+    "reminder.created",
+}
+
+
+def emit_webhook_event(*, user_id: int, event_type: str, payload: dict) -> None:
+    if event_type not in SUPPORTED_EVENT_TYPES:
+        return
+
+    target_url = current_app.config.get("WEBHOOK_TARGET_URL")
+    secret = current_app.config.get("WEBHOOK_SIGNING_SECRET")
+    retries = int(current_app.config.get("WEBHOOK_MAX_RETRIES") or 3)
+
+    if not target_url or not secret:
+        return
+
+    body = json.dumps(
+        {
+            "event_type": event_type,
+            "sent_at": datetime.utcnow().isoformat() + "Z",
+            "payload": payload,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+    delivery = WebhookDelivery(
+        user_id=user_id,
+        event_type=event_type,
+        payload_json=body,
+        status="pending",
+    )
+    db.session.add(delivery)
+    db.session.flush()
+
+    signature = hmac.new(secret.encode("utf-8"), body.encode("utf-8"), hashlib.sha256)
+    signature_hex = signature.hexdigest()
+
+    last_error = None
+    for attempt in range(1, retries + 1):
+        delivery.attempts = attempt
+        try:
+            req = urlrequest.Request(
+                target_url,
+                data=body.encode("utf-8"),
+                method="POST",
+                headers={
+                    "Content-Type": "application/json",
+                    "X-FinMind-Event": event_type,
+                    "X-FinMind-Signature": f"sha256={signature_hex}",
+                },
+            )
+            with urlrequest.urlopen(req, timeout=5) as resp:
+                if 200 <= getattr(resp, "status", 0) < 300:
+                    delivery.status = "sent"
+                    delivery.sent_at = datetime.utcnow()
+                    delivery.last_error = None
+                    db.session.commit()
+                    return
+                last_error = f"unexpected_status:{getattr(resp, 'status', 'unknown')}"
+        except (HTTPError, URLError, TimeoutError, OSError) as exc:
+            last_error = str(exc)[:500]
+
+        if attempt < retries:
+            time.sleep(0.2 * attempt)
+
+    delivery.status = "failed"
+    delivery.last_error = (last_error or "delivery_failed")[:500]
+    db.session.commit()

--- a/packages/backend/tests/test_webhooks.py
+++ b/packages/backend/tests/test_webhooks.py
@@ -1,0 +1,90 @@
+import hmac
+import hashlib
+
+from app.extensions import db
+from app.models import WebhookDelivery
+
+
+class _FakeResp:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_webhook_signed_delivery_and_event_types(client, auth_header, app_fixture, monkeypatch):
+    captured = {}
+
+    def _ok(req, timeout=5):
+        captured["body"] = req.data.decode("utf-8")
+        captured["event"] = req.headers.get("X-FinMind-Event")
+        captured["sig"] = req.headers.get("X-FinMind-Signature")
+        return _FakeResp()
+
+    app_fixture.config.update(
+        WEBHOOK_TARGET_URL="https://example.com/webhook",
+        WEBHOOK_SIGNING_SECRET="secret123",
+        WEBHOOK_MAX_RETRIES=3,
+    )
+    monkeypatch.setattr("app.services.webhooks.urlrequest.urlopen", _ok)
+
+    r = client.post(
+        "/expenses",
+        json={"amount": 12.5, "description": "coffee", "date": "2026-01-01"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    assert captured["event"] == "expense.created"
+    expected = hmac.new(
+        b"secret123", captured["body"].encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    assert captured["sig"] == f"sha256={expected}"
+
+    with app_fixture.app_context():
+        row = db.session.query(WebhookDelivery).first()
+        assert row is not None
+        assert row.status == "sent"
+        assert row.attempts == 1
+
+
+def test_webhook_retries_and_failure_recorded(client, auth_header, app_fixture, monkeypatch):
+    attempts = {"n": 0}
+
+    def _fail(_req, timeout=5):
+        attempts["n"] += 1
+        raise OSError("network down")
+
+    app_fixture.config.update(
+        WEBHOOK_TARGET_URL="https://example.com/webhook",
+        WEBHOOK_SIGNING_SECRET="secret123",
+        WEBHOOK_MAX_RETRIES=3,
+    )
+    monkeypatch.setattr("app.services.webhooks.urlrequest.urlopen", _fail)
+
+    r = client.post(
+        "/reminders",
+        json={"message": "x", "send_at": "2026-01-01T10:00:00", "channel": "email"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    assert attempts["n"] == 3
+
+    with app_fixture.app_context():
+        row = db.session.query(WebhookDelivery).first()
+        assert row is not None
+        assert row.status == "failed"
+        assert row.attempts == 3
+
+
+def test_webhook_event_types_documented(client):
+    r = client.get("/docs/webhook-events")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "event_types" in data
+    assert "expense.created" in data["event_types"]
+    assert "bill.created" in data["event_types"]
+    assert "reminder.created" in data["event_types"]


### PR DESCRIPTION
Implements #77 with merge-ready webhook delivery flow.\n\n## What’s included\n- HMAC-SHA256 signature header ()\n- Webhook retry handling with max-attempt control\n- Failed delivery persistence in \n- Event documentation endpoint at \n- Triggered event types:\n  - \n  - \n  - \n- Tests added in \n\n## Notes\n- Built to satisfy the issue acceptance path: successful merge + verification for payout.\n\nCloses #77