### PR TITLE
feat: Lifestyle inflation detection insights (closes #118)

### DIFF
--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,7 +1,7 @@
 from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from ..services.ai import monthly_budget_suggestion
+from ..services.ai import monthly_budget_suggestion, detect_lifestyle_inflation
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +23,14 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/lifestyle-inflation")
+@jwt_required()
+def lifestyle_inflation():
+    uid = int(get_jwt_identity())
+    months = request.args.get("months", 6, type=int)
+    months = max(2, min(months, 24))
+    result = detect_lifestyle_inflation(uid, months=months)
+    logger.info("Lifestyle inflation served user=%s months=%d", uid, months)
+    return jsonify(result)

--- a/packages/backend/app/services/ai.py
+++ b/packages/backend/app/services/ai.py
@@ -166,6 +166,108 @@ def _gemini_budget_suggestion(
     return parsed
 
 
+def detect_lifestyle_inflation(
+    uid: int,
+    months: int = 6,
+) -> dict:
+    """Detect categories where spending is trending upward over recent months.
+
+    Returns a list of categories with rising spend, month-by-month totals,
+    and an overall lifestyle inflation score.
+    """
+    from datetime import date
+
+    today = date.today().replace(day=1)
+    month_labels: list[str] = []
+    for i in range(months - 1, -1, -1):
+        year = today.year
+        month = today.month - i
+        while month <= 0:
+            month += 12
+            year -= 1
+        month_labels.append(f"{year:04d}-{month:02d}")
+
+    # Build per-category monthly spend
+    category_trends: dict[str, list[float]] = {}
+    for ym in month_labels:
+        year, month = map(int, ym.split("-"))
+        rows = (
+            db.session.query(
+                Expense.category_id,
+                func.coalesce(func.sum(Expense.amount), 0),
+            )
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type != "INCOME",
+            )
+            .group_by(Expense.category_id)
+            .all()
+        )
+        for cat_id, total in rows:
+            key = str(cat_id or "uncat")
+            category_trends.setdefault(key, []).append(float(total or 0))
+
+    # Fill missing months with 0
+    for key in category_trends:
+        while len(category_trends[key]) < months:
+            category_trends[key].insert(0, 0.0)
+
+    # Detect rising categories
+    rising: list[dict] = []
+    for cat_id, spends in category_trends.items():
+        first_half = sum(spends[: months // 2])
+        second_half = sum(spends[months // 2 :])
+        if first_half > 0:
+            change_pct = round(((second_half - first_half) / first_half) * 100, 2)
+        elif second_half > 0:
+            change_pct = 100.0
+        else:
+            change_pct = 0.0
+        if change_pct > 10:  # >10% increase = lifestyle creep
+            rising.append(
+                {
+                    "category_id": cat_id,
+                    "change_pct": change_pct,
+                    "first_half_total": round(first_half, 2),
+                    "second_half_total": round(second_half, 2),
+                    "monthly": [round(s, 2) for s in spends],
+                }
+            )
+
+    rising.sort(key=lambda x: x["change_pct"], reverse=True)
+
+    # Overall inflation score: average change across all categories with spend
+    all_cats = [
+        c
+        for c in category_trends.values()
+        if sum(c) > 0
+    ]
+    if all_cats:
+        overall_changes = []
+        for spends in all_cats:
+            fh = sum(spends[: months // 2])
+            sh = sum(spends[months // 2 :])
+            if fh > 0:
+                overall_changes.append(((sh - fh) / fh) * 100)
+        inflation_score = (
+            round(sum(overall_changes) / len(overall_changes), 2)
+            if overall_changes
+            else 0.0
+        )
+    else:
+        inflation_score = 0.0
+
+    return {
+        "period_months": months,
+        "month_labels": month_labels,
+        "inflation_score": inflation_score,
+        "rising_categories": rising,
+        "total_rising": len(rising),
+    }
+
+
 def monthly_budget_suggestion(
     uid: int,
     ym: str,

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -90,3 +90,62 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_lifestyle_inflation_returns_expected_fields(client, auth_header):
+    r = client.get("/insights/lifestyle-inflation", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert "period_months" in payload
+    assert "month_labels" in payload
+    assert "inflation_score" in payload
+    assert "rising_categories" in payload
+    assert "total_rising" in payload
+    assert isinstance(payload["month_labels"], list)
+
+
+def test_lifestyle_inflation_detects_rising_spend(client, auth_header):
+    today = date.today().replace(day=15)
+    # Low spend 3 months ago
+    old = today - timedelta(days=90)
+    # High spend this month
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 100,
+            "description": "Old dining",
+            "date": old.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 500,
+            "description": "New dining",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/insights/lifestyle-inflation?months=6", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["inflation_score"] > 0
+
+
+def test_lifestyle_inflation_months_clamped(client, auth_header):
+    r = client.get("/insights/lifestyle-inflation?months=999", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period_months"] <= 24
+
+    r = client.get("/insights/lifestyle-inflation?months=0", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period_months"] >= 2


### PR DESCRIPTION
## Summary
Adds a new `/insights/lifestyle-inflation` endpoint that detects categories where user spending is trending upward over time.

## Changes
- **app/services/ai.py**: Added `detect_lifestyle_inflation()` function that:
  - Aggregates per-category spending across N months (default 6, clamped to 2-24)
  - Compares first-half vs second-half spend to detect rising categories (>10% increase = lifestyle creep)
  - Calculates an overall inflation score (average change across all categories)
  - Returns month-by-month breakdowns for each rising category

- **app/routes/insights.py**: Added GET /insights/lifestyle-inflation?months=6 endpoint (JWT-protected)

- **tests/test_insights.py**: Added 3 tests:
  - test_lifestyle_inflation_returns_expected_fields
  - test_lifestyle_inflation_detects_rising_spend
  - test_lifestyle_inflation_months_clamped

## Closes #118
