### PR TITLE
feat: cash-flow forecast engine — 30/60/90 day projections (#70)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import { Dashboard } from "./pages/Dashboard";
 import { Budgets } from "./pages/Budgets";
 import { Bills } from "./pages/Bills";
 import { Analytics } from "./pages/Analytics";
+import { CashflowForecast } from "./pages/CashflowForecast";
 import Reminders from "./pages/Reminders";
 import Expenses from "./pages/Expenses";
 import { SignIn } from "./pages/SignIn";
@@ -72,6 +73,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Analytics />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="cashflow"
+              element={
+                <ProtectedRoute>
+                  <CashflowForecast />
                 </ProtectedRoute>
               }
             />

--- a/app/src/__tests__/cashflowEngine.test.ts
+++ b/app/src/__tests__/cashflowEngine.test.ts
@@ -1,0 +1,304 @@
+import { generateForecast, aggregateByWeek, computeSummary } from '../api/cashflow';
+import type { RecurringExpense } from '../api/expenses';
+import type { Bill } from '../api/bills';
+
+describe('cashflow engine', () => {
+  const baseDate = new Date('2024-01-01T12:00:00Z');
+
+  it('1. returns array of horizonDays length with 0 values for empty inputs', () => {
+    const points = generateForecast([], [], 30, baseDate);
+    expect(points).toHaveLength(30);
+    expect(points[0].outflow).toBe(0);
+    expect(points[0].inflow).toBe(0);
+    expect(points[29].netFlow).toBe(0);
+  });
+
+  it('2. daily recurring expense appears every day', () => {
+    const expense: RecurringExpense = {
+      id: 1,
+      amount: 10,
+      currency: 'USD',
+      expense_type: 'UTILITIES',
+      category_id: null,
+      description: 'Daily Coffee',
+      cadence: 'DAILY',
+      start_date: '2024-01-01',
+      end_date: null,
+      active: true,
+    };
+    const points = generateForecast([expense], [], 30, baseDate);
+    expect(points[0].outflow).toBe(10);
+    expect(points[29].outflow).toBe(10);
+    expect(points[0].items[0].name).toBe('Daily Coffee');
+  });
+
+  it('3. monthly recurring on 15th only appears on 15th of each month', () => {
+    const expense: RecurringExpense = {
+      id: 2,
+      amount: 50,
+      currency: 'USD',
+      expense_type: 'SUBSCRIPTION',
+      category_id: null,
+      description: 'Monthly Sub',
+      cadence: 'MONTHLY',
+      start_date: '2024-01-15',
+      end_date: null,
+      active: true,
+    };
+    const points = generateForecast([expense], [], 60, baseDate);
+    
+    expect(points[14].outflow).toBe(50);
+    expect(points[14].date).toBe('2024-01-15');
+    
+    expect(points[45].outflow).toBe(50);
+    expect(points[45].date).toBe('2024-02-15');
+
+    expect(points[0].outflow).toBe(0);
+  });
+
+  it('4. weekly recurring appears every 7 days', () => {
+    const expense: RecurringExpense = {
+      id: 3,
+      amount: 20,
+      currency: 'USD',
+      expense_type: 'GROCERIES',
+      category_id: null,
+      description: 'Weekly Groceries',
+      cadence: 'WEEKLY',
+      start_date: '2024-01-01',
+      end_date: null,
+      active: true,
+    };
+    const points = generateForecast([expense], [], 30, baseDate);
+    expect(points[0].outflow).toBe(20);
+    expect(points[7].outflow).toBe(20);
+    expect(points[14].outflow).toBe(20);
+    expect(points[1].outflow).toBe(0);
+  });
+
+  it('5. inactive recurring never appears', () => {
+    const expense: RecurringExpense = {
+      id: 4,
+      amount: 100,
+      currency: 'USD',
+      expense_type: 'OTHER',
+      category_id: null,
+      description: 'Inactive',
+      cadence: 'DAILY',
+      start_date: '2024-01-01',
+      end_date: null,
+      active: false,
+    };
+    const points = generateForecast([expense], [], 30, baseDate);
+    expect(points[0].outflow).toBe(0);
+    expect(points[0].items).toHaveLength(0);
+  });
+
+  it('6. recurring after end_date is excluded', () => {
+    const expense: RecurringExpense = {
+      id: 5,
+      amount: 30,
+      currency: 'USD',
+      expense_type: 'OTHER',
+      category_id: null,
+      description: 'Ends Soon',
+      cadence: 'DAILY',
+      start_date: '2024-01-01',
+      end_date: '2024-01-05',
+      active: true,
+    };
+    const points = generateForecast([expense], [], 30, baseDate);
+    expect(points[0].outflow).toBe(30);
+    expect(points[4].outflow).toBe(30);
+    expect(points[5].outflow).toBe(0);
+  });
+
+  it('7. bill with ONCE cadence appears exactly once', () => {
+    const bill: Bill = {
+      id: 1,
+      name: 'One-time Bill',
+      amount: 100,
+      next_due_date: '2024-01-10',
+      cadence: 'ONCE',
+    };
+    const points = generateForecast([], [bill], 30, baseDate);
+    expect(points[9].outflow).toBe(100);
+    expect(points[9].date).toBe('2024-01-10');
+    expect(points[10].outflow).toBe(0);
+  });
+
+  it('8. bill with MONTHLY cadence appears monthly', () => {
+    const bill: Bill = {
+      id: 2,
+      name: 'Monthly Bill',
+      amount: 200,
+      next_due_date: '2024-01-05',
+      cadence: 'MONTHLY',
+    };
+    const points = generateForecast([], [bill], 60, baseDate);
+    expect(points[4].outflow).toBe(200);
+    expect(points[35].outflow).toBe(200);
+  });
+
+  it('9. bill already paid is excluded', () => {
+    const bill: Bill = {
+      id: 3,
+      name: 'Paid Bill',
+      amount: 100,
+      next_due_date: '2024-01-02',
+      cadence: 'ONCE',
+      paid_at: '2024-01-01T10:00:00Z',
+    };
+    const points = generateForecast([], [bill], 30, baseDate);
+    expect(points[1].outflow).toBe(0);
+  });
+
+  it('10. income recurring is treated as inflow', () => {
+    const expense: RecurringExpense = {
+      id: 6,
+      amount: 1000,
+      currency: 'USD',
+      expense_type: 'INCOME',
+      category_id: null,
+      description: 'Salary',
+      cadence: 'MONTHLY',
+      start_date: '2024-01-01',
+      end_date: null,
+      active: true,
+    };
+    const points = generateForecast([expense], [], 30, baseDate);
+    expect(points[0].inflow).toBe(1000);
+    expect(points[0].outflow).toBe(0);
+    expect(points[0].netFlow).toBe(1000);
+    expect(points[0].cumulativeNet).toBe(1000);
+  });
+
+  it('11. computeSummary correctly computes totals', () => {
+    const expense: RecurringExpense = {
+      id: 7,
+      amount: 1000,
+      currency: 'USD',
+      expense_type: 'INCOME',
+      category_id: null,
+      description: 'Salary',
+      cadence: 'MONTHLY',
+      start_date: '2024-01-01',
+      end_date: null,
+      active: true,
+    };
+    const bill: Bill = {
+      id: 4,
+      name: 'Rent',
+      amount: 800,
+      next_due_date: '2024-01-05',
+      cadence: 'ONCE',
+    };
+    const points = generateForecast([expense], [bill], 30, baseDate);
+    const summary = computeSummary(points);
+    
+    expect(summary.totalInflow).toBe(1000);
+    expect(summary.totalOutflow).toBe(800);
+    expect(summary.netFlow).toBe(200);
+    expect(summary.bestDay?.netFlow).toBe(1000);
+    expect(summary.worstDay?.netFlow).toBe(-800);
+  });
+
+  it('13. past-due ONCE bill (unpaid) is mapped to first day of forecast', () => {
+    const bill: Bill = {
+      id: 10,
+      name: 'Overdue Bill',
+      amount: 150,
+      next_due_date: '2023-12-01',
+      cadence: 'ONCE',
+    };
+    const points = generateForecast([], [bill], 30, baseDate);
+    expect(points[0].outflow).toBe(150);
+    expect(points[0].date).toBe('2024-01-01');
+  });
+
+  it('14. past-due recurring bill fast-forwards to first occurrence within forecast', () => {
+    const bill: Bill = {
+      id: 11,
+      name: 'Overdue Monthly',
+      amount: 300,
+      next_due_date: '2023-11-10',
+      cadence: 'MONTHLY',
+    };
+    const points = generateForecast([], [bill], 30, baseDate);
+    const jan10 = points.find((p) => p.date === '2024-01-10');
+    expect(jan10).toBeDefined();
+    expect(jan10!.outflow).toBe(300);
+    expect(points[0].outflow).toBe(0);
+  });
+
+  it('15. MONTHLY cadence respects calendar months not 30-day multiples', () => {
+    const expense: RecurringExpense = {
+      id: 8,
+      amount: 100,
+      currency: 'USD',
+      expense_type: 'SUBSCRIPTION',
+      category_id: null,
+      description: 'End of Month',
+      cadence: 'MONTHLY',
+      start_date: '2024-01-31',
+      end_date: null,
+      active: true,
+    };
+    const points = generateForecast([expense], [], 60, baseDate);
+    const jan31 = points.find((p) => p.date === '2024-01-31');
+    const feb29 = points.find((p) => p.date === '2024-02-29');
+    expect(jan31).toBeDefined();
+    expect(jan31!.outflow).toBe(100);
+    expect(feb29).toBeDefined();
+    expect(feb29!.outflow).toBe(100);
+  });
+
+  it('16. YEARLY cadence appears once per year', () => {
+    const expense: RecurringExpense = {
+      id: 9,
+      amount: 500,
+      currency: 'USD',
+      expense_type: 'INSURANCE',
+      category_id: null,
+      description: 'Annual Insurance',
+      cadence: 'YEARLY',
+      start_date: '2024-01-15',
+      end_date: null,
+      active: true,
+    };
+    const points = generateForecast([expense], [], 30, baseDate);
+    const jan15 = points.find((p) => p.date === '2024-01-15');
+    expect(jan15).toBeDefined();
+    expect(jan15!.outflow).toBe(500);
+    const nonJan15 = points.filter((p) => p.date !== '2024-01-15');
+    nonJan15.forEach((p) => expect(p.outflow).toBe(0));
+  });
+
+  it('17. recurring with start_date in the future only appears from that date', () => {
+    const expense: RecurringExpense = {
+      id: 10,
+      amount: 50,
+      currency: 'USD',
+      expense_type: 'OTHER',
+      category_id: null,
+      description: 'Future Sub',
+      cadence: 'DAILY',
+      start_date: '2024-01-15',
+      end_date: null,
+      active: true,
+    };
+    const points = generateForecast([expense], [], 30, baseDate);
+    expect(points[0].outflow).toBe(0);
+    expect(points[13].outflow).toBe(0);
+    const jan15 = points.find((p) => p.date === '2024-01-15');
+    expect(jan15!.outflow).toBe(50);
+  });
+
+  it('18. aggregateByWeek returns correct number of weekly buckets', () => {
+    const points = generateForecast([], [], 30, baseDate);
+    const weeks = aggregateByWeek(points);
+    expect(weeks).toHaveLength(5);
+    expect(weeks[0].date).toBe('2024-01-01');
+    expect(weeks[1].date).toBe('2024-01-08');
+  });
+});

--- a/app/src/api/cashflow.ts
+++ b/app/src/api/cashflow.ts
@@ -1,0 +1,240 @@
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  addYears,
+  format,
+  isAfter,
+  isBefore,
+  parseISO,
+  startOfDay,
+  endOfDay
+} from 'date-fns';
+import type { RecurringExpense } from './expenses';
+import type { Bill } from './bills';
+
+export type ForecastItem = {
+  id: string;
+  name: string;
+  amount: number;
+  currency: string;
+  type: 'recurring' | 'bill';
+  isIncome: boolean;
+};
+
+export type ForecastPoint = {
+  date: string;
+  outflow: number;
+  inflow: number;
+  netFlow: number;
+  cumulativeNet: number;
+  items: ForecastItem[];
+};
+
+export function generateForecast(
+  recurringExpenses: RecurringExpense[],
+  bills: Bill[],
+  horizonDays: 30 | 60 | 90,
+  fromDate: Date = new Date()
+): ForecastPoint[] {
+  const start = startOfDay(fromDate);
+  const end = addDays(start, horizonDays - 1);
+  const endOfEnd = endOfDay(end);
+
+  const pointsMap: Record<string, ForecastPoint> = {};
+  for (let i = 0; i < horizonDays; i++) {
+    const current = addDays(start, i);
+    const dateStr = format(current, 'yyyy-MM-dd');
+    pointsMap[dateStr] = {
+      date: dateStr,
+      outflow: 0,
+      inflow: 0,
+      netFlow: 0,
+      cumulativeNet: 0,
+      items: [],
+    };
+  }
+
+  const addItemToDay = (date: Date, item: ForecastItem) => {
+    const dateStr = format(date, 'yyyy-MM-dd');
+    if (pointsMap[dateStr]) {
+      pointsMap[dateStr].items.push(item);
+      if (item.isIncome) {
+        pointsMap[dateStr].inflow += item.amount;
+      } else {
+        pointsMap[dateStr].outflow += item.amount;
+      }
+      pointsMap[dateStr].netFlow = pointsMap[dateStr].inflow - pointsMap[dateStr].outflow;
+    }
+  };
+
+  recurringExpenses.forEach((expense) => {
+    if (!expense.active) return;
+    const startDate = startOfDay(parseISO(expense.start_date));
+    const endDate = expense.end_date ? endOfDay(parseISO(expense.end_date)) : null;
+    const isIncome = expense.expense_type === 'INCOME';
+
+    const fItem: ForecastItem = {
+      id: `recurring-${expense.id}`,
+      name: expense.description || 'Recurring Expense',
+      amount: Number(expense.amount),
+      currency: expense.currency,
+      type: 'recurring',
+      isIncome,
+    };
+
+    let current = startDate;
+    let i = 0;
+
+    while (isBefore(current, endOfEnd) || format(current, 'yyyy-MM-dd') === format(endOfEnd, 'yyyy-MM-dd')) {
+      if (endDate && isAfter(current, endDate) && format(current, 'yyyy-MM-dd') !== format(endDate, 'yyyy-MM-dd')) {
+        break;
+      }
+      
+      if (!isBefore(current, start)) {
+        addItemToDay(current, fItem);
+      }
+
+      if (expense.cadence === 'DAILY') {
+        current = addDays(current, 1);
+      } else if (expense.cadence === 'WEEKLY') {
+        current = addWeeks(current, 1);
+      } else if (expense.cadence === 'MONTHLY') {
+        i++;
+        current = addMonths(startDate, i);
+      } else if (expense.cadence === 'YEARLY') {
+        i++;
+        current = addYears(startDate, i);
+      } else {
+        break;
+      }
+    }
+  });
+
+  bills.forEach((bill) => {
+    if (bill.paid_at) return;
+    if (!bill.next_due_date) return;
+
+    const dueDateRaw = startOfDay(parseISO(bill.next_due_date));
+    const fItem: ForecastItem = {
+      id: `bill-${bill.id}`,
+      name: bill.name,
+      amount: Number(bill.amount),
+      currency: bill.currency || 'USD',
+      type: 'bill',
+      isIncome: false,
+    };
+
+    const cadence = bill.cadence || 'ONCE';
+
+    if (cadence === 'ONCE') {
+      // Past-due unpaid one-time bill: show it on the first day of the forecast
+      const effectiveDate = isBefore(dueDateRaw, start) ? start : dueDateRaw;
+      if (!isAfter(effectiveDate, endOfEnd)) {
+        addItemToDay(effectiveDate, fItem);
+      }
+    } else {
+      // For recurring bills, advance from next_due_date to first occurrence >= start
+      let i = 0;
+      let current = dueDateRaw;
+
+      // Fast-forward past-due recurring bills to first occurrence within forecast window
+      while (isBefore(current, start)) {
+        i++;
+        if (cadence === 'WEEKLY') {
+          current = addWeeks(dueDateRaw, i);
+        } else if (cadence === 'MONTHLY') {
+          current = addMonths(dueDateRaw, i);
+        } else if (cadence === 'YEARLY') {
+          current = addYears(dueDateRaw, i);
+        } else {
+          break;
+        }
+      }
+
+      while (!isAfter(current, endOfEnd)) {
+        addItemToDay(current, fItem);
+
+        i++;
+        if (cadence === 'WEEKLY') {
+          current = addWeeks(dueDateRaw, i);
+        } else if (cadence === 'MONTHLY') {
+          current = addMonths(dueDateRaw, i);
+        } else if (cadence === 'YEARLY') {
+          current = addYears(dueDateRaw, i);
+        } else {
+          break;
+        }
+      }
+    }
+  });
+
+  const points: ForecastPoint[] = [];
+  let cumulative = 0;
+  
+  for (let i = 0; i < horizonDays; i++) {
+    const current = addDays(start, i);
+    const dateStr = format(current, 'yyyy-MM-dd');
+    const pt = pointsMap[dateStr];
+    cumulative += pt.netFlow;
+    pt.cumulativeNet = cumulative;
+    points.push(pt);
+  }
+
+  return points;
+}
+
+export function aggregateByWeek(points: ForecastPoint[]): ForecastPoint[] {
+  const result: ForecastPoint[] = [];
+  let currentWeek: ForecastPoint | null = null;
+  
+  points.forEach((point, index) => {
+    if (index % 7 === 0) {
+      if (currentWeek) {
+        result.push(currentWeek);
+      }
+      currentWeek = {
+        date: point.date,
+        outflow: point.outflow,
+        inflow: point.inflow,
+        netFlow: point.netFlow,
+        cumulativeNet: point.cumulativeNet,
+        items: [...point.items],
+      };
+    } else if (currentWeek) {
+      currentWeek.outflow += point.outflow;
+      currentWeek.inflow += point.inflow;
+      currentWeek.netFlow += point.netFlow;
+      currentWeek.cumulativeNet = point.cumulativeNet;
+      currentWeek.items.push(...point.items);
+    }
+  });
+
+  if (currentWeek) {
+    result.push(currentWeek);
+  }
+
+  return result;
+}
+
+export function computeSummary(points: ForecastPoint[]) {
+  if (points.length === 0) {
+    return { totalOutflow: 0, totalInflow: 0, netFlow: 0, worstDay: null, bestDay: null };
+  }
+
+  let totalOutflow = 0;
+  let totalInflow = 0;
+  let netFlow = 0;
+  let worstDay = points[0];
+  let bestDay = points[0];
+
+  points.forEach((p) => {
+    totalOutflow += p.outflow;
+    totalInflow += p.inflow;
+    netFlow += p.netFlow;
+    if (p.netFlow < worstDay.netFlow) worstDay = p;
+    if (p.netFlow > bestDay.netFlow) bestDay = p;
+  });
+
+  return { totalOutflow, totalInflow, netFlow, worstDay, bestDay };
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -10,6 +10,7 @@ const navigation = [
   { name: 'Dashboard', href: '/dashboard' },
   { name: 'Budgets', href: '/budgets' },
   { name: 'Bills', href: '/bills' },
+  { name: 'Cash Flow', href: '/cashflow' },
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },

--- a/app/src/pages/CashflowForecast.tsx
+++ b/app/src/pages/CashflowForecast.tsx
@@ -1,0 +1,263 @@
+import { useState, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { listRecurringExpenses } from '@/api/expenses';
+import { listBills } from '@/api/bills';
+import { generateForecast, aggregateByWeek, computeSummary } from '@/api/cashflow';
+import { formatMoney } from '@/lib/currency';
+import { Button } from '@/components/ui/button';
+import {
+  FinancialCard,
+  FinancialCardHeader,
+  FinancialCardTitle,
+  FinancialCardContent,
+} from '@/components/ui/financial-card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { format, parseISO } from 'date-fns';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from 'recharts';
+import { RefreshCw, TrendingDown, TrendingUp, Wallet, ArrowRightLeft } from 'lucide-react';
+
+export function CashflowForecast() {
+  const [horizon, setHorizon] = useState<30 | 60 | 90>(30);
+
+  const { data: expenses, isLoading: loadingExpenses, isError: errorExpenses, refetch: refetchExpenses } = useQuery({
+    queryKey: ['recurringExpenses'],
+    queryFn: () => listRecurringExpenses(),
+  });
+
+  const { data: bills, isLoading: loadingBills, isError: errorBills, refetch: refetchBills } = useQuery({
+    queryKey: ['bills'],
+    queryFn: () => listBills(),
+  });
+
+  const handleRefresh = () => {
+    void refetchExpenses();
+    void refetchBills();
+  };
+
+  const isLoading = loadingExpenses || loadingBills;
+  const isError = errorExpenses || errorBills;
+
+  const { forecast, weeklyForecast, summary, allItems } = useMemo(() => {
+    if (!expenses || !bills) {
+      return { forecast: [], weeklyForecast: [], summary: null, allItems: [] };
+    }
+
+    const today = new Date();
+    const dailyPoints = generateForecast(expenses, bills, horizon, today);
+    const weeklyPoints = aggregateByWeek(dailyPoints);
+    const stats = computeSummary(dailyPoints);
+
+    const itemsList = dailyPoints.flatMap((p) =>
+      p.items.map((item) => ({ ...item, date: p.date }))
+    );
+
+    return {
+      forecast: dailyPoints,
+      weeklyForecast: weeklyPoints,
+      summary: stats,
+      allItems: itemsList,
+    };
+  }, [expenses, bills, horizon]);
+
+  const horizons = [30, 60, 90] as const;
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div>
+          <h1 className="page-title">Cash-flow Forecast</h1>
+          <p className="page-subtitle">Predict your future balances and view scheduled transactions.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex bg-muted p-1 rounded-lg">
+            {horizons.map((days) => (
+              <Button
+                key={days}
+                variant={horizon === days ? 'financial' : 'outline'}
+                size="sm"
+                className={`rounded-md px-4 ${horizon !== days ? 'text-muted-foreground' : ''}`}
+                onClick={() => setHorizon(days)}
+              >
+                {days} Days
+              </Button>
+            ))}
+          </div>
+          <Button variant="outline" size="icon" onClick={handleRefresh} disabled={isLoading}>
+            <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+          </Button>
+        </div>
+      </div>
+
+      {isError && (
+        <div className="error text-destructive p-4 border border-destructive/20 rounded-md bg-destructive/10">
+          Failed to load forecast data. Please try again.
+        </div>
+      )}
+
+      {(isLoading || !summary) && !isError ? (
+        <div className="card p-8 text-center text-muted-foreground animate-pulse">
+          Loading forecast data...
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <FinancialCard variant="success">
+              <FinancialCardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <FinancialCardTitle className="text-sm font-medium">Total Inflow</FinancialCardTitle>
+                <TrendingUp className="h-4 w-4" />
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="text-2xl font-bold">{formatMoney(summary.totalInflow)}</div>
+                <p className="text-xs opacity-80 mt-1">Expected incoming</p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant="destructive">
+              <FinancialCardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <FinancialCardTitle className="text-sm font-medium">Total Outflow</FinancialCardTitle>
+                <TrendingDown className="h-4 w-4" />
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="text-2xl font-bold">{formatMoney(summary.totalOutflow)}</div>
+                <p className="text-xs opacity-80 mt-1">Scheduled payments</p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant={summary.netFlow >= 0 ? 'financial' : 'warning'}>
+              <FinancialCardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <FinancialCardTitle className="text-sm font-medium">Net Flow</FinancialCardTitle>
+                <Wallet className="h-4 w-4" />
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="text-2xl font-bold">{formatMoney(summary.netFlow)}</div>
+                <p className="text-xs opacity-80 mt-1">For next {horizon} days</p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard>
+              <FinancialCardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <FinancialCardTitle className="text-sm font-medium">Items Count</FinancialCardTitle>
+                <ArrowRightLeft className="h-4 w-4 text-muted-foreground" />
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="text-2xl font-bold">{allItems.length}</div>
+                <p className="text-xs text-muted-foreground mt-1">Scheduled transactions</p>
+              </FinancialCardContent>
+            </FinancialCard>
+          </div>
+
+          <FinancialCard className="p-0 overflow-hidden border-border/50">
+            <div className="p-6 pb-2">
+              <h3 className="text-lg font-semibold">Cash-flow Trend</h3>
+              <p className="text-sm text-muted-foreground">
+                {horizon > 30 ? 'Weekly aggregated view' : 'Daily forecast view'}
+              </p>
+            </div>
+            <div className="h-[350px] w-full p-4">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={horizon > 30 ? weeklyForecast : forecast} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" opacity={0.5} />
+                  <XAxis 
+                    dataKey="date" 
+                    tickFormatter={(val: string) => format(parseISO(val), 'MMM d')} 
+                    stroke="hsl(var(--muted-foreground))"
+                    fontSize={12}
+                    tickLine={false}
+                    axisLine={false}
+                    dy={10}
+                  />
+                  <YAxis 
+                    tickFormatter={(val: number) => `$${val}`} 
+                    stroke="hsl(var(--muted-foreground))"
+                    fontSize={12}
+                    tickLine={false}
+                    axisLine={false}
+                    dx={-10}
+                  />
+                  <Tooltip 
+                    cursor={{ fill: 'hsl(var(--muted))', opacity: 0.4 }}
+                    contentStyle={{ borderRadius: '8px', border: '1px solid hsl(var(--border))', backgroundColor: 'hsl(var(--card))', color: 'hsl(var(--foreground))' }}
+                    labelFormatter={(val: string) => format(parseISO(val), 'MMM d, yyyy')}
+                    formatter={(value: number) => [formatMoney(value), 'Amount']}
+                  />
+                  <Legend wrapperStyle={{ paddingTop: '10px' }} />
+                  <Bar dataKey="inflow" name="Inflow" fill="hsl(var(--success))" radius={[4, 4, 0, 0]} maxBarSize={40} />
+                  <Bar dataKey="outflow" name="Outflow" fill="hsl(var(--destructive))" radius={[4, 4, 0, 0]} maxBarSize={40} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </FinancialCard>
+
+          <FinancialCard className="p-0 overflow-hidden border-border/50">
+            <div className="p-6 pb-4 border-b border-border/50">
+              <h3 className="text-lg font-semibold">Scheduled Transactions</h3>
+              <p className="text-sm text-muted-foreground">All upcoming items in the next {horizon} days.</p>
+            </div>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader className="bg-muted/30">
+                  <TableRow>
+                    <TableHead className="w-[120px]">Date</TableHead>
+                    <TableHead>Name</TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {allItems.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4} className="h-24 text-center text-muted-foreground">
+                        No scheduled transactions found.
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    allItems.slice().sort((a, b) => a.date.localeCompare(b.date)).map((item, idx) => (
+                      <TableRow key={`${item.id}-${item.date}-${idx}`}>
+                        <TableCell className="font-medium text-muted-foreground">
+                          {format(parseISO(item.date), 'MMM d, yyyy')}
+                        </TableCell>
+                        <TableCell className="font-semibold">{item.name}</TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <Badge variant="outline" className="text-[10px] capitalize">
+                              {item.type}
+                            </Badge>
+                            {item.isIncome ? (
+                              <Badge variant="secondary" className="bg-success/10 text-success hover:bg-success/20">Income</Badge>
+                            ) : (
+                              <Badge variant="secondary" className="bg-destructive/10 text-destructive hover:bg-destructive/20">Expense</Badge>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className={`text-right font-bold ${item.isIncome ? 'text-success' : ''}`}>
+                          {item.isIncome ? '+' : '-'}{formatMoney(item.amount, item.currency)}
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </FinancialCard>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem Summary

No forecasting capability existed in FinMind, leaving users unable to anticipate future cash shortfalls or plan ahead based on recurring obligations.

## Solution

A pure-TypeScript forecast engine that projects 30, 60, or 90 days of cash flow from recurring expenses and bills — no backend changes required.

## Architecture

**`src/api/cashflow.ts`** — Pure forecast engine (no React, no side effects):
- `generateForecast(recurringExpenses, bills, horizon, fromDate?)` → `ForecastPoint[]`
- `aggregateByWeek(points)` → weekly bucketed view for 60/90 day charts
- `computeSummary(points)` → totals, best/worst day

**`src/pages/CashflowForecast.tsx`** — React page using react-query:
- Horizon selector (30 / 60 / 90 days) with active state
- 4 summary cards: Total Inflow, Total Outflow, Net Flow, Items Count
- Recharts `BarChart` — daily for 30d, weekly aggregated for 60/90d
- Scheduled transactions table with Income/Expense badges
- Error state preserves header + reload button (user can retry in-page)

## Forecast Logic

| Source | Cadence | Handling |
|--------|---------|----------|
| RecurringExpense | DAILY / WEEKLY / MONTHLY / YEARLY | Calendar-correct stepping from `start_date` |
| RecurringExpense | `active: false` | Skipped |
| RecurringExpense | after `end_date` | Excluded |
| RecurringExpense | `expense_type === 'INCOME'` | Treated as inflow |
| Bill | ONCE / WEEKLY / MONTHLY / YEARLY | Stepped from `next_due_date` |
| Bill | `paid_at` set | Excluded |
| Bill (past-due, ONCE) | `next_due_date` < today | Mapped to forecast day 0 |
| Bill (past-due, recurring) | `next_due_date` < today | Fast-forwarded to first occurrence ≥ today |

MONTHLY uses `date-fns/addMonths` (calendar months, not ×30 days). YEARLY uses `addYears`. Both anchor on the original `start_date` to avoid drift.

## Acceptance Criteria

- ✅ Forecast updates when expenses or bills change (react-query refetch + reload button)
- ✅ Handles recurring transactions (DAILY/WEEKLY/MONTHLY/YEARLY with calendar-correct stepping)
- ✅ Graph-ready API output (`ForecastPoint[]` with `date/outflow/inflow/netFlow/cumulativeNet/items`)

## Test Evidence

```
Test Suites: 10 passed, 10 total
Tests:       44 passed, 44 total
TypeScript:  0 errors
```

**17 new unit tests** cover:
- Empty inputs, all cadences (daily/weekly/monthly/yearly)
- Inactive recurring, past-end-date recurring
- ONCE bill, monthly bill, paid bill exclusion
- Income treated as inflow
- **Past-due ONCE bill** → maps to forecast start
- **Past-due recurring bill** → fast-forwards to first future occurrence
- **MONTHLY month-end anchor** (Jan 31 → Feb 29 in 2024)
- **Future start_date** → no entries before that date
- computeSummary totals, aggregateByWeek bucketing

## Files Changed

| File | Change |
|------|--------|
| `src/api/cashflow.ts` | New: forecast engine |
| `src/pages/CashflowForecast.tsx` | New: forecast page |
| `src/__tests__/cashflowEngine.test.ts` | New: 17 unit tests |
| `src/App.tsx` | Add `/cashflow` protected route |
| `src/components/layout/Navbar.tsx` | Add "Cash Flow" nav link |

Resolves: https://github.com/rohitdash08/FinMind/issues/70