### PR TITLE
feat: smart weekly financial digest with trend analysis

### DIFF
--- a/backend/app/db/schema.sql
+++ b/backend/app/db/schema.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS expenses (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    amount NUMERIC(12, 2) NOT NULL,
+    category VARCHAR(100) NOT NULL,
+    description TEXT,
+    date DATE NOT NULL DEFAULT CURRENT_DATE,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS weekly_digest (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    week_start DATE NOT NULL,
+    week_end DATE NOT NULL,
+    total_spent NUMERIC(12, 2) NOT NULL DEFAULT 0,
+    category_breakdown JSONB NOT NULL DEFAULT '{}',
+    trends JSONB NOT NULL DEFAULT '{}',
+    insights TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, week_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_expenses_user_date ON expenses (user_id, date);
+CREATE INDEX IF NOT EXISTS idx_weekly_digest_user_week ON weekly_digest (user_id, week_start);

--- a/backend/app/routes/insights.py
+++ b/backend/app/routes/insights.py
@@ -1,0 +1,76 @@
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+
+from app.services.insights import generate_weekly_digest, get_digest_history
+
+bp = Blueprint("insights", __name__, url_prefix="/api/insights")
+
+
+@bp.route("/weekly-digest", methods=["POST"])
+def weekly_digest():
+    """
+    Generate (or refresh) the weekly financial digest for a user.
+
+    Request JSON body:
+        user_id (int, required): The user to generate the digest for.
+        ref_date (str, optional): ISO date (YYYY-MM-DD) used as the reference
+            point for the week. Defaults to today.
+
+    Returns:
+        200 JSON digest object on success.
+        400 JSON error if user_id is missing or inputs are invalid.
+    """
+    body = request.get_json(silent=True) or {}
+
+    user_id = body.get("user_id")
+    if not user_id:
+        return jsonify({"error": "user_id is required"}), 400
+
+    ref_date_str = body.get("ref_date")
+    ref_date = None
+    if ref_date_str:
+        try:
+            ref_date = date.fromisoformat(ref_date_str)
+        except ValueError:
+            return jsonify({"error": "ref_date must be ISO format YYYY-MM-DD"}), 400
+
+    try:
+        digest = generate_weekly_digest(int(user_id), ref_date)
+    except Exception as exc:  # pragma: no cover
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify(digest), 200
+
+
+@bp.route("/weekly-digest/history", methods=["GET"])
+def weekly_digest_history():
+    """
+    Retrieve stored weekly digest history for a user.
+
+    Query parameters:
+        user_id (int, required): The user whose history to fetch.
+        limit   (int, optional): Maximum number of records to return (default 10).
+
+    Returns:
+        200 JSON list of digest objects on success.
+        400 JSON error if user_id is missing or inputs are invalid.
+    """
+    user_id = request.args.get("user_id")
+    if not user_id:
+        return jsonify({"error": "user_id is required"}), 400
+
+    limit_str = request.args.get("limit", "10")
+    try:
+        limit = int(limit_str)
+        if limit < 1:
+            raise ValueError
+    except ValueError:
+        return jsonify({"error": "limit must be a positive integer"}), 400
+
+    try:
+        history = get_digest_history(int(user_id), limit)
+    except Exception as exc:  # pragma: no cover
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify(history), 200

--- a/backend/app/services/insights.py
+++ b/backend/app/services/insights.py
@@ -1,0 +1,205 @@
+from datetime import date, timedelta
+from typing import Any
+
+from app.db.connection import get_db
+
+
+def get_week_bounds(ref: date | None = None) -> tuple[date, date]:
+    """Return the Monday and Sunday surrounding *ref* (defaults to today)."""
+    ref = ref or date.today()
+    week_start = ref - timedelta(days=ref.weekday())
+    week_end = week_start + timedelta(days=6)
+    return week_start, week_end
+
+
+def _fetch_expenses(user_id: int, week_start: date, week_end: date) -> list[dict]:
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT amount, category, description, date
+                FROM expenses
+                WHERE user_id = %s AND date BETWEEN %s AND %s
+                ORDER BY date
+                """,
+                (user_id, week_start, week_end),
+            )
+            cols = [desc[0] for desc in cur.description]
+            return [dict(zip(cols, row)) for row in cur.fetchall()]
+
+
+def _aggregate(expenses: list[dict]) -> tuple[float, dict[str, float]]:
+    total = 0.0
+    by_category: dict[str, float] = {}
+    for exp in expenses:
+        amt = float(exp["amount"])
+        total += amt
+        by_category[exp["category"]] = by_category.get(exp["category"], 0.0) + amt
+    return total, by_category
+
+
+def _fetch_previous_total(user_id: int, prev_start: date, prev_end: date) -> float:
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COALESCE(SUM(amount), 0)
+                FROM expenses
+                WHERE user_id = %s AND date BETWEEN %s AND %s
+                """,
+                (user_id, prev_start, prev_end),
+            )
+            row = cur.fetchone()
+            return float(row[0]) if row else 0.0
+
+
+def _calculate_trends(
+    total: float,
+    by_category: dict[str, float],
+    prev_total: float,
+) -> dict[str, Any]:
+    if prev_total == 0:
+        week_over_week_pct = None
+    else:
+        week_over_week_pct = round((total - prev_total) / prev_total * 100, 2)
+
+    top_category = max(by_category, key=lambda k: by_category[k]) if by_category else None
+
+    return {
+        "week_over_week_change_pct": week_over_week_pct,
+        "top_category": top_category,
+        "top_category_amount": by_category.get(top_category, 0.0) if top_category else 0.0,
+        "previous_week_total": prev_total,
+    }
+
+
+def _generate_insights(
+    total: float,
+    by_category: dict[str, float],
+    trends: dict[str, Any],
+) -> str:
+    lines: list[str] = []
+
+    lines.append(f"Total spending this week: ${total:.2f}.")
+
+    change = trends["week_over_week_change_pct"]
+    if change is None:
+        lines.append("No data available for the previous week to compare.")
+    elif change > 0:
+        lines.append(f"Spending increased by {change}% compared to last week.")
+    elif change < 0:
+        lines.append(f"Spending decreased by {abs(change)}% compared to last week — great job!")
+    else:
+        lines.append("Spending is on par with last week.")
+
+    if trends["top_category"]:
+        lines.append(
+            f"Highest spend category: {trends['top_category']} "
+            f"(${trends['top_category_amount']:.2f})."
+        )
+
+    if by_category:
+        sorted_cats = sorted(by_category.items(), key=lambda x: x[1], reverse=True)
+        breakdown = ", ".join(f"{cat}: ${amt:.2f}" for cat, amt in sorted_cats)
+        lines.append(f"Category breakdown — {breakdown}.")
+
+    return " ".join(lines)
+
+
+def _upsert_digest(
+    user_id: int,
+    week_start: date,
+    week_end: date,
+    total: float,
+    by_category: dict[str, float],
+    trends: dict[str, Any],
+    insights: str,
+) -> dict[str, Any]:
+    import json
+
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO weekly_digest
+                    (user_id, week_start, week_end, total_spent,
+                     category_breakdown, trends, insights)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (user_id, week_start) DO UPDATE SET
+                    week_end          = EXCLUDED.week_end,
+                    total_spent       = EXCLUDED.total_spent,
+                    category_breakdown = EXCLUDED.category_breakdown,
+                    trends            = EXCLUDED.trends,
+                    insights          = EXCLUDED.insights,
+                    created_at        = NOW()
+                RETURNING id, created_at
+                """,
+                (
+                    user_id,
+                    week_start,
+                    week_end,
+                    total,
+                    json.dumps(by_category),
+                    json.dumps(trends),
+                    insights,
+                ),
+            )
+            row = cur.fetchone()
+            conn.commit()
+    return {
+        "id": row[0],
+        "user_id": user_id,
+        "week_start": week_start.isoformat(),
+        "week_end": week_end.isoformat(),
+        "total_spent": total,
+        "category_breakdown": by_category,
+        "trends": trends,
+        "insights": insights,
+        "created_at": row[1].isoformat(),
+    }
+
+
+def generate_weekly_digest(user_id: int, ref: date | None = None) -> dict[str, Any]:
+    """Build (or refresh) the weekly digest for *user_id* relative to *ref*."""
+    week_start, week_end = get_week_bounds(ref)
+    prev_start = week_start - timedelta(weeks=1)
+    prev_end = week_end - timedelta(weeks=1)
+
+    expenses = _fetch_expenses(user_id, week_start, week_end)
+    total, by_category = _aggregate(expenses)
+    prev_total = _fetch_previous_total(user_id, prev_start, prev_end)
+    trends = _calculate_trends(total, by_category, prev_total)
+    insights = _generate_insights(total, by_category, trends)
+
+    return _upsert_digest(
+        user_id, week_start, week_end, total, by_category, trends, insights
+    )
+
+
+def get_digest_history(user_id: int, limit: int = 10) -> list[dict[str, Any]]:
+    """Return the *limit* most recent weekly digests for *user_id*."""
+    with get_db() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, user_id, week_start, week_end, total_spent,
+                       category_breakdown, trends, insights, created_at
+                FROM weekly_digest
+                WHERE user_id = %s
+                ORDER BY week_start DESC
+                LIMIT %s
+                """,
+                (user_id, limit),
+            )
+            cols = [desc[0] for desc in cur.description]
+            rows = cur.fetchall()
+
+    results = []
+    for row in rows:
+        record = dict(zip(cols, row))
+        record["week_start"] = record["week_start"].isoformat()
+        record["week_end"] = record["week_end"].isoformat()
+        record["total_spent"] = float(record["total_spent"])
+        record["created_at"] = record["created_at"].isoformat()
+        results.append(record)
+    return results

