### PR TITLE
feat: add weekly smart digest financial summary endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-summary`
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -32,3 +32,31 @@ export async function getBudgetSuggestion(params?: {
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
 }
+
+export type WeeklySummary = {
+  period: {
+    start_date: string;
+    end_date: string;
+    days: number;
+  };
+  totals: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    savings_rate_pct: number;
+  };
+  trends: {
+    income_change_pct: number;
+    expenses_change_pct: number;
+    net_flow_change_pct: number;
+  };
+  top_categories: Array<{ category_id: string; amount: number; share_pct: number }>;
+  daily: Array<{ date: string; income: number; expenses: number; net_flow: number }>;
+  insights: string[];
+  method: 'heuristic' | string;
+};
+
+export async function getWeeklySummary(endDate?: string): Promise<WeeklySummary> {
+  const query = endDate ? `?end_date=${encodeURIComponent(endDate)}` : '';
+  return api<WeeklySummary>(`/insights/weekly-summary${query}`);
+}

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,62 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/weekly-summary:
+    get:
+      summary: Get 7-day financial digest with trends and insights
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: end_date
+          required: false
+          schema: { type: string, format: date }
+          description: Inclusive week end date (defaults to today)
+      responses:
+        '200':
+          description: Weekly digest
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                period:
+                  start_date: 2026-02-23
+                  end_date: 2026-03-01
+                  days: 7
+                totals:
+                  income: 1200
+                  expenses: 300
+                  net_flow: 900
+                  savings_rate_pct: 75
+                trends:
+                  income_change_pct: 20
+                  expenses_change_pct: -25
+                  net_flow_change_pct: 50
+                top_categories:
+                  - category_id: uncat
+                    amount: 300
+                    share_pct: 100
+                daily:
+                  - date: 2026-02-23
+                    income: 0
+                    expenses: 0
+                    net_flow: 0
+                insights:
+                  - Great progress — spending dropped compared with last week.
+                method: heuristic
+        '400':
+          description: Invalid end_date format
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,8 +1,10 @@
-from datetime import date
-from flask import Blueprint, jsonify, request
-from flask_jwt_extended import jwt_required, get_jwt_identity
-from ..services.ai import monthly_budget_suggestion
 import logging
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.ai import monthly_budget_suggestion, weekly_financial_summary
 
 bp = Blueprint("insights", __name__)
 logger = logging.getLogger("finmind.insights")
@@ -23,3 +25,26 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    raw_end_date = (request.args.get("end_date") or "").strip()
+    if raw_end_date:
+        try:
+            end_date = date.fromisoformat(raw_end_date)
+        except ValueError:
+            return jsonify(error="invalid end_date, expected YYYY-MM-DD"), 400
+    else:
+        end_date = date.today()
+
+    payload = weekly_financial_summary(uid, end_date=end_date)
+    logger.info(
+        "Weekly summary served user=%s start=%s end=%s",
+        uid,
+        payload["period"]["start_date"],
+        payload["period"]["end_date"],
+    )
+    return jsonify(payload)

--- a/packages/backend/app/services/ai.py
+++ b/packages/backend/app/services/ai.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date, timedelta
 from urllib import request
 
 from sqlalchemy import extract, func
@@ -164,6 +165,181 @@ def _gemini_budget_suggestion(
     parsed["persona"] = persona
     parsed["method"] = "gemini"
     return parsed
+
+
+def _range_totals(uid: int, start_date: date, end_date: date) -> tuple[float, float]:
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start_date,
+            Expense.spent_at <= end_date,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start_date,
+            Expense.spent_at <= end_date,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+    return float(income or 0), float(expenses or 0)
+
+
+def _range_category_spend(uid: int, start_date: date, end_date: date) -> list[dict]:
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(func.sum(Expense.amount), 0),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start_date,
+            Expense.spent_at <= end_date,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+    return sorted(
+        [
+            {
+                "category_id": str(category_id or "uncat"),
+                "amount": round(float(amount), 2),
+            }
+            for category_id, amount in rows
+        ],
+        key=lambda item: item["amount"],
+        reverse=True,
+    )
+
+
+def _pct_change(current: float, previous: float) -> float:
+    if previous == 0:
+        return 0.0 if current == 0 else 100.0
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def _daily_net(uid: int, start_date: date, end_date: date) -> list[dict]:
+    daily = []
+    cursor = start_date
+    while cursor <= end_date:
+        income, expenses = _range_totals(uid, cursor, cursor)
+        net = round(income - expenses, 2)
+        daily.append(
+            {
+                "date": cursor.isoformat(),
+                "income": round(income, 2),
+                "expenses": round(expenses, 2),
+                "net_flow": net,
+            }
+        )
+        cursor += timedelta(days=1)
+    return daily
+
+
+def _build_weekly_insights(
+    current_income: float,
+    current_expenses: float,
+    previous_expenses: float,
+    top_categories: list[dict],
+) -> list[str]:
+    insights = []
+    if current_expenses > previous_expenses:
+        insights.append(
+            "Spending increased week over week — review variable categories."
+        )
+    elif current_expenses < previous_expenses:
+        insights.append(
+            "Great progress — spending dropped compared with last week."
+        )
+    else:
+        insights.append(
+            "Spending is flat versus last week; keep monitoring consistency."
+        )
+
+    if current_income > 0:
+        savings_rate = max(
+            0.0,
+            ((current_income - current_expenses) / current_income) * 100,
+        )
+        insights.append(f"Estimated savings rate this week is {savings_rate:.1f}%.")
+    else:
+        insights.append(
+            "No income recorded this week; focus on reducing discretionary spend."
+        )
+
+    if top_categories:
+        top = top_categories[0]
+        top_category_note = (
+            f"Top spending category this week: "
+            f"{top['category_id']} ({top['amount']:.2f})."
+        )
+        insights.append(top_category_note)
+    return insights[:3]
+
+
+def weekly_financial_summary(uid: int, end_date: date | None = None) -> dict:
+    week_end = end_date or date.today()
+    week_start = week_end - timedelta(days=6)
+    previous_end = week_start - timedelta(days=1)
+    previous_start = previous_end - timedelta(days=6)
+
+    current_income, current_expenses = _range_totals(uid, week_start, week_end)
+    previous_income, previous_expenses = _range_totals(
+        uid,
+        previous_start,
+        previous_end,
+    )
+    current_net = round(current_income - current_expenses, 2)
+    previous_net = round(previous_income - previous_expenses, 2)
+
+    top_categories = _range_category_spend(uid, week_start, week_end)[:3]
+    expense_share_denominator = current_expenses if current_expenses > 0 else 1.0
+    for item in top_categories:
+        item["share_pct"] = round((item["amount"] / expense_share_denominator) * 100, 2)
+
+    savings_rate = round(
+        (
+            ((current_income - current_expenses) / current_income) * 100
+            if current_income > 0
+            else 0.0
+        ),
+        2,
+    )
+
+    return {
+        "period": {
+            "start_date": week_start.isoformat(),
+            "end_date": week_end.isoformat(),
+            "days": 7,
+        },
+        "totals": {
+            "income": round(current_income, 2),
+            "expenses": round(current_expenses, 2),
+            "net_flow": current_net,
+            "savings_rate_pct": savings_rate,
+        },
+        "trends": {
+            "income_change_pct": _pct_change(current_income, previous_income),
+            "expenses_change_pct": _pct_change(current_expenses, previous_expenses),
+            "net_flow_change_pct": _pct_change(current_net, previous_net),
+        },
+        "top_categories": top_categories,
+        "daily": _daily_net(uid, week_start, week_end),
+        "insights": _build_weekly_insights(
+            current_income=current_income,
+            current_expenses=current_expenses,
+            previous_expenses=previous_expenses,
+            top_categories=top_categories,
+        ),
+        "method": "heuristic",
+    }
 
 
 def monthly_budget_suggestion(

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -90,3 +90,84 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_weekly_summary_returns_totals_trends_and_daily(client, auth_header):
+    week_end = date(2026, 3, 1)
+
+    previous_week_entries = [
+        {
+            "amount": 1000,
+            "expense_type": "INCOME",
+            "date": "2026-02-17",
+            "description": "salary",
+        },
+        {
+            "amount": 300,
+            "expense_type": "EXPENSE",
+            "date": "2026-02-18",
+            "description": "rent",
+        },
+        {
+            "amount": 100,
+            "expense_type": "EXPENSE",
+            "date": "2026-02-20",
+            "description": "food",
+        },
+    ]
+    current_week_entries = [
+        {
+            "amount": 1200,
+            "expense_type": "INCOME",
+            "date": "2026-02-24",
+            "description": "salary",
+        },
+        {
+            "amount": 250,
+            "expense_type": "EXPENSE",
+            "date": "2026-02-25",
+            "description": "rent",
+        },
+        {
+            "amount": 50,
+            "expense_type": "EXPENSE",
+            "date": "2026-02-28",
+            "description": "groceries",
+        },
+    ]
+
+    for payload in [*previous_week_entries, *current_week_entries]:
+        response = client.post("/expenses", json=payload, headers=auth_header)
+        assert response.status_code == 201
+
+    response = client.get(
+        f"/insights/weekly-summary?end_date={week_end.isoformat()}",
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload["period"] == {
+        "start_date": "2026-02-23",
+        "end_date": "2026-03-01",
+        "days": 7,
+    }
+    assert payload["totals"]["income"] == 1200.0
+    assert payload["totals"]["expenses"] == 300.0
+    assert payload["totals"]["net_flow"] == 900.0
+    assert payload["trends"]["expenses_change_pct"] == -25.0
+    assert payload["trends"]["income_change_pct"] == 20.0
+    assert len(payload["daily"]) == 7
+    assert payload["daily"][0]["date"] == "2026-02-23"
+    assert len(payload["insights"]) >= 1
+    assert payload["method"] == "heuristic"
+
+
+def test_weekly_summary_rejects_invalid_end_date(client, auth_header):
+    response = client.get(
+        "/insights/weekly-summary?end_date=03-01-2026",
+        headers=auth_header,
+    )
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "invalid end_date" in payload["error"]


### PR DESCRIPTION
## Summary
- add `GET /insights/weekly-summary` for a 7-day financial digest
- include totals, week-over-week trends, top categories, daily net flow, and actionable insights
- expose weekly summary types/helpers in frontend API client
- document endpoint in README and OpenAPI spec

## Validation
- `python3 -m py_compile packages/backend/app/services/ai.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py`
- exercised endpoint with in-memory SQLite + Flask test client (`/insights/weekly-summary?end_date=2026-03-01` returned 200 and expected totals/trends)
- note: full pytest run currently needs Redis host wiring in local env

Closes #121
