### PR TITLE
feat: Advanced search across transactions & bills (#105)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .search import bp as search_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(search_bp, url_prefix="/search")

--- a/packages/backend/app/routes/search.py
+++ b/packages/backend/app/routes/search.py
@@ -1,0 +1,299 @@
+"""Advanced search across transactions and bills.
+
+Provides a unified ``/search`` endpoint that queries both expenses and bills
+with flexible filter parameters: free-text query, category, amount range,
+date range, expense type, and result type selection.
+"""
+
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import or_
+from ..extensions import db
+from ..models import Bill, Category, Expense
+import logging
+
+bp = Blueprint("search", __name__)
+logger = logging.getLogger("finmind.search")
+
+_MAX_PAGE_SIZE = 200
+
+
+@bp.get("")
+@jwt_required()
+def search():
+    """Search across expenses and bills.
+
+    Query parameters
+    ----------------
+    q : str, optional
+        Free-text search term matched against expense descriptions/notes,
+        bill names, and category names (case-insensitive substring match).
+    category_id : int, optional
+        Filter expenses by category id.
+    category : str, optional
+        Filter expenses whose category *name* contains this substring
+        (case-insensitive).  Ignored when ``category_id`` is provided.
+    amount_min : decimal, optional
+        Minimum amount (inclusive).
+    amount_max : decimal, optional
+        Maximum amount (inclusive).
+    from : str (YYYY-MM-DD), optional
+        Start date (inclusive) — applies to ``spent_at`` for expenses and
+        ``next_due_date`` for bills.
+    to : str (YYYY-MM-DD), optional
+        End date (inclusive).
+    expense_type : str, optional
+        Filter expenses by type (e.g. EXPENSE, INCOME).
+    type : str, optional
+        Restrict results to ``expenses``, ``bills``, or ``all`` (default).
+    sort : str, optional
+        Sort field — ``date`` (default), ``amount``, or ``name``.
+    order : str, optional
+        ``asc`` or ``desc`` (default).
+    page : int, optional
+        Page number (1-indexed, default 1).
+    page_size : int, optional
+        Results per page (default 50, max 200).
+
+    Returns
+    -------
+    JSON with ``results`` (list), ``total`` count, ``page``, ``page_size``,
+    and per-type counts ``expense_count`` / ``bill_count``.
+    """
+
+    uid = int(get_jwt_identity())
+
+    # --- Parse common params ---------------------------------------------------
+    q = (request.args.get("q") or "").strip()
+    category_id = _parse_int(request.args.get("category_id"))
+    category_name = (request.args.get("category") or "").strip()
+    amount_min = _parse_decimal(request.args.get("amount_min"))
+    amount_max = _parse_decimal(request.args.get("amount_max"))
+    from_date = _parse_date(request.args.get("from"))
+    to_date = _parse_date(request.args.get("to"))
+    expense_type = (request.args.get("expense_type") or "").strip().upper() or None
+    result_type = (request.args.get("type") or "all").strip().lower()
+    sort_field = (request.args.get("sort") or "date").strip().lower()
+    order = (request.args.get("order") or "desc").strip().lower()
+
+    try:
+        page = max(1, int(request.args.get("page", "1")))
+        page_size = min(_MAX_PAGE_SIZE, max(1, int(request.args.get("page_size", "50"))))
+    except ValueError:
+        return jsonify(error="invalid pagination parameters"), 400
+
+    if result_type not in ("all", "expenses", "bills"):
+        return jsonify(error="type must be 'all', 'expenses', or 'bills'"), 400
+    if sort_field not in ("date", "amount", "name"):
+        return jsonify(error="sort must be 'date', 'amount', or 'name'"), 400
+    if order not in ("asc", "desc"):
+        return jsonify(error="order must be 'asc' or 'desc'"), 400
+
+    # --- Resolve category name → ids (if needed) ------------------------------
+    matching_cat_ids: list[int] | None = None
+    if category_id is not None:
+        matching_cat_ids = [category_id]
+    elif category_name:
+        cats = (
+            db.session.query(Category.id)
+            .filter(Category.user_id == uid, Category.name.ilike(f"%{category_name}%"))
+            .all()
+        )
+        matching_cat_ids = [c.id for c in cats]
+
+    # --- Build results ---------------------------------------------------------
+    expense_results: list[dict] = []
+    bill_results: list[dict] = []
+
+    if result_type in ("all", "expenses"):
+        expense_results = _search_expenses(
+            uid, q, matching_cat_ids, amount_min, amount_max,
+            from_date, to_date, expense_type,
+        )
+
+    if result_type in ("all", "bills"):
+        bill_results = _search_bills(
+            uid, q, amount_min, amount_max, from_date, to_date,
+        )
+
+    # --- Merge, sort, paginate -------------------------------------------------
+    combined = expense_results + bill_results
+    combined = _sort_results(combined, sort_field, order)
+
+    total = len(combined)
+    start = (page - 1) * page_size
+    page_items = combined[start: start + page_size]
+
+    logger.info(
+        "Search user=%s q=%r total=%s (expenses=%s bills=%s)",
+        uid, q, total, len(expense_results), len(bill_results),
+    )
+
+    return jsonify(
+        results=page_items,
+        total=total,
+        page=page,
+        page_size=page_size,
+        expense_count=len(expense_results),
+        bill_count=len(bill_results),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _search_expenses(
+    uid: int,
+    q: str,
+    cat_ids: list[int] | None,
+    amount_min: Decimal | None,
+    amount_max: Decimal | None,
+    from_date: date | None,
+    to_date: date | None,
+    expense_type: str | None,
+) -> list[dict]:
+    """Return matching expenses as dicts with ``result_type='expense'``."""
+    query = db.session.query(Expense).filter(Expense.user_id == uid)
+
+    if q:
+        like = f"%{q}%"
+        # Also search through category names via a subquery
+        cat_subq = (
+            db.session.query(Category.id)
+            .filter(Category.user_id == uid, Category.name.ilike(like))
+            .subquery()
+        )
+        query = query.filter(
+            or_(
+                Expense.notes.ilike(like),
+                Expense.category_id.in_(cat_subq),
+            )
+        )
+
+    if cat_ids is not None:
+        if not cat_ids:
+            return []  # category name matched nothing
+        query = query.filter(Expense.category_id.in_(cat_ids))
+
+    if amount_min is not None:
+        query = query.filter(Expense.amount >= amount_min)
+    if amount_max is not None:
+        query = query.filter(Expense.amount <= amount_max)
+    if from_date:
+        query = query.filter(Expense.spent_at >= from_date)
+    if to_date:
+        query = query.filter(Expense.spent_at <= to_date)
+    if expense_type:
+        query = query.filter(Expense.expense_type == expense_type)
+
+    rows = query.order_by(Expense.spent_at.desc()).limit(_MAX_PAGE_SIZE).all()
+
+    # Pre-fetch category names for matched expenses
+    cat_ids_needed = {e.category_id for e in rows if e.category_id}
+    cat_map: dict[int, str] = {}
+    if cat_ids_needed:
+        cats = (
+            db.session.query(Category)
+            .filter(Category.id.in_(cat_ids_needed))
+            .all()
+        )
+        cat_map = {c.id: c.name for c in cats}
+
+    return [
+        {
+            "result_type": "expense",
+            "id": e.id,
+            "description": e.notes or "",
+            "amount": float(e.amount),
+            "currency": e.currency,
+            "date": e.spent_at.isoformat(),
+            "expense_type": e.expense_type,
+            "category_id": e.category_id,
+            "category_name": cat_map.get(e.category_id, ""),
+        }
+        for e in rows
+    ]
+
+
+def _search_bills(
+    uid: int,
+    q: str,
+    amount_min: Decimal | None,
+    amount_max: Decimal | None,
+    from_date: date | None,
+    to_date: date | None,
+) -> list[dict]:
+    """Return matching bills as dicts with ``result_type='bill'``."""
+    query = db.session.query(Bill).filter(Bill.user_id == uid, Bill.active == True)  # noqa: E712
+
+    if q:
+        query = query.filter(Bill.name.ilike(f"%{q}%"))
+
+    if amount_min is not None:
+        query = query.filter(Bill.amount >= amount_min)
+    if amount_max is not None:
+        query = query.filter(Bill.amount <= amount_max)
+    if from_date:
+        query = query.filter(Bill.next_due_date >= from_date)
+    if to_date:
+        query = query.filter(Bill.next_due_date <= to_date)
+
+    rows = query.order_by(Bill.next_due_date.desc()).limit(_MAX_PAGE_SIZE).all()
+
+    return [
+        {
+            "result_type": "bill",
+            "id": b.id,
+            "description": b.name,
+            "amount": float(b.amount),
+            "currency": b.currency,
+            "date": b.next_due_date.isoformat(),
+            "cadence": b.cadence.value,
+            "autopay_enabled": b.autopay_enabled,
+        }
+        for b in rows
+    ]
+
+
+def _sort_results(items: list[dict], field: str, order: str) -> list[dict]:
+    """Sort combined results by the chosen field."""
+    reverse = order == "desc"
+    if field == "date":
+        return sorted(items, key=lambda x: x.get("date", ""), reverse=reverse)
+    if field == "amount":
+        return sorted(items, key=lambda x: x.get("amount", 0), reverse=reverse)
+    if field == "name":
+        return sorted(items, key=lambda x: x.get("description", "").lower(), reverse=reverse)
+    return items
+
+
+def _parse_int(raw: str | None) -> int | None:
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _parse_decimal(raw: str | None) -> Decimal | None:
+    if raw is None:
+        return None
+    try:
+        return Decimal(raw)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _parse_date(raw: str | None) -> date | None:
+    if raw is None:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return None

--- a/packages/backend/tests/test_search.py
+++ b/packages/backend/tests/test_search.py
@@ -1,0 +1,302 @@
+"""Tests for the advanced search endpoint ``GET /search``."""
+
+import pytest
+from datetime import date
+
+
+def _create_category(client, headers, name="Groceries"):
+    r = client.post("/categories", json={"name": name}, headers=headers)
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+def _create_expense(client, headers, **overrides):
+    payload = {
+        "amount": 50.00,
+        "description": "Test expense",
+        "date": "2026-01-15",
+        "expense_type": "EXPENSE",
+    }
+    payload.update(overrides)
+    r = client.post("/expenses", json=payload, headers=headers)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def _create_bill(client, headers, **overrides):
+    payload = {
+        "name": "Netflix",
+        "amount": 15.99,
+        "next_due_date": "2026-02-01",
+        "cadence": "MONTHLY",
+    }
+    payload.update(overrides)
+    r = client.post("/bills", json=payload, headers=headers)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+class TestSearchBasic:
+    """Basic search functionality."""
+
+    def test_search_requires_auth(self, client):
+        r = client.get("/search")
+        assert r.status_code in (401, 422)
+
+    def test_empty_search_returns_structure(self, client, auth_header):
+        r = client.get("/search", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "results" in data
+        assert "total" in data
+        assert "page" in data
+        assert "page_size" in data
+        assert "expense_count" in data
+        assert "bill_count" in data
+
+    def test_search_returns_expenses_and_bills(self, client, auth_header):
+        _create_expense(client, auth_header, description="Coffee at Starbucks")
+        _create_bill(client, auth_header, name="Spotify")
+
+        r = client.get("/search", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["total"] == 2
+        assert data["expense_count"] == 1
+        assert data["bill_count"] == 1
+
+        types = {item["result_type"] for item in data["results"]}
+        assert types == {"expense", "bill"}
+
+
+class TestSearchTextQuery:
+    """Free-text query (q parameter)."""
+
+    def test_q_matches_expense_description(self, client, auth_header):
+        _create_expense(client, auth_header, description="Coffee at Starbucks")
+        _create_expense(client, auth_header, description="Lunch at subway")
+
+        r = client.get("/search?q=coffee", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["results"][0]["description"] == "Coffee at Starbucks"
+
+    def test_q_matches_bill_name(self, client, auth_header):
+        _create_bill(client, auth_header, name="Netflix Premium")
+        _create_bill(client, auth_header, name="Spotify Family")
+
+        r = client.get("/search?q=netflix", headers=auth_header)
+        data = r.get_json()
+        assert data["bill_count"] == 1
+        assert data["results"][0]["description"] == "Netflix Premium"
+
+    def test_q_matches_category_name(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, name="Entertainment")
+        _create_expense(
+            client, auth_header, description="Movie tickets",
+            category_id=cat_id,
+        )
+        _create_expense(client, auth_header, description="Bus fare")
+
+        r = client.get("/search?q=entertainment", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["results"][0]["category_name"] == "Entertainment"
+
+    def test_q_case_insensitive(self, client, auth_header):
+        _create_expense(client, auth_header, description="UBER ride")
+
+        r = client.get("/search?q=uber", headers=auth_header)
+        assert r.get_json()["expense_count"] == 1
+
+        r = client.get("/search?q=UBER", headers=auth_header)
+        assert r.get_json()["expense_count"] == 1
+
+
+class TestSearchFilters:
+    """Filter parameters: category, amount, date, expense_type."""
+
+    def test_filter_by_category_id(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, name="Food")
+        _create_expense(
+            client, auth_header, description="Pizza",
+            category_id=cat_id,
+        )
+        _create_expense(client, auth_header, description="Gas")
+
+        r = client.get(f"/search?category_id={cat_id}", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["results"][0]["category_name"] == "Food"
+
+    def test_filter_by_category_name(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, name="Transport")
+        _create_expense(
+            client, auth_header, description="Taxi",
+            category_id=cat_id,
+        )
+        _create_expense(client, auth_header, description="Lunch")
+
+        r = client.get("/search?category=transport", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+
+    def test_filter_by_amount_range(self, client, auth_header):
+        _create_expense(client, auth_header, amount=10.00, description="Small")
+        _create_expense(client, auth_header, amount=100.00, description="Big")
+        _create_expense(client, auth_header, amount=50.00, description="Medium")
+
+        r = client.get("/search?amount_min=40&amount_max=60", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["results"][0]["description"] == "Medium"
+
+    def test_filter_by_date_range(self, client, auth_header):
+        _create_expense(
+            client, auth_header, description="Jan expense", date="2026-01-10",
+        )
+        _create_expense(
+            client, auth_header, description="Feb expense", date="2026-02-15",
+        )
+
+        r = client.get("/search?from=2026-02-01&to=2026-02-28", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["results"][0]["description"] == "Feb expense"
+
+    def test_filter_by_expense_type(self, client, auth_header):
+        _create_expense(
+            client, auth_header, description="Salary",
+            expense_type="INCOME", amount=5000,
+        )
+        _create_expense(
+            client, auth_header, description="Rent",
+            expense_type="EXPENSE", amount=1200,
+        )
+
+        r = client.get("/search?expense_type=INCOME", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["results"][0]["description"] == "Salary"
+
+
+class TestSearchTypeFilter:
+    """type parameter to restrict result types."""
+
+    def test_type_expenses_only(self, client, auth_header):
+        _create_expense(client, auth_header, description="Coffee")
+        _create_bill(client, auth_header, name="Netflix")
+
+        r = client.get("/search?type=expenses", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["bill_count"] == 0
+
+    def test_type_bills_only(self, client, auth_header):
+        _create_expense(client, auth_header, description="Coffee")
+        _create_bill(client, auth_header, name="Netflix")
+
+        r = client.get("/search?type=bills", headers=auth_header)
+        data = r.get_json()
+        assert data["expense_count"] == 0
+        assert data["bill_count"] == 1
+
+    def test_invalid_type_returns_400(self, client, auth_header):
+        r = client.get("/search?type=invalid", headers=auth_header)
+        assert r.status_code == 400
+
+
+class TestSearchSortingAndPagination:
+    """Sorting and pagination."""
+
+    def test_sort_by_amount_asc(self, client, auth_header):
+        _create_expense(client, auth_header, amount=100, description="Big")
+        _create_expense(client, auth_header, amount=10, description="Small")
+        _create_expense(client, auth_header, amount=50, description="Medium")
+
+        r = client.get("/search?sort=amount&order=asc&type=expenses", headers=auth_header)
+        data = r.get_json()
+        amounts = [item["amount"] for item in data["results"]]
+        assert amounts == sorted(amounts)
+
+    def test_sort_by_name(self, client, auth_header):
+        _create_expense(client, auth_header, description="Zebra rent")
+        _create_expense(client, auth_header, description="Apple store")
+
+        r = client.get(
+            "/search?sort=name&order=asc&type=expenses", headers=auth_header,
+        )
+        data = r.get_json()
+        names = [item["description"] for item in data["results"]]
+        assert names == sorted(names, key=str.lower)
+
+    def test_pagination(self, client, auth_header):
+        for i in range(5):
+            _create_expense(
+                client, auth_header, description=f"Item {i}", amount=float(i + 1),
+            )
+
+        r = client.get(
+            "/search?type=expenses&page=1&page_size=2&sort=amount&order=asc",
+            headers=auth_header,
+        )
+        data = r.get_json()
+        assert data["total"] == 5
+        assert data["page"] == 1
+        assert data["page_size"] == 2
+        assert len(data["results"]) == 2
+
+        r2 = client.get(
+            "/search?type=expenses&page=3&page_size=2&sort=amount&order=asc",
+            headers=auth_header,
+        )
+        data2 = r2.get_json()
+        assert len(data2["results"]) == 1  # last page
+
+    def test_invalid_sort_returns_400(self, client, auth_header):
+        r = client.get("/search?sort=invalid", headers=auth_header)
+        assert r.status_code == 400
+
+    def test_invalid_order_returns_400(self, client, auth_header):
+        r = client.get("/search?order=sideways", headers=auth_header)
+        assert r.status_code == 400
+
+
+class TestSearchCombined:
+    """Combined filter + text scenarios."""
+
+    def test_q_with_amount_filter(self, client, auth_header):
+        _create_expense(
+            client, auth_header, description="Coffee small", amount=3.50,
+        )
+        _create_expense(
+            client, auth_header, description="Coffee large", amount=7.00,
+        )
+        _create_expense(
+            client, auth_header, description="Tea", amount=2.50,
+        )
+
+        r = client.get("/search?q=coffee&amount_min=5", headers=auth_header)
+        data = r.get_json()
+        assert data["total"] == 1
+        assert data["results"][0]["description"] == "Coffee large"
+
+    def test_q_with_date_and_type_filter(self, client, auth_header):
+        _create_expense(
+            client, auth_header, description="Coffee Jan",
+            date="2026-01-10",
+        )
+        _create_expense(
+            client, auth_header, description="Coffee Feb",
+            date="2026-02-10",
+        )
+        _create_bill(client, auth_header, name="Coffee subscription")
+
+        r = client.get(
+            "/search?q=coffee&from=2026-02-01&type=expenses",
+            headers=auth_header,
+        )
+        data = r.get_json()
+        assert data["expense_count"] == 1
+        assert data["bill_count"] == 0
+        assert data["results"][0]["description"] == "Coffee Feb"


### PR DESCRIPTION
## Summary

Implements a unified `GET /search` endpoint that searches across both expenses and bills, fulfilling the requirements of issue #105.

### Features

| Parameter | Description |
|-----------|-------------|
| `q` | Free-text search across expense descriptions, bill names, and category names (case-insensitive) |
| `category_id` | Filter by exact category ID |
| `category` | Filter by category name (fuzzy substring match) |
| `amount_min` / `amount_max` | Amount range filtering |
| `from` / `to` | Date range filtering (applies to `spent_at` for expenses, `next_due_date` for bills) |
| `expense_type` | Filter by expense type (e.g., EXPENSE, INCOME) |
| `type` | Restrict to `expenses`, `bills`, or `all` (default) |
| `sort` | Sort by `date` (default), `amount`, or `name` |
| `order` | `asc` or `desc` (default) |
| `page` / `page_size` | Pagination (default 50, max 200) |

### Response Format

```json
{
  "results": [...],
  "total": 42,
  "page": 1,
  "page_size": 50,
  "expense_count": 35,
  "bill_count": 7
}
```

Each result includes `result_type` (`expense` or `bill`) for easy frontend distinction. Expense results also include resolved `category_name`.

### Files Changed

- `packages/backend/app/routes/search.py` — New search blueprint
- `packages/backend/app/routes/__init__.py` — Blueprint registration
- `packages/backend/tests/test_search.py` — 22 comprehensive tests

### Tests

22 tests covering:
- Auth requirement
- Response structure
- Text query matching (descriptions, bill names, category names)
- All filter parameters individually
- Combined filters
- Sorting (by date, amount, name)
- Pagination
- Input validation (400 responses for invalid params)

Closes #105