### PR TITLE
feat: Multi-account financial overview dashboard (fixes #132)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,89 @@
+"""Multi-account financial overview API endpoints."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.accounts import (
+    create_account,
+    get_accounts,
+    get_account,
+    update_account,
+    delete_account,
+    overview,
+)
+import logging
+
+bp = Blueprint("accounts", __name__)
+logger = logging.getLogger("finmind.accounts")
+
+
+@bp.get("/")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    active_only = request.args.get("active_only", "true").lower() == "true"
+    return jsonify(get_accounts(uid, active_only))
+
+
+@bp.post("/")
+@jwt_required()
+def add_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or not data.get("name") or not data.get("account_type"):
+        return jsonify({"error": "name and account_type are required"}), 400
+    try:
+        acct = create_account(
+            uid,
+            data["name"],
+            data["account_type"],
+            data.get("currency", "INR"),
+            data.get("balance", 0),
+        )
+        logger.info("Account created user=%s name=%s", uid, data["name"])
+        return jsonify(acct), 201
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@bp.get("/<int:account_id>")
+@jwt_required()
+def get_one(account_id):
+    uid = int(get_jwt_identity())
+    acct = get_account(uid, account_id)
+    if not acct:
+        return jsonify({"error": "Account not found"}), 404
+    return jsonify(acct)
+
+
+@bp.put("/<int:account_id>")
+@jwt_required()
+def update_one(account_id):
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    try:
+        acct = update_account(uid, account_id, **data)
+        if not acct:
+            return jsonify({"error": "Account not found"}), 404
+        logger.info("Account updated user=%s id=%s", uid, account_id)
+        return jsonify(acct)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def delete_one(account_id):
+    uid = int(get_jwt_identity())
+    if delete_account(uid, account_id):
+        logger.info("Account deleted user=%s id=%s", uid, account_id)
+        return jsonify({"message": "Account deleted"}), 200
+    return jsonify({"error": "Account not found"}), 404
+
+
+@bp.get("/overview")
+@jwt_required()
+def get_overview():
+    uid = int(get_jwt_identity())
+    result = overview(uid)
+    logger.info("Overview served user=%s accounts=%s", uid, result["total_accounts"])
+    return jsonify(result)

--- a/packages/backend/app/services/accounts.py
+++ b/packages/backend/app/services/accounts.py
@@ -1,0 +1,122 @@
+"""Multi-account financial overview service.
+
+Supports linking multiple financial accounts (bank, credit card, cash, investment)
+and provides a unified dashboard view across all accounts.
+"""
+
+from datetime import datetime, date, timedelta
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Expense, Category
+
+
+class AccountType:
+    BANK = "bank"
+    CREDIT_CARD = "credit_card"
+    CASH = "cash"
+    INVESTMENT = "investment"
+    SAVINGS = "savings"
+
+    ALL = [BANK, CREDIT_CARD, CASH, INVESTMENT, SAVINGS]
+
+
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    account_type = db.Column(db.String(50), nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    balance = db.Column(db.Numeric(14, 2), default=0, nullable=False)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+def create_account(user_id: int, name: str, account_type: str,
+                   currency: str = "INR", balance: float = 0) -> dict:
+    if account_type not in AccountType.ALL:
+        raise ValueError(f"Invalid account type. Must be one of: {AccountType.ALL}")
+
+    account = FinancialAccount(
+        user_id=user_id,
+        name=name,
+        account_type=account_type,
+        currency=currency,
+        balance=balance,
+    )
+    db.session.add(account)
+    db.session.commit()
+    return _serialize(account)
+
+
+def get_accounts(user_id: int, active_only: bool = True) -> list[dict]:
+    q = FinancialAccount.query.filter_by(user_id=user_id)
+    if active_only:
+        q = q.filter_by(is_active=True)
+    return [_serialize(a) for a in q.order_by(FinancialAccount.name).all()]
+
+
+def get_account(user_id: int, account_id: int) -> dict | None:
+    a = FinancialAccount.query.filter_by(id=account_id, user_id=user_id).first()
+    return _serialize(a) if a else None
+
+
+def update_account(user_id: int, account_id: int, **kwargs) -> dict | None:
+    a = FinancialAccount.query.filter_by(id=account_id, user_id=user_id).first()
+    if not a:
+        return None
+    for key in ("name", "account_type", "currency", "balance", "is_active"):
+        if key in kwargs:
+            if key == "account_type" and kwargs[key] not in AccountType.ALL:
+                raise ValueError(f"Invalid account type. Must be one of: {AccountType.ALL}")
+            setattr(a, key, kwargs[key])
+    db.session.commit()
+    return _serialize(a)
+
+
+def delete_account(user_id: int, account_id: int) -> bool:
+    a = FinancialAccount.query.filter_by(id=account_id, user_id=user_id).first()
+    if not a:
+        return False
+    db.session.delete(a)
+    db.session.commit()
+    return True
+
+
+def overview(user_id: int) -> dict:
+    """Unified financial overview across all active accounts."""
+    accounts = FinancialAccount.query.filter_by(user_id=user_id, is_active=True).all()
+
+    total_balance = sum(float(a.balance) for a in accounts)
+    by_type = {}
+    for a in accounts:
+        by_type.setdefault(a.account_type, {"count": 0, "total": 0})
+        by_type[a.account_type]["count"] += 1
+        by_type[a.account_type]["total"] += float(a.balance)
+
+    by_currency = {}
+    for a in accounts:
+        by_currency.setdefault(a.currency, 0)
+        by_currency[a.currency] += float(a.balance)
+
+    return {
+        "total_accounts": len(accounts),
+        "total_balance": round(total_balance, 2),
+        "by_type": {k: {"count": v["count"], "total": round(v["total"], 2)} for k, v in by_type.items()},
+        "by_currency": {k: round(v, 2) for k, v in by_currency.items()},
+        "accounts": [_serialize(a) for a in accounts],
+    }
+
+
+def _serialize(a: FinancialAccount) -> dict:
+    return {
+        "id": a.id,
+        "name": a.name,
+        "account_type": a.account_type,
+        "currency": a.currency,
+        "balance": float(a.balance),
+        "is_active": a.is_active,
+        "created_at": a.created_at.isoformat(),
+        "updated_at": a.updated_at.isoformat(),
+    }

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,191 @@
+"""Tests for multi-account financial overview."""
+
+import pytest
+from app.services.accounts import (
+    AccountType,
+    FinancialAccount,
+    create_account,
+    get_accounts,
+    get_account,
+    update_account,
+    delete_account,
+    overview,
+)
+
+
+@pytest.fixture
+def app():
+    from app import create_app
+    from app.config import Settings
+
+    settings = Settings()
+    settings.database_url = "sqlite:///:memory:"
+    app = create_app(settings)
+    with app.app_context():
+        from app.extensions import db
+
+        db.create_all()
+        yield app
+
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        from app.extensions import db
+        from app.models import User
+        from werkzeug.security import generate_password_hash
+
+        u = User(email="test@example.com", password_hash=generate_password_hash("pass"))
+        db.session.add(u)
+        db.session.commit()
+        return u.id
+
+
+@pytest.fixture
+def token(app, user):
+    with app.app_context():
+        from flask_jwt_extended import create_access_token
+
+        return create_access_token(identity=str(user))
+
+
+class TestAccountService:
+    def test_create_account(self, app, user):
+        with app.app_context():
+            acct = create_account(user, "Main Bank", AccountType.BANK, "USD", 1000)
+            assert acct["name"] == "Main Bank"
+            assert acct["account_type"] == "bank"
+            assert acct["balance"] == 1000
+
+    def test_create_invalid_type(self, app, user):
+        with app.app_context():
+            with pytest.raises(ValueError):
+                create_account(user, "Bad", "invalid_type")
+
+    def test_list_accounts(self, app, user):
+        with app.app_context():
+            create_account(user, "Bank A", AccountType.BANK)
+            create_account(user, "Card B", AccountType.CREDIT_CARD)
+            accts = get_accounts(user)
+            assert len(accts) == 2
+
+    def test_list_active_only(self, app, user):
+        with app.app_context():
+            create_account(user, "Active", AccountType.BANK)
+            a2 = create_account(user, "Inactive", AccountType.CASH)
+            update_account(user, a2["id"], is_active=False)
+            active = get_accounts(user, active_only=True)
+            all_accts = get_accounts(user, active_only=False)
+            assert len(active) == 1
+            assert len(all_accts) == 2
+
+    def test_get_account(self, app, user):
+        with app.app_context():
+            created = create_account(user, "Test", AccountType.SAVINGS, balance=500)
+            fetched = get_account(user, created["id"])
+            assert fetched["name"] == "Test"
+            assert fetched["balance"] == 500
+
+    def test_get_nonexistent(self, app, user):
+        with app.app_context():
+            assert get_account(user, 9999) is None
+
+    def test_update_account(self, app, user):
+        with app.app_context():
+            created = create_account(user, "Old Name", AccountType.BANK)
+            updated = update_account(user, created["id"], name="New Name", balance=2000)
+            assert updated["name"] == "New Name"
+            assert updated["balance"] == 2000
+
+    def test_update_nonexistent(self, app, user):
+        with app.app_context():
+            assert update_account(user, 9999, name="X") is None
+
+    def test_delete_account(self, app, user):
+        with app.app_context():
+            created = create_account(user, "ToDelete", AccountType.CASH)
+            assert delete_account(user, created["id"]) is True
+            assert get_account(user, created["id"]) is None
+
+    def test_delete_nonexistent(self, app, user):
+        with app.app_context():
+            assert delete_account(user, 9999) is False
+
+    def test_overview(self, app, user):
+        with app.app_context():
+            create_account(user, "Bank", AccountType.BANK, "USD", 5000)
+            create_account(user, "Card", AccountType.CREDIT_CARD, "USD", -500)
+            create_account(user, "Cash", AccountType.CASH, "INR", 2000)
+            result = overview(user)
+            assert result["total_accounts"] == 3
+            assert result["total_balance"] == 6500.0
+            assert "bank" in result["by_type"]
+            assert "USD" in result["by_currency"]
+            assert "INR" in result["by_currency"]
+
+    def test_overview_empty(self, app, user):
+        with app.app_context():
+            result = overview(user)
+            assert result["total_accounts"] == 0
+            assert result["total_balance"] == 0
+
+
+class TestAccountAPI:
+    def test_create_endpoint(self, app, user, token):
+        client = app.test_client()
+        resp = client.post(
+            "/accounts/",
+            json={"name": "My Bank", "account_type": "bank", "balance": 1000},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["name"] == "My Bank"
+
+    def test_create_missing_fields(self, app, user, token):
+        client = app.test_client()
+        resp = client.post(
+            "/accounts/",
+            json={"name": "No Type"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 400
+
+    def test_list_endpoint(self, app, user, token):
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token}"}
+        client.post("/accounts/", json={"name": "A", "account_type": "bank"}, headers=h)
+        client.post("/accounts/", json={"name": "B", "account_type": "cash"}, headers=h)
+        resp = client.get("/accounts/", headers=h)
+        assert resp.status_code == 200
+        assert len(resp.get_json()) == 2
+
+    def test_overview_endpoint(self, app, user, token):
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token}"}
+        client.post("/accounts/", json={"name": "Bank", "account_type": "bank", "balance": 3000}, headers=h)
+        resp = client.get("/accounts/overview", headers=h)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total_balance"] == 3000
+
+    def test_update_endpoint(self, app, user, token):
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token}"}
+        r = client.post("/accounts/", json={"name": "Old", "account_type": "bank"}, headers=h)
+        aid = r.get_json()["id"]
+        resp = client.put(f"/accounts/{aid}", json={"name": "New"}, headers=h)
+        assert resp.status_code == 200
+        assert resp.get_json()["name"] == "New"
+
+    def test_delete_endpoint(self, app, user, token):
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token}"}
+        r = client.post("/accounts/", json={"name": "Del", "account_type": "cash"}, headers=h)
+        aid = r.get_json()["id"]
+        resp = client.delete(f"/accounts/{aid}", headers=h)
+        assert resp.status_code == 200
+
+    def test_get_not_found(self, app, user, token):
+        client = app.test_client()
+        resp = client.get("/accounts/9999", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 404


### PR DESCRIPTION
## Summary
Support viewing multiple financial accounts in one unified view.

## Changes
- **Model** (`FinancialAccount` in `services/accounts.py`): 5 account types (bank, credit_card, cash, investment, savings) with balance, currency, active status
- **Service** (`app/services/accounts.py`): Full CRUD + unified overview aggregation (total balance, breakdown by type & currency)
- **Routes** (`app/routes/accounts.py`):
  - `GET /accounts/` — list accounts (with `?active_only=true/false`)
  - `POST /accounts/` — create account
  - `GET /accounts/<id>` — get single account
  - `PUT /accounts/<id>` — update account
  - `DELETE /accounts/<id>` — delete account
  - `GET /accounts/overview` — unified multi-account dashboard
- **Tests** (`tests/test_accounts.py`): 19 test cases covering service logic + API endpoints

## API Example
```
GET /accounts/overview
{
  "total_accounts": 3,
  "total_balance": 6500.00,
  "by_type": {"bank": {"count": 1, "total": 5000}, ...},
  "by_currency": {"USD": 4500, "INR": 2000},
  "accounts": [...]
}
```

Fixes #132