### PR TITLE
feat: goal-based savings tracking & milestones

### DIFF
--- a/app/src/api/savings.ts
+++ b/app/src/api/savings.ts
@@ -1,0 +1,136 @@
+import axios from "axios";
+
+const BASE = "/savings";
+
+export type GoalStatus = "active" | "completed" | "cancelled";
+
+export interface Milestone {
+  id: number;
+  goal_id: number;
+  name: string;
+  target_amount: string;
+  reached_at: string | null;
+  created_at: string;
+}
+
+export interface SavingsGoal {
+  id: number;
+  user_id: number;
+  name: string;
+  description: string | null;
+  target_amount: string;
+  current_amount: string;
+  currency: string;
+  status: GoalStatus;
+  deadline: string | null;
+  created_at: string;
+  updated_at: string;
+  milestones: Milestone[];
+}
+
+export interface CreateGoalPayload {
+  name: string;
+  target_amount: string;
+  description?: string;
+  currency?: string;
+  deadline?: string;
+}
+
+export interface UpdateGoalPayload {
+  name?: string;
+  description?: string;
+  target_amount?: string;
+  current_amount?: string;
+  currency?: string;
+  status?: GoalStatus;
+  deadline?: string;
+}
+
+export interface CreateMilestonePayload {
+  name: string;
+  target_amount: string;
+}
+
+export interface UpdateMilestonePayload {
+  name?: string;
+  target_amount?: string;
+  reached_at?: string;
+}
+
+// Goals
+
+export const createGoal = (userId: number, payload: CreateGoalPayload) =>
+  axios
+    .post<SavingsGoal>(`${BASE}/goals`, payload, { params: { user_id: userId } })
+    .then((r) => r.data);
+
+export const listGoals = (userId: number) =>
+  axios
+    .get<SavingsGoal[]>(`${BASE}/goals`, { params: { user_id: userId } })
+    .then((r) => r.data);
+
+export const getGoal = (userId: number, goalId: number) =>
+  axios
+    .get<SavingsGoal>(`${BASE}/goals/${goalId}`, { params: { user_id: userId } })
+    .then((r) => r.data);
+
+export const updateGoal = (
+  userId: number,
+  goalId: number,
+  payload: UpdateGoalPayload
+) =>
+  axios
+    .patch<SavingsGoal>(`${BASE}/goals/${goalId}`, payload, {
+      params: { user_id: userId },
+    })
+    .then((r) => r.data);
+
+export const deleteGoal = (userId: number, goalId: number) =>
+  axios
+    .delete(`${BASE}/goals/${goalId}`, { params: { user_id: userId } })
+    .then((r) => r.data);
+
+// Milestones
+
+export const createMilestone = (
+  userId: number,
+  goalId: number,
+  payload: CreateMilestonePayload
+) =>
+  axios
+    .post<Milestone>(`${BASE}/goals/${goalId}/milestones`, payload, {
+      params: { user_id: userId },
+    })
+    .then((r) => r.data);
+
+export const listMilestones = (userId: number, goalId: number) =>
+  axios
+    .get<Milestone[]>(`${BASE}/goals/${goalId}/milestones`, {
+      params: { user_id: userId },
+    })
+    .then((r) => r.data);
+
+export const updateMilestone = (
+  userId: number,
+  goalId: number,
+  milestoneId: number,
+  payload: UpdateMilestonePayload
+) =>
+  axios
+    .patch<Milestone>(
+      `${BASE}/goals/${goalId}/milestones/${milestoneId}`,
+      payload,
+      { params: { user_id: userId } }
+    )
+    .then((r) => r.data);
+
+export const deleteMilestone = (
+  userId: number,
+  goalId: number,
+  milestoneId: number
+) =>
+  axios
+    .delete(`${BASE}/goals/${goalId}/milestones/${milestoneId}`, {
+      params: { user_id: userId },
+    })
+    .then((r) => r.data);

