### PR TITLE
feat: Bulk import validation & preview improvements (fixes #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ See `backend/app/db/schema.sql`. Key tables:
   - On expense/bill create/update/delete -> delete affected monthly_summary, upcoming_bills, insights
 - Rate limiting (optional): `rl:{userId}:{endpoint}:{minute}` with short TTL
 
+## Bulk Import Validation & Preview
+The Expenses import flow validates each parsed row before committing:
+- Inline editing for date, description, amount, and category on every row
+- Per-row validation warnings (yellow) and errors (red): missing/invalid dates, negative/zero amounts, empty descriptions, future dates, large amounts (>10,000)
+- Summary bar showing valid/warning/error counts
+- Rows can be removed individually
+- "Confirm Import" is blocked until all errors are resolved
+- Validation logic lives in `app/src/lib/import-validation.ts` with unit tests in `app/src/__tests__/import-validation.test.ts`
+
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`

--- a/app/src/__tests__/import-validation.test.ts
+++ b/app/src/__tests__/import-validation.test.ts
@@ -1,0 +1,108 @@
+import { validateTransaction, validateImportBatch, type ValidationWarning } from '@/lib/import-validation';
+import type { ImportTransaction } from '@/api/expenses';
+
+function makeTx(overrides: Partial<ImportTransaction> = {}): ImportTransaction {
+  return {
+    date: '2025-06-15',
+    amount: 42.5,
+    description: 'Groceries',
+    category_id: null,
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+describe('validateTransaction', () => {
+  it('returns no warnings for a valid transaction', () => {
+    expect(validateTransaction(makeTx(), 0)).toEqual([]);
+  });
+
+  it('returns error when date is missing', () => {
+    const result = validateTransaction(makeTx({ date: '' }), 0);
+    expect(result).toEqual([
+      expect.objectContaining({ field: 'date', severity: 'error', message: 'Date is missing' }),
+    ]);
+  });
+
+  it('returns error for invalid date format', () => {
+    const result = validateTransaction(makeTx({ date: '15/06/2025' }), 0);
+    expect(result).toEqual([
+      expect.objectContaining({ field: 'date', severity: 'error', message: expect.stringContaining('Invalid date') }),
+    ]);
+  });
+
+  it('returns error for negative amount', () => {
+    const result = validateTransaction(makeTx({ amount: -10 }), 0);
+    expect(result).toEqual([
+      expect.objectContaining({ field: 'amount', severity: 'error', message: 'Amount is negative' }),
+    ]);
+  });
+
+  it('returns error for zero amount', () => {
+    const result = validateTransaction(makeTx({ amount: 0 }), 0);
+    expect(result).toEqual([
+      expect.objectContaining({ field: 'amount', severity: 'error', message: 'Amount is zero' }),
+    ]);
+  });
+
+  it('returns warning for empty description', () => {
+    const result = validateTransaction(makeTx({ description: '' }), 0);
+    expect(result).toEqual([
+      expect.objectContaining({ field: 'description', severity: 'warning', message: 'Description is empty' }),
+    ]);
+  });
+
+  it('returns warning for future date', () => {
+    const future = new Date();
+    future.setFullYear(future.getFullYear() + 1);
+    const dateStr = future.toISOString().slice(0, 10);
+    const result = validateTransaction(makeTx({ date: dateStr }), 0);
+    expect(result).toEqual([
+      expect.objectContaining({ field: 'date', severity: 'warning', message: 'Date is in the future' }),
+    ]);
+  });
+
+  it('returns warning for large amount', () => {
+    const result = validateTransaction(makeTx({ amount: 15000 }), 0);
+    expect(result).toEqual([
+      expect.objectContaining({ field: 'amount', severity: 'warning', message: expect.stringContaining('exceeds') }),
+    ]);
+  });
+
+  it('uses 1-based row numbers', () => {
+    const result = validateTransaction(makeTx({ amount: -1 }), 4);
+    expect(result[0].row).toBe(5);
+  });
+});
+
+describe('validateImportBatch', () => {
+  it('aggregates errors and warnings correctly', () => {
+    const txs: ImportTransaction[] = [
+      makeTx(),                          // valid
+      makeTx({ amount: -5 }),            // error
+      makeTx({ description: '' }),       // warning
+      makeTx({ date: 'bad', amount: 0 }),// 2 errors
+    ];
+    const result = validateImportBatch(txs);
+    expect(result.errors.length).toBe(3);
+    expect(result.warnings.length).toBe(1);
+    expect(result.hasBlockingErrors).toBe(true);
+  });
+
+  it('returns hasBlockingErrors false when only warnings exist', () => {
+    const txs: ImportTransaction[] = [
+      makeTx({ description: '' }),
+    ];
+    const result = validateImportBatch(txs);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.hasBlockingErrors).toBe(false);
+  });
+
+  it('handles empty array', () => {
+    const result = validateImportBatch([]);
+    expect(result.errors).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.hasBlockingErrors).toBe(false);
+  });
+});

--- a/app/src/lib/import-validation.ts
+++ b/app/src/lib/import-validation.ts
@@ -1,0 +1,83 @@
+import type { ImportTransaction } from '@/api/expenses';
+
+export type ValidationWarning = {
+  row: number;
+  field: string;
+  severity: 'error' | 'warning';
+  message: string;
+};
+
+export type BatchValidationResult = {
+  warnings: ValidationWarning[];
+  errors: ValidationWarning[];
+  hasBlockingErrors: boolean;
+};
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function isValidDate(dateStr: string): boolean {
+  if (!ISO_DATE_RE.test(dateStr)) return false;
+  const d = new Date(dateStr + 'T00:00:00');
+  return !isNaN(d.getTime());
+}
+
+function isFutureDate(dateStr: string): boolean {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const d = new Date(dateStr + 'T00:00:00');
+  return d.getTime() > today.getTime();
+}
+
+const LARGE_AMOUNT_THRESHOLD = 10_000;
+
+export function validateTransaction(
+  tx: ImportTransaction,
+  index: number,
+): ValidationWarning[] {
+  const warnings: ValidationWarning[] = [];
+  const row = index + 1;
+
+  // Date checks
+  if (!tx.date || tx.date.trim() === '') {
+    warnings.push({ row, field: 'date', severity: 'error', message: 'Date is missing' });
+  } else if (!isValidDate(tx.date)) {
+    warnings.push({ row, field: 'date', severity: 'error', message: 'Invalid date format (expected YYYY-MM-DD)' });
+  } else if (isFutureDate(tx.date)) {
+    warnings.push({ row, field: 'date', severity: 'warning', message: 'Date is in the future' });
+  }
+
+  // Amount checks
+  if (tx.amount < 0) {
+    warnings.push({ row, field: 'amount', severity: 'error', message: 'Amount is negative' });
+  } else if (tx.amount === 0) {
+    warnings.push({ row, field: 'amount', severity: 'error', message: 'Amount is zero' });
+  } else if (tx.amount > LARGE_AMOUNT_THRESHOLD) {
+    warnings.push({ row, field: 'amount', severity: 'warning', message: `Amount exceeds ${LARGE_AMOUNT_THRESHOLD.toLocaleString()}` });
+  }
+
+  // Description checks
+  if (!tx.description || tx.description.trim() === '') {
+    warnings.push({ row, field: 'description', severity: 'warning', message: 'Description is empty' });
+  }
+
+  return warnings;
+}
+
+export function validateImportBatch(
+  transactions: ImportTransaction[],
+): BatchValidationResult {
+  const all: ValidationWarning[] = [];
+
+  for (let i = 0; i < transactions.length; i++) {
+    all.push(...validateTransaction(transactions[i], i));
+  }
+
+  const errors = all.filter((w) => w.severity === 'error');
+  const warnings = all.filter((w) => w.severity === 'warning');
+
+  return {
+    errors,
+    warnings,
+    hasBlockingErrors: errors.length > 0,
+  };
+}

--- a/app/src/pages/Expenses.tsx
+++ b/app/src/pages/Expenses.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/api/expenses';
 import { listCategories, type Category } from '@/api/categories';
 import { formatMoney } from '@/lib/currency';
+import { validateImportBatch, type ValidationWarning } from '@/lib/import-validation';
 
 export default function Expenses() {
   const { toast } = useToast();
@@ -73,6 +74,7 @@ export default function Expenses() {
   const [previewDuplicates, setPreviewDuplicates] = useState<number>(0);
   const [importLoading, setImportLoading] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [validationResult, setValidationResult] = useState<ReturnType<typeof validateImportBatch> | null>(null);
   const [recurringItems, setRecurringItems] = useState<RecurringExpense[]>([]);
   const [recurringAmount, setRecurringAmount] = useState('');
   const [recurringDescription, setRecurringDescription] = useState('');
@@ -251,6 +253,7 @@ export default function Expenses() {
       const data = await previewExpenseImport(importFile);
       setPreview(data.transactions);
       setPreviewDuplicates(data.duplicates);
+      setValidationResult(validateImportBatch(data.transactions));
       toast({ title: 'Import preview ready', description: `${data.total} rows parsed.` });
     } catch (error: unknown) {
       const message = getErrorMessage(error, 'Failed to preview import');
@@ -277,6 +280,7 @@ export default function Expenses() {
       setPreview([]);
       setPreviewDuplicates(0);
       setImportFile(null);
+      setValidationResult(null);
       await refresh();
     } catch (error: unknown) {
       const message = getErrorMessage(error, 'Failed to import expenses');
@@ -285,6 +289,28 @@ export default function Expenses() {
     } finally {
       setImporting(false);
     }
+  }
+
+  function updatePreviewRow(index: number, field: keyof ImportTransaction, value: string | number) {
+    setPreview((prev) => {
+      const next = [...prev];
+      next[index] = { ...next[index], [field]: value };
+      setValidationResult(validateImportBatch(next));
+      return next;
+    });
+  }
+
+  function removePreviewRow(index: number) {
+    setPreview((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      setValidationResult(next.length > 0 ? validateImportBatch(next) : null);
+      return next;
+    });
+  }
+
+  function getRowWarnings(row: number): ValidationWarning[] {
+    if (!validationResult) return [];
+    return [...validationResult.errors, ...validationResult.warnings].filter((w) => w.row === row);
   }
 
   async function onCreateRecurring() {
@@ -445,21 +471,102 @@ export default function Expenses() {
           />
           <div className="flex gap-2">
             <Button variant="outline" onClick={onPreviewImport} disabled={importLoading || !importFile}>Preview Import</Button>
-            <Button onClick={onCommitImport} disabled={importing || preview.length === 0}>Confirm Import</Button>
+            <Button
+              onClick={onCommitImport}
+              disabled={importing || preview.length === 0 || (validationResult?.hasBlockingErrors ?? false)}
+            >
+              Confirm Import
+            </Button>
           </div>
-          {preview.length > 0 && (
-            <div className="rounded-md border p-3">
-              <div className="mb-2 text-sm text-muted-foreground">
-                Preview rows: {preview.length} | Detected duplicates: {previewDuplicates}
+          {preview.length > 0 && validationResult && (
+            <div className="rounded-md border p-3 space-y-3">
+              <div className="flex flex-wrap gap-3 text-sm">
+                <span className="text-muted-foreground">Rows: {preview.length}</span>
+                <span className="text-muted-foreground">Duplicates: {previewDuplicates}</span>
+                <span className="text-green-600">
+                  {preview.length - validationResult.errors.length - validationResult.warnings.length} valid
+                </span>
+                {validationResult.warnings.length > 0 && (
+                  <span className="text-yellow-600">{validationResult.warnings.length} warnings</span>
+                )}
+                {validationResult.errors.length > 0 && (
+                  <span className="text-red-600">{validationResult.errors.length} errors</span>
+                )}
               </div>
-              <div className="max-h-40 overflow-y-auto text-sm">
-                {preview.slice(0, 10).map((row, idx) => (
-                  <div key={`${row.date}-${row.amount}-${idx}`} className="grid grid-cols-3 gap-2 border-b py-1">
-                    <span>{row.date}</span>
-                    <span>{row.description}</span>
-                    <span className="text-right">{formatMoney(Number(row.amount))}</span>
-                  </div>
-                ))}
+              {validationResult.hasBlockingErrors && (
+                <div className="text-sm text-red-600 font-medium">
+                  Fix all errors before importing.
+                </div>
+              )}
+              <div className="max-h-72 overflow-y-auto text-sm space-y-1">
+                {preview.map((row, idx) => {
+                  const rowWarnings = getRowWarnings(idx + 1);
+                  const hasError = rowWarnings.some((w) => w.severity === 'error');
+                  const hasWarn = rowWarnings.some((w) => w.severity === 'warning');
+                  return (
+                    <div
+                      key={`preview-${idx}`}
+                      className={`rounded border p-2 ${hasError ? 'border-red-400 bg-red-50' : hasWarn ? 'border-yellow-400 bg-yellow-50' : 'border-border'}`}
+                    >
+                      <div className="grid grid-cols-[1fr_2fr_1fr_1fr_auto] gap-2 items-center">
+                        <Input
+                          aria-label={`Row ${idx + 1} date`}
+                          type="date"
+                          value={row.date}
+                          onChange={(e) => updatePreviewRow(idx, 'date', e.target.value)}
+                          className="h-8 text-xs"
+                        />
+                        <Input
+                          aria-label={`Row ${idx + 1} description`}
+                          value={row.description}
+                          onChange={(e) => updatePreviewRow(idx, 'description', e.target.value)}
+                          className="h-8 text-xs"
+                          placeholder="Description"
+                        />
+                        <Input
+                          aria-label={`Row ${idx + 1} amount`}
+                          type="number"
+                          value={row.amount}
+                          onChange={(e) => updatePreviewRow(idx, 'amount', Number(e.target.value))}
+                          className="h-8 text-xs"
+                          min="0"
+                          step="0.01"
+                        />
+                        <select
+                          aria-label={`Row ${idx + 1} category`}
+                          className="input h-8 text-xs"
+                          value={row.category_id ?? ''}
+                          onChange={(e) => updatePreviewRow(idx, 'category_id', e.target.value ? Number(e.target.value) : null as any)}
+                        >
+                          <option value="">—</option>
+                          {categories.map((c) => (
+                            <option key={c.id} value={c.id}>{c.name}</option>
+                          ))}
+                        </select>
+                        <Button
+                          variant="outline"
+                          className="h-8 px-2 text-xs"
+                          onClick={() => removePreviewRow(idx)}
+                          aria-label={`Remove row ${idx + 1}`}
+                        >
+                          ✕
+                        </Button>
+                      </div>
+                      {rowWarnings.length > 0 && (
+                        <div className="mt-1 space-y-0.5">
+                          {rowWarnings.map((w, wi) => (
+                            <div
+                              key={`w-${idx}-${wi}`}
+                              className={`text-xs ${w.severity === 'error' ? 'text-red-600' : 'text-yellow-700'}`}
+                            >
+                              {w.severity === 'error' ? '⛔' : '⚠️'} {w.field}: {w.message}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
Adds validation warnings and data corrections to the bulk import preview, as requested in #115.

## Changes

### New: `app/src/lib/import-validation.ts`
Pure validation module with:
- `validateTransaction()` — checks each row for: missing/invalid dates, negative/zero amounts, empty descriptions, future dates, suspiciously large amounts (>10,000)
- `validateImportBatch()` — aggregates all warnings and errors, returns `hasBlockingErrors` flag
- Each issue tagged with severity (`error` or `warning`), row number, and field name

### Enhanced: `app/src/pages/Expenses.tsx`
- All rows shown (scrollable), not just first 10
- Inline editing for date, description, amount on every row
- Category assignment dropdown per row
- Per-row validation indicators (red = error, yellow = warning)
- Summary bar: valid/warning/error counts
- Remove row button per row
- "Confirm Import" blocked when blocking errors exist
- Re-validates on every edit or row removal

### New: `app/src/__tests__/import-validation.test.ts`
12 unit tests covering all validation rules and batch aggregation.

### Updated: `README.md`
Added documentation section for the import validation feature.

## Testing
All 12 tests pass: `npm test -- --testPathPattern=import-validation`