### PR TITLE
feat: Add weekly financial digest endpoint (/insights/weekly-digest)

### DIFF
--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -480,6 +480,72 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
+  /insights/weekly-digest:
+    get:
+      summary: Get weekly financial summary with trends and insights
+      description: >
+        Generates a comprehensive weekly financial digest including spending
+        breakdown, week-over-week trends, category analysis, and actionable
+        insights.
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          description: "Monday of the target week (YYYY-MM-DD). Defaults to current week."
+          schema: { type: string, pattern: '^\d{4}-\d{2}-\d{2}$' }
+      responses:
+        '200':
+          description: Weekly digest
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  period:
+                    type: object
+                    properties:
+                      week_start: { type: string, example: "2026-03-09" }
+                      week_end: { type: string, example: "2026-03-15" }
+                      label: { type: string, example: "Week of Mar 09, 2026" }
+                  summary:
+                    type: object
+                    properties:
+                      income: { type: number, example: 500.00 }
+                      expenses: { type: number, example: 175.00 }
+                      net: { type: number, example: 325.00 }
+                      transaction_count: { type: integer, example: 5 }
+                  trends:
+                    type: object
+                    properties:
+                      spending_wow_change_pct: { type: number, example: -12.5 }
+                      previous_week_expenses: { type: number, example: 200.00 }
+                      previous_week_income: { type: number, example: 450.00 }
+                      previous_week_net: { type: number, example: 250.00 }
+                  categories:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        category_id: { type: integer, nullable: true }
+                        category_name: { type: string }
+                        amount: { type: number }
+                        share_pct: { type: number }
+                  insights:
+                    type: array
+                    items: { type: string }
+                    example: ["You're in the green this week!", "Great savings rate: 65% this week."]
+        '400':
+          description: Invalid week_start format
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
 components:
   securitySchemes:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,8 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.weekly_digest import generate_weekly_digest, _week_range
+from ..services.cache import cache_get, cache_set
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +25,37 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-digest")
+@jwt_required()
+def weekly_digest():
+    """Generate a weekly financial summary with trends and insights.
+
+    Query params:
+      - week_start: ISO date (YYYY-MM-DD) for the Monday of the target week.
+                    Defaults to the current week.
+
+    Returns:
+      - period: week date range
+      - summary: income, expenses, net, transaction count
+      - trends: week-over-week spending change percentage
+      - categories: spending breakdown by category
+      - insights: human-readable financial insights
+    """
+    uid = int(get_jwt_identity())
+    ws_param = request.args.get("week_start", "").strip()
+
+    if ws_param:
+        try:
+            week_start = date.fromisoformat(ws_param)
+        except ValueError:
+            return jsonify(error="Invalid week_start format, expected YYYY-MM-DD"), 400
+    else:
+        week_start = None
+
+    # Generate digest (uses DB queries)
+    digest = generate_weekly_digest(uid, week_start)
+
+    logger.info("Weekly digest served user=%s week=%s", uid, digest["period"]["label"])
+    return jsonify(digest)

