### PR TITLE
feat(household): Shared household budgeting support (#134)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .household import bp as household_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(household_bp, url_prefix="/households")

--- a/packages/backend/app/routes/household.py
+++ b/packages/backend/app/routes/household.py
@@ -1,0 +1,86 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.household import (
+    create_household,
+    generate_invite,
+    accept_invite,
+    get_household_members,
+    household_summary,
+    get_user_households,
+    HouseholdMember,
+)
+import logging
+
+bp = Blueprint("households", __name__)
+logger = logging.getLogger("finmind.households")
+
+
+def _check_membership(household_id: int, user_id: int) -> bool:
+    return HouseholdMember.query.filter_by(
+        household_id=household_id, user_id=user_id
+    ).first() is not None
+
+
+@bp.post("")
+@jwt_required()
+def create():
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    name = (data or {}).get("name", "").strip()
+    if not name:
+        return jsonify({"error": "name is required"}), 400
+    result = create_household(uid, name)
+    logger.info("Household created id=%s by user=%s", result["id"], uid)
+    return jsonify(result), 201
+
+
+@bp.get("")
+@jwt_required()
+def list_households():
+    uid = int(get_jwt_identity())
+    return jsonify(get_user_households(uid))
+
+
+@bp.post("/<int:hid>/invite")
+@jwt_required()
+def invite(hid):
+    uid = int(get_jwt_identity())
+    if not _check_membership(hid, uid):
+        return jsonify({"error": "Not a member"}), 403
+    result = generate_invite(hid, uid)
+    return jsonify(result), 201
+
+
+@bp.post("/join")
+@jwt_required()
+def join():
+    uid = int(get_jwt_identity())
+    data = request.get_json()
+    code = (data or {}).get("invite_code", "").strip()
+    if not code:
+        return jsonify({"error": "invite_code is required"}), 400
+    try:
+        result = accept_invite(uid, code)
+        logger.info("User %s joined household %s", uid, result["household_id"])
+        return jsonify(result)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+
+@bp.get("/<int:hid>/members")
+@jwt_required()
+def members(hid):
+    uid = int(get_jwt_identity())
+    if not _check_membership(hid, uid):
+        return jsonify({"error": "Not a member"}), 403
+    return jsonify(get_household_members(hid))
+
+
+@bp.get("/<int:hid>/summary")
+@jwt_required()
+def summary(hid):
+    uid = int(get_jwt_identity())
+    if not _check_membership(hid, uid):
+        return jsonify({"error": "Not a member"}), 403
+    ym = request.args.get("month")
+    return jsonify(household_summary(hid, ym))

--- a/packages/backend/app/services/household.py
+++ b/packages/backend/app/services/household.py
@@ -1,0 +1,177 @@
+"""Household budgeting service.
+
+Allows multiple users to collaborate on shared household finances
+with invite-based membership and aggregated spending views.
+"""
+
+from datetime import date, datetime
+
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Category, Expense
+
+
+class Household(db.Model):
+    __tablename__ = "households"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(200), nullable=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    members = db.relationship("HouseholdMember", backref="household", lazy=True)
+
+
+class HouseholdMember(db.Model):
+    __tablename__ = "household_members"
+    id = db.Column(db.Integer, primary_key=True)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    role = db.Column(db.String(20), default="member", nullable=False)  # owner/member
+    joined_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint("household_id", "user_id", name="uq_household_user"),
+    )
+
+
+class HouseholdInvite(db.Model):
+    __tablename__ = "household_invites"
+    id = db.Column(db.Integer, primary_key=True)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=False)
+    invite_code = db.Column(db.String(64), unique=True, nullable=False)
+    created_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    used_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+
+def create_household(owner_id: int, name: str) -> dict:
+    h = Household(name=name, owner_id=owner_id)
+    db.session.add(h)
+    db.session.flush()
+    m = HouseholdMember(household_id=h.id, user_id=owner_id, role="owner")
+    db.session.add(m)
+    db.session.commit()
+    return {"id": h.id, "name": h.name, "owner_id": owner_id}
+
+
+def generate_invite(household_id: int, created_by: int, hours: int = 48) -> dict:
+    import secrets
+    from datetime import timedelta
+
+    code = secrets.token_urlsafe(16)
+    expires = datetime.utcnow() + timedelta(hours=hours)
+    inv = HouseholdInvite(
+        household_id=household_id,
+        invite_code=code,
+        created_by=created_by,
+        expires_at=expires,
+    )
+    db.session.add(inv)
+    db.session.commit()
+    return {"invite_code": code, "expires_at": expires.isoformat()}
+
+
+def accept_invite(user_id: int, invite_code: str) -> dict:
+    inv = HouseholdInvite.query.filter_by(invite_code=invite_code, used_by=None).first()
+    if not inv:
+        raise ValueError("Invalid or expired invite code.")
+    if inv.expires_at < datetime.utcnow():
+        raise ValueError("Invite code has expired.")
+
+    existing = HouseholdMember.query.filter_by(
+        household_id=inv.household_id, user_id=user_id
+    ).first()
+    if existing:
+        raise ValueError("Already a member of this household.")
+
+    m = HouseholdMember(household_id=inv.household_id, user_id=user_id, role="member")
+    inv.used_by = user_id
+    db.session.add(m)
+    db.session.commit()
+    return {"household_id": inv.household_id, "role": "member"}
+
+
+def get_household_members(household_id: int) -> list[dict]:
+    members = HouseholdMember.query.filter_by(household_id=household_id).all()
+    return [
+        {"user_id": m.user_id, "role": m.role, "joined_at": m.joined_at.isoformat()}
+        for m in members
+    ]
+
+
+def household_summary(household_id: int, ym: str | None = None) -> dict:
+    """Aggregate spending across all household members for a given month."""
+    if ym is None:
+        ym = date.today().strftime("%Y-%m")
+    year, month = map(int, ym.split("-"))
+
+    member_ids = [
+        m.user_id
+        for m in HouseholdMember.query.filter_by(household_id=household_id).all()
+    ]
+    if not member_ids:
+        return {"month": ym, "total_spending": 0, "total_income": 0, "members": []}
+
+    income = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id.in_(member_ids),
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+    spending = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id.in_(member_ids),
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+
+    # Per-member breakdown
+    per_member = []
+    for uid in member_ids:
+        member_spend = float(
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type != "INCOME",
+            )
+            .scalar()
+            or 0
+        )
+        per_member.append({"user_id": uid, "spending": round(member_spend, 2)})
+
+    return {
+        "month": ym,
+        "total_income": round(income, 2),
+        "total_spending": round(spending, 2),
+        "net_flow": round(income - spending, 2),
+        "member_count": len(member_ids),
+        "members": per_member,
+    }
+
+
+def get_user_households(user_id: int) -> list[dict]:
+    memberships = HouseholdMember.query.filter_by(user_id=user_id).all()
+    result = []
+    for m in memberships:
+        h = Household.query.get(m.household_id)
+        if h:
+            result.append({
+                "id": h.id,
+                "name": h.name,
+                "role": m.role,
+                "member_count": HouseholdMember.query.filter_by(household_id=h.id).count(),
+            })
+    return result

