### PR TITLE
feat: Bank Sync Connector Architecture (Issue #75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ See `backend/app/db/schema.sql`. Key tables:
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
 - Expenses: CRUD `/expenses`
+- Bank sync: pluggable connectors via `/expenses/bank-sync/import` and `/expenses/bank-sync/refresh` (includes `mock` connector)
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -8,6 +8,7 @@ from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
+from ..services.bank_connectors import get_connector
 import logging
 
 bp = Blueprint("expenses", __name__)
@@ -286,29 +287,53 @@ def import_commit():
     if not isinstance(rows, list) or not rows:
         return jsonify(error="transactions required"), 400
     transactions = expense_import.normalize_import_rows(rows)
-    inserted = 0
-    duplicates = 0
-    touched_months: set[str] = set()
-    for t in transactions:
-        if _is_duplicate(uid, t):
-            duplicates += 1
-            continue
-        expense = Expense(
-            user_id=uid,
-            amount=t["amount"],
-            currency=t.get("currency") or (user.preferred_currency if user else "INR"),
-            expense_type=str(t.get("expense_type") or "EXPENSE").upper(),
-            category_id=t.get("category_id"),
-            notes=t["description"],
-            spent_at=date.fromisoformat(t["date"]),
-        )
-        db.session.add(expense)
-        inserted += 1
-        touched_months.add(t["date"][:7])
-    db.session.commit()
-    for ym in touched_months:
-        _invalidate_expense_cache(uid, ym + "-01")
+    inserted, duplicates = _persist_transactions(uid, user, transactions)
     return jsonify(inserted=inserted, duplicates=duplicates), 201
+
+
+@bp.post("/bank-sync/import")
+@jwt_required()
+def bank_sync_import():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    payload = request.get_json() or {}
+    connector_name = str(payload.get("connector") or "mock")
+    connector = _resolve_bank_connector(connector_name)
+    if connector is None:
+        return jsonify(error=f"unknown connector: {connector_name}"), 400
+
+    rows = connector.import_transactions(
+        user_id=uid,
+        credentials=payload.get("credentials") or {},
+    )
+    transactions = expense_import.normalize_import_rows(rows)
+    if payload.get("commit", False):
+        inserted, duplicates = _persist_transactions(uid, user, transactions)
+        return jsonify(total=len(transactions), inserted=inserted, duplicates=duplicates), 201
+
+    duplicates = sum(1 for tx in transactions if _is_duplicate(uid, tx))
+    return jsonify(total=len(transactions), duplicates=duplicates, transactions=transactions), 200
+
+
+@bp.post("/bank-sync/refresh")
+@jwt_required()
+def bank_sync_refresh():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    payload = request.get_json() or {}
+    connector_name = str(payload.get("connector") or "mock")
+    connector = _resolve_bank_connector(connector_name)
+    if connector is None:
+        return jsonify(error=f"unknown connector: {connector_name}"), 400
+
+    rows = connector.refresh_transactions(
+        user_id=uid,
+        credentials=payload.get("credentials") or {},
+        last_sync_at=payload.get("last_sync_at"),
+    )
+    transactions = expense_import.normalize_import_rows(rows)
+    inserted, duplicates = _persist_transactions(uid, user, transactions)
+    return jsonify(total=len(transactions), inserted=inserted, duplicates=duplicates), 200
 
 
 def _expense_to_dict(e: Expense) -> dict:
@@ -382,6 +407,37 @@ def _is_duplicate(uid: int, row: dict) -> bool:
         .first()
         is not None
     )
