### PR TITLE
feat: Add natural language query endpoint for financial data

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .query import bp as query_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(query_bp, url_prefix="/query")

--- a/packages/backend/app/routes/query.py
+++ b/packages/backend/app/routes/query.py
@@ -1,0 +1,47 @@
+"""
+Natural Language Query Routes
+"""
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.nlp_query import process_natural_language_query
+
+bp = Blueprint("query", __name__, url_prefix="/query")
+
+
+@bp.route("", methods=["POST"])
+@jwt_required()
+def natural_language_query():
+    """
+    POST /query
+    Body: { "query": "How much did I spend on food last quarter?" }
+    
+    Returns:
+    {
+      "answer": "You spent 1234.56 INR on food from 2025-10-01 to 2025-12-31.",
+      "total_amount": 1234.56,
+      "currency": "INR",
+      "transaction_count": 15,
+      "date_range": {
+        "start": "2025-10-01",
+        "end": "2025-12-31"
+      },
+      "category": "food",
+      "source_data": [...]
+    }
+    """
+    user_id = get_jwt_identity()
+    data = request.get_json()
+    
+    if not data or "query" not in data:
+        return jsonify({"error": "Missing 'query' field"}), 400
+    
+    query = data["query"].strip()
+    if not query:
+        return jsonify({"error": "Query cannot be empty"}), 400
+    
+    try:
+        result = process_natural_language_query(user_id, query)
+        return jsonify(result), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/packages/backend/app/services/nlp_query.py
+++ b/packages/backend/app/services/nlp_query.py
@@ -1,0 +1,295 @@
+"""
+Natural Language Query Service for FinMind
+Allows users to query their financial data using natural language.
+"""
+import json
+import re
+from datetime import datetime, timedelta
+from urllib import request
+from typing import Dict, Any, List, Tuple
+
+from sqlalchemy import extract, func, and_, or_
+from ..config import Settings
+from ..extensions import db
+from ..models import Expense, Category
+
+_settings = Settings()
+
+
+def _parse_date_range(query: str) -> Tuple[datetime, datetime]:
+    """
+    Extract date range from natural language query.
+    Returns (start_date, end_date) tuple.
+    """
+    query_lower = query.lower()
+    today = datetime.now().date()
+    
+    # Last quarter
+    if "last quarter" in query_lower or "previous quarter" in query_lower:
+        current_month = today.month
+        current_quarter = (current_month - 1) // 3
+        if current_quarter == 0:
+            # Last quarter of previous year
+            start = datetime(today.year - 1, 10, 1).date()
+            end = datetime(today.year - 1, 12, 31).date()
+        else:
+            start_month = (current_quarter - 1) * 3 + 1
+            end_month = start_month + 2
+            start = datetime(today.year, start_month, 1).date()
+            # Last day of end_month
+            if end_month == 12:
+                end = datetime(today.year, 12, 31).date()
+            else:
+                end = (datetime(today.year, end_month + 1, 1) - timedelta(days=1)).date()
+        return start, end
+    
+    # This quarter
+    if "this quarter" in query_lower or "current quarter" in query_lower:
+        current_month = today.month
+        current_quarter = (current_month - 1) // 3
+        start_month = current_quarter * 3 + 1
+        start = datetime(today.year, start_month, 1).date()
+        end = today
+        return start, end
+    
+    # Last month
+    if "last month" in query_lower or "previous month" in query_lower:
+        if today.month == 1:
+            start = datetime(today.year - 1, 12, 1).date()
+            end = datetime(today.year - 1, 12, 31).date()
+        else:
+            start = datetime(today.year, today.month - 1, 1).date()
+            end = (datetime(today.year, today.month, 1) - timedelta(days=1)).date()
+        return start, end
+    
+    # This month
+    if "this month" in query_lower or "current month" in query_lower:
+        start = datetime(today.year, today.month, 1).date()
+        end = today
+        return start, end
+    
+    # Last year
+    if "last year" in query_lower or "previous year" in query_lower:
+        start = datetime(today.year - 1, 1, 1).date()
+        end = datetime(today.year - 1, 12, 31).date()
+        return start, end
+    
+    # This year
+    if "this year" in query_lower or "current year" in query_lower:
+        start = datetime(today.year, 1, 1).date()
+        end = today
+        return start, end
+    
+    # Last N days
+    days_match = re.search(r'last (\d+) days?', query_lower)
+    if days_match:
+        days = int(days_match.group(1))
+        start = (today - timedelta(days=days)).date()
+        end = today
+        return start, end
+    
+    # Default: last 30 days
+    start = (today - timedelta(days=30)).date()
+    end = today
+    return start, end
+
+
+def _extract_category(query: str, user_id: int) -> int | None:
+    """
+    Extract category from query by matching against user's categories.
+    """
+    query_lower = query.lower()
+    
+    # Get user's categories
+    categories = db.session.query(Category).filter(Category.user_id == user_id).all()
+    
+    for cat in categories:
+        if cat.name.lower() in query_lower:
+            return cat.id
+    
+    # Common category keywords
+    category_keywords = {
+        'food': ['food', 'restaurant', 'dining', 'meal', 'lunch', 'dinner', 'breakfast'],
+        'transport': ['transport', 'uber', 'taxi', 'gas', 'fuel', 'car'],
+        'entertainment': ['entertainment', 'movie', 'game', 'fun'],
+        'shopping': ['shopping', 'clothes', 'clothing'],
+        'utilities': ['utilities', 'electricity', 'water', 'internet'],
+        'health': ['health', 'medical', 'doctor', 'medicine'],
+    }
+    
+    for cat_name, keywords in category_keywords.items():
+        for keyword in keywords:
+            if keyword in query_lower:
+                # Try to find matching category
+                cat = db.session.query(Category).filter(
+                    Category.user_id == user_id,
+                    func.lower(Category.name).like(f'%{cat_name}%')
+                ).first()
+                if cat:
+                    return cat.id
+    
+    return None
+
+
+def _query_expenses(user_id: int, start_date, end_date, category_id: int | None = None) -> List[Dict]:
+    """
+    Query expenses with filters.
+    """
+    query = db.session.query(Expense).filter(
+        Expense.user_id == user_id,
+        Expense.spent_at >= start_date,
+        Expense.spent_at <= end_date,
+        Expense.expense_type != "INCOME"
+    )
+    
+    if category_id:
+        query = query.filter(Expense.category_id == category_id)
+    
+    expenses = query.all()
+    
+    return [{
+        'id': e.id,
+        'amount': float(e.amount),
+        'currency': e.currency,
+        'category_id': e.category_id,
+        'notes': e.notes,
+        'spent_at': e.spent_at.isoformat(),
+    } for e in expenses]
+
+
+def _use_gemini_to_parse(query: str, api_key: str, model: str) -> Dict[str, Any]:
+    """
+    Use Gemini to parse natural language query into structured format.
+    """
+    prompt = f"""Parse this financial query into JSON with these keys:
+- intent: "spending_query" or "income_query" or "budget_query"
+- time_period: "last_quarter", "this_month", "last_year", etc.
+- category: extracted category name or null
+- amount_comparison: "greater_than", "less_than", "equal_to", or null
+- amount_value: numeric value or null
+
+Query: "{query}"
+
+Return ONLY valid JSON, no markdown."""
+
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent?key={api_key}"
+    )
+    body = json.dumps({
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"temperature": 0.1},
+    }).encode("utf-8")
+    
+    req = request.Request(
+        url=url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    
+    with request.urlopen(req, timeout=10) as resp:  # nosec B310
+        payload = json.loads(resp.read().decode("utf-8"))
+    
+    text = (
+        payload.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])[0]
+        .get("text", "")
+    )
+    
+    # Extract JSON from response
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lower().startswith("json"):
+            text = text[4:].strip()
+    
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1:
+        return json.loads(text[start:end + 1])
+    
+    return {}
+
+
+def process_natural_language_query(user_id: int, query: str) -> Dict[str, Any]:
+    """
+    Main function to process natural language financial queries.
+    
+    Args:
+        user_id: User ID
+        query: Natural language query (e.g., "How much did I spend on food last quarter?")
+    
+    Returns:
+        Dict with answer, source_data, and metadata
+    """
+    # Parse date range
+    start_date, end_date = _parse_date_range(query)
+    
+    # Extract category
+    category_id = _extract_category(query, user_id)
+    
+    # Get category name if exists
+    category_name = None
+    if category_id:
+        cat = db.session.query(Category).filter(Category.id == category_id).first()
+        if cat:
+            category_name = cat.name
+    
+    # Query expenses
+    expenses = _query_expenses(user_id, start_date, end_date, category_id)
+    
+    # Calculate total
+    total_amount = sum(e['amount'] for e in expenses)
+    
+    # Build answer
+    period_str = f"{start_date.isoformat()} to {end_date.isoformat()}"
+    category_str = f" on {category_name}" if category_name else ""
+    
+    answer = f"You spent {total_amount:.2f} {expenses[0]['currency'] if expenses else 'INR'}{category_str} from {period_str}."
+    
+    # Try to use Gemini for better answer formatting if available
+    gemini_key = (_settings.gemini_api_key or "").strip()
+    if gemini_key and expenses:
+        try:
+            # Generate natural answer using Gemini
+            summary_prompt = f"""Given this financial data, provide a concise, friendly answer to the user's question.
+
+Question: {query}
+Total spent: {total_amount:.2f}
+Period: {period_str}
+Category: {category_name or 'all categories'}
+Number of transactions: {len(expenses)}
+
+Provide a 1-2 sentence natural answer."""
+            
+            url = f"https://generativelanguage.googleapis.com/v1beta/models/{_settings.gemini_model}:generateContent?key={gemini_key}"
+            body = json.dumps({
+                "contents": [{"parts": [{"text": summary_prompt}]}],
+                "generationConfig": {"temperature": 0.3},
+            }).encode("utf-8")
+            
+            req = request.Request(url=url, data=body, headers={"Content-Type": "application/json"}, method="POST")
+            with request.urlopen(req, timeout=10) as resp:  # nosec B310
+                payload = json.loads(resp.read().decode("utf-8"))
+            
+            ai_answer = payload.get("candidates", [{}])[0].get("content", {}).get("parts", [{}])[0].get("text", "").strip()
+            if ai_answer:
+                answer = ai_answer
+        except Exception:
+            pass  # Fall back to default answer
+    
+    return {
+        "answer": answer,
+        "total_amount": round(total_amount, 2),
+        "currency": expenses[0]['currency'] if expenses else 'INR',
+        "transaction_count": len(expenses),
+        "date_range": {
+            "start": start_date.isoformat(),
+            "end": end_date.isoformat(),
+        },
+        "category": category_name,
+        "source_data": expenses[:10],  # Return max 10 transactions as examples
+        "query": query,
+    }

