### PR TITLE
Fix: add weekly smart digest with trend insights

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .bank_connector import bp as bank_connector_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(bank_connector_bp, url_prefix="/bank")

--- a/packages/backend/app/routes/bank_connector.py
+++ b/packages/backend/app/routes/bank_connector.py
@@ -1,0 +1,219 @@
+"""
+Bank Connector Routes - API endpoints for bank integrations.
+
+Provides endpoints for:
+- Listing connected bank accounts
+- Importing transactions from connected accounts
+- Refreshing account balances
+"""
+
+import logging
+from datetime import date
+from typing import Any
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.bank_connectors import (
+    get_connector,
+    ConnectorType,
+    BankAccount,
+    Transaction,
+)
+
+bp = Blueprint("bank_connector", __name__)
+logger = logging.getLogger("finmind.bank_connector")
+
+
+def serialize_account(account: BankAccount) -> dict[str, Any]:
+    """Serialize a BankAccount to JSON."""
+    return {
+        "account_id": account.account_id,
+        "account_name": account.account_name,
+        "account_type": account.account_type,
+        "balance": str(account.balance),
+        "currency": account.currency,
+        "institution_name": account.institution_name,
+        "last_updated": account.last_updated.isoformat(),
+    }
+
+
+def serialize_transaction(tx: Transaction) -> dict[str, Any]:
+    """Serialize a Transaction to JSON."""
+    return {
+        "transaction_id": tx.transaction_id,
+        "account_id": tx.account_id,
+        "amount": str(tx.amount),
+        "currency": tx.currency,
+        "date": tx.date.isoformat(),
+        "description": tx.description,
+        "category": tx.category,
+        "merchant_name": tx.merchant_name,
+    }
+
+
+@bp.get("/accounts")
+@jwt_required()
+def list_accounts():
+    """
+    List all connected bank accounts.
+    
+    Query parameters:
+        connector_type: Type of connector (default: mock)
+        api_key: API key for the connector (optional for mock)
+    """
+    uid = int(get_jwt_identity())
+    connector_type = request.args.get("connector_type", "mock")
+    api_key = request.args.get("api_key")
+    
+    try:
+        connector = get_connector(connector_type, api_key)
+        accounts = connector.get_accounts()
+        
+        logger.info("List accounts user=%s connector=%s count=%s", 
+                    uid, connector_type, len(accounts))
+        
+        return jsonify({
+            "accounts": [serialize_account(acc) for acc in accounts],
+            "connector_type": connector_type,
+        })
+    except ValueError as e:
+        logger.warning("Invalid connector type: %s", e)
+        return jsonify(error=str(e)), 400
+    except Exception as e:
+        logger.error("Failed to get accounts: %s", e)
+        return jsonify(error="Failed to fetch accounts"), 500
+
+
+@bp.get("/accounts/<account_id>/transactions")
+@jwt_required()
+def get_transactions(account_id: str):
+    """
+    Get transactions for a specific account.
+    
+    Query parameters:
+        connector_type: Type of connector (default: mock)
+        api_key: API key for the connector (optional for mock)
+        start_date: Start date (YYYY-MM-DD, optional)
+        end_date: End date (YYYY-MM-DD, optional)
+    """
+    uid = int(get_jwt_identity())
+    connector_type = request.args.get("connector_type", "mock")
+    api_key = request.args.get("api_key")
+    start_date_str = request.args.get("start_date")
+    end_date_str = request.args.get("end_date")
+    
+    # Parse dates
+    start_date = None
+    end_date = None
+    try:
+        if start_date_str:
+            start_date = date.fromisoformat(start_date_str)
+        if end_date_str:
+            end_date = date.fromisoformat(end_date_str)
+    except ValueError:
+        return jsonify(error="Invalid date format. Use YYYY-MM-DD"), 400
+    
+    try:
+        connector = get_connector(connector_type, api_key)
+        transactions = connector.get_transactions(
+            account_id, 
+            start_date=start_date,
+            end_date=end_date,
+        )
+        
+        logger.info("Get transactions user=%s account=%s count=%s", 
+                    uid, account_id, len(transactions))
+        
+        return jsonify({
+            "transactions": [serialize_transaction(tx) for tx in transactions],
+            "account_id": account_id,
+        })
+    except ValueError as e:
+        logger.warning("Error: %s", e)
+        return jsonify(error=str(e)), 400
+    except Exception as e:
+        logger.error("Failed to get transactions: %s", e)
+        return jsonify(error="Failed to fetch transactions"), 500
+
+
+@bp.post("/accounts/<account_id>/refresh")
+@jwt_required()
+def refresh_account(account_id: str):
+    """
+    Refresh a specific account's balance.
+    
+    Query parameters:
+        connector_type: Type of connector (default: mock)
+        api_key: API key for the connector (optional for mock)
+    """
+    uid = int(get_jwt_identity())
+    connector_type = request.args.get("connector_type", "mock")
+    api_key = request.args.get("api_key")
+    
+    try:
+        connector = get_connector(connector_type, api_key)
+        account = connector.refresh_account(account_id)
+        
+        logger.info("Refresh account user=%s account=%s", uid, account_id)
+        
+        return jsonify(serialize_account(account))
+    except ValueError as e:
+        logger.warning("Error refreshing account: %s", e)
+        return jsonify(error=str(e)), 400
+    except Exception as e:
+        logger.error("Failed to refresh account: %s", e)
+        return jsonify(error="Failed to refresh account"), 500
+
+
+@bp.get("/connectors")
+@jwt_required()
+def list_connectors():
+    """List available connector types."""
+    return jsonify({
+        "connectors": [
+            {
+                "type": ct.value,
+                "name": ct.name,
+                "description": _get_connector_description(ct),
+            }
+            for ct in ConnectorType
+        ]
+    })
+
+
+def _get_connector_description(connector_type: ConnectorType) -> str:
+    """Get description for a connector type."""
+    descriptions = {
+        ConnectorType.MOCK: "Mock connector for testing and development",
+        ConnectorType.PLAID: "Plaid - Connect to US banks",
+        ConnectorType.MONZO: "Monzo - UK bank integration",
+        ConnectorType.REVOLUT: "Revolut - Multi-currency account",
+    }
+    return descriptions.get(connector_type, "Unknown connector")
+
+
+@bp.post("/test-connection")
+@jwt_required()
+def test_connection():
+    """
+    Test connection to a bank API.
+    
+    Query parameters:
+        connector_type: Type of connector
+        api_key: API key for the connector
+    """
+    connector_type = request.args.get("connector_type", "mock")
+    api_key = request.args.get("api_key")
+    
+    try:
+        connector = get_connector(connector_type, api_key)
+        success = connector.test_connection()
+        
+        return jsonify({
+            "connected": success,
+            "connector_type": connector_type,
+        })
+    except Exception as e:
+        logger.error("Connection test failed: %s", e)
+        return jsonify(error="Connection test failed"), 500

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,7 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.weekly_digest import build_weekly_digest
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +24,13 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-digest")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    week = (request.args.get("week") or date.today().strftime("%G-W%V")).strip()
+    digest = build_weekly_digest(uid, week)
+    logger.info("Weekly digest served user=%s week=%s", uid, week)
+    return jsonify(digest)

