### PR TITLE
feat: Locale-aware date, currency & number formatting (fixes #131)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .locale import bp as locale_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(locale_bp, url_prefix="/locale")

--- a/packages/backend/app/routes/locale.py
+++ b/packages/backend/app/routes/locale.py
@@ -1,0 +1,73 @@
+"""Locale-aware formatting API."""
+
+from datetime import date
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.locale_formatting import (
+    get_locale, update_locale, format_currency, format_date,
+    format_number, get_supported_currencies, get_date_formats, get_number_formats,
+)
+
+bp = Blueprint("locale", __name__)
+
+
+@bp.get("/")
+@jwt_required()
+def get_loc():
+    uid = int(get_jwt_identity())
+    return jsonify(get_locale(uid))
+
+
+@bp.put("/")
+@jwt_required()
+def update():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    try:
+        return jsonify(update_locale(uid, **data))
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@bp.post("/format/currency")
+@jwt_required()
+def fmt_currency():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    amount = float(data.get("amount", 0))
+    return jsonify({"formatted": format_currency(uid, amount)})
+
+
+@bp.post("/format/date")
+@jwt_required()
+def fmt_date():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    d = date.fromisoformat(data.get("date", date.today().isoformat()))
+    return jsonify({"formatted": format_date(uid, d)})
+
+
+@bp.post("/format/number")
+@jwt_required()
+def fmt_number():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    return jsonify({"formatted": format_number(uid, float(data.get("value", 0)), int(data.get("decimals", 2)))})
+
+
+@bp.get("/currencies")
+@jwt_required()
+def currencies():
+    return jsonify(get_supported_currencies())
+
+
+@bp.get("/date-formats")
+@jwt_required()
+def date_fmts():
+    return jsonify(get_date_formats())
+
+
+@bp.get("/number-formats")
+@jwt_required()
+def number_fmts():
+    return jsonify(get_number_formats())

--- a/packages/backend/app/services/locale_formatting.py
+++ b/packages/backend/app/services/locale_formatting.py
@@ -1,0 +1,144 @@
+"""Locale-aware date, currency & number formatting.
+
+Per-user locale preferences with formatting utilities for
+dates, currencies, and numbers.
+"""
+
+import locale as _locale
+from datetime import datetime, date
+from ..extensions import db
+
+
+class UserLocale(db.Model):
+    __tablename__ = "user_locales"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, unique=True)
+    language = db.Column(db.String(10), default="en")
+    country = db.Column(db.String(10), default="US")
+    currency = db.Column(db.String(3), default="USD")
+    date_format = db.Column(db.String(20), default="YYYY-MM-DD")
+    number_format = db.Column(db.String(20), default="1,234.56")  # grouping style
+    timezone = db.Column(db.String(50), default="UTC")
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+SUPPORTED_CURRENCIES = [
+    {"code": "USD", "symbol": "$", "name": "US Dollar"},
+    {"code": "EUR", "symbol": "€", "name": "Euro"},
+    {"code": "GBP", "symbol": "£", "name": "British Pound"},
+    {"code": "JPY", "symbol": "¥", "name": "Japanese Yen"},
+    {"code": "CNY", "symbol": "¥", "name": "Chinese Yuan"},
+    {"code": "KRW", "symbol": "₩", "name": "Korean Won"},
+    {"code": "INR", "symbol": "₹", "name": "Indian Rupee"},
+    {"code": "BRL", "symbol": "R$", "name": "Brazilian Real"},
+    {"code": "CAD", "symbol": "CA$", "name": "Canadian Dollar"},
+    {"code": "AUD", "symbol": "A$", "name": "Australian Dollar"},
+]
+
+DATE_FORMATS = {
+    "YYYY-MM-DD": "%Y-%m-%d",
+    "MM/DD/YYYY": "%m/%d/%Y",
+    "DD/MM/YYYY": "%d/%m/%Y",
+    "DD.MM.YYYY": "%d.%m.%Y",
+    "YYYY年MM月DD日": "%Y年%m月%d日",
+}
+
+NUMBER_STYLES = {
+    "1,234.56": {"group": ",", "decimal": "."},
+    "1.234,56": {"group": ".", "decimal": ","},
+    "1 234,56": {"group": " ", "decimal": ","},
+    "1'234.56": {"group": "'", "decimal": "."},
+}
+
+
+def get_locale(user_id: int) -> dict:
+    loc = UserLocale.query.filter_by(user_id=user_id).first()
+    if not loc:
+        loc = UserLocale(user_id=user_id)
+        db.session.add(loc)
+        db.session.commit()
+    return _serialize(loc)
+
+
+def update_locale(user_id: int, **kwargs) -> dict:
+    loc = UserLocale.query.filter_by(user_id=user_id).first()
+    if not loc:
+        loc = UserLocale(user_id=user_id)
+        db.session.add(loc)
+
+    for key in ("language", "country", "currency", "date_format", "number_format", "timezone"):
+        if key in kwargs and kwargs[key] is not None:
+            if key == "currency" and kwargs[key] not in [c["code"] for c in SUPPORTED_CURRENCIES]:
+                raise ValueError(f"Unsupported currency: {kwargs[key]}")
+            if key == "date_format" and kwargs[key] not in DATE_FORMATS:
+                raise ValueError(f"Unsupported date format: {kwargs[key]}")
+            if key == "number_format" and kwargs[key] not in NUMBER_STYLES:
+                raise ValueError(f"Unsupported number format: {kwargs[key]}")
+            setattr(loc, key, kwargs[key])
+
+    db.session.commit()
+    return _serialize(loc)
+
+
+def format_currency(user_id: int, amount: float) -> str:
+    loc = UserLocale.query.filter_by(user_id=user_id).first()
+    currency = loc.currency if loc else "USD"
+    number_fmt = loc.number_format if loc else "1,234.56"
+
+    symbol = next((c["symbol"] for c in SUPPORTED_CURRENCIES if c["code"] == currency), "$")
+    formatted = _format_number(amount, number_fmt, decimals=2)
+    return f"{symbol}{formatted}"
+
+
+def format_date(user_id: int, d: date) -> str:
+    loc = UserLocale.query.filter_by(user_id=user_id).first()
+    fmt = loc.date_format if loc else "YYYY-MM-DD"
+    py_fmt = DATE_FORMATS.get(fmt, "%Y-%m-%d")
+    return d.strftime(py_fmt)
+
+
+def format_number(user_id: int, value: float, decimals: int = 2) -> str:
+    loc = UserLocale.query.filter_by(user_id=user_id).first()
+    number_fmt = loc.number_format if loc else "1,234.56"
+    return _format_number(value, number_fmt, decimals)
+
+
+def get_supported_currencies() -> list[dict]:
+    return SUPPORTED_CURRENCIES
+
+
+def get_date_formats() -> list[str]:
+    return list(DATE_FORMATS.keys())
+
+
+def get_number_formats() -> list[str]:
+    return list(NUMBER_STYLES.keys())
+
+
+def _format_number(value: float, style: str, decimals: int = 2) -> str:
+    fmt = NUMBER_STYLES.get(style, NUMBER_STYLES["1,234.56"])
+    negative = value < 0
+    value = abs(value)
+
+    int_part = int(value)
+    dec_part = round(value - int_part, decimals)
+    dec_str = f"{dec_part:.{decimals}f}"[2:]  # strip "0."
+
+    # Group digits
+    int_str = str(int_part)
+    groups = []
+    while int_str:
+        groups.append(int_str[-3:])
+        int_str = int_str[:-3]
+    grouped = fmt["group"].join(reversed(groups))
+
+    result = f"{grouped}{fmt['decimal']}{dec_str}" if decimals > 0 else grouped
+    return f"-{result}" if negative else result
+
+
+def _serialize(loc: UserLocale) -> dict:
+    return {
+        "language": loc.language, "country": loc.country,
+        "currency": loc.currency, "date_format": loc.date_format,
+        "number_format": loc.number_format, "timezone": loc.timezone,
+    }