--- a/backend/tests/test_insights.py
+++ b/backend/tests/test_insights.py
@@ -1,0 +1,219 @@
+"""Tests for the weekly financial digest service and API endpoints."""
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.insights import (
+    _aggregate,
+    _calculate_trends,
+    _generate_insights,
+    get_week_bounds,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — pure helpers (no DB)
+# ---------------------------------------------------------------------------
+
+class TestGetWeekBounds:
+    def test_monday_input(self):
+        monday = date(2024, 1, 1)  # known Monday
+        start, end = get_week_bounds(monday)
+        assert start == monday
+        assert end == date(2024, 1, 7)
+
+    def test_wednesday_input(self):
+        wednesday = date(2024, 1, 3)
+        start, end = get_week_bounds(wednesday)
+        assert start == date(2024, 1, 1)
+        assert end == date(2024, 1, 7)
+
+    def test_sunday_input(self):
+        sunday = date(2024, 1, 7)
+        start, end = get_week_bounds(sunday)
+        assert start == date(2024, 1, 1)
+        assert end == date(2024, 1, 7)
+
+    def test_defaults_to_today(self):
+        start, end = get_week_bounds()
+        today = date.today()
+        assert start <= today <= end
+        assert (end - start).days == 6
+
+
+class TestAggregate:
+    def test_empty(self):
+        total, breakdown = _aggregate([])
+        assert total == 0.0
+        assert breakdown == {}
+
+    def test_single_expense(self):
+        expenses = [{"amount": "50.00", "category": "Food", "description": "", "date": date.today()}]
+        total, breakdown = _aggregate(expenses)
+        assert total == 50.0
+        assert breakdown == {"Food": 50.0}
+
+    def test_multiple_categories(self):
+        expenses = [
+            {"amount": "30.00", "category": "Food", "description": "", "date": date.today()},
+            {"amount": "20.00", "category": "Food", "description": "", "date": date.today()},
+            {"amount": "100.00", "category": "Rent", "description": "", "date": date.today()},
+        ]
+        total, breakdown = _aggregate(expenses)
+        assert total == 150.0
+        assert breakdown["Food"] == 50.0
+        assert breakdown["Rent"] == 100.0
+
+
+class TestCalculateTrends:
+    def test_no_previous_data(self):
+        trends = _calculate_trends(100.0, {"Food": 100.0}, 0.0)
+        assert trends["week_over_week_change_pct"] is None
+        assert trends["top_category"] == "Food"
+
+    def test_increase(self):
+        trends = _calculate_trends(120.0, {"Food": 120.0}, 100.0)
+        assert trends["week_over_week_change_pct"] == 20.0
+
+    def test_decrease(self):
+        trends = _calculate_trends(80.0, {"Food": 80.0}, 100.0)
+        assert trends["week_over_week_change_pct"] == -20.0
+
+    def test_no_change(self):
+        trends = _calculate_trends(100.0, {"Food": 100.0}, 100.0)
+        assert trends["week_over_week_change_pct"] == 0.0
+
+    def test_top_category_selected(self):
+        by_cat = {"Food": 40.0, "Rent": 200.0, "Entertainment": 60.0}
+        trends = _calculate_trends(300.0, by_cat, 0.0)
+        assert trends["top_category"] == "Rent"
+        assert trends["top_category_amount"] == 200.0
+
+    def test_empty_categories(self):
+        trends = _calculate_trends(0.0, {}, 0.0)
+        assert trends["top_category"] is None
+
+
+class TestGenerateInsights:
+    def _trends(self, change_pct, top_cat="Food", top_amt=50.0, prev=100.0):
+        return {
+            "week_over_week_change_pct": change_pct,
+            "top_category": top_cat,
+            "top_category_amount": top_amt,
+            "previous_week_total": prev,
+        }
+
+    def test_includes_total(self):
+        text = _generate_insights(150.0, {"Food": 150.0}, self._trends(50.0))
+        assert "$150.00" in text
+
+    def test_increase_message(self):
+        text = _generate_insights(150.0, {"Food": 150.0}, self._trends(50.0))
+        assert "increased" in text.lower()
+
+    def test_decrease_message(self):
+        text = _generate_insights(80.0, {"Food": 80.0}, self._trends(-20.0))
+        assert "decreased" in text.lower()
+
+    def test_no_previous_message(self):
+        text = _generate_insights(80.0, {"Food": 80.0}, self._trends(None))
+        assert "no data" in text.lower()
+
+    def test_top_category_mentioned(self):
+        text = _generate_insights(100.0, {"Rent": 100.0}, self._trends(0.0, top_cat="Rent", top_amt=100.0))
+        assert "Rent" in text
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests — API endpoints (Flask test client)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def app():
+    """Create a minimal Flask app with the insights blueprint registered."""
+    from flask import Flask
+    from app.routes.insights import bp
+
+    flask_app = Flask(__name__)
+    flask_app.register_blueprint(bp)
+    flask_app.config["TESTING"] = True
+    return flask_app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+_SAMPLE_DIGEST = {
+    "id": 1,
+    "user_id": 42,
+    "week_start": "2024-01-01",
+    "week_end": "2024-01-07",
+    "total_spent": 250.0,
+    "category_breakdown": {"Food": 150.0, "Transport": 100.0},
+    "trends": {"week_over_week_change_pct": 10.0, "top_category": "Food",
+               "top_category_amount": 150.0, "previous_week_total": 227.27},
+    "insights": "Total spending this week: $250.00.",
+    "created_at": "2024-01-08T00:00:00",
+}
+
+
+class TestWeeklyDigestEndpoint:
+    def test_missing_user_id(self, client):
+        resp = client.post("/api/insights/weekly-digest", json={})
+        assert resp.status_code == 400
+        assert "user_id" in resp.get_json()["error"]
+
+    def test_invalid_ref_date(self, client):
+        resp = client.post("/api/insights/weekly-digest", json={"user_id": 1, "ref_date": "not-a-date"})
+        assert resp.status_code == 400
+
+    @patch("app.routes.insights.generate_weekly_digest", return_value=_SAMPLE_DIGEST)
+    def test_success(self, mock_gen, client):
+        resp = client.post("/api/insights/weekly-digest", json={"user_id": 42})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["user_id"] == 42
+        assert data["total_spent"] == 250.0
+        mock_gen.assert_called_once_with(42, None)
+
+    @patch("app.routes.insights.generate_weekly_digest", return_value=_SAMPLE_DIGEST)
+    def test_success_with_ref_date(self, mock_gen, client):
+        resp = client.post(
+            "/api/insights/weekly-digest",
+            json={"user_id": 42, "ref_date": "2024-01-03"},
+        )
+        assert resp.status_code == 200
+        mock_gen.assert_called_once_with(42, date(2024, 1, 3))
+
+
+class TestWeeklyDigestHistoryEndpoint:
+    def test_missing_user_id(self, client):
+        resp = client.get("/api/insights/weekly-digest/history")
+        assert resp.status_code == 400
+
+    def test_invalid_limit(self, client):
+        resp = client.get("/api/insights/weekly-digest/history?user_id=1&limit=abc")
+        assert resp.status_code == 400
+
+    def test_negative_limit(self, client):
+        resp = client.get("/api/insights/weekly-digest/history?user_id=1&limit=-1")
+        assert resp.status_code == 400
+
+    @patch("app.routes.insights.get_digest_history", return_value=[_SAMPLE_DIGEST])
+    def test_success(self, mock_hist, client):
+        resp = client.get("/api/insights/weekly-digest/history?user_id=42")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert isinstance(data, list)
+        assert data[0]["user_id"] == 42
+        mock_hist.assert_called_once_with(42, 10)
+
+    @patch("app.routes.insights.get_digest_history", return_value=[])
+    def test_success_empty(self, mock_hist, client):
+        resp = client.get("/api/insights/weekly-digest/history?user_id=99&limit=5")
+        assert resp.status_code == 200
+        assert resp.get_json() == []
+        mock_hist.assert_called_once_with(99, 5)

--- a/docs/weekly_digest.md
+++ b/docs/weekly_digest.md
@@ -1,0 +1,114 @@
+# Weekly Financial Digest
+
+The weekly digest feature aggregates a user's expense data for a given week,
+calculates week-over-week trends, and generates a plain-English insight summary.
+Results are persisted in the `weekly_digest` table so historical summaries can
+be retrieved without recomputation.
+
+---
+
+## Database Schema
+
+### `expenses`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | SERIAL PK | |
+| `user_id` | INTEGER | Foreign key to users |
+| `amount` | NUMERIC(12,2) | Positive value |
+| `category` | VARCHAR(100) | e.g. Food, Transport |
+| `description` | TEXT | Optional |
+| `date` | DATE | Transaction date |
+| `created_at` | TIMESTAMP | Auto-set |
+
+### `weekly_digest`
+| Column | Type | Notes |
+|---|---|---|
+| `id` | SERIAL PK | |
+| `user_id` | INTEGER | |
+| `week_start` | DATE | Monday of the week |
+| `week_end` | DATE | Sunday of the week |
+| `total_spent` | NUMERIC(12,2) | Sum of expenses |
+| `category_breakdown` | JSONB | `{category: amount}` |
+| `trends` | JSONB | Trend metrics |
+| `insights` | TEXT | Generated summary |
+| `created_at` | TIMESTAMP | Auto-set |
+
+The pair `(user_id, week_start)` is unique — re-generating a digest for the
+same week performs an upsert.
+
+---
+
+## API Endpoints
+
+### `POST /api/insights/weekly-digest`
+
+Generate (or refresh) the weekly digest for a user.
+
+**Request body (JSON)**
+```json
+{
+  "user_id": 42,
+  "ref_date": "2024-01-03"  // optional — ISO date within the target week
+}
+```
+
+**Response `200`**
+```json
+{
+  "id": 1,
+  "user_id": 42,
+  "week_start": "2024-01-01",
+  "week_end": "2024-01-07",
+  "total_spent": 250.00,
+  "category_breakdown": {"Food": 150.00, "Transport": 100.00},
+  "trends": {
+    "week_over_week_change_pct": 10.0,
+    "top_category": "Food",
+    "top_category_amount": 150.00,
+    "previous_week_total": 227.27
+  },
+  "insights": "Total spending this week: $250.00. Spending increased by 10.0% compared to last week. Highest spend category: Food ($150.00).",
+  "created_at": "2024-01-08T00:00:00"
+}
+```
+
+**Error responses**
+| Status | Reason |
+|---|---|
+| 400 | `user_id` missing or `ref_date` not valid ISO date |
+| 500 | Unexpected server error |
+
+---
+
+### `GET /api/insights/weekly-digest/history`
+
+Retrieve stored weekly digests for a user.
+
+**Query parameters**
+| Parameter | Required | Default | Description |
+|---|---|---|---|
+| `user_id` | yes | — | User ID |
+| `limit` | no | `10` | Max records to return |
+
+**Response `200`** — Array of digest objects (same shape as above), ordered
+from most recent to oldest.
+
+---
+
+## Service Layer
+
+All business logic lives in `backend/app/services/insights.py`.
+
+| Function | Description |
+|---|---|
+| `get_week_bounds(ref)` | Returns `(week_start, week_end)` for the week containing `ref` |
+| `generate_weekly_digest(user_id, ref)` | Full pipeline: fetch → aggregate → trend → insight → upsert |
+| `get_digest_history(user_id, limit)` | Returns stored digests from `weekly_digest` table |
+
+---
+
+## Running Tests
+
+```bash
+pytest backend/tests/test_insights.py -v
+```


### PR DESCRIPTION
## What
- Add `weekly_digest` and `expenses` tables to `schema.sql`
- Implement `generate_weekly_digest` and `get_digest_history` in `services/insights.py` — aggregates expenses, calculates week-over-week trends, generates plain-English insights, and upserts results
- Add `POST /api/insights/weekly-digest` and `GET /api/insights/weekly-digest/history` endpoints in `routes/insights.py`
- Add comprehensive unit and API tests in `backend/tests/test_insights.py`
- Add feature documentation in `docs/weekly_digest.md`

## Why
- Fixes weekly financial summary digest feature (acceptance criteria: production-ready implementation, tests, documentation)

Closes #121

---
*Automated fix by [SnipeLink LLC](https://snipelink.com)*