### PR TITLE
feat: Smart payee & merchant alias management (fixes #114)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .merchants import bp as merchants_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(merchants_bp, url_prefix="/merchants")

--- a/packages/backend/app/routes/merchants.py
+++ b/packages/backend/app/routes/merchants.py
@@ -1,0 +1,69 @@
+"""Smart payee & merchant alias API."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.merchant_alias import (
+    set_alias, get_aliases, delete_alias, suggest_merges,
+    bulk_set_aliases, merchant_summary,
+)
+import logging
+
+bp = Blueprint("merchants", __name__)
+logger = logging.getLogger("finmind.merchants")
+
+
+@bp.get("/aliases")
+@jwt_required()
+def list_aliases():
+    uid = int(get_jwt_identity())
+    return jsonify(get_aliases(uid))
+
+
+@bp.post("/aliases")
+@jwt_required()
+def create_alias():
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or not data.get("raw_name") or not data.get("display_name"):
+        return jsonify({"error": "raw_name and display_name are required"}), 400
+    try:
+        alias = set_alias(uid, data["raw_name"], data["display_name"])
+        logger.info("Alias set user=%s raw=%s display=%s", uid, data["raw_name"], data["display_name"])
+        return jsonify(alias), 201
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@bp.post("/aliases/bulk")
+@jwt_required()
+def bulk_aliases():
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or not isinstance(data.get("aliases"), list):
+        return jsonify({"error": "aliases array is required"}), 400
+    results = bulk_set_aliases(uid, data["aliases"])
+    return jsonify(results), 201
+
+
+@bp.delete("/aliases/<int:alias_id>")
+@jwt_required()
+def remove_alias(alias_id):
+    uid = int(get_jwt_identity())
+    if delete_alias(uid, alias_id):
+        return jsonify({"message": "Alias deleted"})
+    return jsonify({"error": "Alias not found"}), 404
+
+
+@bp.get("/suggest-merges")
+@jwt_required()
+def get_suggestions():
+    uid = int(get_jwt_identity())
+    threshold = float(request.args.get("threshold", 0.7))
+    return jsonify(suggest_merges(uid, threshold))
+
+
+@bp.get("/summary")
+@jwt_required()
+def get_summary():
+    uid = int(get_jwt_identity())
+    return jsonify(merchant_summary(uid))

--- a/packages/backend/app/services/merchant_alias.py
+++ b/packages/backend/app/services/merchant_alias.py
@@ -1,0 +1,146 @@
+"""Smart payee & merchant alias management.
+
+Maps messy transaction descriptions to clean merchant names,
+supports user-defined aliases, and auto-suggests merges for similar names.
+"""
+
+from datetime import datetime
+from difflib import SequenceMatcher
+from collections import defaultdict
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Expense
+
+
+class MerchantAlias(db.Model):
+    __tablename__ = "merchant_aliases"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    raw_name = db.Column(db.String(300), nullable=False)
+    display_name = db.Column(db.String(200), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (db.UniqueConstraint("user_id", "raw_name"),)
+
+
+def set_alias(user_id: int, raw_name: str, display_name: str) -> dict:
+    """Create or update a merchant alias."""
+    raw_name = raw_name.strip()
+    display_name = display_name.strip()
+    if not raw_name or not display_name:
+        raise ValueError("raw_name and display_name are required")
+
+    existing = MerchantAlias.query.filter_by(user_id=user_id, raw_name=raw_name).first()
+    if existing:
+        existing.display_name = display_name
+    else:
+        existing = MerchantAlias(user_id=user_id, raw_name=raw_name, display_name=display_name)
+        db.session.add(existing)
+    db.session.commit()
+    return _serialize(existing)
+
+
+def get_aliases(user_id: int) -> list[dict]:
+    aliases = MerchantAlias.query.filter_by(user_id=user_id).order_by(MerchantAlias.display_name).all()
+    return [_serialize(a) for a in aliases]
+
+
+def delete_alias(user_id: int, alias_id: int) -> bool:
+    a = MerchantAlias.query.filter_by(id=alias_id, user_id=user_id).first()
+    if not a:
+        return False
+    db.session.delete(a)
+    db.session.commit()
+    return True
+
+
+def resolve_name(user_id: int, raw_name: str) -> str:
+    """Resolve a raw transaction description to a display name."""
+    alias = MerchantAlias.query.filter_by(user_id=user_id, raw_name=raw_name).first()
+    return alias.display_name if alias else raw_name
+
+
+def suggest_merges(user_id: int, threshold: float = 0.7) -> list[dict]:
+    """Find similar merchant descriptions that could be merged."""
+    descriptions = (
+        db.session.query(Expense.description, func.count(Expense.id))
+        .filter(Expense.user_id == user_id)
+        .group_by(Expense.description)
+        .having(func.count(Expense.id) >= 1)
+        .all()
+    )
+
+    names = [(d, c) for d, c in descriptions if d]
+    suggestions = []
+    seen = set()
+
+    for i, (name_a, count_a) in enumerate(names):
+        for j, (name_b, count_b) in enumerate(names):
+            if i >= j:
+                continue
+            pair_key = tuple(sorted([name_a, name_b]))
+            if pair_key in seen:
+                continue
+
+            similarity = SequenceMatcher(None, name_a.lower(), name_b.lower()).ratio()
+            if similarity >= threshold:
+                seen.add(pair_key)
+                suggested = name_a if count_a >= count_b else name_b
+                suggestions.append({
+                    "names": [name_a, name_b],
+                    "counts": [count_a, count_b],
+                    "similarity": round(similarity, 2),
+                    "suggested_name": suggested,
+                })
+
+    suggestions.sort(key=lambda x: x["similarity"], reverse=True)
+    return suggestions
+
+
+def bulk_set_aliases(user_id: int, aliases: list[dict]) -> list[dict]:
+    """Set multiple aliases at once. Each dict needs raw_name and display_name."""
+    results = []
+    for a in aliases:
+        results.append(set_alias(user_id, a["raw_name"], a["display_name"]))
+    return results
+
+
+def merchant_summary(user_id: int) -> dict:
+    """Summary of merchant/payee usage with alias resolution."""
+    rows = (
+        db.session.query(Expense.description, func.count(Expense.id), func.sum(Expense.amount))
+        .filter(Expense.user_id == user_id)
+        .group_by(Expense.description)
+        .all()
+    )
+
+    alias_map = {a.raw_name: a.display_name for a in MerchantAlias.query.filter_by(user_id=user_id).all()}
+
+    merged = defaultdict(lambda: {"count": 0, "total": 0, "raw_names": []})
+    for desc, count, total in rows:
+        display = alias_map.get(desc, desc)
+        merged[display]["count"] += count
+        merged[display]["total"] += float(total)
+        if desc not in merged[display]["raw_names"]:
+            merged[display]["raw_names"].append(desc)
+
+    merchants = [
+        {"name": name, "transaction_count": d["count"], "total_spent": round(d["total"], 2), "raw_names": d["raw_names"]}
+        for name, d in merged.items()
+    ]
+    merchants.sort(key=lambda x: x["total_spent"], reverse=True)
+
+    return {
+        "total_merchants": len(merchants),
+        "total_aliases": len(alias_map),
+        "merchants": merchants,
+    }
+
+
+def _serialize(a: MerchantAlias) -> dict:
+    return {
+        "id": a.id,
+        "raw_name": a.raw_name,
+        "display_name": a.display_name,
+        "created_at": a.created_at.isoformat(),
+    }

--- a/packages/backend/tests/test_merchant_alias.py
+++ b/packages/backend/tests/test_merchant_alias.py
@@ -1,0 +1,184 @@
+"""Tests for smart payee & merchant alias management."""
+
+import pytest
+from app.services.merchant_alias import (
+    MerchantAlias, set_alias, get_aliases, delete_alias,
+    resolve_name, suggest_merges, bulk_set_aliases, merchant_summary,
+)
+
+
+@pytest.fixture
+def app():
+    from app import create_app
+    from app.config import Settings
+    settings = Settings()
+    settings.database_url = "sqlite:///:memory:"
+    app = create_app(settings)
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        yield app
+
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        from app.extensions import db
+        from app.models import User
+        from werkzeug.security import generate_password_hash
+        u = User(email="test@example.com", password_hash=generate_password_hash("pass"))
+        db.session.add(u)
+        db.session.commit()
+        return u.id
+
+
+@pytest.fixture
+def token(app, user):
+    with app.app_context():
+        from flask_jwt_extended import create_access_token
+        return create_access_token(identity=str(user))
+
+
+@pytest.fixture
+def seed_expenses(app, user):
+    with app.app_context():
+        from app.extensions import db
+        from app.models import Category, Expense
+        from datetime import date
+        cat = Category(user_id=user, name="Food")
+        db.session.add(cat)
+        db.session.flush()
+        for desc in ["STARBUCKS #1234", "STARBUCKS #5678", "Starbucks Coffee", "MCDONALDS", "McDonalds #99"]:
+            db.session.add(Expense(user_id=user, category_id=cat.id, amount=10, description=desc, date=date.today()))
+        db.session.commit()
+        return user
+
+
+class TestAliasService:
+    def test_set_alias(self, app, user):
+        with app.app_context():
+            a = set_alias(user, "STARBUCKS #1234", "Starbucks")
+            assert a["raw_name"] == "STARBUCKS #1234"
+            assert a["display_name"] == "Starbucks"
+
+    def test_update_alias(self, app, user):
+        with app.app_context():
+            set_alias(user, "SBUX", "Starbucks")
+            updated = set_alias(user, "SBUX", "Starbucks Coffee")
+            assert updated["display_name"] == "Starbucks Coffee"
+
+    def test_empty_raises(self, app, user):
+        with app.app_context():
+            with pytest.raises(ValueError):
+                set_alias(user, "", "Name")
+
+    def test_get_aliases(self, app, user):
+        with app.app_context():
+            set_alias(user, "A", "Alpha")
+            set_alias(user, "B", "Beta")
+            aliases = get_aliases(user)
+            assert len(aliases) == 2
+
+    def test_delete_alias(self, app, user):
+        with app.app_context():
+            a = set_alias(user, "DEL", "Delete Me")
+            assert delete_alias(user, a["id"]) is True
+            assert len(get_aliases(user)) == 0
+
+    def test_delete_nonexistent(self, app, user):
+        with app.app_context():
+            assert delete_alias(user, 9999) is False
+
+    def test_resolve_with_alias(self, app, user):
+        with app.app_context():
+            set_alias(user, "SBUX #123", "Starbucks")
+            assert resolve_name(user, "SBUX #123") == "Starbucks"
+
+    def test_resolve_without_alias(self, app, user):
+        with app.app_context():
+            assert resolve_name(user, "Unknown Store") == "Unknown Store"
+
+    def test_bulk_set(self, app, user):
+        with app.app_context():
+            results = bulk_set_aliases(user, [
+                {"raw_name": "A", "display_name": "Alpha"},
+                {"raw_name": "B", "display_name": "Beta"},
+            ])
+            assert len(results) == 2
+
+    def test_suggest_merges(self, app, seed_expenses):
+        with app.app_context():
+            suggestions = suggest_merges(seed_expenses, threshold=0.5)
+            assert isinstance(suggestions, list)
+            # Should find STARBUCKS variants as similar
+            starbucks = [s for s in suggestions if any("STARBUCKS" in n or "Starbucks" in n for n in s["names"])]
+            assert len(starbucks) > 0
+
+    def test_merchant_summary(self, app, seed_expenses):
+        with app.app_context():
+            result = merchant_summary(seed_expenses)
+            assert result["total_merchants"] == 5
+            assert result["total_aliases"] == 0
+
+    def test_summary_with_aliases(self, app, seed_expenses):
+        with app.app_context():
+            set_alias(seed_expenses, "STARBUCKS #1234", "Starbucks")
+            set_alias(seed_expenses, "STARBUCKS #5678", "Starbucks")
+            result = merchant_summary(seed_expenses)
+            starbucks = [m for m in result["merchants"] if m["name"] == "Starbucks"]
+            assert len(starbucks) == 1
+            assert starbucks[0]["transaction_count"] == 2
+
+
+class TestMerchantAPI:
+    def test_create_alias(self, app, user, token):
+        client = app.test_client()
+        resp = client.post(
+            "/merchants/aliases",
+            json={"raw_name": "SBUX", "display_name": "Starbucks"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 201
+
+    def test_create_missing_fields(self, app, user, token):
+        client = app.test_client()
+        resp = client.post(
+            "/merchants/aliases",
+            json={"raw_name": "SBUX"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 400
+
+    def test_list_aliases(self, app, user, token):
+        client = app.test_client()
+        h = {"Authorization": f"Bearer {token}"}
+        client.post("/merchants/aliases", json={"raw_name": "A", "display_name": "B"}, headers=h)
+        resp = client.get("/merchants/aliases", headers=h)
+        assert resp.status_code == 200
+        assert len(resp.get_json()) == 1
+
+    def test_suggest_merges_endpoint(self, app, seed_expenses, token):
+        client = app.test_client()
+        resp = client.get(
+            "/merchants/suggest-merges",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+    def test_summary_endpoint(self, app, seed_expenses, token):
+        client = app.test_client()
+        resp = client.get(
+            "/merchants/summary",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert "total_merchants" in resp.get_json()
+
+    def test_bulk_endpoint(self, app, user, token):
+        client = app.test_client()
+        resp = client.post(
+            "/merchants/aliases/bulk",
+            json={"aliases": [{"raw_name": "X", "display_name": "Y"}]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 201


### PR DESCRIPTION
## Summary
Map messy transaction descriptions to clean merchant names with fuzzy merge suggestions.

## Features
- **Alias CRUD**: Map raw names ("STARBUCKS #1234") to display names ("Starbucks")
- **Bulk aliases**: Set multiple aliases in one request
- **Fuzzy merge suggestions**: Auto-detect similar descriptions using SequenceMatcher
- **Merchant summary**: Aggregated spending per merchant with alias resolution
- **Name resolution**: Resolve raw descriptions to display names

## API
- `GET /merchants/aliases` — list aliases
- `POST /merchants/aliases` — create alias
- `POST /merchants/aliases/bulk` — bulk create
- `DELETE /merchants/aliases/<id>` — delete alias
- `GET /merchants/suggest-merges?threshold=0.7` — fuzzy merge suggestions
- `GET /merchants/summary` — merchant spending summary

## Tests
18 test cases covering service logic + API endpoints.

Fixes #114