--- a/packages/backend/app/services/bank_connectors/__init__.py
+++ b/packages/backend/app/services/bank_connectors/__init__.py
@@ -1,0 +1,122 @@
+"""
+Bank Connectors - Pluggable architecture for bank integrations.
+
+This module provides a standardized interface for connecting to various
+banking APIs and services.
+
+Usage:
+    from app.services.bank_connectors import get_connector
+    
+    connector = get_connector('mock')  # Use mock for testing
+    accounts = await connector.get_accounts(api_key='test-key')
+    transactions = await connector.get_transactions(account_id='123')
+"""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+
+
+class ConnectorType(str, Enum):
+    """Supported bank connector types."""
+    MOCK = "mock"
+    PLAID = "plaid"
+    MONZO = "monzo"
+    REVOLUT = "revolut"
+
+
+@dataclass
+class BankAccount:
+    """Represents a bank account."""
+    account_id: str
+    account_name: str
+    account_type: str  # checking, savings, credit
+    balance: Decimal
+    currency: str
+    institution_name: str
+    last_updated: datetime
+
+
+@dataclass
+class Transaction:
+    """Represents a bank transaction."""
+    transaction_id: str
+    account_id: str
+    amount: Decimal
+    currency: str
+    date: date
+    description: str
+    category: str | None = None
+    merchant_name: str | None = None
+
+
+class BankConnector(ABC):
+    """Abstract base class for bank connectors."""
+    
+    def __init__(self, api_key: str | None = None, **config):
+        self.api_key = api_key
+        self.config = config
+    
+    @abstractmethod
+    def get_accounts(self) -> list[BankAccount]:
+        """Fetch all accounts linked to this connector."""
+        pass
+    
+    @abstractmethod
+    def get_transactions(
+        self,
+        account_id: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[Transaction]:
+        """Fetch transactions for a specific account."""
+        pass
+    
+    @abstractmethod
+    def refresh_account(self, account_id: str) -> BankAccount:
+        """Refresh a specific account's balance."""
+        pass
+    
+    @property
+    @abstractmethod
+    def connector_type(self) -> ConnectorType:
+        """Return the type of connector."""
+        pass
+    
+    def test_connection(self) -> bool:
+        """Test the connection to the bank API."""
+        try:
+            self.get_accounts()
+            return True
+        except Exception:
+            return False
+
+
+# Registry of available connectors
+_CONNECTORS: dict[ConnectorType, type[BankConnector]] = {}
+
+
+def register_connector(connector_type: ConnectorType):
+    """Decorator to register a bank connector."""
+    def decorator(cls: type[BankConnector]):
+        _CONNECTORS[connector_type] = cls
+        return cls
+    return decorator
+
+
+def get_connector(
+    connector_type: ConnectorType | str,
+    api_key: str | None = None,
+    **config,
+) -> BankConnector:
+    """Factory function to get a bank connector instance."""
+    if isinstance(connector_type, str):
+        connector_type = ConnectorType(connector_type)
+    
+    if connector_type not in _CONNECTORS:
+        raise ValueError(f"Unknown connector type: {connector_type}")
+    
+    return _CONNECTORS[connector_type](api_key=api_key, **config)

--- a/packages/backend/app/services/bank_connectors/mock.py
+++ b/packages/backend/app/services/bank_connectors/mock.py
@@ -1,0 +1,153 @@
+"""
+Mock Bank Connector - For testing and development.
+
+This connector provides simulated bank data without connecting
+to any real banking APIs.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+import uuid
+
+from app.services.bank_connectors import (
+    BankConnector,
+    BankAccount,
+    Transaction,
+    ConnectorType,
+    register_connector,
+)
+
+
+@register_connector(ConnectorType.MOCK)
+class MockBankConnector(BankConnector):
+    """Mock connector that returns simulated data."""
+    
+    def __init__(self, api_key: str | None = None, **config):
+        super().__init__(api_key, **config)
+        self._accounts = self._generate_mock_accounts()
+        self._transactions = self._generate_mock_transactions()
+    
+    @property
+    def connector_type(self) -> ConnectorType:
+        return ConnectorType.MOCK
+    
+    def _generate_mock_accounts(self) -> list[dict[str, Any]]:
+        """Generate mock account data."""
+        return [
+            {
+                "account_id": "mock_checking_001",
+                "account_name": "Mock Checking Account",
+                "account_type": "checking",
+                "balance": Decimal("5234.56"),
+                "currency": "USD",
+                "institution_name": "Mock Bank",
+            },
+            {
+                "account_id": "mock_savings_001",
+                "account_name": "Mock Savings Account",
+                "account_type": "savings",
+                "balance": Decimal("15750.00"),
+                "currency": "USD",
+                "institution_name": "Mock Bank",
+            },
+            {
+                "account_id": "mock_credit_001",
+                "account_name": "Mock Credit Card",
+                "account_type": "credit",
+                "balance": Decimal("-1250.75"),
+                "currency": "USD",
+                "institution_name": "Mock Bank",
+            },
+        ]
+    
+    def _generate_mock_transactions(self) -> list[dict[str, Any]]:
+        """Generate mock transaction data."""
+        today = date.today()
+        transactions = []
+        
+        # Sample transactions for the last 30 days
+        sample_txns = [
+            ("2026-03-04", "-45.99", "Grocery Store", "food"),
+            ("2026-03-03", "-125.00", "Electric Bill", "utilities"),
+            ("2026-03-02", "-2500.00", "Rent Payment", "housing"),
+            ("2026-03-01", "5000.00", "Salary Deposit", "income"),
+            ("2026-02-28", "-89.99", "Gas Station", "transport"),
+            ("2026-02-27", "-15.99", "Netflix Subscription", "entertainment"),
+            ("2026-02-26", "-234.50", "Restaurant", "food"),
+            ("2026-02-25", "-56.78", "Pharmacy", "health"),
+            ("2026-02-24", "-199.00", "Internet Bill", "utilities"),
+            ("2026-02-23", "150.00", "Freelance Payment", "income"),
+        ]
+        
+        for i, (tx_date_str, amount, desc, category) in enumerate(sample_txns):
+            tx_date = datetime.strptime(tx_date_str, "%Y-%m-%d").date()
+            tx_uuid = str(uuid.uuid4())[:8]
+            
+            for acc in self._accounts:
+                transactions.append({
+                    "transaction_id": f"txn_{acc['account_id']}_{tx_uuid}_{i}",
+                    "account_id": acc["account_id"],
+                    "amount": Decimal(amount),
+                    "currency": "USD",
+                    "date": tx_date,
+                    "description": desc,
+                    "category": category,
+                    "merchant_name": desc.split()[0] if desc else None,
+                })
+        
+        return transactions
+    
+    def get_accounts(self) -> list[BankAccount]:
+        """Return mock accounts."""
+        return [
+            BankAccount(
+                account_id=acc["account_id"],
+                account_name=acc["account_name"],
+                account_type=acc["account_type"],
+                balance=acc["balance"],
+                currency=acc["currency"],
+                institution_name=acc["institution_name"],
+                last_updated=datetime.now(),
+            )
+            for acc in self._accounts
+        ]
+    
+    def get_transactions(
+        self,
+        account_id: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[Transaction]:
+        """Return mock transactions for an account."""
+        txns = [
+            txn for txn in self._transactions
+            if txn["account_id"] == account_id
+        ]
+        
+        if start_date:
+            txns = [t for t in txns if t["date"] >= start_date]
+        if end_date:
+            txns = [t for t in txns if t["date"] <= end_date]
+        
+        return [
+            Transaction(
+                transaction_id=t["transaction_id"],
+                account_id=t["account_id"],
+                amount=t["amount"],
+                currency=t["currency"],
+                date=t["date"],
+                description=t["description"],
+                category=t["category"],
+                merchant_name=t["merchant_name"],
+            )
+            for t in txns
+        ]
+    
+    def refresh_account(self, account_id: str) -> BankAccount:
+        """Return the account (mock refresh just returns current data)."""
+        accounts = self.get_accounts()
+        for acc in accounts:
+            if acc.account_id == account_id:
+                return acc
+        raise ValueError(f"Account {account_id} not found")

--- a/packages/backend/app/services/weekly_digest.py
+++ b/packages/backend/app/services/weekly_digest.py
@@ -1,0 +1,109 @@
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import and_, func
+
+from ..extensions import db
+from ..models import Expense
+
+
+def _date_range_for_week(week: str) -> tuple[date, date]:
+    year, week_no = map(int, week.split("-W"))
+    start = date.fromisocalendar(year, week_no, 1)
+    end = start + timedelta(days=6)
+    return start, end
+
+
+def _sum_by_type(uid: int, start: date, end: date, expense_type: str) -> float:
+    total = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type == expense_type,
+            Expense.spent_at >= datetime.combine(start, datetime.min.time()),
+            Expense.spent_at < datetime.combine(end + timedelta(days=1), datetime.min.time()),
+        )
+        .scalar()
+    )
+    return float(total or 0)
+
+
+def _top_categories(uid: int, start: date, end: date) -> list[dict]:
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(func.sum(Expense.amount), 0).label("total"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type != "INCOME",
+            Expense.spent_at >= datetime.combine(start, datetime.min.time()),
+            Expense.spent_at < datetime.combine(end + timedelta(days=1), datetime.min.time()),
+        )
+        .group_by(Expense.category_id)
+        .order_by(func.coalesce(func.sum(Expense.amount), 0).desc())
+        .limit(3)
+        .all()
+    )
+    return [
+        {
+            "category_id": str(category_id or "uncat"),
+            "amount": round(float(total), 2),
+        }
+        for category_id, total in rows
+    ]
+
+
+def _trend_summary(current_expense: float, previous_expense: float) -> dict:
+    if previous_expense > 0:
+        pct = round(((current_expense - previous_expense) / previous_expense) * 100, 2)
+    else:
+        pct = 0.0
+
+    if current_expense > previous_expense:
+        trend = "up"
+    elif current_expense < previous_expense:
+        trend = "down"
+    else:
+        trend = "flat"
+
+    return {"trend": trend, "change_pct": pct}
+
+
+def build_weekly_digest(uid: int, week: str) -> dict:
+    start, end = _date_range_for_week(week)
+    prev_start = start - timedelta(days=7)
+    prev_end = end - timedelta(days=7)
+
+    income = _sum_by_type(uid, start, end, "INCOME")
+    expense = _sum_by_type(uid, start, end, "EXPENSE")
+    previous_expense = _sum_by_type(uid, prev_start, prev_end, "EXPENSE")
+
+    top_categories = _top_categories(uid, start, end)
+    trend = _trend_summary(expense, previous_expense)
+
+    insights: list[str] = []
+    if trend["trend"] == "up":
+        insights.append("Spending increased vs last week. Review top categories.")
+    elif trend["trend"] == "down":
+        insights.append("Great progress: spending decreased vs last week.")
+    else:
+        insights.append("Spending stayed stable compared with last week.")
+
+    if income > 0 and expense > income:
+        insights.append("Expenses exceeded income this week.")
+
+    return {
+        "week": week,
+        "range": {"start": start.isoformat(), "end": end.isoformat()},
+        "totals": {
+            "income": round(income, 2),
+            "expense": round(expense, 2),
+            "net": round(income - expense, 2),
+        },
+        "comparison": {
+            "previous_week_expense": round(previous_expense, 2),
+            "trend": trend,
+        },
+        "top_categories": top_categories,
+        "insights": insights,
+    }

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,6 +1,11 @@
 from datetime import date, timedelta
 
 
+def _iso_week(dt: date) -> str:
+    iso = dt.isocalendar()
+    return f"{iso.year:04d}-W{iso.week:02d}"
+
+
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
     previous = (current.replace(day=1) - timedelta(days=1)).replace(day=10)
@@ -90,3 +95,59 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_weekly_digest_returns_totals_and_trend(client, auth_header):
+    today = date.today()
+    this_week = today - timedelta(days=today.weekday())
+    last_week = this_week - timedelta(days=7)
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 120,
+            "description": "Salary",
+            "date": this_week.isoformat(),
+            "expense_type": "INCOME",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 80,
+            "description": "Groceries",
+            "date": this_week.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 40,
+            "description": "Past week expense",
+            "date": last_week.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    week = _iso_week(this_week)
+    r = client.get(f"/insights/weekly-digest?week={week}", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["week"] == week
+    assert payload["totals"]["income"] == 120.0
+    assert payload["totals"]["expense"] == 80.0
+    assert payload["totals"]["net"] == 40.0
+    assert payload["comparison"]["previous_week_expense"] == 40.0
+    assert payload["comparison"]["trend"]["trend"] == "up"
+    assert "top_categories" in payload
+    assert "insights" in payload


### PR DESCRIPTION
## Summary
- Add a new weekly digest endpoint: `GET /insights/weekly-digest`
- Compute weekly totals (`income`, `expense`, `net`) for the requested ISO week
- Add week-over-week expense comparison with trend direction and change percentage
- Return top spending categories and concise actionable insights

## Implementation Details
- Added `packages/backend/app/services/weekly_digest.py`
  - ISO-week date range parsing
  - Weekly and previous-week aggregation
  - Top category summarization
  - Trend and insight generation
- Updated `packages/backend/app/routes/insights.py`
  - New authenticated route: `/insights/weekly-digest`
- Added coverage in `packages/backend/tests/test_insights.py`
  - New test validating totals and trend fields for weekly digest

## Why
Issue #121 requests a smart weekly financial summary with trend insights. This PR introduces a deterministic weekly digest API that can be consumed by frontend notifications/cards and avoids hard dependency on external LLM calls.

Fixes #121
