### PR TITLE
feat(compression): API response compression & payload optimization (#129)

### DIFF
--- a/deploy/helm/finmind/Chart.yaml
+++ b/deploy/helm/finmind/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: finmind
+description: FinMind - AI-powered personal finance tracker
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - finance
+  - budgeting
+  - analytics
+maintainers:
+  - name: FinMind Contributors

--- a/packages/backend/app/middleware/compression.py
+++ b/packages/backend/app/middleware/compression.py
@@ -1,0 +1,135 @@
+"""API response compression and payload optimization middleware."""
+
+import gzip
+import json
+from io import BytesIO
+from flask import Flask, request, Response
+from functools import wraps
+
+
+def init_compression(app: Flask, minimum_size: int = 500, compression_level: int = 6):
+    """Initialize gzip compression for API responses.
+
+    Args:
+        app: Flask application instance.
+        minimum_size: Minimum response size in bytes to compress.
+        compression_level: Gzip compression level (1-9).
+    """
+
+    @app.after_request
+    def compress_response(response: Response) -> Response:
+        # Skip if client doesn't accept gzip
+        if "gzip" not in request.headers.get("Accept-Encoding", ""):
+            return response
+
+        # Skip non-JSON and small responses
+        if response.content_type and "application/json" not in response.content_type:
+            return response
+
+        if (
+            response.status_code < 200
+            or response.status_code >= 300
+            or response.direct_passthrough
+        ):
+            return response
+
+        data = response.get_data()
+        if len(data) < minimum_size:
+            return response
+
+        # Compress
+        buf = BytesIO()
+        with gzip.GzipFile(
+            fileobj=buf, mode="wb", compresslevel=compression_level
+        ) as f:
+            f.write(data)
+
+        compressed = buf.getvalue()
+
+        # Only use compressed if actually smaller
+        if len(compressed) >= len(data):
+            return response
+
+        response.set_data(compressed)
+        response.headers["Content-Encoding"] = "gzip"
+        response.headers["Content-Length"] = len(compressed)
+        response.headers["Vary"] = "Accept-Encoding"
+
+        return response
+
+    return app
+
+
+def slim_response(fields=None, exclude=None):
+    """Decorator to optimize JSON payload by selecting/excluding fields.
+
+    Usage:
+        @slim_response(fields=['id', 'name', 'amount'])
+        def get_items(): ...
+
+        @slim_response(exclude=['internal_notes', 'debug_info'])
+        def get_details(): ...
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            result = f(*args, **kwargs)
+
+            # Support ?fields=id,name,amount query param override
+            query_fields = request.args.get("fields")
+            if query_fields:
+                active_fields = set(query_fields.split(","))
+            elif fields:
+                active_fields = set(fields)
+            else:
+                active_fields = None
+
+            active_exclude = set(exclude) if exclude else set()
+
+            if isinstance(result, tuple):
+                data, status = result[0], result[1] if len(result) > 1 else 200
+            else:
+                data, status = result, 200
+
+            if isinstance(data, Response):
+                return result
+
+            data = _filter_payload(data, active_fields, active_exclude)
+            return data, status
+
+        return wrapper
+
+    return decorator
+
+
+def _filter_payload(data, fields, exclude):
+    """Filter dict or list of dicts by field selection."""
+    if isinstance(data, dict):
+        return _filter_dict(data, fields, exclude)
+    elif isinstance(data, list):
+        return [_filter_dict(item, fields, exclude) for item in data if isinstance(item, dict)]
+    return data
+
+
+def _filter_dict(d, fields, exclude):
+    """Filter a single dict."""
+    if not isinstance(d, dict):
+        return d
+    result = {}
+    for k, v in d.items():
+        if fields and k not in fields:
+            continue
+        if k in exclude:
+            continue
+        result[k] = v
+    return result
+
+
+def add_pagination_headers(response: Response, page: int, per_page: int, total: int):
+    """Add standard pagination headers to reduce payload metadata."""
+    response.headers["X-Page"] = str(page)
+    response.headers["X-Per-Page"] = str(per_page)
+    response.headers["X-Total"] = str(total)
+    response.headers["X-Total-Pages"] = str((total + per_page - 1) // per_page)
+    return response

--- a/packages/backend/tests/test_compression.py
+++ b/packages/backend/tests/test_compression.py
@@ -1,0 +1,119 @@
+"""Tests for API response compression and payload optimization."""
+
+import gzip
+import json
+import pytest
+from flask import Flask, jsonify
+from app.middleware.compression import (
+    init_compression,
+    slim_response,
+    _filter_payload,
+    add_pagination_headers,
+)
+
+
+@pytest.fixture
+def compression_app():
+    """Create a test app with compression enabled."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    init_compression(app, minimum_size=50, compression_level=6)
+
+    @app.route("/large")
+    def large_response():
+        data = {"items": [{"id": i, "name": f"item_{i}", "value": i * 100} for i in range(100)]}
+        return jsonify(data)
+
+    @app.route("/small")
+    def small_response():
+        return jsonify({"ok": True})
+
+    @app.route("/error")
+    def error_response():
+        return jsonify({"error": "not found"}), 404
+
+    return app
+
+
+@pytest.fixture
+def comp_client(compression_app):
+    return compression_app.test_client()
+
+
+class TestGzipCompression:
+    def test_compresses_large_response(self, comp_client):
+        resp = comp_client.get("/large", headers={"Accept-Encoding": "gzip"})
+        assert resp.status_code == 200
+        assert resp.headers.get("Content-Encoding") == "gzip"
+        decompressed = gzip.decompress(resp.data)
+        data = json.loads(decompressed)
+        assert len(data["items"]) == 100
+
+    def test_no_compression_without_header(self, comp_client):
+        resp = comp_client.get("/large")
+        assert resp.headers.get("Content-Encoding") is None
+        data = resp.get_json()
+        assert len(data["items"]) == 100
+
+    def test_no_compression_small_response(self, comp_client):
+        resp = comp_client.get("/small", headers={"Accept-Encoding": "gzip"})
+        assert resp.headers.get("Content-Encoding") is None
+        assert resp.get_json() == {"ok": True}
+
+    def test_no_compression_error_response(self, comp_client):
+        resp = comp_client.get("/error", headers={"Accept-Encoding": "gzip"})
+        assert resp.status_code == 404
+        assert resp.headers.get("Content-Encoding") is None
+
+    def test_compressed_smaller_than_original(self, comp_client):
+        resp_plain = comp_client.get("/large")
+        resp_gzip = comp_client.get("/large", headers={"Accept-Encoding": "gzip"})
+        assert len(resp_gzip.data) < len(resp_plain.data)
+
+
+class TestPayloadFiltering:
+    def test_filter_fields(self):
+        data = {"id": 1, "name": "test", "secret": "hidden"}
+        result = _filter_payload(data, fields={"id", "name"}, exclude=set())
+        assert result == {"id": 1, "name": "test"}
+
+    def test_filter_exclude(self):
+        data = {"id": 1, "name": "test", "secret": "hidden"}
+        result = _filter_payload(data, fields=None, exclude={"secret"})
+        assert result == {"id": 1, "name": "test"}
+
+    def test_filter_list(self):
+        data = [
+            {"id": 1, "name": "a", "extra": "x"},
+            {"id": 2, "name": "b", "extra": "y"},
+        ]
+        result = _filter_payload(data, fields={"id", "name"}, exclude=set())
+        assert result == [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+
+    def test_filter_empty_fields(self):
+        data = {"id": 1, "name": "test"}
+        result = _filter_payload(data, fields=None, exclude=set())
+        assert result == {"id": 1, "name": "test"}
+
+    def test_filter_non_dict(self):
+        assert _filter_payload("string", None, set()) == "string"
+        assert _filter_payload(42, None, set()) == 42
+
+
+class TestPaginationHeaders:
+    def test_pagination_headers(self, compression_app):
+        with compression_app.test_request_context():
+            from flask import make_response
+            resp = make_response(jsonify([]))
+            add_pagination_headers(resp, page=2, per_page=20, total=95)
+            assert resp.headers["X-Page"] == "2"
+            assert resp.headers["X-Per-Page"] == "20"
+            assert resp.headers["X-Total"] == "95"
+            assert resp.headers["X-Total-Pages"] == "5"
+
+    def test_pagination_single_page(self, compression_app):
+        with compression_app.test_request_context():
+            from flask import make_response
+            resp = make_response(jsonify([]))
+            add_pagination_headers(resp, page=1, per_page=50, total=10)
+            assert resp.headers["X-Total-Pages"] == "1"


### PR DESCRIPTION
## Summary
Reduce payload size and improve response times with gzip compression and payload optimization.

Closes #129

## Changes
- **Gzip middleware**: `packages/backend/app/middleware/compression.py`
  - Auto-compresses JSON responses >500 bytes when client accepts gzip
  - Configurable minimum size and compression level
  - Only compresses when result is actually smaller
  - Adds proper Content-Encoding, Content-Length, Vary headers

- **Payload optimization**:
  - `@slim_response` decorator for field selection/exclusion
  - Query param `?fields=id,name` for client-side field selection
  - `add_pagination_headers()` utility for X-Page/X-Total headers

- **Tests**: 12 test cases covering compression, filtering, pagination

## Acceptance Criteria
- [x] Production ready implementation
- [x] Includes tests (12 cases)
- [x] Follows existing code patterns