--- a/packages/backend/tests/test_locale_formatting.py
+++ b/packages/backend/tests/test_locale_formatting.py
@@ -1,0 +1,182 @@
+"""Tests for locale-aware formatting."""
+
+import pytest
+from datetime import date
+from app.services.locale_formatting import (
+    get_locale, update_locale, format_currency, format_date,
+    format_number, get_supported_currencies, get_date_formats, get_number_formats,
+)
+
+
+@pytest.fixture
+def app():
+    from app import create_app
+    from app.config import Settings
+    settings = Settings()
+    settings.database_url = "sqlite:///:memory:"
+    app = create_app(settings)
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        yield app
+
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        from app.extensions import db
+        from app.models import User
+        from werkzeug.security import generate_password_hash
+        u = User(email="test@example.com", password_hash=generate_password_hash("pass"))
+        db.session.add(u)
+        db.session.commit()
+        return u.id
+
+
+@pytest.fixture
+def token(app, user):
+    with app.app_context():
+        from flask_jwt_extended import create_access_token
+        return create_access_token(identity=str(user))
+
+
+class TestLocale:
+    def test_default(self, app, user):
+        with app.app_context():
+            loc = get_locale(user)
+            assert loc["currency"] == "USD"
+            assert loc["language"] == "en"
+
+    def test_update(self, app, user):
+        with app.app_context():
+            loc = update_locale(user, currency="EUR", language="de", date_format="DD.MM.YYYY")
+            assert loc["currency"] == "EUR"
+            assert loc["date_format"] == "DD.MM.YYYY"
+
+    def test_invalid_currency(self, app, user):
+        with app.app_context():
+            with pytest.raises(ValueError):
+                update_locale(user, currency="XYZ")
+
+    def test_invalid_date_format(self, app, user):
+        with app.app_context():
+            with pytest.raises(ValueError):
+                update_locale(user, date_format="BAD")
+
+    def test_invalid_number_format(self, app, user):
+        with app.app_context():
+            with pytest.raises(ValueError):
+                update_locale(user, number_format="BAD")
+
+
+class TestFormatCurrency:
+    def test_usd(self, app, user):
+        with app.app_context():
+            get_locale(user)
+            assert format_currency(user, 1234.56) == "$1,234.56"
+
+    def test_eur(self, app, user):
+        with app.app_context():
+            update_locale(user, currency="EUR", number_format="1.234,56")
+            assert format_currency(user, 1234.56) == "€1.234,56"
+
+    def test_cny(self, app, user):
+        with app.app_context():
+            update_locale(user, currency="CNY")
+            assert format_currency(user, 99.9) == "¥99.90"
+
+    def test_negative(self, app, user):
+        with app.app_context():
+            get_locale(user)
+            assert format_currency(user, -50) == "$-50.00"
+
+
+class TestFormatDate:
+    def test_iso(self, app, user):
+        with app.app_context():
+            get_locale(user)
+            assert format_date(user, date(2026, 2, 27)) == "2026-02-27"
+
+    def test_us(self, app, user):
+        with app.app_context():
+            update_locale(user, date_format="MM/DD/YYYY")
+            assert format_date(user, date(2026, 2, 27)) == "02/27/2026"
+
+    def test_eu(self, app, user):
+        with app.app_context():
+            update_locale(user, date_format="DD/MM/YYYY")
+            assert format_date(user, date(2026, 2, 27)) == "27/02/2026"
+
+    def test_chinese(self, app, user):
+        with app.app_context():
+            update_locale(user, date_format="YYYY年MM月DD日")
+            assert format_date(user, date(2026, 2, 27)) == "2026年02月27日"
+
+
+class TestFormatNumber:
+    def test_default(self, app, user):
+        with app.app_context():
+            get_locale(user)
+            assert format_number(user, 1234567.89) == "1,234,567.89"
+
+    def test_european(self, app, user):
+        with app.app_context():
+            update_locale(user, number_format="1.234,56")
+            assert format_number(user, 1234567.89) == "1.234.567,89"
+
+    def test_swiss(self, app, user):
+        with app.app_context():
+            update_locale(user, number_format="1'234.56")
+            assert format_number(user, 1234.5) == "1'234.50"
+
+
+class TestCatalogs:
+    def test_currencies(self, app):
+        with app.app_context():
+            c = get_supported_currencies()
+            assert len(c) >= 5
+            assert any(x["code"] == "USD" for x in c)
+
+    def test_date_formats(self, app):
+        with app.app_context():
+            assert len(get_date_formats()) >= 4
+
+    def test_number_formats(self, app):
+        with app.app_context():
+            assert len(get_number_formats()) >= 3
+
+
+class TestAPI:
+    def test_get(self, app, user, token):
+        client = app.test_client()
+        resp = client.get("/locale/", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_update(self, app, user, token):
+        client = app.test_client()
+        resp = client.put("/locale/", json={"currency": "GBP"},
+                          headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_format_currency(self, app, user, token):
+        client = app.test_client()
+        resp = client.post("/locale/format/currency", json={"amount": 99.99},
+                           headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_format_date(self, app, user, token):
+        client = app.test_client()
+        resp = client.post("/locale/format/date", json={"date": "2026-02-27"},
+                           headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_format_number(self, app, user, token):
+        client = app.test_client()
+        resp = client.post("/locale/format/number", json={"value": 1234.5},
+                           headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+    def test_currencies(self, app, user, token):
+        client = app.test_client()
+        resp = client.get("/locale/currencies", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
Per-user locale preferences with formatting utilities for dates, currencies, and numbers.

## Features
- **10 currencies**: USD, EUR, GBP, JPY, CNY, KRW, INR, BRL, CAD, AUD
- **5 date formats**: ISO, US, EU, German, Chinese
- **4 number styles**: US, European, French, Swiss
- **Format utilities**: Currency with symbol, date with locale, number with grouping
- **Per-user preferences**: Stored and applied automatically

## API
- `GET /locale/` — get user locale
- `PUT /locale/` — update locale preferences
- `POST /locale/format/currency` — format amount as currency
- `POST /locale/format/date` — format date
- `POST /locale/format/number` — format number
- `GET /locale/currencies` — supported currencies
- `GET /locale/date-formats` — supported date formats
- `GET /locale/number-formats` — supported number formats

## Tests
24 test cases covering locale CRUD, all format types, catalogs, and API.

Fixes #131