### PR TITLE
feat: Spending trend heatmap visualization (fixes #116)

### DIFF
--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,17 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type HeatmapDay = {
+  date: string;
+  total: number;
+  count: number;
+};
+
+export async function getSpendingHeatmap(year?: number): Promise<HeatmapDay[]> {
+  const y = year ?? new Date().getFullYear();
+  return api<HeatmapDay[]>(`/insights/heatmap?year=${y}`);
+}
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;

--- a/app/src/components/SpendingHeatmap.tsx
+++ b/app/src/components/SpendingHeatmap.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { getSpendingHeatmap, type HeatmapDay } from '@/api/insights';
+import { useToast } from '@/hooks/use-toast';
+
+const DAYS = ['Mon', '', 'Wed', '', 'Fri', '', ''];
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+function intensityClass(amount: number, max: number): string {
+  if (amount === 0 || max === 0) return 'bg-muted';
+  const ratio = amount / max;
+  if (ratio < 0.25) return 'bg-green-200 dark:bg-green-900';
+  if (ratio < 0.5) return 'bg-green-400 dark:bg-green-700';
+  if (ratio < 0.75) return 'bg-green-500 dark:bg-green-500';
+  return 'bg-green-700 dark:bg-green-300';
+}
+
+function buildGrid(year: number, data: HeatmapDay[]) {
+  const map = new Map(data.map((d) => [d.date, d]));
+  const jan1 = new Date(year, 0, 1);
+  const startDow = (jan1.getDay() + 6) % 7; // Mon=0
+
+  const cells: Array<{ date: string; total: number; count: number; blank?: boolean }> = [];
+  // leading blanks
+  for (let i = 0; i < startDow; i++) cells.push({ date: '', total: 0, count: 0, blank: true });
+
+  const d = new Date(year, 0, 1);
+  while (d.getFullYear() === year) {
+    const iso = d.toISOString().slice(0, 10);
+    const entry = map.get(iso);
+    cells.push({ date: iso, total: entry?.total ?? 0, count: entry?.count ?? 0 });
+    d.setDate(d.getDate() + 1);
+  }
+
+  // group into weeks (columns of 7)
+  const weeks: typeof cells[] = [];
+  for (let i = 0; i < cells.length; i += 7) {
+    const week = cells.slice(i, i + 7);
+    while (week.length < 7) week.push({ date: '', total: 0, count: 0, blank: true });
+    weeks.push(week);
+  }
+  return weeks;
+}
+
+export function SpendingHeatmap() {
+  const { toast } = useToast();
+  const [year, setYear] = useState(() => new Date().getFullYear());
+  const [data, setData] = useState<HeatmapDay[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    getSpendingHeatmap(year)
+      .then(setData)
+      .catch((e) => toast({ title: 'Heatmap error', description: String(e) }))
+      .finally(() => setLoading(false));
+  }, [year]);
+
+  const weeks = useMemo(() => buildGrid(year, data), [year, data]);
+  const maxTotal = useMemo(() => Math.max(...data.map((d) => d.total), 0), [data]);
+
+  // figure out which week index each month starts
+  const monthLabels = useMemo(() => {
+    const labels: Array<{ month: string; col: number }> = [];
+    let seen = -1;
+    weeks.forEach((week, wi) => {
+      for (const cell of week) {
+        if (cell.blank || !cell.date) continue;
+        const m = parseInt(cell.date.slice(5, 7), 10) - 1;
+        if (m !== seen) {
+          seen = m;
+          labels.push({ month: MONTHS[m], col: wi });
+        }
+        break;
+      }
+    });
+    return labels;
+  }, [weeks]);
+
+  return (
+    <FinancialCard variant="financial">
+      <FinancialCardHeader className="flex flex-row items-center justify-between">
+        <FinancialCardTitle>Spending Heatmap</FinancialCardTitle>
+        <div className="flex items-center gap-2">
+          <button
+            aria-label="Previous year"
+            className="rounded px-2 py-1 text-sm border hover:bg-muted"
+            onClick={() => setYear((y) => y - 1)}
+          >
+            ←
+          </button>
+          <span className="text-sm font-medium">{year}</span>
+          <button
+            aria-label="Next year"
+            className="rounded px-2 py-1 text-sm border hover:bg-muted"
+            onClick={() => setYear((y) => y + 1)}
+          >
+            →
+          </button>
+        </div>
+      </FinancialCardHeader>
+      <FinancialCardContent>
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading heatmap…</div>
+        ) : (
+          <div className="relative overflow-x-auto">
+            {/* Month labels */}
+            <div className="flex ml-8 mb-1 text-xs text-muted-foreground">
+              {monthLabels.map((ml) => (
+                <span
+                  key={ml.month}
+                  className="absolute text-xs"
+                  style={{ left: `${ml.col * 14 + 32}px` }}
+                >
+                  {ml.month}
+                </span>
+              ))}
+            </div>
+            <div className="flex gap-0 mt-5" role="grid" aria-label={`Spending heatmap for ${year}`}>
+              {/* Day labels */}
+              <div className="flex flex-col gap-[2px] mr-1 text-xs text-muted-foreground">
+                {DAYS.map((d, i) => (
+                  <div key={i} className="h-[12px] w-6 text-right leading-[12px]">{d}</div>
+                ))}
+              </div>
+              {/* Grid */}
+              {weeks.map((week, wi) => (
+                <div key={wi} className="flex flex-col gap-[2px]">
+                  {week.map((cell, di) => (
+                    <div
+                      key={di}
+                      role="gridcell"
+                      aria-label={cell.blank ? undefined : `${cell.date}: spent ${cell.total.toFixed(2)}`}
+                      className={`h-[12px] w-[12px] rounded-sm ${
+                        cell.blank ? 'bg-transparent' : intensityClass(cell.total, maxTotal)
+                      } cursor-pointer transition-colors`}
+                      onMouseEnter={(e) => {
+                        if (cell.blank) return;
+                        const rect = e.currentTarget.getBoundingClientRect();
+                        setTooltip({
+                          x: rect.left + rect.width / 2,
+                          y: rect.top - 8,
+                          text: `${cell.date}\n${cell.total.toFixed(2)} (${cell.count} txn${cell.count !== 1 ? 's' : ''})`,
+                        });
+                      }}
+                      onMouseLeave={() => setTooltip(null)}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+            {/* Legend */}
+            <div className="flex items-center gap-1 mt-3 text-xs text-muted-foreground">
+              <span>Less</span>
+              <div className="h-[12px] w-[12px] rounded-sm bg-muted" />
+              <div className="h-[12px] w-[12px] rounded-sm bg-green-200 dark:bg-green-900" />
+              <div className="h-[12px] w-[12px] rounded-sm bg-green-400 dark:bg-green-700" />
+              <div className="h-[12px] w-[12px] rounded-sm bg-green-500 dark:bg-green-500" />
+              <div className="h-[12px] w-[12px] rounded-sm bg-green-700 dark:bg-green-300" />
+              <span>More</span>
+            </div>
+            {/* Tooltip */}
+            {tooltip && (
+              <div
+                className="fixed z-50 rounded bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md border whitespace-pre pointer-events-none"
+                style={{ left: tooltip.x, top: tooltip.y, transform: 'translate(-50%, -100%)' }}
+              >
+                {tooltip.text}
+              </div>
+            )}
+          </div>
+        )}
+      </FinancialCardContent>
+    </FinancialCard>
+  );
+}

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -12,6 +12,7 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
+import { SpendingHeatmap } from '@/components/SpendingHeatmap';
 
 const PERSONAS = [
   'Balanced coach',
@@ -122,6 +123,8 @@ export function Analytics() {
         <div className="card text-red-600">{error}</div>
       ) : data ? (
         <div className="space-y-6">
+          <SpendingHeatmap />
+
           <div className="grid gap-4 md:grid-cols-4">
             <FinancialCard variant="financial">
               <FinancialCardHeader className="pb-2">

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,7 +1,10 @@
 from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func, extract
 from ..services.ai import monthly_budget_suggestion
+from ..models import Expense
+from ..extensions import db
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +26,34 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/heatmap")
+@jwt_required()
+def spending_heatmap():
+    uid = int(get_jwt_identity())
+    year = request.args.get("year", date.today().year, type=int)
+    start = date(year, 1, 1)
+    end = date(year, 12, 31)
+
+    rows = (
+        db.session.query(
+            Expense.spent_at,
+            func.sum(Expense.amount).label("total"),
+            func.count(Expense.id).label("count"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .group_by(Expense.spent_at)
+        .all()
+    )
+
+    data = [
+        {"date": row.spent_at.isoformat(), "total": float(row.total), "count": row.count}
+        for row in rows
+    ]
+    logger.info("Heatmap served user=%s year=%s days=%d", uid, year, len(data))
+    return jsonify(data)

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,6 +1,43 @@
 from datetime import date, timedelta
 
 
+def test_heatmap_returns_daily_totals(client, auth_header):
+    today = date.today()
+    # Create two expenses on the same day
+    for amount in [100, 50]:
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": amount,
+                "description": "heatmap test",
+                "date": today.isoformat(),
+                "expense_type": "EXPENSE",
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get(f"/insights/heatmap?year={today.year}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert isinstance(data, list)
+    day_entry = next((d for d in data if d["date"] == today.isoformat()), None)
+    assert day_entry is not None
+    assert day_entry["total"] == 150.0
+    assert day_entry["count"] == 2
+
+
+def test_heatmap_empty_year(client, auth_header):
+    r = client.get("/insights/heatmap?year=2000", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_heatmap_requires_auth(client):
+    r = client.get("/insights/heatmap?year=2026")
+    assert r.status_code == 401
+
+
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
     previous = (current.replace(day=1) - timedelta(days=1)).replace(day=10)


### PR DESCRIPTION
## Summary
Adds a GitHub-style spending heatmap visualization to the Analytics page, addressing #116.

## Changes

### Backend
- **GET /api/insights/heatmap?year=** — returns daily spending totals grouped by date for the given year
- Response format: `[{date, total, count}, ...]`

### Frontend
- **SpendingHeatmap** component: calendar heatmap grid (7 rows × 52+ cols), green color intensity scale, hover tooltips with date/amount/count, year navigation, legend
- Integrated into the Analytics page above existing budget cards
- API client function added to `insights.ts`

### Tests
- `test_heatmap_returns_daily_totals` — verifies aggregation
- `test_heatmap_empty_year` — verifies empty response
- `test_heatmap_requires_auth` — verifies JWT protection

Fixes #116