### PR TITLE
feat: add weekly financial digest insights endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-digest`
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,7 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.digest import weekly_digest
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +24,25 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-digest")
+@jwt_required()
+def get_weekly_digest():
+    uid = int(get_jwt_identity())
+    year = request.args.get("year", type=int)
+    week = request.args.get("week", type=int)
+    user_gemini_key = (request.headers.get("X-Gemini-Api-Key") or "").strip() or None
+    persona = (request.headers.get("X-Insight-Persona") or "").strip() or None
+    try:
+        digest = weekly_digest(
+            uid,
+            year,
+            week,
+            gemini_api_key=user_gemini_key,
+            persona=persona,
+        )
+    except ValueError:
+        return jsonify(error="invalid ISO week or year"), 400
+    logger.info("Weekly digest served user=%s week=%s", uid, digest["week"])
+    return jsonify(digest)

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,248 @@
+import json
+from datetime import date, timedelta
+from urllib import request
+
+from sqlalchemy import func
+
+from ..config import Settings
+from ..extensions import db
+from ..models import Category, Expense
+
+_settings = Settings()
+DEFAULT_WEEKLY_PERSONA = (
+    "You are FinMind's weekly finance analyst. Return concise, practical insights "
+    "based on trends, category concentration, and net cash flow."
+)
+
+
+def _scoped_expense_query(uid: int):
+    return db.session.query(Expense).filter(Expense.user_id == uid)
+
+
+def _week_bounds(iso_year: int, iso_week: int) -> tuple[date, date]:
+    start = date.fromisocalendar(iso_year, iso_week, 1)
+    end = date.fromisocalendar(iso_year, iso_week, 7)
+    return start, end
+
+
+def _weekly_totals(uid: int, start: date, end: date) -> tuple[float, float]:
+    scoped = _scoped_expense_query(uid)
+    income = (
+        scoped.filter(
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "INCOME",
+        )
+        .with_entities(func.coalesce(func.sum(Expense.amount), 0))
+        .scalar()
+    )
+    expenses = (
+        scoped.filter(
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .with_entities(func.coalesce(func.sum(Expense.amount), 0))
+        .scalar()
+    )
+    return float(income or 0), float(expenses or 0)
+
+
+def _category_breakdown(uid: int, start: date, end: date) -> list[dict]:
+    rows = (
+        _scoped_expense_query(uid)
+        .outerjoin(Category, Category.id == Expense.category_id)
+        .filter(
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .with_entities(
+            func.coalesce(Category.name, "Uncategorized").label("category_name"),
+            func.coalesce(func.sum(Expense.amount), 0).label("amount"),
+        )
+        .group_by(Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .all()
+    )
+    return [
+        {"category": str(row.category_name), "amount": round(float(row.amount), 2)}
+        for row in rows
+    ]
+
+
+def _daily_breakdown(uid: int, start: date, end: date) -> list[dict]:
+    rows = (
+        _scoped_expense_query(uid)
+        .filter(
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .with_entities(
+            Expense.spent_at,
+            func.coalesce(func.sum(Expense.amount), 0).label("amount"),
+        )
+        .group_by(Expense.spent_at)
+        .all()
+    )
+    by_day = {row.spent_at: round(float(row.amount), 2) for row in rows}
+    return [
+        {
+            "date": (start + timedelta(days=i)).isoformat(),
+            "expenses": by_day.get(start + timedelta(days=i), 0.0),
+        }
+        for i in range(7)
+    ]
+
+
+def _transaction_count(uid: int, start: date, end: date) -> int:
+    return int(
+        _scoped_expense_query(uid)
+        .filter(Expense.spent_at >= start, Expense.spent_at <= end)
+        .with_entities(func.count(Expense.id))
+        .scalar()
+        or 0
+    )
+
+
+def _heuristic_weekly_insights(payload: dict) -> list[str]:
+    totals = payload["totals"]
+    expenses = totals["expenses"]
+    previous = payload["previous_week_expenses"]
+    wow = payload["week_over_week_change_pct"]
+    category_breakdown = payload["category_breakdown"]
+
+    if payload["transaction_count"] == 0:
+        return [
+            "No transactions recorded this week.",
+            "Set one spending cap and track it daily next week.",
+        ]
+
+    insights = [
+        (
+            f"Weekly expenses: {expenses:.2f} with "
+            f"{wow:+.2f}% vs previous week ({previous:.2f})."
+        ),
+        f"Net cash flow this week: {totals['net']:.2f}.",
+    ]
+    if category_breakdown:
+        top = category_breakdown[0]
+        insights.append(f"Top spend category: {top['category']} ({top['amount']:.2f}).")
+    else:
+        insights.append("No expense categories were detected this week.")
+    return insights
+
+
+def _extract_json_object(raw_text: str) -> dict:
+    text = (raw_text or "").strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:].strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError("model did not return JSON object")
+    return json.loads(text[start : end + 1])
+
+
+def _gemini_weekly_insights(
+    payload: dict, api_key: str, model: str, persona: str
+) -> list[str]:
+    prompt = (
+        f"{persona}\n"
+        'Return strict JSON only: {"insights":["...","...","..."]}.\n'
+        f"week={payload['week']}\n"
+        f"totals={payload['totals']}\n"
+        f"week_over_week_change_pct={payload['week_over_week_change_pct']}\n"
+        f"category_breakdown={payload['category_breakdown']}\n"
+        f"daily_breakdown={payload['daily_breakdown']}"
+    )
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent?key={api_key}"
+    )
+    body = json.dumps(
+        {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {"temperature": 0.2},
+        }
+    ).encode("utf-8")
+    req = request.Request(
+        url=url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as resp:  # nosec B310
+        payload = json.loads(resp.read().decode("utf-8"))
+    text = (
+        payload.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])[0]
+        .get("text", "")
+    )
+    parsed = _extract_json_object(text)
+    insights = parsed.get("insights") or []
+    if not isinstance(insights, list):
+        raise ValueError("insights is not a list")
+    return [str(item).strip() for item in insights if str(item).strip()]
+
+
+def weekly_digest(
+    uid: int,
+    iso_year: int | None = None,
+    iso_week: int | None = None,
+    *,
+    gemini_api_key: str | None = None,
+    gemini_model: str | None = None,
+    persona: str | None = None,
+) -> dict:
+    if iso_year is None or iso_week is None:
+        today = date.today()
+        iso_year, iso_week, _ = today.isocalendar()
+
+    start, end = _week_bounds(iso_year, iso_week)
+    previous_start = start - timedelta(days=7)
+    previous_end = end - timedelta(days=7)
+
+    income, expenses = _weekly_totals(uid, start, end)
+    _, previous_expenses = _weekly_totals(uid, previous_start, previous_end)
+    week_over_week = (
+        round(((expenses - previous_expenses) / previous_expenses) * 100, 2)
+        if previous_expenses > 0
+        else 0.0
+    )
+
+    payload = {
+        "week": f"{iso_year}-W{iso_week:02d}",
+        "period": {"start": start.isoformat(), "end": end.isoformat()},
+        "totals": {
+            "income": round(income, 2),
+            "expenses": round(expenses, 2),
+            "net": round(income - expenses, 2),
+        },
+        "transaction_count": _transaction_count(uid, start, end),
+        "previous_week_expenses": round(previous_expenses, 2),
+        "week_over_week_change_pct": week_over_week,
+        "category_breakdown": _category_breakdown(uid, start, end),
+        "daily_breakdown": _daily_breakdown(uid, start, end),
+    }
+
+    payload["insights"] = _heuristic_weekly_insights(payload)
+    payload["method"] = "heuristic"
+
+    key = (gemini_api_key or "").strip() or (_settings.gemini_api_key or "")
+    model = gemini_model or _settings.gemini_model
+    persona_text = (persona or DEFAULT_WEEKLY_PERSONA).strip()
+    if key:
+        try:
+            ai_insights = _gemini_weekly_insights(payload, key, model, persona_text)
+            if ai_insights:
+                payload["insights"] = ai_insights
+                payload["method"] = "gemini"
+        except Exception:
+            payload.setdefault("warnings", []).append("gemini_unavailable")
+
+    return payload

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,115 @@
+from datetime import date, timedelta
+
+import pytest
+from flask_jwt_extended import create_access_token
+
+from app.extensions import db
+from app.models import User
+
+
+@pytest.fixture(autouse=True)
+def _disable_expense_cache(monkeypatch):
+    monkeypatch.setattr(
+        "app.routes.expenses.cache_delete_patterns",
+        lambda *_args, **_kwargs: None,
+    )
+
+
+def _register_and_auth_header(client, app_fixture, email: str):
+    r = client.post("/auth/register", json={"email": email, "password": "password123"})
+    assert r.status_code in (201, 409)
+    with app_fixture.app_context():
+        user = db.session.query(User).filter_by(email=email).first()
+        assert user is not None
+        token = create_access_token(identity=str(user.id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _create_expense(client, auth, amount: float, day: date, expense_type="EXPENSE"):
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": amount,
+            "description": f"{expense_type.lower()}-{day.isoformat()}",
+            "date": day.isoformat(),
+            "expense_type": expense_type,
+        },
+        headers=auth,
+    )
+    assert r.status_code == 201
+
+
+def test_weekly_digest_returns_summary_and_trend_fields(client, app_fixture):
+    auth = _register_and_auth_header(client, app_fixture, "digest-user@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+    iso_year, iso_week, _ = monday.isocalendar()
+
+    _create_expense(client, auth, 1200.0, monday, expense_type="INCOME")
+    _create_expense(client, auth, 180.0, monday + timedelta(days=2))
+
+    r = client.get(
+        f"/insights/weekly-digest?year={iso_year}&week={iso_week}",
+        headers=auth,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["week"] == f"{iso_year}-W{iso_week:02d}"
+    assert set(payload["period"].keys()) == {"start", "end"}
+    assert set(payload["totals"].keys()) == {"income", "expenses", "net"}
+    assert payload["totals"]["income"] == 1200.0
+    assert payload["totals"]["expenses"] == 180.0
+    assert payload["totals"]["net"] == 1020.0
+    assert payload["transaction_count"] == 2
+    assert isinstance(payload["category_breakdown"], list)
+    assert isinstance(payload["daily_breakdown"], list)
+    assert isinstance(payload["insights"], list)
+    assert payload["method"] == "heuristic"
+
+
+def test_weekly_digest_computes_week_over_week_change(client, app_fixture):
+    auth = _register_and_auth_header(client, app_fixture, "digest-wow@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+    prev_monday = monday - timedelta(days=7)
+    iso_year, iso_week, _ = monday.isocalendar()
+
+    _create_expense(client, auth, 200.0, prev_monday)
+    _create_expense(client, auth, 100.0, monday)
+
+    r = client.get(
+        f"/insights/weekly-digest?year={iso_year}&week={iso_week}",
+        headers=auth,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["previous_week_expenses"] == 200.0
+    assert payload["week_over_week_change_pct"] == -50.0
+
+
+def test_weekly_digest_defaults_to_current_week(client, app_fixture):
+    auth = _register_and_auth_header(client, app_fixture, "digest-default@example.com")
+    r = client.get("/insights/weekly-digest", headers=auth)
+    assert r.status_code == 200
+    payload = r.get_json()
+    year, week, _ = date.today().isocalendar()
+    assert payload["week"] == f"{year}-W{week:02d}"
+
+
+def test_weekly_digest_fallback_when_gemini_errors(client, app_fixture, monkeypatch):
+    auth = _register_and_auth_header(client, app_fixture, "digest-ai@example.com")
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("gemini down")
+
+    monkeypatch.setattr("app.services.digest._gemini_weekly_insights", _boom)
+
+    r = client.get(
+        "/insights/weekly-digest",
+        headers={**auth, "X-Gemini-Api-Key": "fake-key"},
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["method"] == "heuristic"
+    assert "gemini_unavailable" in payload.get("warnings", [])


### PR DESCRIPTION
## Summary
Implements issue #121 by adding a weekly digest endpoint that returns trends and actionable insights.

/claim #121

## What changed
- Added `GET /insights/weekly-digest`.
- Added weekly digest service with:
  - weekly totals (`income`, `expenses`, `net`)
  - previous-week expense baseline
  - week-over-week change percent
  - category breakdown
  - daily breakdown (7 days)
  - transaction count
  - heuristic insights
- Added optional Gemini insight generation with graceful fallback to heuristic output.
- Added tests for:
  - required response structure
  - week-over-week calculation
  - default current-week behavior
  - Gemini fallback behavior
- Updated README API endpoint docs.

## Validation
- `PYTHONPATH=. flake8 app/services/digest.py app/routes/insights.py tests/test_digest.py`
- `PYTHONPATH=. pytest -q tests/test_digest.py`

## Notes
- Route returns `400` for invalid ISO year/week values.
