### PR TITLE
feat: resilient background job retry & monitoring

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import { Savings } from "./pages/Savings";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="savings"
+              element={
+                <ProtectedRoute>
+                  <Savings />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/savings.ts
+++ b/app/src/api/savings.ts
@@ -1,0 +1,71 @@
+import { api } from './client';
+
+export type SavingsGoalStatus = 'ACTIVE' | 'COMPLETED' | 'PAUSED';
+
+export type SavingsGoal = {
+  id: number;
+  name: string;
+  target_amount: number;
+  current_amount: number;
+  currency: string;
+  deadline?: string | null;
+  notes?: string | null;
+  status: SavingsGoalStatus;
+  progress_pct: number;
+  milestones_reached: number[];
+  next_milestone_pct: number | null;
+  created_at: string;
+};
+
+export type SavingsDeposit = {
+  id: number;
+  amount: number;
+  note?: string | null;
+  deposited_at: string;
+  created_at: string;
+};
+
+export type SavingsGoalCreate = {
+  name: string;
+  target_amount: number;
+  currency?: string;
+  deadline?: string | null;
+  notes?: string | null;
+  initial_amount?: number;
+};
+
+export type SavingsGoalUpdate = Partial<Omit<SavingsGoalCreate, 'initial_amount'>> & {
+  status?: SavingsGoalStatus;
+};
+
+export async function listGoals(status?: string): Promise<SavingsGoal[]> {
+  const qs = status ? `?status=${status}` : '';
+  return api<SavingsGoal[]>(`/savings${qs}`);
+}
+
+export async function createGoal(payload: SavingsGoalCreate): Promise<SavingsGoal> {
+  return api<SavingsGoal>('/savings', { method: 'POST', body: payload });
+}
+
+export async function getGoal(id: number): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${id}`);
+}
+
+export async function updateGoal(id: number, payload: SavingsGoalUpdate): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function deleteGoal(id: number): Promise<{ message: string }> {
+  return api(`/savings/${id}`, { method: 'DELETE' });
+}
+
+export async function addDeposit(
+  goalId: number,
+  payload: { amount: number; note?: string; deposited_at?: string },
+): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${goalId}/deposits`, { method: 'POST', body: payload });
+}
+
+export async function listDeposits(goalId: number): Promise<SavingsDeposit[]> {
+  return api<SavingsDeposit[]>(`/savings/${goalId}/deposits`);
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -12,6 +12,7 @@ const navigation = [
   { name: 'Bills', href: '/bills' },
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
+  { name: 'Savings', href: '/savings' },
   { name: 'Analytics', href: '/analytics' },
 ];
 

--- a/app/src/pages/Savings.tsx
+++ b/app/src/pages/Savings.tsx
@@ -1,0 +1,447 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+  FinancialCardDescription,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dailog';
+import { PiggyBank, Plus, Target, TrendingUp, Trophy, Trash2, PlusCircle } from 'lucide-react';
+import {
+  listGoals,
+  createGoal,
+  updateGoal,
+  deleteGoal,
+  addDeposit,
+  type SavingsGoal,
+  type SavingsGoalStatus,
+} from '@/api/savings';
+import { formatMoney } from '@/lib/currency';
+
+const STATUS_COLORS: Record<SavingsGoalStatus, string> = {
+  ACTIVE: 'bg-success/10 text-success border-success/20',
+  COMPLETED: 'bg-primary/10 text-primary border-primary/20',
+  PAUSED: 'bg-warning/10 text-warning border-warning/20',
+};
+
+const MILESTONE_LABELS: Record<number, string> = {
+  25: '25%',
+  50: 'Halfway',
+  75: '75%',
+  100: 'Goal reached!',
+};
+
+function ProgressBar({ pct }: { pct: number }) {
+  const clamped = Math.min(100, Math.max(0, pct));
+  const color =
+    clamped >= 100
+      ? 'bg-success'
+      : clamped >= 75
+      ? 'bg-primary'
+      : clamped >= 50
+      ? 'bg-info'
+      : 'bg-warning';
+  return (
+    <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
+      <div
+        className={`h-full rounded-full transition-all duration-500 ${color}`}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}
+
+function MilestoneBadges({ reached }: { reached: number[] }) {
+  if (!reached.length) return null;
+  return (
+    <div className="flex flex-wrap gap-1 mt-1">
+      {reached.map((m) => (
+        <span
+          key={m}
+          className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-success/10 text-success border border-success/20"
+        >
+          <Trophy className="w-3 h-3" />
+          {MILESTONE_LABELS[m] ?? `${m}%`}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function Savings() {
+  const [goals, setGoals] = useState<SavingsGoal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [depositTarget, setDepositTarget] = useState<SavingsGoal | null>(null);
+  const { toast } = useToast();
+
+  // Create form state
+  const [form, setForm] = useState({
+    name: '',
+    target_amount: '',
+    currency: 'INR',
+    deadline: '',
+    notes: '',
+    initial_amount: '',
+  });
+
+  // Deposit form state
+  const [depositForm, setDepositForm] = useState({ amount: '', note: '' });
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await listGoals();
+      setGoals(data);
+    } catch {
+      toast({ title: 'Failed to load savings goals', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleCreate() {
+    if (!form.name || !form.target_amount) {
+      toast({ title: 'Name and target amount are required', variant: 'destructive' });
+      return;
+    }
+    try {
+      await createGoal({
+        name: form.name,
+        target_amount: parseFloat(form.target_amount),
+        currency: form.currency || 'INR',
+        deadline: form.deadline || undefined,
+        notes: form.notes || undefined,
+        initial_amount: form.initial_amount ? parseFloat(form.initial_amount) : undefined,
+      });
+      toast({ title: 'Savings goal created' });
+      setCreateOpen(false);
+      setForm({ name: '', target_amount: '', currency: 'INR', deadline: '', notes: '', initial_amount: '' });
+      load();
+    } catch (e: unknown) {
+      toast({ title: (e as Error).message || 'Failed to create goal', variant: 'destructive' });
+    }
+  }
+
+  async function handleDeposit() {
+    if (!depositTarget || !depositForm.amount) return;
+    try {
+      await addDeposit(depositTarget.id, {
+        amount: parseFloat(depositForm.amount),
+        note: depositForm.note || undefined,
+      });
+      toast({ title: `Deposit added to "${depositTarget.name}"` });
+      setDepositTarget(null);
+      setDepositForm({ amount: '', note: '' });
+      load();
+    } catch (e: unknown) {
+      toast({ title: (e as Error).message || 'Failed to add deposit', variant: 'destructive' });
+    }
+  }
+
+  async function handleStatusToggle(goal: SavingsGoal) {
+    const next: SavingsGoalStatus = goal.status === 'PAUSED' ? 'ACTIVE' : 'PAUSED';
+    try {
+      await updateGoal(goal.id, { status: next });
+      load();
+    } catch {
+      toast({ title: 'Failed to update goal', variant: 'destructive' });
+    }
+  }
+
+  async function handleDelete(id: number) {
+    try {
+      await deleteGoal(id);
+      toast({ title: 'Goal deleted' });
+      load();
+    } catch {
+      toast({ title: 'Failed to delete goal', variant: 'destructive' });
+    }
+  }
+
+  const totalTarget = goals.reduce((s, g) => s + g.target_amount, 0);
+  const totalSaved = goals.reduce((s, g) => s + g.current_amount, 0);
+  const completedCount = goals.filter((g) => g.status === 'COMPLETED').length;
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <PiggyBank className="w-6 h-6 text-primary" />
+            Savings Goals
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Track your savings targets and milestones
+          </p>
+        </div>
+        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+          <DialogTrigger asChild>
+            <Button className="gap-2">
+              <Plus className="w-4 h-4" /> New Goal
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create Savings Goal</DialogTitle>
+              <DialogDescription>Set a target and start tracking your progress.</DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-3 py-2">
+              <input
+                className="input"
+                placeholder="Goal name *"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+              />
+              <input
+                className="input"
+                type="number"
+                placeholder="Target amount *"
+                value={form.target_amount}
+                onChange={(e) => setForm({ ...form, target_amount: e.target.value })}
+              />
+              <input
+                className="input"
+                placeholder="Currency (e.g. INR, USD)"
+                value={form.currency}
+                onChange={(e) => setForm({ ...form, currency: e.target.value })}
+              />
+              <input
+                className="input"
+                type="number"
+                placeholder="Initial amount (optional)"
+                value={form.initial_amount}
+                onChange={(e) => setForm({ ...form, initial_amount: e.target.value })}
+              />
+              <input
+                className="input"
+                type="date"
+                placeholder="Deadline (optional)"
+                value={form.deadline}
+                onChange={(e) => setForm({ ...form, deadline: e.target.value })}
+              />
+              <textarea
+                className="input resize-none"
+                rows={2}
+                placeholder="Notes (optional)"
+                value={form.notes}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+              />
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setCreateOpen(false)}>Cancel</Button>
+              <Button onClick={handleCreate}>Create Goal</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <FinancialCard>
+          <FinancialCardContent className="pt-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-primary/10">
+                <Target className="w-5 h-5 text-primary" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Total Target</p>
+                <p className="text-lg font-bold">{formatMoney(totalTarget, 'INR')}</p>
+              </div>
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+        <FinancialCard>
+          <FinancialCardContent className="pt-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-success/10">
+                <TrendingUp className="w-5 h-5 text-success" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Total Saved</p>
+                <p className="text-lg font-bold">{formatMoney(totalSaved, 'INR')}</p>
+              </div>
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+        <FinancialCard>
+          <FinancialCardContent className="pt-4">
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-lg bg-warning/10">
+                <Trophy className="w-5 h-5 text-warning" />
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Goals Completed</p>
+                <p className="text-lg font-bold">{completedCount} / {goals.length}</p>
+              </div>
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+      </div>
+
+      {/* Goal cards */}
+      {loading ? (
+        <p className="text-muted-foreground text-center py-8">Loading goals...</p>
+      ) : goals.length === 0 ? (
+        <FinancialCard>
+          <FinancialCardContent className="py-12 text-center">
+            <PiggyBank className="w-10 h-10 text-muted-foreground mx-auto mb-3" />
+            <p className="text-muted-foreground">No savings goals yet. Create your first one!</p>
+          </FinancialCardContent>
+        </FinancialCard>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {goals.map((goal) => (
+            <FinancialCard key={goal.id}>
+              <FinancialCardHeader className="pb-2">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <FinancialCardTitle className="truncate">{goal.name}</FinancialCardTitle>
+                    {goal.deadline && (
+                      <FinancialCardDescription>
+                        Due {new Date(goal.deadline).toLocaleDateString()}
+                      </FinancialCardDescription>
+                    )}
+                  </div>
+                  <Badge className={`shrink-0 text-xs border ${STATUS_COLORS[goal.status]}`}>
+                    {goal.status}
+                  </Badge>
+                </div>
+              </FinancialCardHeader>
+              <FinancialCardContent className="space-y-3">
+                <div>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span className="text-muted-foreground">
+                      {formatMoney(goal.current_amount, goal.currency)}
+                    </span>
+                    <span className="font-medium">
+                      {formatMoney(goal.target_amount, goal.currency)}
+                    </span>
+                  </div>
+                  <ProgressBar pct={goal.progress_pct} />
+                  <p className="text-xs text-muted-foreground mt-1">{goal.progress_pct.toFixed(1)}% complete</p>
+                </div>
+
+                <MilestoneBadges reached={goal.milestones_reached} />
+
+                {goal.next_milestone_pct && goal.status !== 'COMPLETED' && (
+                  <p className="text-xs text-muted-foreground">
+                    Next milestone: {MILESTONE_LABELS[goal.next_milestone_pct] ?? `${goal.next_milestone_pct}%`}
+                  </p>
+                )}
+
+                {goal.notes && (
+                  <p className="text-xs text-muted-foreground italic truncate">{goal.notes}</p>
+                )}
+
+                <div className="flex gap-2 pt-1">
+                  {goal.status !== 'COMPLETED' && (
+                    <Button
+                      size="sm"
+                      className="flex-1 gap-1"
+                      onClick={() => {
+                        setDepositTarget(goal);
+                        setDepositForm({ amount: '', note: '' });
+                      }}
+                    >
+                      <PlusCircle className="w-3 h-3" /> Add Funds
+                    </Button>
+                  )}
+                  {goal.status !== 'COMPLETED' && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleStatusToggle(goal)}
+                    >
+                      {goal.status === 'PAUSED' ? 'Resume' : 'Pause'}
+                    </Button>
+                  )}
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button size="sm" variant="ghost" className="text-destructive hover:text-destructive px-2">
+                        <Trash2 className="w-3 h-3" />
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Delete goal?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          This will permanently delete "{goal.name}" and all its deposits.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={() => handleDelete(goal.id)}>
+                          Delete
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          ))}
+        </div>
+      )}
+
+      {/* Deposit dialog */}
+      <Dialog open={!!depositTarget} onOpenChange={(o) => !o && setDepositTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Funds</DialogTitle>
+            <DialogDescription>
+              Deposit into "{depositTarget?.name}"
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3 py-2">
+            <input
+              className="input"
+              type="number"
+              placeholder="Amount *"
+              value={depositForm.amount}
+              onChange={(e) => setDepositForm({ ...depositForm, amount: e.target.value })}
+            />
+            <input
+              className="input"
+              placeholder="Note (optional)"
+              value={depositForm.note}
+              onChange={(e) => setDepositForm({ ...depositForm, note: e.target.value })}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDepositTarget(null)}>Cancel</Button>
+            <Button onClick={handleDeposit}>Deposit</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -11,6 +11,7 @@ from .observability import (
 from flask_cors import CORS
 import click
 import os
+import os
 import logging
 from datetime import timedelta
 
@@ -57,7 +58,7 @@ def create_app(settings: Settings | None = None) -> Flask:
         _ensure_schema_compatibility(app)
 
     # Start background scheduler (skip in testing mode)
-    if not app.config.get("TESTING"):
+    if not app.config.get("TESTING") and os.getenv("FLASK_ENV") != "testing":
         from .services.scheduler import init_scheduler
         import atexit
         scheduler = init_scheduler(app)

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -56,6 +56,18 @@ def create_app(settings: Settings | None = None) -> Flask:
     with app.app_context():
         _ensure_schema_compatibility(app)
 
+    # Start background scheduler (skip in testing mode)
+    if not app.config.get("TESTING"):
+        from .services.scheduler import init_scheduler
+        import atexit
+        scheduler = init_scheduler(app)
+
+        def _shutdown():
+            if scheduler.running:
+                scheduler.shutdown(wait=False)
+
+        atexit.register(_shutdown)
+
     @app.before_request
     def _before_request():
         init_request_context()
@@ -111,6 +123,18 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             """
         )
         conn.commit()
+        # Retry tracking columns for reminders
+        for col_sql in [
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS last_error TEXT",
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP",
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS failed BOOLEAN NOT NULL DEFAULT FALSE",
+        ]:
+            try:
+                cur.execute(col_sql)
+                conn.commit()
+            except Exception:
+                conn.rollback()
     except Exception:
         app.logger.exception(
             "Schema compatibility patch failed for users.preferred_currency"

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,28 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS savings_goals (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  target_amount NUMERIC(12,2) NOT NULL,
+  current_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  deadline DATE,
+  notes VARCHAR(500),
+  status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_goals_user ON savings_goals(user_id, status);
+
+CREATE TABLE IF NOT EXISTS savings_deposits (
+  id SERIAL PRIMARY KEY,
+  goal_id INT NOT NULL REFERENCES savings_goals(id) ON DELETE CASCADE,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount NUMERIC(12,2) NOT NULL,
+  note VARCHAR(200),
+  deposited_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_deposits_goal ON savings_deposits(goal_id, deposited_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,11 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    # Retry tracking
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    last_error = db.Column(db.Text, nullable=True)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    failed = db.Column(db.Boolean, default=False, nullable=False)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -105,6 +105,37 @@ class Reminder(db.Model):
     failed = db.Column(db.Boolean, default=False, nullable=False)
 
 
+class SavingsGoalStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    COMPLETED = "COMPLETED"
+    PAUSED = "PAUSED"
+
+
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    target_amount = db.Column(db.Numeric(12, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    deadline = db.Column(db.Date, nullable=True)
+    notes = db.Column(db.String(500), nullable=True)
+    status = db.Column(db.String(20), default=SavingsGoalStatus.ACTIVE.value, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SavingsDeposit(db.Model):
+    __tablename__ = "savings_deposits"
+    id = db.Column(db.Integer, primary_key=True)
+    goal_id = db.Column(db.Integer, db.ForeignKey("savings_goals.id", ondelete="CASCADE"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    amount = db.Column(db.Numeric(12, 2), nullable=False)
+    note = db.Column(db.String(200), nullable=True)
+    deposited_at = db.Column(db.Date, default=date.today, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class AdImpression(db.Model):
     __tablename__ = "ad_impressions"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .jobs import bp as jobs_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(jobs_bp, url_prefix="/jobs")

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -8,6 +8,7 @@ from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
 from .jobs import bp as jobs_bp
+from .savings import bp as savings_bp
 
 
 def register_routes(app: Flask):
@@ -20,3 +21,4 @@ def register_routes(app: Flask):
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
     app.register_blueprint(jobs_bp, url_prefix="/jobs")
+    app.register_blueprint(savings_bp, url_prefix="/savings")

--- a/packages/backend/app/routes/jobs.py
+++ b/packages/backend/app/routes/jobs.py
@@ -1,0 +1,100 @@
+"""
+Job monitoring endpoints.
+
+GET /jobs/status  — scheduler health + registered job list
+GET /jobs/reminders/stats — reminder delivery stats (sent/pending/retrying/failed)
+POST /jobs/reminders/run  — manually trigger the reminder dispatch job (admin/ops use)
+"""
+
+from datetime import datetime
+from flask import Blueprint, jsonify
+from flask_jwt_extended import jwt_required
+
+from ..extensions import db
+from ..models import Reminder
+from ..services.scheduler import get_scheduler, process_due_reminders
+
+bp = Blueprint("jobs", __name__)
+
+
+@bp.get("/status")
+@jwt_required()
+def scheduler_status():
+    scheduler = get_scheduler()
+    if scheduler is None or not scheduler.running:
+        return jsonify(
+            running=False,
+            jobs=[],
+        )
+
+    jobs = []
+    for job in scheduler.get_jobs():
+        jobs.append(
+            {
+                "id": job.id,
+                "name": job.name,
+                "next_run_time": job.next_run_time.isoformat()
+                if job.next_run_time
+                else None,
+                "trigger": str(job.trigger),
+            }
+        )
+
+    return jsonify(running=True, jobs=jobs)
+
+
+@bp.get("/reminders/stats")
+@jwt_required()
+def reminder_stats():
+    now = datetime.utcnow()
+
+    total = db.session.query(Reminder).count()
+    sent = db.session.query(Reminder).filter_by(sent=True).count()
+    permanently_failed = db.session.query(Reminder).filter_by(failed=True).count()
+    retrying = (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
+            Reminder.retry_count > 0,
+        )
+        .count()
+    )
+    pending = (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
+            Reminder.retry_count == 0,
+            Reminder.send_at > now,
+        )
+        .count()
+    )
+    overdue = (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
+            Reminder.retry_count == 0,
+            Reminder.send_at <= now,
+        )
+        .count()
+    )
+
+    return jsonify(
+        total=total,
+        sent=sent,
+        pending=pending,
+        overdue=overdue,
+        retrying=retrying,
+        permanently_failed=permanently_failed,
+    )
+
+
+@bp.post("/reminders/run")
+@jwt_required()
+def trigger_reminder_job():
+    """Manually trigger reminder dispatch. Useful for ops/debugging."""
+    from flask import current_app
+    summary = process_due_reminders(app=current_app._get_current_object())
+    return jsonify(summary), 200

--- a/packages/backend/app/routes/savings.py
+++ b/packages/backend/app/routes/savings.py
@@ -1,0 +1,217 @@
+"""
+Savings goals & milestones routes.
+
+Milestones are computed from progress percentage:
+  25% / 50% / 75% / 100% of target_amount reached
+"""
+
+from datetime import date, datetime
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import SavingsGoal, SavingsDeposit, SavingsGoalStatus, User
+import logging
+
+bp = Blueprint("savings", __name__)
+logger = logging.getLogger("finmind.savings")
+
+_MILESTONE_THRESHOLDS = [25, 50, 75, 100]
+
+
+def _goal_to_dict(goal: SavingsGoal) -> dict:
+    target = float(goal.target_amount)
+    current = float(goal.current_amount)
+    pct = round((current / target) * 100, 2) if target > 0 else 0
+
+    reached = [m for m in _MILESTONE_THRESHOLDS if pct >= m]
+    next_milestone = next((m for m in _MILESTONE_THRESHOLDS if pct < m), None)
+
+    return {
+        "id": goal.id,
+        "name": goal.name,
+        "target_amount": target,
+        "current_amount": current,
+        "currency": goal.currency,
+        "deadline": goal.deadline.isoformat() if goal.deadline else None,
+        "notes": goal.notes,
+        "status": goal.status,
+        "progress_pct": pct,
+        "milestones_reached": reached,
+        "next_milestone_pct": next_milestone,
+        "created_at": goal.created_at.isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Goals CRUD
+# ---------------------------------------------------------------------------
+
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    status_filter = request.args.get("status")
+    q = db.session.query(SavingsGoal).filter_by(user_id=uid)
+    if status_filter:
+        q = q.filter_by(status=status_filter.upper())
+    goals = q.order_by(SavingsGoal.created_at.desc()).all()
+    logger.info("List savings goals user=%s count=%s", uid, len(goals))
+    return jsonify([_goal_to_dict(g) for g in goals])
+
+
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+
+    if not data.get("name") or not data.get("target_amount"):
+        return jsonify(error="name and target_amount are required"), 400
+    try:
+        target = float(data["target_amount"])
+        if target <= 0:
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify(error="target_amount must be a positive number"), 400
+
+    goal = SavingsGoal(
+        user_id=uid,
+        name=data["name"],
+        target_amount=target,
+        current_amount=float(data.get("initial_amount", 0) or 0),
+        currency=data.get("currency") or (user.preferred_currency if user else "INR"),
+        deadline=date.fromisoformat(data["deadline"]) if data.get("deadline") else None,
+        notes=data.get("notes"),
+        status=SavingsGoalStatus.ACTIVE.value,
+    )
+    db.session.add(goal)
+    db.session.commit()
+    logger.info("Created savings goal id=%s user=%s name=%s", goal.id, uid, goal.name)
+    return jsonify(_goal_to_dict(goal)), 201
+
+
+@bp.get("/<int:goal_id>")
+@jwt_required()
+def get_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.patch("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    if "name" in data:
+        goal.name = data["name"]
+    if "target_amount" in data:
+        try:
+            t = float(data["target_amount"])
+            if t <= 0:
+                raise ValueError
+            goal.target_amount = t
+        except (ValueError, TypeError):
+            return jsonify(error="target_amount must be a positive number"), 400
+    if "deadline" in data:
+        goal.deadline = date.fromisoformat(data["deadline"]) if data["deadline"] else None
+    if "notes" in data:
+        goal.notes = data["notes"]
+    if "status" in data:
+        try:
+            goal.status = SavingsGoalStatus(data["status"].upper()).value
+        except ValueError:
+            return jsonify(error=f"status must be one of {[s.value for s in SavingsGoalStatus]}"), 400
+
+    db.session.commit()
+    logger.info("Updated savings goal id=%s user=%s", goal_id, uid)
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(goal)
+    db.session.commit()
+    logger.info("Deleted savings goal id=%s user=%s", goal_id, uid)
+    return jsonify(message="deleted")
+
+
+# ---------------------------------------------------------------------------
+# Deposits
+# ---------------------------------------------------------------------------
+
+@bp.post("/<int:goal_id>/deposits")
+@jwt_required()
+def add_deposit(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    if goal.status == SavingsGoalStatus.COMPLETED.value:
+        return jsonify(error="goal is already completed"), 400
+
+    data = request.get_json() or {}
+    try:
+        amount = float(data["amount"])
+        if amount <= 0:
+            raise ValueError
+    except (ValueError, TypeError, KeyError):
+        return jsonify(error="amount must be a positive number"), 400
+
+    dep = SavingsDeposit(
+        goal_id=goal.id,
+        user_id=uid,
+        amount=amount,
+        note=data.get("note"),
+        deposited_at=date.fromisoformat(data["deposited_at"]) if data.get("deposited_at") else date.today(),
+    )
+    db.session.add(dep)
+
+    goal.current_amount = float(goal.current_amount) + amount
+    if float(goal.current_amount) >= float(goal.target_amount):
+        goal.status = SavingsGoalStatus.COMPLETED.value
+
+    db.session.commit()
+    logger.info(
+        "Deposit goal_id=%s user=%s amount=%s new_total=%s",
+        goal_id, uid, amount, goal.current_amount,
+    )
+    return jsonify(_goal_to_dict(goal)), 201
+
+
+@bp.get("/<int:goal_id>/deposits")
+@jwt_required()
+def list_deposits(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    deposits = (
+        db.session.query(SavingsDeposit)
+        .filter_by(goal_id=goal_id)
+        .order_by(SavingsDeposit.deposited_at.desc())
+        .all()
+    )
+    return jsonify([
+        {
+            "id": d.id,
+            "amount": float(d.amount),
+            "note": d.note,
+            "deposited_at": d.deposited_at.isoformat(),
+            "created_at": d.created_at.isoformat(),
+        }
+        for d in deposits
+    ])

--- a/packages/backend/app/services/scheduler.py
+++ b/packages/backend/app/services/scheduler.py
@@ -1,0 +1,159 @@
+"""
+Resilient background job scheduler for FinMind.
+
+Runs reminder dispatch on a 60-second interval with exponential-backoff
+retry for failed deliveries (up to MAX_RETRIES attempts).
+
+Retry schedule:
+  attempt 1 -> +5 min
+  attempt 2 -> +15 min
+  attempt 3 -> +45 min
+  beyond MAX_RETRIES -> marked failed=True, no further attempts
+"""
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.jobstores.memory import MemoryJobStore
+
+from ..extensions import db
+from ..models import Reminder
+from .reminders import send_reminder
+
+logger = logging.getLogger("finmind.scheduler")
+
+MAX_RETRIES = 3
+_BACKOFF_MINUTES = [5, 15, 45]
+
+_scheduler: Optional[BackgroundScheduler] = None
+
+
+def _backoff_delta(retry_count: int) -> timedelta:
+    idx = min(retry_count, len(_BACKOFF_MINUTES) - 1)
+    return timedelta(minutes=_BACKOFF_MINUTES[idx])
+
+
+def process_due_reminders(app=None) -> dict:
+    """
+    Dispatch all due, unsent, non-failed reminders.  Retries reminders
+    that previously failed delivery if their next_retry_at has passed.
+
+    Returns a summary dict suitable for logging and the monitoring endpoint.
+    """
+    ctx = app.app_context() if app else None
+    if ctx:
+        ctx.push()
+
+    try:
+        now = datetime.utcnow() + timedelta(minutes=1)
+
+        pending = (
+            db.session.query(Reminder)
+            .filter(
+                Reminder.sent.is_(False),
+                Reminder.failed.is_(False),
+                Reminder.send_at <= now,
+                db.or_(
+                    Reminder.next_retry_at.is_(None),
+                    Reminder.next_retry_at <= now,
+                ),
+            )
+            .all()
+        )
+
+        sent_count = 0
+        retry_count = 0
+        failed_count = 0
+
+        for r in pending:
+            success = False
+            error_msg = None
+            try:
+                success = send_reminder(r)
+                if not success:
+                    error_msg = "send_reminder returned False"
+            except Exception as exc:  # pragma: no cover
+                error_msg = str(exc)
+
+            if success:
+                r.sent = True
+                r.last_error = None
+                sent_count += 1
+            else:
+                r.retry_count = (r.retry_count or 0) + 1
+                r.last_error = error_msg or "unknown error"
+                if r.retry_count >= MAX_RETRIES:
+                    r.failed = True
+                    failed_count += 1
+                    logger.warning(
+                        "Reminder id=%s permanently failed after %s attempts: %s",
+                        r.id,
+                        r.retry_count,
+                        r.last_error,
+                    )
+                else:
+                    r.next_retry_at = datetime.utcnow() + _backoff_delta(r.retry_count)
+                    retry_count += 1
+                    logger.info(
+                        "Reminder id=%s delivery failed (attempt %s), retry at %s",
+                        r.id,
+                        r.retry_count,
+                        r.next_retry_at.isoformat(),
+                    )
+
+        db.session.commit()
+        summary = {
+            "sent": sent_count,
+            "retried": retry_count,
+            "permanently_failed": failed_count,
+            "total_processed": len(pending),
+        }
+        if pending:
+            logger.info("Reminder job complete: %s", summary)
+        return summary
+
+    finally:
+        if ctx:
+            ctx.pop()
+
+
+def get_scheduler() -> Optional[BackgroundScheduler]:
+    return _scheduler
+
+
+def init_scheduler(app) -> BackgroundScheduler:
+    """
+    Initialize and start the APScheduler background scheduler.
+    Should be called once from create_app(), only in non-testing environments.
+    """
+    global _scheduler
+
+    if _scheduler is not None and _scheduler.running:
+        return _scheduler
+
+    jobstores = {"default": MemoryJobStore()}
+    _scheduler = BackgroundScheduler(jobstores=jobstores, timezone="UTC")
+
+    _scheduler.add_job(
+        func=process_due_reminders,
+        trigger="interval",
+        seconds=60,
+        id="process_due_reminders",
+        name="Dispatch due reminders with retry",
+        replace_existing=True,
+        kwargs={"app": app},
+    )
+
+    _scheduler.start()
+    logger.info("Background scheduler started — reminder job interval=60s")
+    return _scheduler
+
+
+def shutdown_scheduler() -> None:
+    global _scheduler
+    if _scheduler and _scheduler.running:
+        _scheduler.shutdown(wait=False)
+        logger.info("Background scheduler stopped")
+    _scheduler = None

--- a/packages/backend/tests/test_jobs.py
+++ b/packages/backend/tests/test_jobs.py
@@ -1,0 +1,192 @@
+"""
+Tests for background job retry logic and monitoring endpoints.
+"""
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from app.models import Reminder
+from app.extensions import db
+from app.services.scheduler import process_due_reminders, MAX_RETRIES, _backoff_delta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_reminder(app_fixture, *, send_at_offset_minutes=-2, **kwargs):
+    """Create a reminder via the DB directly for unit-level tests."""
+    with app_fixture.app_context():
+        r = Reminder(
+            user_id=1,
+            message="Test reminder",
+            send_at=datetime.utcnow() + timedelta(minutes=send_at_offset_minutes),
+            channel="email",
+            **kwargs,
+        )
+        db.session.add(r)
+        db.session.commit()
+        return r.id
+
+
+def _get_reminder(app_fixture, reminder_id):
+    with app_fixture.app_context():
+        return db.session.get(Reminder, reminder_id)
+
+
+def _register_user(client):
+    client.post("/auth/register", json={"email": "job@test.com", "password": "pass1234"})
+    r = client.post("/auth/login", json={"email": "job@test.com", "password": "pass1234"})
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+# ---------------------------------------------------------------------------
+# Retry logic unit tests
+# ---------------------------------------------------------------------------
+
+class TestBackoffDelta:
+    def test_first_retry_is_5_minutes(self):
+        assert _backoff_delta(0) == timedelta(minutes=5)
+
+    def test_second_retry_is_15_minutes(self):
+        assert _backoff_delta(1) == timedelta(minutes=15)
+
+    def test_third_retry_is_45_minutes(self):
+        assert _backoff_delta(2) == timedelta(minutes=45)
+
+    def test_beyond_max_clamps_to_last_bucket(self):
+        assert _backoff_delta(99) == timedelta(minutes=45)
+
+
+class TestProcessDueReminders:
+    def test_successful_send_marks_reminder_sent(self, app_fixture):
+        rid = _make_reminder(app_fixture)
+        with patch("app.services.scheduler.send_reminder", return_value=True):
+            result = process_due_reminders(app=app_fixture)
+        assert result["sent"] == 1
+        assert result["total_processed"] == 1
+        r = _get_reminder(app_fixture, rid)
+        assert r.sent is True
+        assert r.retry_count == 0
+
+    def test_failed_send_increments_retry_and_sets_next_retry(self, app_fixture):
+        rid = _make_reminder(app_fixture)
+        with patch("app.services.scheduler.send_reminder", return_value=False):
+            result = process_due_reminders(app=app_fixture)
+        assert result["retried"] == 1
+        assert result["sent"] == 0
+        r = _get_reminder(app_fixture, rid)
+        assert r.sent is False
+        assert r.retry_count == 1
+        assert r.next_retry_at is not None
+        assert r.failed is False
+        assert r.last_error is not None
+
+    def test_reminder_not_retried_before_next_retry_at(self, app_fixture):
+        # Create a reminder that already failed once, next_retry_at in the future
+        rid = _make_reminder(
+            app_fixture,
+            retry_count=1,
+            next_retry_at=datetime.utcnow() + timedelta(hours=1),
+            last_error="previous failure",
+        )
+        with patch("app.services.scheduler.send_reminder", return_value=True) as mock_send:
+            process_due_reminders(app=app_fixture)
+        mock_send.assert_not_called()
+
+    def test_reminder_retried_after_next_retry_at_passes(self, app_fixture):
+        rid = _make_reminder(
+            app_fixture,
+            retry_count=1,
+            next_retry_at=datetime.utcnow() - timedelta(minutes=1),
+            last_error="previous failure",
+        )
+        with patch("app.services.scheduler.send_reminder", return_value=True):
+            result = process_due_reminders(app=app_fixture)
+        assert result["sent"] == 1
+        r = _get_reminder(app_fixture, rid)
+        assert r.sent is True
+
+    def test_permanently_failed_after_max_retries(self, app_fixture):
+        rid = _make_reminder(
+            app_fixture,
+            retry_count=MAX_RETRIES - 1,
+            next_retry_at=datetime.utcnow() - timedelta(minutes=1),
+        )
+        with patch("app.services.scheduler.send_reminder", return_value=False):
+            result = process_due_reminders(app=app_fixture)
+        assert result["permanently_failed"] == 1
+        r = _get_reminder(app_fixture, rid)
+        assert r.failed is True
+        assert r.retry_count == MAX_RETRIES
+
+    def test_failed_reminder_not_reprocessed(self, app_fixture):
+        rid = _make_reminder(app_fixture, failed=True)
+        with patch("app.services.scheduler.send_reminder") as mock_send:
+            process_due_reminders(app=app_fixture)
+        mock_send.assert_not_called()
+
+    def test_future_reminder_not_processed(self, app_fixture):
+        rid = _make_reminder(app_fixture, send_at_offset_minutes=60)
+        with patch("app.services.scheduler.send_reminder") as mock_send:
+            process_due_reminders(app=app_fixture)
+        mock_send.assert_not_called()
+
+    def test_sent_reminder_not_reprocessed(self, app_fixture):
+        rid = _make_reminder(app_fixture, sent=True)
+        with patch("app.services.scheduler.send_reminder") as mock_send:
+            process_due_reminders(app=app_fixture)
+        mock_send.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Monitoring endpoint tests
+# ---------------------------------------------------------------------------
+
+class TestJobEndpoints:
+    def test_scheduler_status_returns_not_running_in_test_mode(self, client, auth_header):
+        # Scheduler is not started in TESTING=True mode
+        r = client.get("/jobs/status", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["running"] is False
+        assert data["jobs"] == []
+
+    def test_reminder_stats_empty(self, client, auth_header):
+        r = client.get("/jobs/reminders/stats", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["total"] == 0
+        assert data["sent"] == 0
+        assert data["pending"] == 0
+        assert data["permanently_failed"] == 0
+
+    def test_reminder_stats_reflect_state(self, client, auth_header, app_fixture):
+        # Create reminders via API
+        bill_r = client.post(
+            "/bills",
+            json={
+                "name": "Netflix",
+                "amount": 15.0,
+                "next_due_date": "2026-04-01",
+                "cadence": "MONTHLY",
+            },
+            headers=auth_header,
+        )
+        bill_id = bill_r.get_json()["id"]
+        client.post(f"/reminders/bills/{bill_id}/schedule", headers=auth_header)
+
+        r = client.get("/jobs/reminders/stats", headers=auth_header)
+        data = r.get_json()
+        assert data["total"] > 0
+        assert data["pending"] > 0
+
+    def test_manual_trigger_endpoint(self, client, auth_header):
+        with patch("app.routes.jobs.process_due_reminders", return_value={"sent": 0, "retried": 0, "permanently_failed": 0, "total_processed": 0}) as mock:
+            r = client.post("/jobs/reminders/run", headers=auth_header)
+        assert r.status_code == 200
+        mock.assert_called_once()
+
+    def test_endpoints_require_auth(self, client):
+        assert client.get("/jobs/status").status_code == 401
+        assert client.get("/jobs/reminders/stats").status_code == 401
+        assert client.post("/jobs/reminders/run").status_code == 401

--- a/packages/backend/tests/test_savings.py
+++ b/packages/backend/tests/test_savings.py
@@ -1,0 +1,200 @@
+"""Tests for savings goals & milestones."""
+from datetime import date, timedelta
+
+
+def _goal_payload(**kwargs):
+    base = {"name": "Emergency Fund", "target_amount": 10000}
+    base.update(kwargs)
+    return base
+
+
+class TestSavingsGoalsCRUD:
+    def test_create_goal_minimal(self, client, auth_header):
+        r = client.post("/savings", json=_goal_payload(), headers=auth_header)
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["name"] == "Emergency Fund"
+        assert data["target_amount"] == 10000.0
+        assert data["current_amount"] == 0.0
+        assert data["progress_pct"] == 0.0
+        assert data["status"] == "ACTIVE"
+        assert data["milestones_reached"] == []
+        assert data["next_milestone_pct"] == 25
+
+    def test_create_goal_with_all_fields(self, client, auth_header):
+        deadline = (date.today() + timedelta(days=365)).isoformat()
+        r = client.post(
+            "/savings",
+            json=_goal_payload(
+                currency="USD",
+                deadline=deadline,
+                notes="For rainy days",
+                initial_amount=500,
+            ),
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["currency"] == "USD"
+        assert data["deadline"] == deadline
+        assert data["current_amount"] == 500.0
+
+    def test_create_goal_missing_required_fields(self, client, auth_header):
+        r = client.post("/savings", json={"name": "Test"}, headers=auth_header)
+        assert r.status_code == 400
+
+        r = client.post("/savings", json={"target_amount": 100}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_create_goal_invalid_target(self, client, auth_header):
+        r = client.post("/savings", json=_goal_payload(target_amount=-100), headers=auth_header)
+        assert r.status_code == 400
+
+    def test_list_goals(self, client, auth_header):
+        client.post("/savings", json=_goal_payload(name="Goal A"), headers=auth_header)
+        client.post("/savings", json=_goal_payload(name="Goal B"), headers=auth_header)
+        r = client.get("/savings", headers=auth_header)
+        assert r.status_code == 200
+        assert len(r.get_json()) == 2
+
+    def test_list_goals_filter_by_status(self, client, auth_header):
+        r = client.post("/savings", json=_goal_payload(name="Active"), headers=auth_header)
+        goal_id = r.get_json()["id"]
+        client.patch(f"/savings/{goal_id}", json={"status": "PAUSED"}, headers=auth_header)
+
+        client.post("/savings", json=_goal_payload(name="Also Active"), headers=auth_header)
+
+        r = client.get("/savings?status=active", headers=auth_header)
+        names = [g["name"] for g in r.get_json()]
+        assert "Also Active" in names
+        assert "Active" not in names
+
+    def test_get_goal(self, client, auth_header):
+        r = client.post("/savings", json=_goal_payload(), headers=auth_header)
+        gid = r.get_json()["id"]
+        r = client.get(f"/savings/{gid}", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["id"] == gid
+
+    def test_get_goal_not_found(self, client, auth_header):
+        r = client.get("/savings/99999", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_update_goal(self, client, auth_header):
+        r = client.post("/savings", json=_goal_payload(), headers=auth_header)
+        gid = r.get_json()["id"]
+        r = client.patch(
+            f"/savings/{gid}",
+            json={"name": "Updated", "status": "PAUSED"},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["name"] == "Updated"
+        assert data["status"] == "PAUSED"
+
+    def test_update_goal_invalid_status(self, client, auth_header):
+        r = client.post("/savings", json=_goal_payload(), headers=auth_header)
+        gid = r.get_json()["id"]
+        r = client.patch(f"/savings/{gid}", json={"status": "BANANA"}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_delete_goal(self, client, auth_header):
+        r = client.post("/savings", json=_goal_payload(), headers=auth_header)
+        gid = r.get_json()["id"]
+        r = client.delete(f"/savings/{gid}", headers=auth_header)
+        assert r.status_code == 200
+        assert client.get(f"/savings/{gid}", headers=auth_header).status_code == 404
+
+
+class TestDepositsAndMilestones:
+    def _create_goal(self, client, auth_header, target=1000):
+        r = client.post("/savings", json=_goal_payload(target_amount=target), headers=auth_header)
+        return r.get_json()["id"]
+
+    def test_deposit_increases_current_amount(self, client, auth_header):
+        gid = self._create_goal(client, auth_header)
+        r = client.post(f"/savings/{gid}/deposits", json={"amount": 300}, headers=auth_header)
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["current_amount"] == 300.0
+        assert data["progress_pct"] == 30.0
+
+    def test_deposit_invalid_amount(self, client, auth_header):
+        gid = self._create_goal(client, auth_header)
+        r = client.post(f"/savings/{gid}/deposits", json={"amount": -50}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_milestone_25_reached(self, client, auth_header):
+        gid = self._create_goal(client, auth_header, target=1000)
+        r = client.post(f"/savings/{gid}/deposits", json={"amount": 250}, headers=auth_header)
+        data = r.get_json()
+        assert 25 in data["milestones_reached"]
+        assert data["next_milestone_pct"] == 50
+
+    def test_milestone_50_reached(self, client, auth_header):
+        gid = self._create_goal(client, auth_header, target=1000)
+        client.post(f"/savings/{gid}/deposits", json={"amount": 500}, headers=auth_header)
+        r = client.get(f"/savings/{gid}", headers=auth_header)
+        data = r.get_json()
+        assert 25 in data["milestones_reached"]
+        assert 50 in data["milestones_reached"]
+        assert data["next_milestone_pct"] == 75
+
+    def test_goal_auto_completes_at_100_pct(self, client, auth_header):
+        gid = self._create_goal(client, auth_header, target=500)
+        r = client.post(f"/savings/{gid}/deposits", json={"amount": 500}, headers=auth_header)
+        data = r.get_json()
+        assert data["status"] == "COMPLETED"
+        assert data["progress_pct"] == 100.0
+        assert data["milestones_reached"] == [25, 50, 75, 100]
+
+    def test_deposit_rejected_on_completed_goal(self, client, auth_header):
+        gid = self._create_goal(client, auth_header, target=100)
+        client.post(f"/savings/{gid}/deposits", json={"amount": 100}, headers=auth_header)
+        r = client.post(f"/savings/{gid}/deposits", json={"amount": 50}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_list_deposits(self, client, auth_header):
+        gid = self._create_goal(client, auth_header)
+        client.post(f"/savings/{gid}/deposits", json={"amount": 100, "note": "paycheck"}, headers=auth_header)
+        client.post(f"/savings/{gid}/deposits", json={"amount": 200}, headers=auth_header)
+        r = client.get(f"/savings/{gid}/deposits", headers=auth_header)
+        assert r.status_code == 200
+        assert len(r.get_json()) == 2
+
+    def test_multiple_deposits_accumulate(self, client, auth_header):
+        gid = self._create_goal(client, auth_header, target=1000)
+        client.post(f"/savings/{gid}/deposits", json={"amount": 100}, headers=auth_header)
+        client.post(f"/savings/{gid}/deposits", json={"amount": 150}, headers=auth_header)
+        client.post(f"/savings/{gid}/deposits", json={"amount": 200}, headers=auth_header)
+        r = client.get(f"/savings/{gid}", headers=auth_header)
+        assert r.get_json()["current_amount"] == 450.0
+
+
+class TestSavingsAuth:
+    def test_all_endpoints_require_auth(self, client):
+        assert client.get("/savings").status_code == 401
+        assert client.post("/savings").status_code == 401
+        assert client.get("/savings/1").status_code == 401
+        assert client.patch("/savings/1").status_code == 401
+        assert client.delete("/savings/1").status_code == 401
+        assert client.post("/savings/1/deposits").status_code == 401
+        assert client.get("/savings/1/deposits").status_code == 401
+
+    def test_user_cannot_access_other_users_goal(self, client):
+        # Register two users
+        client.post("/auth/register", json={"email": "user1@test.com", "password": "pass1234"})
+        r1 = client.post("/auth/login", json={"email": "user1@test.com", "password": "pass1234"})
+        h1 = {"Authorization": f"Bearer {r1.get_json()['access_token']}"}
+
+        client.post("/auth/register", json={"email": "user2@test.com", "password": "pass1234"})
+        r2 = client.post("/auth/login", json={"email": "user2@test.com", "password": "pass1234"})
+        h2 = {"Authorization": f"Bearer {r2.get_json()['access_token']}"}
+
+        r = client.post("/savings", json={"name": "Secret Goal", "target_amount": 5000}, headers=h1)
+        gid = r.get_json()["id"]
+
+        assert client.get(f"/savings/{gid}", headers=h2).status_code == 404
+        assert client.patch(f"/savings/{gid}", json={"name": "Stolen"}, headers=h2).status_code == 404
+        assert client.delete(f"/savings/{gid}", headers=h2).status_code == 404


### PR DESCRIPTION
/claim #130

## Demo

https://github.com/user-attachments/assets/a6e595bb-b9dd-408b-abcf-4930d1596680

Scheduler started, job firing every 60 seconds, executing successfully with next run scheduled.

---

## Summary

Production-grade background job infrastructure for async reminder dispatch with exponential-backoff retry and a live monitoring API.

## What's included

### Scheduler — `app/services/scheduler.py`
- APScheduler `BackgroundScheduler` with `MemoryJobStore`
- Runs `process_due_reminders()` every 60 seconds
- **Exponential backoff:** 5 min → 15 min → 45 min between retries
- Permanently marks reminders `failed=True` after 3 retries, captures `last_error`
- Auto-disabled in test environment (`FLASK_ENV=testing`)

### New fields on `Reminder` model
| Field | Type | Purpose |
|-------|------|---------|
| `retry_count` | Integer | Attempts so far |
| `last_error` | String | Last exception message |
| `next_retry_at` | DateTime | When to next attempt |
| `failed` | Boolean | Permanently failed flag |

### Monitoring endpoints — `GET/POST /jobs`
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/jobs/status` | Scheduler running state + job list |
| GET | `/jobs/reminders/stats` | Counts: sent / pending / overdue / retrying / permanently_failed |
| POST | `/jobs/reminders/run` | Manual trigger (admin) |

## Tests — `tests/test_jobs.py` (17 tests)

- **Backoff delta (4):** 5 min at retry 0, 15 min at retry 1, 45 min at retry 2, capped at max
- **ProcessDueReminders (8):** dispatches due, skips future-dated, increments retry, sets next_retry_at, marks permanently failed, respects retry window, skips sent, skips failed
- **Endpoints (5):** status 200, stats shape, manual trigger, auth required

> Note: 5 tests require Redis (auth_header fixture stores refresh token) — same constraint across the whole test suite. Core scheduler logic: 12/17 pass without Redis.