### PR TITLE
feat: Household collaborative budgeting (fixes #134)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .households import bp as households_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(households_bp, url_prefix="/households")

--- a/packages/backend/app/routes/households.py
+++ b/packages/backend/app/routes/households.py
@@ -1,0 +1,100 @@
+"""Household collaborative budgeting API endpoints."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.households import (
+    create_household, get_user_households, get_household,
+    add_member, remove_member, set_budget, get_budget_summary, delete_household,
+)
+import logging
+
+bp = Blueprint("households", __name__)
+logger = logging.getLogger("finmind.households")
+
+
+@bp.get("/")
+@jwt_required()
+def list_households():
+    uid = int(get_jwt_identity())
+    return jsonify(get_user_households(uid))
+
+
+@bp.post("/")
+@jwt_required()
+def create():
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or not data.get("name"):
+        return jsonify({"error": "name is required"}), 400
+    h = create_household(uid, data["name"])
+    logger.info("Household created user=%s name=%s", uid, data["name"])
+    return jsonify(h), 201
+
+
+@bp.get("/<int:hid>")
+@jwt_required()
+def get_one(hid):
+    uid = int(get_jwt_identity())
+    h = get_household(uid, hid)
+    if not h:
+        return jsonify({"error": "Household not found or access denied"}), 404
+    return jsonify(h)
+
+
+@bp.post("/<int:hid>/members")
+@jwt_required()
+def invite_member(hid):
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or not data.get("email"):
+        return jsonify({"error": "email is required"}), 400
+    result = add_member(uid, hid, data["email"])
+    if not result:
+        return jsonify({"error": "Household not found, not owner, or user not found"}), 404
+    logger.info("Member added household=%s email=%s", hid, data["email"])
+    return jsonify(result)
+
+
+@bp.delete("/<int:hid>/members/<int:member_uid>")
+@jwt_required()
+def kick_member(hid, member_uid):
+    uid = int(get_jwt_identity())
+    if remove_member(uid, hid, member_uid):
+        return jsonify({"message": "Member removed"})
+    return jsonify({"error": "Cannot remove member"}), 400
+
+
+@bp.post("/<int:hid>/budgets")
+@jwt_required()
+def set_budget_endpoint(hid):
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or not data.get("category_name") or not data.get("monthly_limit"):
+        return jsonify({"error": "category_name and monthly_limit are required"}), 400
+    try:
+        result = set_budget(uid, hid, data["category_name"], data["monthly_limit"], data.get("month"))
+        if not result:
+            return jsonify({"error": "Household not found or access denied"}), 404
+        return jsonify(result)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@bp.get("/<int:hid>/budgets")
+@jwt_required()
+def budget_summary(hid):
+    uid = int(get_jwt_identity())
+    month = request.args.get("month")
+    result = get_budget_summary(uid, hid, month)
+    if not result:
+        return jsonify({"error": "Household not found or access denied"}), 404
+    return jsonify(result)
+
+
+@bp.delete("/<int:hid>")
+@jwt_required()
+def delete(hid):
+    uid = int(get_jwt_identity())
+    if delete_household(uid, hid):
+        return jsonify({"message": "Household deleted"})
+    return jsonify({"error": "Not found or not owner"}), 404

--- a/packages/backend/app/services/households.py
+++ b/packages/backend/app/services/households.py
@@ -1,0 +1,198 @@
+"""Household collaborative budgeting service.
+
+Allows multiple users to form a household, share expenses,
+set joint budgets, and track spending together.
+"""
+
+from datetime import datetime, date
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Expense, Category, User
+
+
+class Household(db.Model):
+    __tablename__ = "households"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    members = db.relationship("HouseholdMember", backref="household", lazy=True, cascade="all, delete-orphan")
+    budgets = db.relationship("HouseholdBudget", backref="household", lazy=True, cascade="all, delete-orphan")
+
+
+class HouseholdMember(db.Model):
+    __tablename__ = "household_members"
+    id = db.Column(db.Integer, primary_key=True)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    role = db.Column(db.String(20), default="member", nullable=False)  # owner, member
+    joined_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (db.UniqueConstraint("household_id", "user_id"),)
+
+
+class HouseholdBudget(db.Model):
+    __tablename__ = "household_budgets"
+    id = db.Column(db.Integer, primary_key=True)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=False)
+    category_name = db.Column(db.String(100), nullable=False)
+    monthly_limit = db.Column(db.Numeric(14, 2), nullable=False)
+    month = db.Column(db.String(7), nullable=False)  # YYYY-MM
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+def create_household(owner_id: int, name: str) -> dict:
+    h = Household(name=name, owner_id=owner_id)
+    db.session.add(h)
+    db.session.flush()
+    m = HouseholdMember(household_id=h.id, user_id=owner_id, role="owner")
+    db.session.add(m)
+    db.session.commit()
+    return _serialize_household(h)
+
+
+def get_user_households(user_id: int) -> list[dict]:
+    member_rows = HouseholdMember.query.filter_by(user_id=user_id).all()
+    hids = [m.household_id for m in member_rows]
+    if not hids:
+        return []
+    households = Household.query.filter(Household.id.in_(hids)).all()
+    return [_serialize_household(h) for h in households]
+
+
+def get_household(user_id: int, household_id: int) -> dict | None:
+    if not _is_member(user_id, household_id):
+        return None
+    h = Household.query.get(household_id)
+    return _serialize_household(h) if h else None
+
+
+def add_member(owner_id: int, household_id: int, user_email: str) -> dict | None:
+    h = Household.query.get(household_id)
+    if not h or h.owner_id != owner_id:
+        return None
+    user = User.query.filter_by(email=user_email).first()
+    if not user:
+        return None
+    existing = HouseholdMember.query.filter_by(household_id=household_id, user_id=user.id).first()
+    if existing:
+        return _serialize_household(h)
+    m = HouseholdMember(household_id=household_id, user_id=user.id, role="member")
+    db.session.add(m)
+    db.session.commit()
+    return _serialize_household(h)
+
+
+def remove_member(owner_id: int, household_id: int, member_user_id: int) -> bool:
+    h = Household.query.get(household_id)
+    if not h or h.owner_id != owner_id:
+        return False
+    if member_user_id == owner_id:
+        return False  # can't remove owner
+    m = HouseholdMember.query.filter_by(household_id=household_id, user_id=member_user_id).first()
+    if not m:
+        return False
+    db.session.delete(m)
+    db.session.commit()
+    return True
+
+
+def set_budget(user_id: int, household_id: int, category_name: str,
+               monthly_limit: float, month: str | None = None) -> dict | None:
+    if not _is_member(user_id, household_id):
+        return None
+    if monthly_limit <= 0:
+        raise ValueError("monthly_limit must be positive")
+    month = month or date.today().strftime("%Y-%m")
+    existing = HouseholdBudget.query.filter_by(
+        household_id=household_id, category_name=category_name, month=month
+    ).first()
+    if existing:
+        existing.monthly_limit = monthly_limit
+    else:
+        b = HouseholdBudget(
+            household_id=household_id, category_name=category_name,
+            monthly_limit=monthly_limit, month=month,
+        )
+        db.session.add(b)
+    db.session.commit()
+    return get_budget_summary(user_id, household_id, month)
+
+
+def get_budget_summary(user_id: int, household_id: int, month: str | None = None) -> dict | None:
+    if not _is_member(user_id, household_id):
+        return None
+    month = month or date.today().strftime("%Y-%m")
+    h = Household.query.get(household_id)
+    member_ids = [m.user_id for m in h.members]
+
+    budgets = HouseholdBudget.query.filter_by(household_id=household_id, month=month).all()
+
+    # Get actual spending by all members
+    year, mo = int(month[:4]), int(month[5:7])
+    spending = (
+        db.session.query(Category.name, func.sum(Expense.amount))
+        .join(Category, Expense.category_id == Category.id)
+        .filter(
+            Expense.user_id.in_(member_ids),
+            func.extract("year", Expense.date) == year,
+            func.extract("month", Expense.date) == mo,
+        )
+        .group_by(Category.name)
+        .all()
+    )
+    spending_map = {name: float(total) for name, total in spending}
+
+    budget_items = []
+    for b in budgets:
+        spent = spending_map.get(b.category_name, 0)
+        limit = float(b.monthly_limit)
+        budget_items.append({
+            "category": b.category_name,
+            "limit": limit,
+            "spent": round(spent, 2),
+            "remaining": round(limit - spent, 2),
+            "pct_used": round(spent / limit * 100, 1) if limit > 0 else 0,
+        })
+
+    total_limit = sum(float(b.monthly_limit) for b in budgets)
+    total_spent = sum(i["spent"] for i in budget_items)
+
+    return {
+        "household_id": household_id,
+        "month": month,
+        "total_budget": round(total_limit, 2),
+        "total_spent": round(total_spent, 2),
+        "total_remaining": round(total_limit - total_spent, 2),
+        "categories": budget_items,
+        "member_count": len(member_ids),
+    }
+
+
+def delete_household(owner_id: int, household_id: int) -> bool:
+    h = Household.query.get(household_id)
+    if not h or h.owner_id != owner_id:
+        return False
+    db.session.delete(h)
+    db.session.commit()
+    return True
+
+
+def _is_member(user_id: int, household_id: int) -> bool:
+    return HouseholdMember.query.filter_by(
+        household_id=household_id, user_id=user_id
+    ).first() is not None
+
+
+def _serialize_household(h: Household) -> dict:
+    return {
+        "id": h.id,
+        "name": h.name,
+        "owner_id": h.owner_id,
+        "members": [
+            {"user_id": m.user_id, "role": m.role, "joined_at": m.joined_at.isoformat()}
+            for m in h.members
+        ],
+        "created_at": h.created_at.isoformat(),
+    }

--- a/packages/backend/tests/test_households.py
+++ b/packages/backend/tests/test_households.py
@@ -1,0 +1,222 @@
+"""Tests for household collaborative budgeting."""
+
+import pytest
+from app.services.households import (
+    Household, HouseholdMember, HouseholdBudget,
+    create_household, get_user_households, get_household,
+    add_member, remove_member, set_budget, get_budget_summary, delete_household,
+)
+
+
+@pytest.fixture
+def app():
+    from app import create_app
+    from app.config import Settings
+
+    settings = Settings()
+    settings.database_url = "sqlite:///:memory:"
+    app = create_app(settings)
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        yield app
+
+
+@pytest.fixture
+def users(app):
+    with app.app_context():
+        from app.extensions import db
+        from app.models import User
+        from werkzeug.security import generate_password_hash
+
+        u1 = User(email="owner@example.com", password_hash=generate_password_hash("pass"))
+        u2 = User(email="member@example.com", password_hash=generate_password_hash("pass"))
+        u3 = User(email="outsider@example.com", password_hash=generate_password_hash("pass"))
+        db.session.add_all([u1, u2, u3])
+        db.session.commit()
+        return u1.id, u2.id, u3.id
+
+
+@pytest.fixture
+def token_for(app, users):
+    def _make(uid):
+        with app.app_context():
+            from flask_jwt_extended import create_access_token
+            return create_access_token(identity=str(uid))
+    return _make
+
+
+class TestHouseholdService:
+    def test_create(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "My Home")
+            assert h["name"] == "My Home"
+            assert h["owner_id"] == owner
+            assert len(h["members"]) == 1
+            assert h["members"][0]["role"] == "owner"
+
+    def test_list_households(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            create_household(owner, "Home 1")
+            create_household(owner, "Home 2")
+            hs = get_user_households(owner)
+            assert len(hs) == 2
+
+    def test_get_household(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "Test")
+            fetched = get_household(owner, h["id"])
+            assert fetched["name"] == "Test"
+
+    def test_get_household_denied(self, app, users):
+        owner, _, outsider = users
+        with app.app_context():
+            h = create_household(owner, "Private")
+            assert get_household(outsider, h["id"]) is None
+
+    def test_add_member(self, app, users):
+        owner, member, _ = users
+        with app.app_context():
+            h = create_household(owner, "Shared")
+            result = add_member(owner, h["id"], "member@example.com")
+            assert len(result["members"]) == 2
+
+    def test_add_member_not_owner(self, app, users):
+        owner, member, _ = users
+        with app.app_context():
+            h = create_household(owner, "Shared")
+            assert add_member(member, h["id"], "outsider@example.com") is None
+
+    def test_add_nonexistent_user(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "Test")
+            assert add_member(owner, h["id"], "nobody@example.com") is None
+
+    def test_add_duplicate_member(self, app, users):
+        owner, member, _ = users
+        with app.app_context():
+            h = create_household(owner, "Test")
+            add_member(owner, h["id"], "member@example.com")
+            result = add_member(owner, h["id"], "member@example.com")
+            assert len(result["members"]) == 2  # no duplicate
+
+    def test_remove_member(self, app, users):
+        owner, member, _ = users
+        with app.app_context():
+            h = create_household(owner, "Test")
+            add_member(owner, h["id"], "member@example.com")
+            assert remove_member(owner, h["id"], member) is True
+            updated = get_household(owner, h["id"])
+            assert len(updated["members"]) == 1
+
+    def test_remove_owner_fails(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "Test")
+            assert remove_member(owner, h["id"], owner) is False
+
+    def test_set_budget(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "Home")
+            result = set_budget(owner, h["id"], "Food", 5000, "2026-02")
+            assert result["total_budget"] == 5000
+            assert len(result["categories"]) == 1
+
+    def test_set_budget_invalid(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "Home")
+            with pytest.raises(ValueError):
+                set_budget(owner, h["id"], "Food", -100)
+
+    def test_budget_summary_empty(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "Home")
+            result = get_budget_summary(owner, h["id"], "2026-02")
+            assert result["total_budget"] == 0
+            assert result["total_spent"] == 0
+
+    def test_delete_household(self, app, users):
+        owner, _, _ = users
+        with app.app_context():
+            h = create_household(owner, "Del")
+            assert delete_household(owner, h["id"]) is True
+            assert get_household(owner, h["id"]) is None
+
+    def test_delete_not_owner(self, app, users):
+        owner, member, _ = users
+        with app.app_context():
+            h = create_household(owner, "Test")
+            add_member(owner, h["id"], "member@example.com")
+            assert delete_household(member, h["id"]) is False
+
+
+class TestHouseholdAPI:
+    def test_create_endpoint(self, app, users, token_for):
+        owner, _, _ = users
+        client = app.test_client()
+        resp = client.post(
+            "/households/",
+            json={"name": "API Home"},
+            headers={"Authorization": f"Bearer {token_for(owner)}"},
+        )
+        assert resp.status_code == 201
+        assert resp.get_json()["name"] == "API Home"
+
+    def test_create_missing_name(self, app, users, token_for):
+        owner, _, _ = users
+        client = app.test_client()
+        resp = client.post(
+            "/households/",
+            json={},
+            headers={"Authorization": f"Bearer {token_for(owner)}"},
+        )
+        assert resp.status_code == 400
+
+    def test_list_endpoint(self, app, users, token_for):
+        owner, _, _ = users
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token_for(owner)}"}
+        client.post("/households/", json={"name": "H1"}, headers=h)
+        resp = client.get("/households/", headers=h)
+        assert resp.status_code == 200
+        assert len(resp.get_json()) == 1
+
+    def test_add_member_endpoint(self, app, users, token_for):
+        owner, member, _ = users
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token_for(owner)}"}
+        r = client.post("/households/", json={"name": "Shared"}, headers=h)
+        hid = r.get_json()["id"]
+        resp = client.post(f"/households/{hid}/members", json={"email": "member@example.com"}, headers=h)
+        assert resp.status_code == 200
+        assert len(resp.get_json()["members"]) == 2
+
+    def test_set_budget_endpoint(self, app, users, token_for):
+        owner, _, _ = users
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token_for(owner)}"}
+        r = client.post("/households/", json={"name": "Budget"}, headers=h)
+        hid = r.get_json()["id"]
+        resp = client.post(
+            f"/households/{hid}/budgets",
+            json={"category_name": "Food", "monthly_limit": 3000},
+            headers=h,
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["total_budget"] == 3000
+
+    def test_delete_endpoint(self, app, users, token_for):
+        owner, _, _ = users
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token_for(owner)}"}
+        r = client.post("/households/", json={"name": "Del"}, headers=h)
+        hid = r.get_json()["id"]
+        resp = client.delete(f"/households/{hid}", headers=h)
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
Allow multiple users to collaborate on household finances with shared budgets.

## Changes
- **Models**: `Household`, `HouseholdMember`, `HouseholdBudget` with cascading deletes
- **Service** (`app/services/households.py`):
  - Create household (auto-adds owner as member)
  - Invite members by email (owner-only)
  - Remove members (owner-only, can't remove self)
  - Set monthly budgets per category
  - Budget summary aggregating spending from all members
  - Role-based access control (owner vs member)
- **Routes** (`app/routes/households.py`):
  - `GET /households/` — list user's households
  - `POST /households/` — create household
  - `GET /households/<id>` — get household details
  - `POST /households/<id>/members` — invite member
  - `DELETE /households/<id>/members/<uid>` — remove member
  - `POST /households/<id>/budgets` — set category budget
  - `GET /households/<id>/budgets` — budget summary with spending
  - `DELETE /households/<id>` — delete household
- **Tests**: 21 test cases (service + API)

## API Example
```
GET /households/1/budgets?month=2026-02
{
  "total_budget": 8000,
  "total_spent": 3500,
  "total_remaining": 4500,
  "categories": [{"category": "Food", "limit": 5000, "spent": 2000, "remaining": 3000, "pct_used": 40.0}],
  "member_count": 3
}
```

Fixes #134