--- a/packages/backend/app/services/weekly_digest.py
+++ b/packages/backend/app/services/weekly_digest.py
@@ -1,0 +1,217 @@
+"""Weekly financial digest service.
+
+Generates a comprehensive weekly financial summary including:
+- Week spending vs income
+- Category breakdown
+- Week-over-week trend comparison
+- Insights and anomalies
+"""
+
+from datetime import date, timedelta
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Expense, Category
+
+
+def _week_range(ref_date: date | None = None) -> tuple[date, date]:
+    """Return (monday, sunday) for the week containing ref_date (default today)."""
+    today = ref_date or date.today()
+    monday = today - timedelta(days=today.weekday())
+    sunday = monday + timedelta(days=6)
+    return monday, sunday
+
+
+def _previous_week_range(monday: date) -> tuple[date, date]:
+    """Return (monday, sunday) for the week immediately before the given monday."""
+    prev_monday = monday - timedelta(days=7)
+    prev_sunday = prev_monday + timedelta(days=6)
+    return prev_monday, prev_sunday
+
+
+def _week_totals(
+    uid: int, start: date, end: date
+) -> tuple[float, float]:
+    """Return (income, expenses) for a user in a date range."""
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+    return float(income or 0), float(expenses or 0)
+
+
+def _category_breakdown(
+    uid: int, start: date, end: date
+) -> list[dict]:
+    """Return category spending breakdown for a date range."""
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(Category.name, "Uncategorized").label("category_name"),
+            func.coalesce(func.sum(Expense.amount), 0).label("total_amount"),
+        )
+        .outerjoin(
+            Category,
+            (Category.id == Expense.category_id) & (Category.user_id == uid),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id, Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .all()
+    )
+    total = sum(float(r.total_amount or 0) for r in rows)
+    return [
+        {
+            "category_id": r.category_id,
+            "category_name": r.category_name,
+            "amount": round(float(r.total_amount or 0), 2),
+            "share_pct": (
+                round((float(r.total_amount or 0) / total) * 100, 2)
+                if total > 0
+                else 0
+            ),
+        }
+        for r in rows
+    ]
+
+
+def _generate_insights(
+    current_income: float,
+    current_expenses: float,
+    prev_income: float,
+    prev_expenses: float,
+    categories: list[dict],
+) -> list[str]:
+    """Generate human-readable insights from the data."""
+    insights = []
+
+    # Net flow insight
+    net = current_income - current_expenses
+    prev_net = prev_income - prev_expenses
+    if net > 0 and prev_net <= 0:
+        insights.append("You're in the green this week — income exceeds expenses!")
+    elif net < 0:
+        burn = abs(net)
+        if prev_expenses > 0 and current_expenses > prev_expenses:
+            pct = round(((current_expenses - prev_expenses) / prev_expenses) * 100, 1)
+            insights.append(
+                f"Spending up {pct}% vs last week. Biggest driver: {categories[0]['category_name'] if categories else 'unknown'}."
+            )
+        else:
+            insights.append(f"You spent {burn:.2f} more than you earned this week.")
+
+    # Category concentration
+    if categories and len(categories) >= 1:
+        top = categories[0]
+        if top["share_pct"] > 50:
+            insights.append(
+                f"{top['category_name']} is {top['share_pct']}% of your week's spending — consider diversifying."
+            )
+
+    # Savings rate
+    if current_income > 0:
+        savings_rate = round(((current_income - current_expenses) / current_income) * 100, 1)
+        if savings_rate > 30:
+            insights.append(f"Great savings rate: {savings_rate}% this week.")
+        elif savings_rate < 0:
+            insights.append(f"Negative savings rate ({savings_rate}%) — expenses outpacing income.")
+
+    if not insights:
+        insights.append("Quiet week financially. Keep tracking to build trends.")
+
+    return insights
+
+
+def generate_weekly_digest(
+    uid: int, week_start: date | None = None
+) -> dict:
+    """Generate a complete weekly financial digest for a user.
+
+    Args:
+        uid: User ID
+        week_start: Monday of the target week (defaults to current week)
+
+    Returns:
+        Dict with digest data including summary, categories, trends, insights
+    """
+    if week_start is None:
+        week_start, _ = _week_range()
+    else:
+        # Ensure given date is a Monday
+        week_start = week_start - timedelta(days=week_start.weekday())
+
+    week_end = week_start + timedelta(days=6)
+    prev_start, prev_end = _previous_week_range(week_start)
+
+    current_income, current_expenses = _week_totals(uid, week_start, week_end)
+    prev_income, prev_expenses = _week_totals(uid, prev_start, prev_end)
+    categories = _category_breakdown(uid, week_start, week_end)
+
+    # Week-over-week change
+    if prev_expenses > 0:
+        spending_wow_pct = round(
+            ((current_expenses - prev_expenses) / prev_expenses) * 100, 2
+        )
+    else:
+        spending_wow_pct = 0.0 if current_expenses == 0 else 100.0
+
+    insights = _generate_insights(
+        current_income, current_expenses, prev_income, prev_expenses, categories
+    )
+
+    return {
+        "period": {
+            "week_start": week_start.isoformat(),
+            "week_end": week_end.isoformat(),
+            "label": f"Week of {week_start.strftime('%b %d, %Y')}",
+        },
+        "summary": {
+            "income": round(current_income, 2),
+            "expenses": round(current_expenses, 2),
+            "net": round(current_income - current_expenses, 2),
+            "transaction_count": _transaction_count(uid, week_start, week_end),
+        },
+        "trends": {
+            "spending_wow_change_pct": spending_wow_pct,
+            "previous_week_expenses": round(prev_expenses, 2),
+            "previous_week_income": round(prev_income, 2),
+            "previous_week_net": round(prev_income - prev_expenses, 2),
+        },
+        "categories": categories,
+        "insights": insights,
+    }
+
+
+def _transaction_count(uid: int, start: date, end: date) -> int:
+    """Count transactions in a date range."""
+    count = (
+        db.session.query(func.count(Expense.id))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .scalar()
+    )
+    return int(count or 0)

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
 import pytest
+from unittest.mock import patch, MagicMock
+import fakeredis
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
 
 
@@ -23,26 +24,22 @@ def _setup_db(app):
 def app_fixture():
     # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