+
+
+def _resolve_bank_connector(name: str):
+    registry = current_app.config.get("BANK_CONNECTOR_REGISTRY")
+    return get_connector(name, registry)
+
+
+def _persist_transactions(uid: int, user: User | None, transactions: list[dict]) -> tuple[int, int]:
+    inserted = 0
+    duplicates = 0
+    touched_months: set[str] = set()
+    for t in transactions:
+        if _is_duplicate(uid, t):
+            duplicates += 1
+            continue
+        expense = Expense(
+            user_id=uid,
+            amount=t["amount"],
+            currency=t.get("currency") or (user.preferred_currency if user else "INR"),
+            expense_type=str(t.get("expense_type") or "EXPENSE").upper(),
+            category_id=t.get("category_id"),
+            notes=t["description"],
+            spent_at=date.fromisoformat(t["date"]),
+        )
+        db.session.add(expense)
+        inserted += 1
+        touched_months.add(t["date"][:7])
+    db.session.commit()
+    for ym in touched_months:
+        _invalidate_expense_cache(uid, ym + "-01")
+    return inserted, duplicates
 
 
 def _invalidate_expense_cache(uid: int, at: str):

--- a/packages/backend/app/services/bank_connectors.py
+++ b/packages/backend/app/services/bank_connectors.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from datetime import date, timedelta
+from typing import Any
+
+
+class BankConnector(ABC):
+    """Contract for pluggable bank data providers."""
+
+    name: str
+
+    @abstractmethod
+    def import_transactions(
+        self,
+        *,
+        user_id: int,
+        credentials: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch a full import payload from provider."""
+
+    @abstractmethod
+    def refresh_transactions(
+        self,
+        *,
+        user_id: int,
+        credentials: Mapping[str, Any] | None = None,
+        last_sync_at: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch only new/updated transactions since the prior sync marker."""
+
+
+class MockBankConnector(BankConnector):
+    """Deterministic test connector for local/dev and integration tests."""
+
+    name = "mock"
+
+    def import_transactions(
+        self,
+        *,
+        user_id: int,
+        credentials: Mapping[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        _ = user_id, credentials
+        return [
+            {
+                "date": "2026-02-14",
+                "amount": "32.10",
+                "description": "Mock Grocery Store",
+                "currency": "USD",
+            },
+            {
+                "date": "2026-02-15",
+                "amount": "1200.00",
+                "description": "Mock Payroll",
+                "currency": "USD",
+                "expense_type": "INCOME",
+            },
+        ]
+
+    def refresh_transactions(
+        self,
+        *,
+        user_id: int,
+        credentials: Mapping[str, Any] | None = None,
+        last_sync_at: str | None = None,
+    ) -> list[dict[str, Any]]:
+        _ = user_id, credentials
+        sync_date = date.today() - timedelta(days=1)
+        if last_sync_at:
+            try:
+                sync_date = date.fromisoformat(last_sync_at)
+            except ValueError:
+                sync_date = date.today() - timedelta(days=1)
+
+        return [
+            {
+                "date": (sync_date + timedelta(days=1)).isoformat(),
+                "amount": "19.99",
+                "description": "Mock Streaming Subscription",
+                "currency": "USD",
+            }
+        ]
+
+
+def get_connector_registry() -> dict[str, BankConnector]:
+    return {MockBankConnector.name: MockBankConnector()}
+
+
+def get_connector(name: str, registry: Mapping[str, BankConnector] | None = None) -> BankConnector | None:
+    connectors = registry or get_connector_registry()
+    return connectors.get((name or "").strip().lower())

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -5,6 +5,39 @@ from app.config import Settings
 from app.extensions import db
 from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+from app.routes import auth as auth_routes
+from app.services import cache as cache_service
+
+
+class _FakeRedis:
+    def __init__(self):
+        self._store = {}
+
+    def setex(self, key, ttl, value):
+        self._store[str(key)] = str(value)
+
+    def set(self, key, value):
+        self._store[str(key)] = str(value)
+
+    def get(self, key):
+        return self._store.get(str(key))
+
+    def scan(self, cursor=0, match="*", count=100):
+        # minimal SCAN emulation for tests: return all matched keys in one pass
+        import fnmatch
+
+        keys = [k for k in self._store.keys() if fnmatch.fnmatch(k, match)]
+        return 0, keys
+
+    def delete(self, *keys):
+        for key in keys:
+            self._store.pop(str(key), None)
+
+    def ping(self):
+        return True
+
+    def flushdb(self):
+        self._store.clear()
 
 
 class TestSettings(Settings):
@@ -30,9 +63,20 @@ def app_fixture():
     )
     app = create_app(settings)
     app.config.update(TESTING=True)
+
+    fake_redis = _FakeRedis()
+    try:
+        redis_client.ping()
+    except Exception:
+        auth_routes.redis_client = fake_redis
+        cache_service.redis_client = fake_redis
+    else:
+        auth_routes.redis_client = redis_client
+        cache_service.redis_client = redis_client
+
     _setup_db(app)
     try:
-        redis_client.flushdb()
+        auth_routes.redis_client.flushdb()
     except Exception:
         pass
     yield app
@@ -40,7 +84,7 @@ def app_fixture():
         db.session.remove()
         db.drop_all()
     try:
-        redis_client.flushdb()
+        auth_routes.redis_client.flushdb()
     except Exception:
         pass
 

--- a/packages/backend/tests/test_expenses.py
+++ b/packages/backend/tests/test_expenses.py
@@ -260,3 +260,73 @@ def test_recurring_expense_generate_respects_end_date(client, auth_header):
     assert r.status_code == 200
     generated = r.get_json()
     assert len(generated) == 3
+
+
+def test_bank_sync_import_preview_and_commit_with_mock_connector(client, auth_header):
+    r = client.post(
+        "/expenses/bank-sync/import",
+        json={"connector": "mock"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    preview = r.get_json()
+    assert preview["total"] == 2
+    assert preview["duplicates"] == 0
+
+    r = client.post(
+        "/expenses/bank-sync/import",
+        json={"connector": "mock", "commit": True},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    committed = r.get_json()
+    assert committed["inserted"] == 2
+
+    r = client.post(
+        "/expenses/bank-sync/import",
+        json={"connector": "mock", "commit": True},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    assert r.get_json()["duplicates"] == 2
+
+
+def test_bank_sync_refresh_flow_uses_connector_registry(client, auth_header):
+    class _RefreshOnlyConnector:
+        def import_transactions(self, *, user_id, credentials=None):
+            return []
+
+        def refresh_transactions(
+            self, *, user_id, credentials=None, last_sync_at=None
+        ):
+            return [
+                {
+                    "date": "2026-02-20",
+                    "amount": "4.99",
+                    "description": "Test Refresh Tx",
+                    "currency": "USD",
+                }
+            ]
+
+    client.application.config["BANK_CONNECTOR_REGISTRY"] = {
+        "refresh-test": _RefreshOnlyConnector()
+    }
+
+    r = client.post(
+        "/expenses/bank-sync/refresh",
+        json={"connector": "refresh-test", "last_sync_at": "2026-02-19"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    result = r.get_json()
+    assert result["total"] == 1
+    assert result["inserted"] == 1
+    assert result["duplicates"] == 0
+
+    r = client.post(
+        "/expenses/bank-sync/refresh",
+        json={"connector": "refresh-test", "last_sync_at": "2026-02-19"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["duplicates"] == 1


### PR DESCRIPTION
## Summary
- add a pluggable bank connector interface (`BankConnector`) and registry helpers
- introduce a built-in `mock` connector for predictable import/refresh flows
- add bank sync endpoints for import + refresh under `/expenses/bank-sync/*`
- normalize imported transactions and reuse duplicate detection / persistence pipeline
- document the new API surface in README

## Acceptance Criteria Mapping (Issue #75)
- [x] Connector interface
- [x] Import & refresh support
- [x] Mock connector included

## Testing
- `PYTHONPATH=packages/backend pytest -q packages/backend/tests/test_expenses.py`
- Result: `9 passed`

## Notes
- local env uses Python 3.14 with wheel-only dependency install to avoid Rust toolchain build issues on macOS.

Fixes #75