--- a/backend/app/models/savings_goal.py
+++ b/backend/app/models/savings_goal.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum as PyEnum
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, String, Enum, Text
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class GoalStatus(str, PyEnum):
+    active = "active"
+    completed = "completed"
+    cancelled = "cancelled"
+
+
+class SavingsGoal(Base):
+    __tablename__ = "savings_goals"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+    target_amount = Column(Numeric(12, 2), nullable=False)
+    current_amount = Column(Numeric(12, 2), nullable=False, default=Decimal("0.00"))
+    currency = Column(String(3), nullable=False, default="USD")
+    status = Column(Enum(GoalStatus), nullable=False, default=GoalStatus.active)
+    deadline = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    milestones = relationship("SavingsMilestone", back_populates="goal", cascade="all, delete-orphan")
+
+
+class SavingsMilestone(Base):
+    __tablename__ = "savings_milestones"
+
+    id = Column(Integer, primary_key=True, index=True)
+    goal_id = Column(Integer, ForeignKey("savings_goals.id"), nullable=False, index=True)
+    name = Column(String(255), nullable=False)
+    target_amount = Column(Numeric(12, 2), nullable=False)
+    reached_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    goal = relationship("SavingsGoal", back_populates="milestones")

--- a/backend/app/routes/savings.py
+++ b/backend/app/routes/savings.py
@@ -1,0 +1,169 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.savings_goal import SavingsGoal, SavingsMilestone
+from app.schemas.savings_goal import (
+    MilestoneCreate,
+    MilestoneRead,
+    MilestoneUpdate,
+    SavingsGoalCreate,
+    SavingsGoalRead,
+    SavingsGoalUpdate,
+)
+
+router = APIRouter(prefix="/savings", tags=["savings"])
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _get_goal_or_404(goal_id: int, user_id: int, db: Session) -> SavingsGoal:
+    goal = (
+        db.query(SavingsGoal)
+        .filter(SavingsGoal.id == goal_id, SavingsGoal.user_id == user_id)
+        .first()
+    )
+    if not goal:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Savings goal not found")
+    return goal
+
+
+def _get_milestone_or_404(milestone_id: int, goal_id: int, db: Session) -> SavingsMilestone:
+    milestone = (
+        db.query(SavingsMilestone)
+        .filter(SavingsMilestone.id == milestone_id, SavingsMilestone.goal_id == goal_id)
+        .first()
+    )
+    if not milestone:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Milestone not found")
+    return milestone
+
+
+# ---------------------------------------------------------------------------
+# Savings Goals
+# ---------------------------------------------------------------------------
+
+@router.post("/goals", response_model=SavingsGoalRead, status_code=status.HTTP_201_CREATED)
+def create_goal(
+    payload: SavingsGoalCreate,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    goal = SavingsGoal(**payload.model_dump(), user_id=user_id)
+    db.add(goal)
+    db.commit()
+    db.refresh(goal)
+    return goal
+
+
+@router.get("/goals", response_model=List[SavingsGoalRead])
+def list_goals(
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    return db.query(SavingsGoal).filter(SavingsGoal.user_id == user_id).all()
+
+
+@router.get("/goals/{goal_id}", response_model=SavingsGoalRead)
+def get_goal(
+    goal_id: int,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    return _get_goal_or_404(goal_id, user_id, db)
+
+
+@router.patch("/goals/{goal_id}", response_model=SavingsGoalRead)
+def update_goal(
+    goal_id: int,
+    payload: SavingsGoalUpdate,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    goal = _get_goal_or_404(goal_id, user_id, db)
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(goal, field, value)
+    db.commit()
+    db.refresh(goal)
+    return goal
+
+
+@router.delete("/goals/{goal_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_goal(
+    goal_id: int,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    goal = _get_goal_or_404(goal_id, user_id, db)
+    db.delete(goal)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Milestones
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/goals/{goal_id}/milestones",
+    response_model=MilestoneRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_milestone(
+    goal_id: int,
+    payload: MilestoneCreate,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    _get_goal_or_404(goal_id, user_id, db)
+    milestone = SavingsMilestone(**payload.model_dump(), goal_id=goal_id)
+    db.add(milestone)
+    db.commit()
+    db.refresh(milestone)
+    return milestone
+
+
+@router.get("/goals/{goal_id}/milestones", response_model=List[MilestoneRead])
+def list_milestones(
+    goal_id: int,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    _get_goal_or_404(goal_id, user_id, db)
+    return db.query(SavingsMilestone).filter(SavingsMilestone.goal_id == goal_id).all()
+
+
+@router.patch("/goals/{goal_id}/milestones/{milestone_id}", response_model=MilestoneRead)
+def update_milestone(
+    goal_id: int,
+    milestone_id: int,
+    payload: MilestoneUpdate,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    _get_goal_or_404(goal_id, user_id, db)
+    milestone = _get_milestone_or_404(milestone_id, goal_id, db)
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(milestone, field, value)
+    db.commit()
+    db.refresh(milestone)
+    return milestone
+
+
+@router.delete(
+    "/goals/{goal_id}/milestones/{milestone_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_milestone(
+    goal_id: int,
+    milestone_id: int,
+    user_id: int,
+    db: Session = Depends(get_db),
+):
+    _get_goal_or_404(goal_id, user_id, db)
+    milestone = _get_milestone_or_404(milestone_id, goal_id, db)
+    db.delete(milestone)
+    db.commit()

--- a/backend/app/schemas/savings_goal.py
+++ b/backend/app/schemas/savings_goal.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+from decimal import Decimal
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from app.models.savings_goal import GoalStatus
+
+
+# --- Milestone schemas ---
+
+class MilestoneBase(BaseModel):
+    name: str = Field(..., max_length=255)
+    target_amount: Decimal = Field(..., gt=0)
+
+
+class MilestoneCreate(MilestoneBase):
+    pass
+
+
+class MilestoneUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    target_amount: Optional[Decimal] = Field(None, gt=0)
+    reached_at: Optional[datetime] = None
+
+
+class MilestoneRead(MilestoneBase):
+    id: int
+    goal_id: int
+    reached_at: Optional[datetime]
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+# --- SavingsGoal schemas ---
+
+class SavingsGoalBase(BaseModel):
+    name: str = Field(..., max_length=255)
+    description: Optional[str] = None
+    target_amount: Decimal = Field(..., gt=0)
+    currency: str = Field("USD", max_length=3)
+    deadline: Optional[datetime] = None
+
+
+class SavingsGoalCreate(SavingsGoalBase):
+    pass
+
+
+class SavingsGoalUpdate(BaseModel):
+    name: Optional[str] = Field(None, max_length=255)
+    description: Optional[str] = None
+    target_amount: Optional[Decimal] = Field(None, gt=0)
+    current_amount: Optional[Decimal] = Field(None, ge=0)
+    currency: Optional[str] = Field(None, max_length=3)
+    status: Optional[GoalStatus] = None
+    deadline: Optional[datetime] = None
+
+
+class SavingsGoalRead(SavingsGoalBase):
+    id: int
+    user_id: int
+    current_amount: Decimal
+    status: GoalStatus
+    created_at: datetime
+    updated_at: datetime
+    milestones: List[MilestoneRead] = []
+
+    class Config:
+        from_attributes = True

--- a/backend/tests/test_savings.py
+++ b/backend/tests/test_savings.py
@@ -1,0 +1,193 @@
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+
+DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def db_session():
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+USER_ID = 1
+
+
+# ---------------------------------------------------------------------------
+# Savings Goal tests
+# ---------------------------------------------------------------------------
+
+def test_create_goal(client):
+    resp = client.post(
+        "/savings/goals",
+        params={"user_id": USER_ID},
+        json={"name": "Vacation", "target_amount": "1000.00", "currency": "USD"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Vacation"
+    assert Decimal(data["target_amount"]) == Decimal("1000.00")
+    assert data["status"] == "active"
+    assert data["milestones"] == []
+
+
+def test_list_goals(client):
+    client.post(
+        "/savings/goals",
+        params={"user_id": USER_ID},
+        json={"name": "Car", "target_amount": "5000.00"},
+    )
+    resp = client.get("/savings/goals", params={"user_id": USER_ID})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_get_goal(client):
+    create_resp = client.post(
+        "/savings/goals",
+        params={"user_id": USER_ID},
+        json={"name": "Emergency Fund", "target_amount": "3000.00"},
+    )
+    goal_id = create_resp.json()["id"]
+    resp = client.get(f"/savings/goals/{goal_id}", params={"user_id": USER_ID})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == goal_id
+
+
+def test_get_goal_not_found(client):
+    resp = client.get("/savings/goals/999", params={"user_id": USER_ID})
+    assert resp.status_code == 404
+
+
+def test_update_goal(client):
+    create_resp = client.post(
+        "/savings/goals",
+        params={"user_id": USER_ID},
+        json={"name": "House", "target_amount": "50000.00"},
+    )
+    goal_id = create_resp.json()["id"]
+    resp = client.patch(
+        f"/savings/goals/{goal_id}",
+        params={"user_id": USER_ID},
+        json={"current_amount": "2000.00", "status": "active"},
+    )
+    assert resp.status_code == 200
+    assert Decimal(resp.json()["current_amount"]) == Decimal("2000.00")
+
+
+def test_delete_goal(client):
+    create_resp = client.post(
+        "/savings/goals",
+        params={"user_id": USER_ID},
+        json={"name": "Laptop", "target_amount": "1500.00"},
+    )
+    goal_id = create_resp.json()["id"]
+    resp = client.delete(f"/savings/goals/{goal_id}", params={"user_id": USER_ID})
+    assert resp.status_code == 204
+    assert client.get(f"/savings/goals/{goal_id}", params={"user_id": USER_ID}).status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Milestone tests
+# ---------------------------------------------------------------------------
+
+def _create_goal(client):
+    resp = client.post(
+        "/savings/goals",
+        params={"user_id": USER_ID},
+        json={"name": "Retirement", "target_amount": "100000.00"},
+    )
+    return resp.json()["id"]
+
+
+def test_create_milestone(client):
+    goal_id = _create_goal(client)
+    resp = client.post(
+        f"/savings/goals/{goal_id}/milestones",
+        params={"user_id": USER_ID},
+        json={"name": "25% reached", "target_amount": "25000.00"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "25% reached"
+    assert data["goal_id"] == goal_id
+    assert data["reached_at"] is None
+
+
+def test_list_milestones(client):
+    goal_id = _create_goal(client)
+    client.post(
+        f"/savings/goals/{goal_id}/milestones",
+        params={"user_id": USER_ID},
+        json={"name": "10% reached", "target_amount": "10000.00"},
+    )
+    resp = client.get(f"/savings/goals/{goal_id}/milestones", params={"user_id": USER_ID})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_update_milestone(client):
+    goal_id = _create_goal(client)
+    m_resp = client.post(
+        f"/savings/goals/{goal_id}/milestones",
+        params={"user_id": USER_ID},
+        json={"name": "50% reached", "target_amount": "50000.00"},
+    )
+    milestone_id = m_resp.json()["id"]
+    reached = "2024-06-01T00:00:00"
+    resp = client.patch(
+        f"/savings/goals/{goal_id}/milestones/{milestone_id}",
+        params={"user_id": USER_ID},
+        json={"reached_at": reached},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["reached_at"] is not None
+
+
+def test_delete_milestone(client):
+    goal_id = _create_goal(client)
+    m_resp = client.post(
+        f"/savings/goals/{goal_id}/milestones",
+        params={"user_id": USER_ID},
+        json={"name": "First milestone", "target_amount": "1000.00"},
+    )
+    milestone_id = m_resp.json()["id"]
+    resp = client.delete(
+        f"/savings/goals/{goal_id}/milestones/{milestone_id}",
+        params={"user_id": USER_ID},
+    )
+    assert resp.status_code == 204

--- a/docs/savings-goals.md
+++ b/docs/savings-goals.md
@@ -1,0 +1,97 @@
+# Goal-Based Savings Tracking
+
+This feature allows users to create savings goals, track progress, and define milestones along the way.
+
+## Data Models
+
+### SavingsGoal
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | integer | Primary key |
+| `user_id` | integer | Owner of the goal |
+| `name` | string | Goal name |
+| `description` | string\|null | Optional description |
+| `target_amount` | decimal | Amount to save |
+| `current_amount` | decimal | Amount saved so far |
+| `currency` | string | ISO 4217 currency code (default `USD`) |
+| `status` | enum | `active` \| `completed` \| `cancelled` |
+| `deadline` | datetime\|null | Optional target date |
+| `created_at` | datetime | Creation timestamp |
+| `updated_at` | datetime | Last update timestamp |
+
+### SavingsMilestone
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | integer | Primary key |
+| `goal_id` | integer | Parent goal |
+| `name` | string | Milestone name |
+| `target_amount` | decimal | Amount at which this milestone is reached |
+| `reached_at` | datetime\|null | When this milestone was reached |
+| `created_at` | datetime | Creation timestamp |
+
+## API Endpoints
+
+All endpoints accept a `user_id` query parameter for ownership scoping.
+
+### Goals
+
+```
+POST   /savings/goals                  Create a new goal
+GET    /savings/goals                  List all goals for a user
+GET    /savings/goals/{goal_id}        Get a specific goal
+PATCH  /savings/goals/{goal_id}        Update a goal
+DELETE /savings/goals/{goal_id}        Delete a goal
+```
+
+### Milestones
+
+```
+POST   /savings/goals/{goal_id}/milestones                        Create a milestone
+GET    /savings/goals/{goal_id}/milestones                        List milestones for a goal
+PATCH  /savings/goals/{goal_id}/milestones/{milestone_id}         Update a milestone
+DELETE /savings/goals/{goal_id}/milestones/{milestone_id}         Delete a milestone
+```
+
+## Frontend API Client
+
+All functions are exported from `app/src/api/savings.ts`.
+
+```ts
+import {
+  createGoal,
+  listGoals,
+  getGoal,
+  updateGoal,
+  deleteGoal,
+  createMilestone,
+  listMilestones,
+  updateMilestone,
+  deleteMilestone,
+} from "@/api/savings";
+
+// Create a goal
+const goal = await createGoal(userId, { name: "Vacation", target_amount: "2000.00" });
+
+// Add a milestone
+const milestone = await createMilestone(userId, goal.id, {
+  name: "Halfway there",
+  target_amount: "1000.00",
+});
+
+// Mark milestone as reached
+await updateMilestone(userId, goal.id, milestone.id, {
+  reached_at: new Date().toISOString(),
+});
+
+// Mark goal as completed
+await updateGoal(userId, goal.id, { status: "completed" });
+```
+
+## Running Tests
+
+```bash
+cd backend
+pytest tests/test_savings.py -v
+```


### PR DESCRIPTION
## Summary

## What
- Add `SavingsGoal` and `SavingsMilestone` SQLAlchemy models (`backend/app/models/savings_goal.py`)
- Add Pydantic request/response schemas (`backend/app/schemas/savings_goal.py`)
- Implement REST API routes for full CRUD on goals and milestones (`backend/app/routes/savings.py`)
- Add typed frontend API client (`app/src/api/savings.ts`)
- Add unit/integration tests covering all endpoints (`backend/tests/test_savings.py`)
- Add feature documentation (`docs/savings-goals.md`)

## Why
- Fixes #133 — users can now create savings goals, track progress against a target amount, and define milestones to celebrate along the way

## Changes

- Define SavingsGoal and SavingsMilestone SQLAlchemy models
- Add Pydantic schemas for SavingsGoal and Milestone
- Implement REST API routes for savings goals and milestones CRUD
- Add unit/integration tests for savings goals and milestones routes
- Implement typed frontend API client for savings goals and milestones
- Add documentation for goal-based savings tracking feature

## Testing

- Verified the changes align with the issue requirements
- Kept modifications minimal and surgical to reduce review burden

Closes #133