### PR TITLE
feat(bank-connector): add connector abstraction, mock implementation, and factory for #266

### DIFF
--- a/app/src/lib/bank-connector.test.ts
+++ b/app/src/lib/bank-connector.test.ts
@@ -1,0 +1,56 @@
+// WHY: Focused unit tests prove the abstraction contract holds for both
+// import and refresh flows, and that the factory wires up correctly.
+// These tests run without a network and without mocking fetch.
+
+import { describe, it, expect } from 'vitest';
+import {
+  MockBankConnector,
+  createConnector,
+  type BankTransaction,
+} from './bank-connector';
+
+const FIXTURES: BankTransaction[] = [
+  { id: 'a', date: '2024-01-10', description: 'Old txn', amount: -10, currency: 'USD' },
+  { id: 'b', date: '2024-06-15', description: 'Mid txn', amount: 500, currency: 'USD' },
+  { id: 'c', date: '2024-11-20', description: 'New txn', amount: -75, currency: 'USD' },
+];
+
+describe('MockBankConnector', () => {
+  it('importTransactions returns only transactions within the date range', async () => {
+    const connector = new MockBankConnector(FIXTURES);
+    const from = new Date('2024-01-01');
+    const to = new Date('2024-06-30');
+
+    const { imported, errors } = await connector.importTransactions('acct-1', from, to);
+
+    // WHY: Only 'a' (Jan) and 'b' (Jun) fall within the range; 'c' (Nov) must be excluded.
+    expect(errors).toHaveLength(0);
+    expect(imported).toHaveLength(2);
+    expect(imported.map((t) => t.id)).toEqual(['a', 'b']);
+  });
+
+  it('refreshTransactions returns only transactions strictly after `since`', async () => {
+    const connector = new MockBankConnector(FIXTURES);
+    const since = new Date('2024-06-15'); // same day as 'b' — should be excluded (strictly after)
+
+    const { refreshed, errors } = await connector.refreshTransactions('acct-1', since);
+
+    // WHY: Refresh semantics are "newer than", not "on or after", so 'b' must not appear.
+    expect(errors).toHaveLength(0);
+    expect(refreshed).toHaveLength(1);
+    expect(refreshed[0].id).toBe('c');
+  });
+
+  it('createConnector("mock") returns a working BankConnector via the factory', async () => {
+    // WHY: Validates the factory pattern — callers should never need to import
+    // MockBankConnector directly; the factory is the only public entry point.
+    const connector = createConnector('mock');
+    const from = new Date('2000-01-01');
+    const to = new Date('2099-12-31');
+
+    const { imported } = await connector.importTransactions('acct-x', from, to);
+
+    // Default fixture data has 3 entries — all should come back for a wide range.
+    expect(imported.length).toBeGreaterThan(0);
+  });
+});

--- a/app/src/lib/bank-connector.ts
+++ b/app/src/lib/bank-connector.ts
@@ -1,0 +1,112 @@
+// WHY: Issue #266 requires a connector abstraction for bank integrations.
+// This file defines the core interface and a mock implementation so that:
+// 1. Real bank connectors can be swapped in without changing calling code.
+// 2. The mock validates the import + refresh flows end-to-end in tests/dev.
+
+export interface BankTransaction {
+  id: string;
+  date: string;          // ISO 8601
+  description: string;
+  amount: number;        // positive = credit, negative = debit
+  currency: string;      // ISO 4217
+  category?: string;
+}
+
+export interface ImportResult {
+  imported: BankTransaction[];
+  errors: string[];
+}
+
+export interface RefreshResult {
+  refreshed: BankTransaction[];
+  errors: string[];
+}
+
+// WHY: A single interface ensures every connector (mock, Plaid, Open Banking, etc.)
+// exposes identical surface area, allowing dependency injection at the call site.
+export interface BankConnector {
+  /** One-time full import of historical transactions. */
+  importTransactions(accountId: string, from: Date, to: Date): Promise<ImportResult>;
+
+  /** Incremental refresh — only fetch transactions newer than `since`. */
+  refreshTransactions(accountId: string, since: Date): Promise<RefreshResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Mock connector — deterministic, no network, suitable for tests & local dev.
+// WHY: Having a concrete mock in the same file lets consumers import it
+// directly without a separate test-only package while keeping the abstraction.
+// ---------------------------------------------------------------------------
+
+const MOCK_TRANSACTIONS: BankTransaction[] = [
+  {
+    id: 'mock-txn-001',
+    date: '2024-01-15',
+    description: 'Grocery Store',
+    amount: -42.5,
+    currency: 'USD',
+    category: 'Food',
+  },
+  {
+    id: 'mock-txn-002',
+    date: '2024-02-01',
+    description: 'Salary',
+    amount: 3000,
+    currency: 'USD',
+    category: 'Income',
+  },
+  {
+    id: 'mock-txn-003',
+    date: '2024-03-10',
+    description: 'Electric Bill',
+    amount: -110.0,
+    currency: 'USD',
+    category: 'Utilities',
+  },
+];
+
+export class MockBankConnector implements BankConnector {
+  // WHY: Inject a custom dataset so tests can control exactly what comes back.
+  constructor(private readonly data: BankTransaction[] = MOCK_TRANSACTIONS) {}
+
+  async importTransactions(
+    _accountId: string,
+    from: Date,
+    to: Date
+  ): Promise<ImportResult> {
+    // WHY: Filter by date range to mirror real connector behaviour.
+    const imported = this.data.filter((txn) => {
+      const d = new Date(txn.date);
+      return d >= from && d <= to;
+    });
+    return { imported, errors: [] };
+  }
+
+  async refreshTransactions(
+    _accountId: string,
+    since: Date
+  ): Promise<RefreshResult> {
+    // WHY: Refresh only returns rows newer than `since`, matching incremental-sync semantics.
+    const refreshed = this.data.filter((txn) => new Date(txn.date) > since);
+    return { refreshed, errors: [] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory helper
+// WHY: Centralising connector creation means callers never import concrete
+// classes directly — they ask for a connector by name, making future real
+// connectors a one-line addition here.
+// ---------------------------------------------------------------------------
+export type ConnectorName = 'mock'; // extend union as real connectors are added
+
+export function createConnector(name: ConnectorName): BankConnector {
+  switch (name) {
+    case 'mock':
+      return new MockBankConnector();
+    default: {
+      const exhaustive: never = name;
+      throw new Error(`Unknown connector: ${exhaustive}`);
+    }
+  }
+}


### PR DESCRIPTION
## Problem

There is no abstraction layer for bank integrations, making it impossible to add or swap connectors (import/refresh flows) without touching calling code. Issue #266 requests a connector interface, support for both import and refresh flows, and a mock connector to validate the design.

## Solution

Added `app/src/lib/bank-connector.ts` which exports a `BankConnector` interface with `importTransactions` and `refreshTransactions` methods, a `MockBankConnector` that satisfies the interface with deterministic in-memory data, and a `createConnector` factory that decouples consumers from concrete implementations. Real connectors (Plaid, Open Banking, etc.) can be added by extending the `ConnectorName` union and adding a single `case` to the factory switch—zero changes required at call sites.

## Testing

- Added `bank-connector.test.ts` with three focused cases:
  - Import flow returns only transactions within the requested date range
  - Refresh flow returns only transactions *strictly after* the `since` cursor
  - Factory correctly instantiates a working connector without importing the concrete class

Closes #266