--- a/packages/backend/tests/test_household.py
+++ b/packages/backend/tests/test_household.py
@@ -1,0 +1,104 @@
+from datetime import date
+
+
+def _register_and_login(client, email, password="password123"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def test_create_household(client, auth_header):
+    r = client.post("/households", json={"name": "My Family"}, headers=auth_header)
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["name"] == "My Family"
+    assert "id" in data
+
+
+def test_create_household_no_name(client, auth_header):
+    r = client.post("/households", json={"name": ""}, headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_list_households(client, auth_header):
+    client.post("/households", json={"name": "House A"}, headers=auth_header)
+    r = client.get("/households", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data) >= 1
+    assert data[0]["role"] == "owner"
+
+
+def test_invite_and_join(client, auth_header):
+    # User 1 creates household
+    r = client.post("/households", json={"name": "Shared Home"}, headers=auth_header)
+    hid = r.get_json()["id"]
+
+    # Generate invite
+    r = client.post(f"/households/{hid}/invite", headers=auth_header)
+    assert r.status_code == 201
+    code = r.get_json()["invite_code"]
+
+    # User 2 joins
+    header2 = _register_and_login(client, "user2@example.com")
+    r = client.post("/households/join", json={"invite_code": code}, headers=header2)
+    assert r.status_code == 200
+    assert r.get_json()["role"] == "member"
+
+
+def test_join_invalid_code(client, auth_header):
+    r = client.post(
+        "/households/join", json={"invite_code": "bogus"}, headers=auth_header
+    )
+    assert r.status_code == 400
+
+
+def test_members_list(client, auth_header):
+    r = client.post("/households", json={"name": "Team"}, headers=auth_header)
+    hid = r.get_json()["id"]
+
+    r = client.get(f"/households/{hid}/members", headers=auth_header)
+    assert r.status_code == 200
+    members = r.get_json()
+    assert len(members) == 1
+    assert members[0]["role"] == "owner"
+
+
+def test_household_summary(client, auth_header):
+    r = client.post("/households", json={"name": "Budget Fam"}, headers=auth_header)
+    hid = r.get_json()["id"]
+
+    # Add expense
+    today = date.today()
+    client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "Groceries",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+
+    ym = today.strftime("%Y-%m")
+    r = client.get(f"/households/{hid}/summary?month={ym}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_spending"] == 200
+    assert data["member_count"] == 1
+
+
+def test_non_member_blocked(client, auth_header):
+    r = client.post("/households", json={"name": "Private"}, headers=auth_header)
+    hid = r.get_json()["id"]
+
+    header2 = _register_and_login(client, "outsider@example.com")
+    r = client.get(f"/households/{hid}/members", headers=header2)
+    assert r.status_code == 403
+
+
+def test_requires_auth(client):
+    r = client.post("/households", json={"name": "No Auth"})
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
Implements **Shared household budgeting support** as requested in #134.

### Features

**Household Management API:**
- `POST /households` — Create a new household
- `GET /households` — List user's households
- `POST /households/:id/invite` — Generate invite code (48h expiry)
- `POST /households/join` — Join via invite code
- `GET /households/:id/members` — List members with roles
- `GET /households/:id/summary?month=YYYY-MM` — Aggregated financial summary

**Data Models:**
- `Household` — name, owner
- `HouseholdMember` — user-household link with role (owner/member)
- `HouseholdInvite` — secure invite codes with expiry

**Security:**
- All endpoints require JWT authentication
- Membership check on all household-specific endpoints (403 for non-members)
- Invite codes are cryptographically random with time-based expiry

**Tests** (8 test cases):
- Create household, list households
- Invite generation and join flow
- Invalid invite code handling
- Member listing, household summary
- Non-member access blocked (403)
- Unauthenticated access blocked (401)

Closes #134