### PR TITLE
feat: Universal bank statement normalization layer (fixes #112)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .statements import bp as statements_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(statements_bp, url_prefix="/statements")

--- a/packages/backend/app/routes/statements.py
+++ b/packages/backend/app/routes/statements.py
@@ -1,0 +1,45 @@
+"""Bank statement normalization API."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+from ..services.statement_normalizer import normalize_statement
+import logging
+
+bp = Blueprint("statements", __name__)
+logger = logging.getLogger("finmind.statements")
+
+
+@bp.post("/normalize")
+@jwt_required()
+def normalize():
+    """Normalize a bank statement. Accepts raw content or file upload."""
+    if request.content_type and "multipart" in request.content_type:
+        f = request.files.get("file")
+        if not f:
+            return jsonify({"error": "file is required"}), 400
+        content = f.read().decode("utf-8", errors="replace")
+        hint = request.form.get("format")
+    else:
+        data = request.get_json()
+        if not data or not data.get("content"):
+            return jsonify({"error": "content is required"}), 400
+        content = data["content"]
+        hint = data.get("format")
+
+    result = normalize_statement(content, hint)
+    logger.info("Statement normalized format=%s txns=%s", result["format_detected"], result["total_transactions"])
+    return jsonify(result)
+
+
+@bp.post("/preview")
+@jwt_required()
+def preview():
+    """Preview first 5 normalized transactions without full processing."""
+    data = request.get_json()
+    if not data or not data.get("content"):
+        return jsonify({"error": "content is required"}), 400
+
+    result = normalize_statement(data["content"], data.get("format"))
+    result["transactions"] = result["transactions"][:5]
+    result["preview"] = True
+    return jsonify(result)

--- a/packages/backend/app/services/statement_normalizer.py
+++ b/packages/backend/app/services/statement_normalizer.py
@@ -1,0 +1,235 @@
+"""Universal bank statement normalization layer.
+
+Parses and normalizes bank statements from multiple formats (CSV variants,
+OFX/QFX) into a unified transaction schema for import.
+"""
+
+import csv
+import io
+import re
+from datetime import datetime, date
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class NormalizedTransaction:
+    date: str  # ISO format
+    amount: float
+    description: str
+    raw_description: str
+    transaction_type: str  # debit / credit
+    balance: float | None = None
+    reference: str | None = None
+
+
+# Common date formats across banks
+DATE_FORMATS = [
+    "%Y-%m-%d", "%d/%m/%Y", "%m/%d/%Y", "%d-%m-%Y",
+    "%Y/%m/%d", "%d %b %Y", "%d %B %Y", "%b %d, %Y",
+    "%m-%d-%Y", "%d.%m.%Y",
+]
+
+
+def normalize_statement(content: str, format_hint: str | None = None) -> dict:
+    """Parse a bank statement and return normalized transactions.
+
+    Args:
+        content: Raw file content (CSV or OFX string)
+        format_hint: Optional hint ('csv', 'ofx', 'qfx')
+
+    Returns:
+        Dict with transactions list, stats, and any warnings.
+    """
+    fmt = format_hint or _detect_format(content)
+
+    if fmt in ("ofx", "qfx"):
+        txns, warnings = _parse_ofx(content)
+    else:
+        txns, warnings = _parse_csv(content)
+
+    return {
+        "format_detected": fmt,
+        "total_transactions": len(txns),
+        "transactions": [asdict(t) for t in txns],
+        "summary": _summarize(txns),
+        "warnings": warnings,
+    }
+
+
+def _detect_format(content: str) -> str:
+    stripped = content.strip()
+    if stripped.startswith("OFXHEADER") or "<OFX>" in stripped[:500]:
+        return "ofx"
+    return "csv"
+
+
+def _parse_date(value: str) -> str | None:
+    value = value.strip()
+    for fmt in DATE_FORMATS:
+        try:
+            return datetime.strptime(value, fmt).date().isoformat()
+        except ValueError:
+            continue
+    # OFX date format: YYYYMMDD or YYYYMMDDHHMMSS
+    if re.match(r"^\d{8}", value):
+        try:
+            return datetime.strptime(value[:8], "%Y%m%d").date().isoformat()
+        except ValueError:
+            pass
+    return None
+
+
+def _clean_description(desc: str) -> str:
+    desc = re.sub(r"\s+", " ", desc.strip())
+    desc = re.sub(r"\b\d{4}\*+\d{4}\b", "", desc)  # mask card numbers
+    desc = re.sub(r"\s{2,}", " ", desc).strip()
+    return desc
+
+
+def _parse_amount(value: str) -> float:
+    value = value.strip().replace(",", "").replace(" ", "")
+    value = re.sub(r"[^\d.\-+]", "", value)
+    return float(value) if value else 0.0
+
+
+def _detect_csv_columns(headers: list[str]) -> dict:
+    """Map CSV headers to our expected fields."""
+    mapping = {}
+    header_lower = [h.lower().strip() for h in headers]
+
+    date_keys = ["date", "transaction date", "posting date", "value date", "txn date"]
+    amount_keys = ["amount", "transaction amount", "debit/credit", "sum"]
+    desc_keys = ["description", "narrative", "details", "memo", "particulars", "transaction description"]
+    balance_keys = ["balance", "running balance", "closing balance"]
+    ref_keys = ["reference", "ref", "transaction ref", "cheque no"]
+    debit_keys = ["debit", "withdrawal", "dr"]
+    credit_keys = ["credit", "deposit", "cr"]
+
+    for i, h in enumerate(header_lower):
+        if h in date_keys:
+            mapping["date"] = i
+        elif h in amount_keys:
+            mapping["amount"] = i
+        elif h in desc_keys:
+            mapping["description"] = i
+        elif h in balance_keys:
+            mapping["balance"] = i
+        elif h in ref_keys:
+            mapping["reference"] = i
+        elif h in debit_keys:
+            mapping["debit"] = i
+        elif h in credit_keys:
+            mapping["credit"] = i
+
+    return mapping
+
+
+def _parse_csv(content: str) -> tuple[list[NormalizedTransaction], list[str]]:
+    warnings = []
+    txns = []
+
+    reader = csv.reader(io.StringIO(content))
+    rows = list(reader)
+    if len(rows) < 2:
+        return [], ["File has fewer than 2 rows"]
+
+    mapping = _detect_csv_columns(rows[0])
+    if "date" not in mapping:
+        warnings.append("Could not detect date column")
+        return [], warnings
+
+    has_split = "debit" in mapping and "credit" in mapping
+    if "amount" not in mapping and not has_split:
+        warnings.append("Could not detect amount column")
+        return [], warnings
+
+    for row_idx, row in enumerate(rows[1:], start=2):
+        try:
+            if len(row) <= max(mapping.values()):
+                continue
+
+            parsed_date = _parse_date(row[mapping["date"]])
+            if not parsed_date:
+                warnings.append(f"Row {row_idx}: unparseable date '{row[mapping['date']]}'")
+                continue
+
+            if has_split:
+                debit = _parse_amount(row[mapping["debit"]]) if row[mapping["debit"]].strip() else 0
+                credit = _parse_amount(row[mapping["credit"]]) if row[mapping["credit"]].strip() else 0
+                amount = credit - debit if credit else -debit
+            else:
+                amount = _parse_amount(row[mapping["amount"]])
+
+            raw_desc = row[mapping.get("description", mapping.get("date"))]
+            balance = _parse_amount(row[mapping["balance"]]) if "balance" in mapping and row[mapping["balance"]].strip() else None
+            reference = row[mapping["reference"]].strip() if "reference" in mapping and len(row) > mapping["reference"] else None
+
+            txns.append(NormalizedTransaction(
+                date=parsed_date,
+                amount=abs(amount),
+                description=_clean_description(raw_desc),
+                raw_description=raw_desc.strip(),
+                transaction_type="credit" if amount >= 0 else "debit",
+                balance=balance,
+                reference=reference,
+            ))
+        except (IndexError, ValueError) as e:
+            warnings.append(f"Row {row_idx}: {str(e)}")
+
+    return txns, warnings
+
+
+def _parse_ofx(content: str) -> tuple[list[NormalizedTransaction], list[str]]:
+    """Simple OFX/QFX parser (SGML-style, no XML dependency)."""
+    warnings = []
+    txns = []
+
+    # Extract STMTTRN blocks
+    blocks = re.findall(r"<STMTTRN>(.*?)</STMTTRN>", content, re.DOTALL)
+    if not blocks:
+        # Try without closing tags (some OFX files)
+        blocks = re.findall(r"<STMTTRN>(.*?)(?=<STMTTRN>|</BANKTRANLIST>|$)", content, re.DOTALL)
+
+    for block in blocks:
+        try:
+            dt_match = re.search(r"<DTPOSTED>(\d{8,14})", block)
+            amt_match = re.search(r"<TRNAMT>([\-\d.]+)", block)
+            name_match = re.search(r"<NAME>(.+?)(?:\n|<)", block)
+            memo_match = re.search(r"<MEMO>(.+?)(?:\n|<)", block)
+            ref_match = re.search(r"<FITID>(.+?)(?:\n|<)", block)
+
+            if not dt_match or not amt_match:
+                continue
+
+            parsed_date = _parse_date(dt_match.group(1))
+            amount = float(amt_match.group(1))
+            desc = (name_match.group(1) if name_match else memo_match.group(1) if memo_match else "Unknown").strip()
+
+            txns.append(NormalizedTransaction(
+                date=parsed_date or "unknown",
+                amount=abs(amount),
+                description=_clean_description(desc),
+                raw_description=desc,
+                transaction_type="credit" if amount >= 0 else "debit",
+                reference=ref_match.group(1).strip() if ref_match else None,
+            ))
+        except Exception as e:
+            warnings.append(f"OFX block parse error: {str(e)}")
+
+    return txns, warnings
+
+
+def _summarize(txns: list[NormalizedTransaction]) -> dict:
+    if not txns:
+        return {"total_debits": 0, "total_credits": 0, "net": 0, "date_range": None}
+
+    debits = sum(t.amount for t in txns if t.transaction_type == "debit")
+    credits = sum(t.amount for t in txns if t.transaction_type == "credit")
+    dates = [t.date for t in txns if t.date != "unknown"]
+
+    return {
+        "total_debits": round(debits, 2),
+        "total_credits": round(credits, 2),
+        "net": round(credits - debits, 2),
+        "date_range": {"start": min(dates), "end": max(dates)} if dates else None,
+    }

--- a/packages/backend/tests/test_statement_normalizer.py
+++ b/packages/backend/tests/test_statement_normalizer.py
@@ -1,0 +1,210 @@
+"""Tests for universal bank statement normalization."""
+
+import pytest
+from app.services.statement_normalizer import (
+    normalize_statement, _parse_date, _clean_description,
+    _parse_amount, _detect_format, _detect_csv_columns,
+)
+
+
+SAMPLE_CSV = """Date,Description,Amount,Balance
+2026-02-01,Grocery Store,-45.50,1954.50
+2026-02-02,Salary Deposit,3000.00,4954.50
+2026-02-03,Electric Bill,-120.00,4834.50
+"""
+
+SAMPLE_CSV_SPLIT = """Transaction Date,Narrative,Debit,Credit,Balance
+01/02/2026,Grocery Store,45.50,,1954.50
+02/02/2026,Salary Deposit,,3000.00,4954.50
+03/02/2026,Electric Bill,120.00,,4834.50
+"""
+
+SAMPLE_OFX = """OFXHEADER:100
+<OFX>
+<BANKMSGSRSV1>
+<BANKTRANLIST>
+<STMTTRN>
+<DTPOSTED>20260201
+<TRNAMT>-45.50
+<NAME>Grocery Store
+<FITID>TXN001
+</STMTTRN>
+<STMTTRN>
+<DTPOSTED>20260202
+<TRNAMT>3000.00
+<NAME>Salary Deposit
+<FITID>TXN002
+</STMTTRN>
+</BANKTRANLIST>
+</BANKMSGSRSV1>
+</OFX>"""
+
+
+class TestParseDate:
+    def test_iso(self):
+        assert _parse_date("2026-02-01") == "2026-02-01"
+
+    def test_dd_mm_yyyy(self):
+        assert _parse_date("01/02/2026") == "2026-02-01"
+
+    def test_mm_dd_yyyy(self):
+        assert _parse_date("02/01/2026") == "2026-01-02"
+
+    def test_ofx_format(self):
+        assert _parse_date("20260201") == "2026-02-01"
+
+    def test_ofx_long(self):
+        assert _parse_date("20260201120000") == "2026-02-01"
+
+    def test_invalid(self):
+        assert _parse_date("not-a-date") is None
+
+
+class TestCleanDescription:
+    def test_whitespace(self):
+        assert _clean_description("  Hello   World  ") == "Hello World"
+
+    def test_card_mask(self):
+        assert "****" not in _clean_description("VISA 4532****1234 Purchase")
+
+
+class TestParseAmount:
+    def test_simple(self):
+        assert _parse_amount("45.50") == 45.50
+
+    def test_negative(self):
+        assert _parse_amount("-120.00") == -120.00
+
+    def test_comma(self):
+        assert _parse_amount("1,234.56") == 1234.56
+
+    def test_empty(self):
+        assert _parse_amount("") == 0.0
+
+
+class TestDetectFormat:
+    def test_csv(self):
+        assert _detect_format("Date,Amount\n2026-01-01,100") == "csv"
+
+    def test_ofx(self):
+        assert _detect_format("OFXHEADER:100\n<OFX>") == "ofx"
+
+
+class TestDetectColumns:
+    def test_standard(self):
+        m = _detect_csv_columns(["Date", "Description", "Amount", "Balance"])
+        assert m["date"] == 0
+        assert m["description"] == 1
+        assert m["amount"] == 2
+        assert m["balance"] == 3
+
+    def test_split_debit_credit(self):
+        m = _detect_csv_columns(["Transaction Date", "Narrative", "Debit", "Credit"])
+        assert "debit" in m
+        assert "credit" in m
+
+
+class TestNormalizeCSV:
+    def test_basic(self):
+        result = normalize_statement(SAMPLE_CSV)
+        assert result["format_detected"] == "csv"
+        assert result["total_transactions"] == 3
+        txns = result["transactions"]
+        assert txns[0]["date"] == "2026-02-01"
+        assert txns[0]["amount"] == 45.50
+        assert txns[0]["transaction_type"] == "debit"
+        assert txns[1]["transaction_type"] == "credit"
+
+    def test_split_columns(self):
+        result = normalize_statement(SAMPLE_CSV_SPLIT)
+        assert result["total_transactions"] == 3
+
+    def test_summary(self):
+        result = normalize_statement(SAMPLE_CSV)
+        s = result["summary"]
+        assert s["total_debits"] > 0
+        assert s["total_credits"] > 0
+        assert s["date_range"]["start"] == "2026-02-01"
+
+    def test_empty(self):
+        result = normalize_statement("Date,Amount\n")
+        assert result["total_transactions"] == 0
+
+    def test_bad_rows(self):
+        csv_data = "Date,Amount\n2026-01-01,100\nbaddate,200\n"
+        result = normalize_statement(csv_data)
+        assert len(result["warnings"]) > 0
+
+
+class TestNormalizeOFX:
+    def test_basic(self):
+        result = normalize_statement(SAMPLE_OFX)
+        assert result["format_detected"] == "ofx"
+        assert result["total_transactions"] == 2
+        txns = result["transactions"]
+        assert txns[0]["amount"] == 45.50
+        assert txns[0]["transaction_type"] == "debit"
+        assert txns[0]["reference"] == "TXN001"
+        assert txns[1]["transaction_type"] == "credit"
+
+    def test_format_hint(self):
+        result = normalize_statement(SAMPLE_OFX, format_hint="ofx")
+        assert result["format_detected"] == "ofx"
+
+
+@pytest.fixture
+def app():
+    from app import create_app
+    from app.config import Settings
+    settings = Settings()
+    settings.database_url = "sqlite:///:memory:"
+    app = create_app(settings)
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        yield app
+
+
+@pytest.fixture
+def token(app):
+    with app.app_context():
+        from app.extensions import db
+        from app.models import User
+        from werkzeug.security import generate_password_hash
+        from flask_jwt_extended import create_access_token
+        u = User(email="t@t.com", password_hash=generate_password_hash("p"))
+        db.session.add(u)
+        db.session.commit()
+        return create_access_token(identity=str(u.id))
+
+
+class TestAPI:
+    def test_normalize_endpoint(self, app, token):
+        client = app.test_client()
+        resp = client.post(
+            "/statements/normalize",
+            json={"content": SAMPLE_CSV},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["total_transactions"] == 3
+
+    def test_preview_endpoint(self, app, token):
+        client = app.test_client()
+        resp = client.post(
+            "/statements/preview",
+            json={"content": SAMPLE_CSV},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["preview"] is True
+
+    def test_missing_content(self, app, token):
+        client = app.test_client()
+        resp = client.post(
+            "/statements/normalize",
+            json={},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary
Parse and normalize bank statements from multiple formats into a unified transaction schema.

## Supported Formats
- **CSV**: Auto-detects columns (date, amount, description, balance, debit/credit split). Supports 10+ date formats.
- **OFX/QFX**: SGML-style parser extracting STMTTRN blocks.

## Features
- Auto format detection (CSV vs OFX)
- Column mapping heuristics for varied CSV layouts
- Description cleaning & card number masking
- Transaction summary (debits, credits, net, date range)
- Preview mode (first 5 transactions)
- Detailed warnings for unparseable rows

## API
- `POST /statements/normalize` — full normalization (JSON body or file upload)
- `POST /statements/preview` — preview first 5 transactions

## Tests
22 test cases covering date parsing, amount parsing, CSV/OFX normalization, column detection, and API endpoints.

Fixes #112