### PR TITLE
feat: add shared household budgeting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ See `backend/app/db/schema.sql`. Key tables:
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
-- Expenses: CRUD `/expenses`
-- Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
+- Households: `/households`, `/households/my`, `/households/{id}`, `/households/{id}/members`
+- Expenses: CRUD `/expenses` (supports optional `household_id` for shared records)
+- Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay` (supports optional `household_id`)
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
 

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -100,21 +100,57 @@ def _ensure_schema_compatibility(app: Flask) -> None:
     """Apply minimal compatibility ALTERs for existing deployments."""
     if db.engine.dialect.name != "postgresql":
         return
+    statements = [
+        """
+        ALTER TABLE users
+        ADD COLUMN IF NOT EXISTS preferred_currency VARCHAR(10)
+        NOT NULL DEFAULT 'INR'
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS households (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(120) NOT NULL,
+            created_by INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS household_members (
+            id SERIAL PRIMARY KEY,
+            household_id INT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+            user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            role VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+            joined_at TIMESTAMP NOT NULL DEFAULT NOW()
+        )
+        """,
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_household_members_household_user
+        ON household_members(household_id, user_id)
+        """,
+        """
+        ALTER TABLE categories
+        ADD COLUMN IF NOT EXISTS household_id INT REFERENCES households(id)
+        ON DELETE SET NULL
+        """,
+        """
+        ALTER TABLE expenses
+        ADD COLUMN IF NOT EXISTS household_id INT REFERENCES households(id)
+        ON DELETE SET NULL
+        """,
+        """
+        ALTER TABLE bills
+        ADD COLUMN IF NOT EXISTS household_id INT REFERENCES households(id)
+        ON DELETE SET NULL
+        """,
+    ]
     conn = db.engine.raw_connection()
     try:
         cur = conn.cursor()
-        cur.execute(
-            """
-            ALTER TABLE users
-            ADD COLUMN IF NOT EXISTS preferred_currency VARCHAR(10)
-            NOT NULL DEFAULT 'INR'
-            """
-        )
+        for statement in statements:
+            cur.execute(statement)
         conn.commit()
     except Exception:
-        app.logger.exception(
-            "Schema compatibility patch failed for users.preferred_currency"
-        )
+        app.logger.exception("Schema compatibility patch failed")
         conn.rollback()
     finally:
         conn.close()

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -11,9 +11,26 @@ CREATE TABLE IF NOT EXISTS users (
 ALTER TABLE users
   ADD COLUMN IF NOT EXISTS preferred_currency VARCHAR(10) NOT NULL DEFAULT 'INR';
 
+CREATE TABLE IF NOT EXISTS households (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(120) NOT NULL,
+  created_by INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS household_members (
+  id SERIAL PRIMARY KEY,
+  household_id INT NOT NULL REFERENCES households(id) ON DELETE CASCADE,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role VARCHAR(20) NOT NULL DEFAULT 'MEMBER',
+  joined_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_household_members_household_user UNIQUE (household_id, user_id)
+);
+
 CREATE TABLE IF NOT EXISTS categories (
   id SERIAL PRIMARY KEY,
   user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  household_id INT REFERENCES households(id) ON DELETE SET NULL,
   name VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
@@ -21,6 +38,7 @@ CREATE TABLE IF NOT EXISTS categories (
 CREATE TABLE IF NOT EXISTS expenses (
   id SERIAL PRIMARY KEY,
   user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  household_id INT REFERENCES households(id) ON DELETE SET NULL,
   category_id INT REFERENCES categories(id) ON DELETE SET NULL,
   amount NUMERIC(12,2) NOT NULL,
   currency VARCHAR(10) NOT NULL DEFAULT 'INR',
@@ -68,6 +86,7 @@ END $$;
 CREATE TABLE IF NOT EXISTS bills (
   id SERIAL PRIMARY KEY,
   user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  household_id INT REFERENCES households(id) ON DELETE SET NULL,
   name VARCHAR(200) NOT NULL,
   amount NUMERIC(12,2) NOT NULL,
   currency VARCHAR(10) NOT NULL DEFAULT 'INR',
@@ -83,6 +102,15 @@ CREATE INDEX IF NOT EXISTS idx_bills_user_due ON bills(user_id, next_due_date);
 
 ALTER TABLE bills
   ADD COLUMN IF NOT EXISTS autopay_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE categories
+  ADD COLUMN IF NOT EXISTS household_id INT REFERENCES households(id) ON DELETE SET NULL;
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS household_id INT REFERENCES households(id) ON DELETE SET NULL;
+
+ALTER TABLE bills
+  ADD COLUMN IF NOT EXISTS household_id INT REFERENCES households(id) ON DELETE SET NULL;
 
 CREATE TABLE IF NOT EXISTS reminders (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, UniqueConstraint
 from .extensions import db
 
 
@@ -23,6 +23,7 @@ class Category(db.Model):
     __tablename__ = "categories"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=True)
     name = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
@@ -31,6 +32,7 @@ class Expense(db.Model):
     __tablename__ = "expenses"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=True)
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
@@ -77,6 +79,7 @@ class Bill(db.Model):
     __tablename__ = "bills"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    household_id = db.Column(db.Integer, db.ForeignKey("households.id"), nullable=True)
     name = db.Column(db.String(200), nullable=False)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
@@ -133,3 +136,39 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class HouseholdRole(str, Enum):
+    ADMIN = "ADMIN"
+    MEMBER = "MEMBER"
+
+
+class Household(db.Model):
+    __tablename__ = "households"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    created_by = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class HouseholdMember(db.Model):
+    __tablename__ = "household_members"
+    __table_args__ = (
+        UniqueConstraint(
+            "household_id",
+            "user_id",
+            name="uq_household_members_household_user",
+        ),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    household_id = db.Column(
+        db.Integer, db.ForeignKey("households.id"), nullable=False
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    role = db.Column(
+        db.String(20),
+        default=HouseholdRole.MEMBER.value,
+        nullable=False,
+    )
+    joined_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .households import bp as households_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(households_bp, url_prefix="/households")

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -1,9 +1,11 @@
 from datetime import date, timedelta
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import or_
 from ..extensions import db
 from ..models import Bill, BillCadence, User
 from ..services.cache import cache_delete_patterns
+from ..services.households import household_ids_for_user, is_household_member
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -14,12 +16,15 @@ logger = logging.getLogger("finmind.bills")
 @jwt_required()
 def list_bills():
     uid = int(get_jwt_identity())
-    items = (
-        db.session.query(Bill)
-        .filter_by(user_id=uid, active=True)
-        .order_by(Bill.next_due_date)
-        .all()
-    )
+    household_ids = household_ids_for_user(uid)
+    query = db.session.query(Bill).filter(Bill.active.is_(True))
+    if household_ids:
+        query = query.filter(
+            or_(Bill.user_id == uid, Bill.household_id.in_(household_ids))
+        )
+    else:
+        query = query.filter(Bill.user_id == uid)
+    items = query.order_by(Bill.next_due_date).all()
     logger.info("List bills user=%s count=%s", uid, len(items))
     return jsonify(
         [
@@ -33,6 +38,7 @@ def list_bills():
                 "autopay_enabled": b.autopay_enabled,
                 "channel_whatsapp": b.channel_whatsapp,
                 "channel_email": b.channel_email,
+                "household_id": b.household_id,
             }
             for b in items
         ]
@@ -45,8 +51,14 @@ def create_bill():
     uid = int(get_jwt_identity())
     user = db.session.get(User, uid)
     data = request.get_json() or {}
+    household_id = _parse_household_id(data.get("household_id"))
+    if household_id is False:
+        return jsonify(error="invalid household_id"), 400
+    if household_id is not None and not is_household_member(uid, household_id):
+        return jsonify(error="forbidden"), 403
     b = Bill(
         user_id=uid,
+        household_id=household_id,
         name=data["name"],
         amount=data["amount"],
         currency=data.get("currency") or (user.preferred_currency if user else "INR"),
@@ -70,8 +82,12 @@ def create_bill():
 def mark_paid(bill_id: int):
     uid = int(get_jwt_identity())
     b = db.session.get(Bill, bill_id)
-    if not b or b.user_id != uid:
+    if not b:
         return jsonify(error="not found"), 404
+    if b.household_id is None and b.user_id != uid:
+        return jsonify(error="not found"), 404
+    if b.household_id is not None and not is_household_member(uid, b.household_id):
+        return jsonify(error="forbidden"), 403
     # Move next due date based on cadence
     if b.cadence == BillCadence.MONTHLY:
         b.next_due_date = b.next_due_date + timedelta(days=30)
@@ -89,3 +105,12 @@ def mark_paid(bill_id: int):
         "Marked bill paid id=%s user=%s next_due_date=%s", b.id, uid, b.next_due_date
     )
     return jsonify(message="updated")
+
+
+def _parse_household_id(raw) -> int | None | bool:
+    if raw in (None, ""):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return False

--- a/packages/backend/app/routes/categories.py
+++ b/packages/backend/app/routes/categories.py
@@ -1,8 +1,11 @@
 import logging
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import or_
+
 from ..extensions import db
 from ..models import Category
+from ..services.households import household_ids_for_user, is_household_member
 
 bp = Blueprint("categories", __name__)
 logger = logging.getLogger("finmind.categories")
@@ -12,11 +15,19 @@ logger = logging.getLogger("finmind.categories")
 @jwt_required()
 def list_categories():
     uid = int(get_jwt_identity())
-    items = (
-        db.session.query(Category).filter_by(user_id=uid).order_by(Category.name).all()
-    )
+    ids = household_ids_for_user(uid)
+    query = db.session.query(Category)
+    if ids:
+        query = query.filter(
+            or_(Category.user_id == uid, Category.household_id.in_(ids))
+        )
+    else:
+        query = query.filter(Category.user_id == uid)
+    items = query.order_by(Category.name).all()
     logger.info("List categories for user=%s count=%s", uid, len(items))
-    return jsonify([{"id": c.id, "name": c.name} for c in items])
+    return jsonify(
+        [{"id": c.id, "name": c.name, "household_id": c.household_id} for c in items]
+    )
 
 
 @bp.post("")
@@ -28,15 +39,35 @@ def create_category():
     if not name:
         logger.warning("Create category missing name user=%s", uid)
         return jsonify(error="name required"), 400
-    # Optional: enforce unique name per user
-    exists = db.session.query(Category).filter_by(user_id=uid, name=name).first()
+    household_id = data.get("household_id")
+    if household_id is not None:
+        try:
+            household_id = int(household_id)
+        except (TypeError, ValueError):
+            return jsonify(error="invalid household_id"), 400
+        if not is_household_member(uid, household_id):
+            return jsonify(error="forbidden"), 403
+
+    # Optional: enforce unique name per owner scope
+    if household_id is None:
+        exists = (
+            db.session.query(Category)
+            .filter_by(user_id=uid, household_id=None, name=name)
+            .first()
+        )
+    else:
+        exists = (
+            db.session.query(Category)
+            .filter_by(household_id=household_id, name=name)
+            .first()
+        )
     if exists:
         return jsonify(error="category already exists"), 409
-    c = Category(user_id=uid, name=name)
+    c = Category(user_id=uid, household_id=household_id, name=name)
     db.session.add(c)
     db.session.commit()
     logger.info("Created category id=%s user=%s", c.id, uid)
-    return jsonify(id=c.id, name=c.name), 201
+    return jsonify(id=c.id, name=c.name, household_id=c.household_id), 201
 
 
 @bp.patch("/<int:category_id>")
@@ -44,8 +75,12 @@ def create_category():
 def update_category(category_id: int):
     uid = int(get_jwt_identity())
     c = db.session.get(Category, category_id)
-    if not c or c.user_id != uid:
+    if not c:
         return jsonify(error="not found"), 404
+    if c.household_id is None and c.user_id != uid:
+        return jsonify(error="not found"), 404
+    if c.household_id is not None and not is_household_member(uid, c.household_id):
+        return jsonify(error="forbidden"), 403
     data = request.get_json() or {}
     name = (data.get("name") or "").strip()
     if not name:
@@ -53,7 +88,7 @@ def update_category(category_id: int):
     c.name = name
     db.session.commit()
     logger.info("Updated category id=%s user=%s", c.id, uid)
-    return jsonify(id=c.id, name=c.name)
+    return jsonify(id=c.id, name=c.name, household_id=c.household_id)
 
 
 @bp.delete("/<int:category_id>")
@@ -61,8 +96,12 @@ def update_category(category_id: int):
 def delete_category(category_id: int):
     uid = int(get_jwt_identity())
     c = db.session.get(Category, category_id)
-    if not c or c.user_id != uid:
+    if not c:
         return jsonify(error="not found"), 404
+    if c.household_id is None and c.user_id != uid:
+        return jsonify(error="not found"), 404
+    if c.household_id is not None and not is_household_member(uid, c.household_id):
+        return jsonify(error="forbidden"), 403
     db.session.delete(c)
     db.session.commit()
     logger.info("Deleted category id=%s user=%s", c.id, uid)

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -4,10 +4,12 @@ from decimal import Decimal, InvalidOperation
 
 from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import or_
 from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
+from ..services.households import household_ids_for_user, is_household_member
 import logging
 
 bp = Blueprint("expenses", __name__)
@@ -18,7 +20,14 @@ logger = logging.getLogger("finmind.expenses")
 @jwt_required()
 def list_expenses():
     uid = int(get_jwt_identity())
-    q = db.session.query(Expense).filter_by(user_id=uid)
+    household_ids = household_ids_for_user(uid)
+    q = db.session.query(Expense)
+    if household_ids:
+        q = q.filter(
+            or_(Expense.user_id == uid, Expense.household_id.in_(household_ids))
+        )
+    else:
+        q = q.filter(Expense.user_id == uid)
     from_date = request.args.get("from")
     to_date = request.args.get("to")
     search = (request.args.get("search") or "").strip()
@@ -65,8 +74,14 @@ def create_expense():
     description = (data.get("description") or data.get("notes") or "").strip()
     if not description:
         return jsonify(error="description required"), 400
+    household_id = _parse_household_id(data.get("household_id"))
+    if household_id is False:
+        return jsonify(error="invalid household_id"), 400
+    if household_id is not None and not is_household_member(uid, household_id):
+        return jsonify(error="forbidden"), 403
     e = Expense(
         user_id=uid,
+        household_id=household_id,
         amount=amount,
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
@@ -207,8 +222,12 @@ def generate_recurring_expenses(recurring_id: int):
 def update_expense(expense_id: int):
     uid = int(get_jwt_identity())
     e = db.session.get(Expense, expense_id)
-    if not e or e.user_id != uid:
+    if not e:
         return jsonify(error="not found"), 404
+    if e.household_id is None and e.user_id != uid:
+        return jsonify(error="not found"), 404
+    if e.household_id is not None and not is_household_member(uid, e.household_id):
+        return jsonify(error="forbidden"), 403
     data = request.get_json() or {}
     if "amount" in data:
         amount = _parse_amount(data.get("amount"))
@@ -239,8 +258,12 @@ def update_expense(expense_id: int):
 def delete_expense(expense_id: int):
     uid = int(get_jwt_identity())
     e = db.session.get(Expense, expense_id)
-    if not e or e.user_id != uid:
+    if not e:
         return jsonify(error="not found"), 404
+    if e.household_id is None and e.user_id != uid:
+        return jsonify(error="not found"), 404
+    if e.household_id is not None and not is_household_member(uid, e.household_id):
+        return jsonify(error="forbidden"), 403
     spent_at = e.spent_at.isoformat()
     db.session.delete(e)
     db.session.commit()
@@ -316,6 +339,7 @@ def _expense_to_dict(e: Expense) -> dict:
         "id": e.id,
         "amount": float(e.amount),
         "currency": e.currency,
+        "household_id": e.household_id,
         "category_id": e.category_id,
         "expense_type": e.expense_type,
         "description": e.notes or "",
@@ -350,6 +374,15 @@ def _parse_recurring_cadence(raw: str | None) -> str | None:
     if val in {"DAILY", "WEEKLY", "MONTHLY", "YEARLY"}:
         return val
     return None
+
+
+def _parse_household_id(raw) -> int | None | bool:
+    if raw in (None, ""):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return False
 
 
 def _advance_recurrence_date(at: date, cadence: str) -> date:

--- a/packages/backend/app/routes/households.py
+++ b/packages/backend/app/routes/households.py
@@ -1,0 +1,140 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import Household, HouseholdMember, HouseholdRole, User
+from ..services.households import is_household_admin, is_household_member
+
+bp = Blueprint("households", __name__)
+
+
+@bp.post("")
+@jwt_required()
+def create_household():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+
+    household = Household(name=name, created_by=uid)
+    db.session.add(household)
+    db.session.flush()
+    db.session.add(
+        HouseholdMember(
+            household_id=household.id,
+            user_id=uid,
+            role=HouseholdRole.ADMIN.value,
+        )
+    )
+    db.session.commit()
+    return (
+        jsonify(
+            id=household.id,
+            name=household.name,
+            role=HouseholdRole.ADMIN.value,
+        ),
+        201,
+    )
+
+
+@bp.get("/my")
+@jwt_required()
+def my_households():
+    uid = int(get_jwt_identity())
+    rows = (
+        db.session.query(HouseholdMember, Household)
+        .join(Household, Household.id == HouseholdMember.household_id)
+        .filter(HouseholdMember.user_id == uid)
+        .order_by(Household.created_at.desc())
+        .all()
+    )
+    return jsonify(
+        households=[
+            {
+                "id": household.id,
+                "name": household.name,
+                "role": member.role,
+                "created_at": household.created_at.isoformat(),
+            }
+            for member, household in rows
+        ]
+    )
+
+
+@bp.get("/<int:household_id>")
+@jwt_required()
+def household_details(household_id: int):
+    uid = int(get_jwt_identity())
+    household = db.session.get(Household, household_id)
+    if not household:
+        return jsonify(error="not found"), 404
+    if not is_household_member(uid, household_id):
+        return jsonify(error="forbidden"), 403
+
+    rows = (
+        db.session.query(HouseholdMember, User)
+        .join(User, User.id == HouseholdMember.user_id)
+        .filter(HouseholdMember.household_id == household_id)
+        .order_by(HouseholdMember.joined_at.asc())
+        .all()
+    )
+    return jsonify(
+        id=household.id,
+        name=household.name,
+        created_by=household.created_by,
+        created_at=household.created_at.isoformat(),
+        members=[
+            {
+                "user_id": user.id,
+                "email": user.email,
+                "role": member.role,
+                "joined_at": member.joined_at.isoformat(),
+            }
+            for member, user in rows
+        ],
+    )
+
+
+@bp.post("/<int:household_id>/members")
+@jwt_required()
+def add_member(household_id: int):
+    uid = int(get_jwt_identity())
+    household = db.session.get(Household, household_id)
+    if not household:
+        return jsonify(error="not found"), 404
+    if not is_household_admin(uid, household_id):
+        return jsonify(error="forbidden"), 403
+
+    data = request.get_json() or {}
+    email = (data.get("email") or "").strip().lower()
+    if not email:
+        return jsonify(error="email required"), 400
+
+    invited = db.session.query(User).filter(db.func.lower(User.email) == email).first()
+    if not invited:
+        return jsonify(error="user not found"), 404
+
+    if is_household_member(invited.id, household_id):
+        return jsonify(error="user already a member"), 409
+
+    role = str(data.get("role") or HouseholdRole.MEMBER.value).upper().strip()
+    if role not in {HouseholdRole.ADMIN.value, HouseholdRole.MEMBER.value}:
+        return jsonify(error="invalid role"), 400
+
+    membership = HouseholdMember(
+        household_id=household_id,
+        user_id=invited.id,
+        role=role,
+    )
+    db.session.add(membership)
+    db.session.commit()
+    return (
+        jsonify(
+            household_id=household_id,
+            user_id=invited.id,
+            email=invited.email,
+            role=role,
+        ),
+        201,
+    )

--- a/packages/backend/app/services/households.py
+++ b/packages/backend/app/services/households.py
@@ -1,0 +1,36 @@
+from ..extensions import db
+from ..models import HouseholdMember
+
+
+def household_ids_for_user(user_id: int) -> list[int]:
+    rows = (
+        db.session.query(HouseholdMember.household_id)
+        .filter(HouseholdMember.user_id == user_id)
+        .all()
+    )
+    return [int(row.household_id) for row in rows]
+
+
+def is_household_member(user_id: int, household_id: int) -> bool:
+    return (
+        db.session.query(HouseholdMember.id)
+        .filter(
+            HouseholdMember.user_id == user_id,
+            HouseholdMember.household_id == household_id,
+        )
+        .first()
+        is not None
+    )
+
+
+def is_household_admin(user_id: int, household_id: int) -> bool:
+    return (
+        db.session.query(HouseholdMember.id)
+        .filter(
+            HouseholdMember.user_id == user_id,
+            HouseholdMember.household_id == household_id,
+            HouseholdMember.role == "ADMIN",
+        )
+        .first()
+        is not None
+    )

--- a/packages/backend/tests/test_households.py
+++ b/packages/backend/tests/test_households.py
@@ -1,0 +1,193 @@
+from datetime import date, timedelta
+
+import pytest
+from flask_jwt_extended import create_access_token
+
+from app.extensions import db
+from app.models import User
+
+
+@pytest.fixture(autouse=True)
+def _disable_cache_calls(monkeypatch):
+    monkeypatch.setattr(
+        "app.routes.expenses.cache_delete_patterns", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "app.routes.bills.cache_delete_patterns", lambda *_args, **_kwargs: None
+    )
+
+
+def _register_and_auth_header(
+    client, app_fixture, email: str, password: str = "password123"
+):
+    register = client.post(
+        "/auth/register", json={"email": email, "password": password}
+    )
+    assert register.status_code in (201, 409)
+    with app_fixture.app_context():
+        user = db.session.query(User).filter_by(email=email).first()
+        assert user is not None
+        token = create_access_token(identity=str(user.id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_household(client, auth_header, name: str = "Home HQ") -> int:
+    r = client.post("/households", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201
+    payload = r.get_json()
+    assert payload["name"] == name
+    return payload["id"]
+
+
+def test_household_admin_can_add_member_and_member_can_view_household(
+    client, app_fixture
+):
+    owner_auth = _register_and_auth_header(client, app_fixture, "owner@example.com")
+    member_email = "household-member@example.com"
+    member_auth = _register_and_auth_header(client, app_fixture, member_email)
+    household_id = _create_household(client, owner_auth, name="Roommates")
+
+    r = client.post(
+        f"/households/{household_id}/members",
+        json={"email": member_email},
+        headers=owner_auth,
+    )
+    assert r.status_code == 201
+
+    owner_households = client.get("/households/my", headers=owner_auth)
+    assert owner_households.status_code == 200
+    owner_payload = owner_households.get_json()
+    assert any(
+        h["id"] == household_id and h["role"] == "ADMIN"
+        for h in owner_payload["households"]
+    )
+
+    member_households = client.get("/households/my", headers=member_auth)
+    assert member_households.status_code == 200
+    member_payload = member_households.get_json()
+    assert any(
+        h["id"] == household_id and h["role"] == "MEMBER"
+        for h in member_payload["households"]
+    )
+
+    household_details = client.get(f"/households/{household_id}", headers=member_auth)
+    assert household_details.status_code == 200
+    details = household_details.get_json()
+    member_emails = {m["email"] for m in details["members"]}
+    assert member_email in member_emails
+
+
+def test_household_records_are_shared_with_all_members(client, app_fixture):
+    owner_auth = _register_and_auth_header(client, app_fixture, "owner@example.com")
+    member_email = "shared-finance@example.com"
+    member_auth = _register_and_auth_header(client, app_fixture, member_email)
+    household_id = _create_household(client, owner_auth, name="Shared Finance")
+    add_member = client.post(
+        f"/households/{household_id}/members",
+        json={"email": member_email},
+        headers=owner_auth,
+    )
+    assert add_member.status_code == 201
+
+    create_category = client.post(
+        "/categories",
+        json={"name": "Groceries", "household_id": household_id},
+        headers=owner_auth,
+    )
+    assert create_category.status_code == 201
+    category_id = create_category.get_json()["id"]
+
+    create_expense = client.post(
+        "/expenses",
+        json={
+            "amount": 128.75,
+            "description": "Weekly groceries",
+            "date": "2026-03-01",
+            "category_id": category_id,
+            "household_id": household_id,
+        },
+        headers=owner_auth,
+    )
+    assert create_expense.status_code == 201
+    expense_id = create_expense.get_json()["id"]
+
+    create_bill = client.post(
+        "/bills",
+        json={
+            "name": "Fiber Internet",
+            "amount": 59.9,
+            "next_due_date": (date.today() + timedelta(days=7)).isoformat(),
+            "cadence": "MONTHLY",
+            "household_id": household_id,
+        },
+        headers=owner_auth,
+    )
+    assert create_bill.status_code == 201
+    bill_id = create_bill.get_json()["id"]
+
+    categories_for_member = client.get("/categories", headers=member_auth)
+    assert categories_for_member.status_code == 200
+    category_payload = categories_for_member.get_json()
+    assert any(
+        item["id"] == category_id and item["household_id"] == household_id
+        for item in category_payload
+    )
+
+    expenses_for_member = client.get("/expenses", headers=member_auth)
+    assert expenses_for_member.status_code == 200
+    expense_payload = expenses_for_member.get_json()
+    assert any(
+        item["id"] == expense_id and item["household_id"] == household_id
+        for item in expense_payload
+    )
+
+    bills_for_member = client.get("/bills", headers=member_auth)
+    assert bills_for_member.status_code == 200
+    bill_payload = bills_for_member.get_json()
+    assert any(
+        item["id"] == bill_id and item["household_id"] == household_id
+        for item in bill_payload
+    )
+
+
+def test_non_member_cannot_access_or_write_household_records(client, app_fixture):
+    owner_auth = _register_and_auth_header(client, app_fixture, "owner@example.com")
+    outsider_auth = _register_and_auth_header(
+        client, app_fixture, "outsider@example.com"
+    )
+    household_id = _create_household(client, owner_auth, name="Private Home")
+
+    get_household = client.get(f"/households/{household_id}", headers=outsider_auth)
+    assert get_household.status_code == 403
+
+    create_expense = client.post(
+        "/expenses",
+        json={
+            "amount": 25,
+            "description": "Should fail",
+            "date": "2026-03-02",
+            "household_id": household_id,
+        },
+        headers=outsider_auth,
+    )
+    assert create_expense.status_code == 403
+
+    create_category = client.post(
+        "/categories",
+        json={"name": "Should Not Work", "household_id": household_id},
+        headers=outsider_auth,
+    )
+    assert create_category.status_code == 403
+
+    create_bill = client.post(
+        "/bills",
+        json={
+            "name": "Should Fail",
+            "amount": 12.5,
+            "next_due_date": date.today().isoformat(),
+            "cadence": "MONTHLY",
+            "household_id": household_id,
+        },
+        headers=outsider_auth,
+    )
+    assert create_bill.status_code == 403


### PR DESCRIPTION
## Summary
Implements shared household budgeting for issue #134 with production-ready backend routes, permission checks, tests, and docs updates.

/claim #134

## What changed
- Added `Household`, `HouseholdMember`, and role model support.
- Added household endpoints:
  - `POST /households`
  - `GET /households/my`
  - `GET /households/{id}`
  - `POST /households/{id}/members`
- Added optional `household_id` support for shared records in:
  - categories
  - expenses
  - bills
- Enforced membership/admin authorization for shared data creation and access.
- Added schema compatibility patches + DDL updates for household tables/columns.
- Updated README endpoint docs.

## Validation
- `PYTHONPATH=. flake8 app/services/households.py app/routes/households.py app/routes/categories.py app/routes/expenses.py app/routes/bills.py tests/test_households.py`
- `PYTHONPATH=. pytest -q tests/test_households.py`

## Notes
- Existing personal workflows remain backward compatible (`household_id` is nullable).
