### PR TITLE
feat: GDPR-ready PII export & delete workflow with audit trail

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from app import db
+
+
+class User(db.Model):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    username = db.Column(db.String(100), unique=True, nullable=False)
+    password_hash = db.Column(db.String(255), nullable=False)
+    full_name = db.Column(db.String(255))
+    phone = db.Column(db.String(50))
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    deleted_at = db.Column(db.DateTime, nullable=True)
+
+    audit_logs = db.relationship("AuditLog", backref="user", lazy=True)
+
+    def to_pii_dict(self):
+        return {
+            "id": self.id,
+            "email": self.email,
+            "username": self.username,
+            "full_name": self.full_name,
+            "phone": self.phone,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    def __repr__(self):
+        return f"<User {self.username}>"
+
+
+class AuditLog(db.Model):
+    __tablename__ = "audit_logs"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    action = db.Column(db.String(100), nullable=False)
+    target_user_id = db.Column(db.Integer, nullable=True)
+    metadata = db.Column(db.JSON, nullable=True)
+    ip_address = db.Column(db.String(45), nullable=True)
+    performed_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+    def __repr__(self):
+        return f"<AuditLog {self.action} by user {self.user_id}>"

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,0 +1,102 @@
+import io
+import json
+import zipfile
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request, send_file
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from app import db
+from app.models.user import User
+from app.services import audit_logger
+
+auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+DELETION_CONFIRMATION_PHRASE = "DELETE MY ACCOUNT"
+
+
+@auth_bp.route("/export-data", methods=["GET"])
+@jwt_required()
+def export_data():
+    current_user_id = get_jwt_identity()
+    user = User.query.filter_by(id=current_user_id, deleted_at=None).first()
+
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    pii_data = user.to_pii_dict()
+
+    audit_logs = [
+        {
+            "action": log.action,
+            "performed_at": log.performed_at.isoformat() if log.performed_at else None,
+            "metadata": log.metadata,
+        }
+        for log in user.audit_logs
+    ]
+
+    export_payload = {
+        "exported_at": datetime.utcnow().isoformat(),
+        "profile": pii_data,
+        "audit_logs": audit_logs,
+    }
+
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("user_data.json", json.dumps(export_payload, indent=2))
+    zip_buffer.seek(0)
+
+    audit_logger.log_action(
+        action="PII_EXPORT",
+        performed_by_user_id=current_user_id,
+        target_user_id=current_user_id,
+        metadata={"format": "zip"},
+        ip_address=request.remote_addr,
+    )
+
+    return send_file(
+        zip_buffer,
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name=f"user_{current_user_id}_data.zip",
+    )
+
+
+@auth_bp.route("/delete-account", methods=["DELETE"])
+@jwt_required()
+def delete_account():
+    current_user_id = get_jwt_identity()
+    user = User.query.filter_by(id=current_user_id, deleted_at=None).first()
+
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    body = request.get_json(force=True, silent=True) or {}
+    confirmation = body.get("confirmation", "")
+
+    if confirmation != DELETION_CONFIRMATION_PHRASE:
+        return jsonify(
+            {
+                "error": "Confirmation phrase required",
+                "hint": f'Send {{"confirmation": "{DELETION_CONFIRMATION_PHRASE}"}} to confirm.',
+            }
+        ), 400
+
+    user.email = f"deleted_{user.id}@deleted.invalid"
+    user.username = f"deleted_{user.id}"
+    user.full_name = None
+    user.phone = None
+    user.password_hash = ""
+    user.deleted_at = datetime.utcnow()
+
+    db.session.commit()
+
+    audit_logger.log_action(
+        action="ACCOUNT_DELETED",
+        performed_by_user_id=current_user_id,
+        target_user_id=current_user_id,
+        metadata={"method": "self-service", "irreversible": True},
+        ip_address=request.remote_addr,
+    )
+
+    return jsonify({"message": "Account permanently deleted."}), 200

--- a/backend/app/services/audit_logger.py
+++ b/backend/app/services/audit_logger.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from app import db
+from app.models.user import AuditLog
+
+
+def log_action(action, performed_by_user_id=None, target_user_id=None, metadata=None, ip_address=None):
+    entry = AuditLog(
+        user_id=performed_by_user_id,
+        action=action,
+        target_user_id=target_user_id,
+        metadata=metadata or {},
+        ip_address=ip_address,
+        performed_at=datetime.utcnow(),
+    )
+    db.session.add(entry)
+    db.session.commit()
+    return entry


### PR DESCRIPTION
## Summary

## What
- Added `User` and `AuditLog` SQLAlchemy models (`backend/app/models/user.py`)
- Added `audit_logger` service that persists action records (`backend/app/services/audit_logger.py`)
- Added `GET /auth/export-data` endpoint that generates a ZIP package containing the user's PII as JSON
- Added `DELETE /auth/delete-account` endpoint with a required confirmation phrase (`DELETE MY ACCOUNT`) that irreversibly scrubs PII and soft-deletes the account
- All export and deletion operations are recorded in the `audit_logs` table with actor, target, timestamp, and IP address

## Why
- Fixes GDPR-ready PII Export & Delete Workflow requirement
- Satisfies acceptance criteria: export package generation, irreversible deletion workflow, and audit trail logging

## Changes

- Define User and AuditLog SQLAlchemy models with PII fields and soft-delete support
- Implement audit logger service that persists action records to the AuditLog table
- Implement /auth/export-data (ZIP/JSON PII export) and /auth/delete-account (irreversible deletion with confirmation) with audit trail logging

## Testing

- Verified the changes align with the issue requirements
- Kept modifications minimal and surgical to reduce review burden

Closes #76