-    settings = TestSettings(
-        database_url="sqlite+pysqlite:///:memory:",
-        redis_url="redis://localhost:6379/15",
-        jwt_secret="test-secret-with-32-plus-chars-1234567890",
-    )
-    app = create_app(settings)
-    app.config.update(TESTING=True)
-    _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
-    yield app
-    with app.app_context():
-        db.session.remove()
-        db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis = fakeredis.FakeRedis(decode_responses=True)
+    with patch("app.extensions.redis_client", fake_redis), \
+         patch("app.routes.auth.redis_client", fake_redis), \
+         patch("app.services.cache.redis_client", fake_redis):
+        settings = TestSettings(
+            database_url="sqlite+pysqlite:///:memory:",
+            redis_url="redis://localhost:6379/15",
+            jwt_secret="test-secret-with-32-plus-chars-1234567890",
+        )
+        app = create_app(settings)
+        app.config.update(TESTING=True)
+        _setup_db(app)
+        yield app
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_weekly_digest.py
+++ b/packages/backend/tests/test_weekly_digest.py
@@ -1,0 +1,215 @@
+"""Tests for the weekly financial digest endpoint."""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+
+def _register_and_login(client, email="digest-test@example.com"):
+    """Helper: register + login, return auth header dict."""
+    client.post(
+        "/auth/register",
+        json={"email": email, "password": "pass1234"},
+    )
+    r = client.post("/auth/login", json={"email": email, "password": "pass1234"})
+    assert r.status_code == 200
+    token = r.get_json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _post_expense(client, headers, amount, spent_at, expense_type="EXPENSE",
+                   category_id=None, notes=None):
+    """Helper: create an expense."""
+    body = {
+        "amount": amount,
+        "date": spent_at.isoformat(),
+        "expense_type": expense_type,
+    }
+    if category_id:
+        body["category_id"] = category_id
+    if notes:
+        body["notes"] = notes
+    r = client.post("/expenses", json=body, headers=headers)
+    return r
+
+
+def test_weekly_digest_empty_week(client):
+    """Digest returns zeros when no data exists for the week."""
+    headers = _register_and_login(client, email="empty-week@example.com")
+    r = client.get("/insights/weekly-digest", headers=headers)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["summary"]["income"] == 0.0
+    assert payload["summary"]["expenses"] == 0.0
+    assert payload["summary"]["net"] == 0.0
+    assert payload["summary"]["transaction_count"] == 0
+    assert "insights" in payload
+    assert "categories" in payload
+    assert "period" in payload
+
+
+def test_weekly_digest_with_expenses(client):
+    """Digest correctly aggregates expenses for the current week."""
+    headers = _register_and_login(client, email="expenses-week@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+
+    # Add expenses on different days of the week
+    _post_expense(client, headers, 100, monday, notes="Monday expense")
+    _post_expense(client, headers, 50, monday + timedelta(days=2), notes="Wednesday expense")
+    _post_expense(client, headers, 25, monday + timedelta(days=4), notes="Friday expense")
+
+    r = client.get("/insights/weekly-digest", headers=headers)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["summary"]["expenses"] == 175.0
+    assert payload["summary"]["transaction_count"] == 3
+    assert payload["summary"]["net"] == -175.0
+
+
+def test_weekly_digest_with_income_and_expenses(client):
+    """Digest shows positive net when income > expenses."""
+    headers = _register_and_login(client, email="income-week@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+
+    _post_expense(client, headers, 500, monday, expense_type="INCOME", notes="Salary")
+    _post_expense(client, headers, 100, monday + timedelta(days=1), notes="Groceries")
+
+    r = client.get("/insights/weekly-digest", headers=headers)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["summary"]["income"] == 500.0
+    assert payload["summary"]["expenses"] == 100.0
+    assert payload["summary"]["net"] == 400.0
+
+
+def test_weekly_digest_week_over_week_trend(client):
+    """Digest shows correct week-over-week spending change."""
+    headers = _register_and_login(client, email="trend-week@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+
+    # Previous week expenses
+    prev_monday = monday - timedelta(days=7)
+    _post_expense(client, headers, 200, prev_monday, notes="Last week spend")
+
+    # Current week expenses (50% increase)
+    _post_expense(client, headers, 300, monday, notes="This week spend")
+
+    r = client.get("/insights/weekly-digest", headers=headers)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["summary"]["expenses"] == 300.0
+    assert payload["trends"]["previous_week_expenses"] == 200.0
+    assert payload["trends"]["spending_wow_change_pct"] == 50.0
+
+
+def test_weekly_digest_category_breakdown(client):
+    """Digest provides accurate category breakdown with percentages."""
+    headers = _register_and_login(client, email="cat-week@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+
+    # Create categories first via the categories endpoint
+    r = client.post(
+        "/categories",
+        json={"name": "Food"},
+        headers=headers,
+    )
+    assert r.status_code in (200, 201)
+    food_cat = r.get_json()
+    food_id = food_cat.get("id") or food_cat.get("category_id")
+
+    r = client.post(
+        "/categories",
+        json={"name": "Transport"},
+        headers=headers,
+    )
+    assert r.status_code in (200, 201)
+    transport_cat = r.get_json()
+    transport_id = transport_cat.get("id") or transport_cat.get("category_id")
+
+    _post_expense(client, headers, 80, monday, category_id=food_id, notes="Food spend")
+    _post_expense(client, headers, 20, monday, category_id=transport_id, notes="Transport spend")
+
+    r = client.get("/insights/weekly-digest", headers=headers)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    cats = payload["categories"]
+    assert len(cats) >= 2
+
+    # Top category should be Food (80)
+    food_entry = next((c for c in cats if c["category_name"] == "Food"), None)
+    assert food_entry is not None
+    assert food_entry["amount"] == 80.0
+    assert food_entry["share_pct"] == 80.0
+
+
+def test_weekly_digest_specific_week_start(client):
+    """Digest works with a specific week_start parameter."""
+    headers = _register_and_login(client, email="specific-week@example.com")
+
+    # Target a specific week (not current)
+    target_monday = date(2026, 3, 2)  # A Monday
+    _post_expense(client, headers, 42, target_monday, notes="Target week expense")
+
+    r = client.get(
+        f"/insights/weekly-digest?week_start={target_monday.isoformat()}",
+        headers=headers,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["summary"]["expenses"] == 42.0
+    assert payload["period"]["week_start"] == "2026-03-02"
+    assert payload["period"]["week_end"] == "2026-03-08"
+
+
+def test_weekly_digest_invalid_week_start(client):
+    """Digest returns 400 for invalid date format."""
+    headers = _register_and_login(client, email="invalid-date@example.com")
+    r = client.get(
+        "/insights/weekly-digest?week_start=not-a-date",
+        headers=headers,
+    )
+    assert r.status_code == 400
+    assert "error" in r.get_json()
+
+
+def test_weekly_digest_insights_generated(client):
+    """Digest generates at least one insight even with minimal data."""
+    headers = _register_and_login(client, email="insights-test@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+
+    _post_expense(client, headers, 50, monday, notes="Small expense")
+
+    r = client.get("/insights/weekly-digest", headers=headers)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert len(payload["insights"]) >= 1
+
+
+def test_weekly_digest_previous_week_zeros(client):
+    """When previous week has no data, trends still work correctly."""
+    headers = _register_and_login(client, email="prev-zeros@example.com")
+    today = date.today()
+    monday = today - timedelta(days=today.weekday())
+
+    # Only current week data
+    _post_expense(client, headers, 150, monday, notes="Current week only")
+
+    r = client.get("/insights/weekly-digest", headers=headers)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["trends"]["previous_week_expenses"] == 0.0
+    assert payload["trends"]["spending_wow_change_pct"] == 100.0
+
+
+def test_weekly_digest_requires_auth(client):
+    """Digest returns 401 without authentication."""
+    r = client.get("/insights/weekly-digest")
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary

Implements the **Smart digest with weekly financial summary** feature (FinMind Issue #121).

## What's New

### New Endpoint: `GET /insights/weekly-digest`
Generates a comprehensive weekly financial summary including:

- **Period**: Week date range and human-readable label
- **Summary**: Income, expenses, net flow, transaction count  
- **Trends**: Week-over-week spending change percentage, previous week comparison
- **Categories**: Spending breakdown by category with share percentages
- **Insights**: Auto-generated actionable financial insights (e.g., spending spikes, savings rate, category concentration)

### Query Parameters
- `week_start` (optional): ISO date (YYYY-MM-DD) for the target week. Defaults to the current week.

## Files Changed
- `packages/backend/app/services/weekly_digest.py` — Core digest service with aggregation and insight generation
- `packages/backend/app/routes/insights.py` — New `/weekly-digest` route
- `packages/backend/app/openapi.yaml` — Full OpenAPI documentation for the endpoint
- `packages/backend/tests/test_weekly_digest.py` — 10 comprehensive tests
- `packages/backend/tests/conftest.py` — Use fakeredis for Redis-free CI testing

## Test Results
All **32 tests pass** (22 existing + 10 new):
- ✅ Empty week (zeros)
- ✅ Expenses aggregation
- ✅ Income + expenses (positive net)
- ✅ Week-over-week trends
- ✅ Category breakdown with percentages
- ✅ Specific week_start parameter
- ✅ Invalid date format → 400
- ✅ Insights generation
- ✅ Previous week zero handling
- ✅ Auth required (401)

```
======================= 32 passed, 49 warnings in 7.05s =======================
```

## Acceptance Criteria Met
- ✅ Production-ready implementation
- ✅ Tests included (10 tests)
- ✅ Documentation updated (OpenAPI spec)

---
*PR by noxxxxybot-sketch*