--- a/packages/backend/tests/test_nlp_query.py
+++ b/packages/backend/tests/test_nlp_query.py
@@ -1,0 +1,137 @@
+"""
+Tests for Natural Language Query endpoint
+"""
+import pytest
+from datetime import datetime, timedelta
+
+
+def test_nlp_query_last_quarter(client, auth_headers, sample_user, sample_expenses):
+    """Test querying expenses for last quarter"""
+    response = client.post(
+        "/query",
+        json={"query": "How much did I spend on food last quarter?"},
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.get_json()
+    
+    assert "answer" in data
+    assert "total_amount" in data
+    assert "currency" in data
+    assert "transaction_count" in data
+    assert "date_range" in data
+    assert "source_data" in data
+    
+    assert data["currency"] == "INR"
+    assert isinstance(data["total_amount"], (int, float))
+    assert isinstance(data["transaction_count"], int)
+
+
+def test_nlp_query_this_month(client, auth_headers, sample_user):
+    """Test querying expenses for this month"""
+    response = client.post(
+        "/query",
+        json={"query": "How much did I spend this month?"},
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.get_json()
+    
+    assert "answer" in data
+    assert "date_range" in data
+    
+    # Verify date range is current month
+    today = datetime.now().date()
+    start_of_month = datetime(today.year, today.month, 1).date()
+    
+    assert data["date_range"]["start"] == start_of_month.isoformat()
+    assert data["date_range"]["end"] == today.isoformat()
+
+
+def test_nlp_query_with_category(client, auth_headers, sample_user, sample_category):
+    """Test querying expenses with category filter"""
+    response = client.post(
+        "/query",
+        json={"query": "How much did I spend on food last month?"},
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.get_json()
+    
+    assert "category" in data
+    # Category might be None if no matching expenses
+
+
+def test_nlp_query_missing_query(client, auth_headers):
+    """Test error when query is missing"""
+    response = client.post(
+        "/query",
+        json={},
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "error" in data
+
+
+def test_nlp_query_empty_query(client, auth_headers):
+    """Test error when query is empty"""
+    response = client.post(
+        "/query",
+        json={"query": ""},
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "error" in data
+
+
+def test_nlp_query_unauthorized(client):
+    """Test that endpoint requires authentication"""
+    response = client.post(
+        "/query",
+        json={"query": "How much did I spend?"}
+    )
+    
+    assert response.status_code == 401
+
+
+def test_nlp_query_last_year(client, auth_headers, sample_user):
+    """Test querying expenses for last year"""
+    response = client.post(
+        "/query",
+        json={"query": "What did I spend last year?"},
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.get_json()
+    
+    today = datetime.now().date()
+    last_year = today.year - 1
+    
+    assert data["date_range"]["start"] == f"{last_year}-01-01"
+    assert data["date_range"]["end"] == f"{last_year}-12-31"
+
+
+def test_nlp_query_last_30_days(client, auth_headers, sample_user):
+    """Test querying expenses for last 30 days"""
+    response = client.post(
+        "/query",
+        json={"query": "How much did I spend in the last 30 days?"},
+        headers=auth_headers
+    )
+    
+    assert response.status_code == 200
+    data = response.get_json()
+    
+    today = datetime.now().date()
+    start = (today - timedelta(days=30)).date()
+    
+    assert data["date_range"]["start"] == start.isoformat()
+    assert data["date_range"]["end"] == today.isoformat()


### PR DESCRIPTION
Implements Issue #74 - Natural Language Finance Query

Features:
- New /query endpoint that accepts natural language queries
- Supports date range parsing (last quarter, this month, last year, etc.)
- Automatic category extraction from query text
- Returns accurate answer with source data
- Optional Gemini AI integration for better answer formatting
- Comprehensive test coverage

Example queries:
- 'How much did I spend on food last quarter?'
- 'What did I spend this month?'
- 'How much did I spend in the last 30 days?'

Technical details:
- Added nlp_query.py service with date parsing and category matching
- Added query.py route with JWT authentication
- Added comprehensive pytest tests
- Handles edge cases (empty query, missing auth, etc.)

Closes #74

## Summary
- What changed:
- Why:

## Validation
- [ ] Frontend lint: `cd app && npm run lint`
- [ ] Frontend tests: `cd app && npm test -- --runInBand`
- [ ] Backend tests: `./scripts/test-backend.ps1`
- [ ] Updated docs if needed

## Security and Ownership
- [ ] PR opened from a fork (not direct push to `main`)
- [ ] CODEOWNERS review requested

## Checklist
- [ ] No secrets added
- [ ] No unrelated files changed
- [ ] Breaking changes documented