### PR TITLE
feat(devices): device trust management & recognition

### DIFF
--- a/packages/backend/app/db/031_device_trust.sql
+++ b/packages/backend/app/db/031_device_trust.sql
@@ -1,0 +1,26 @@
+-- Migration: Device trust management
+-- Adds trusted_devices table for device recognition and management
+
+CREATE TABLE IF NOT EXISTS trusted_devices (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    device_id       VARCHAR(64)  NOT NULL,           -- unique device fingerprint
+    device_name     VARCHAR(128),                     -- user-friendly name
+    device_type     VARCHAR(20)  DEFAULT 'unknown',  -- mobile, desktop, tablet, unknown
+    browser         VARCHAR(64),                      -- browser name
+    os              VARCHAR(64),                      -- operating system
+    ip_address      VARCHAR(45),                      -- last known IP (IPv4/IPv6)
+    location        VARCHAR(128),                     -- approximate location
+    trust_level     VARCHAR(20)  DEFAULT 'standard',  -- full, standard, limited
+    is_current      BOOLEAN      DEFAULT FALSE,
+    last_active_at  TIMESTAMP,
+    trusted_at      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    expires_at      TIMESTAMP,
+    revoked         BOOLEAN      DEFAULT FALSE,
+    revoked_at      TIMESTAMP,
+    created_at      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_trusted_devices_user   ON trusted_devices(user_id);
+CREATE INDEX idx_trusted_devices_device ON trusted_devices(user_id, device_id);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,25 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class TrustedDevice(db.Model):
+    __tablename__ = "trusted_devices"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    device_id = db.Column(db.String(64), nullable=False)
+    device_name = db.Column(db.String(128))
+    device_type = db.Column(db.String(20), default="unknown")
+    browser = db.Column(db.String(64))
+    os = db.Column(db.String(64))
+    ip_address = db.Column(db.String(45))
+    location = db.Column(db.String(128))
+    trust_level = db.Column(db.String(20), default="standard")
+    is_current = db.Column(db.Boolean, default=False)
+    last_active_at = db.Column(db.DateTime)
+    trusted_at = db.Column(db.DateTime, default=datetime.utcnow)
+    expires_at = db.Column(db.DateTime)
+    revoked = db.Column(db.Boolean, default=False)
+    revoked_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .device_trust import bp as device_trust_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(device_trust_bp, url_prefix="/devices")

--- a/packages/backend/app/routes/device_trust.py
+++ b/packages/backend/app/routes/device_trust.py
@@ -1,0 +1,143 @@
+"""Routes for device trust management."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.services.device_trust import (
+    register_device,
+    recognize_device,
+    get_user_devices,
+    update_device,
+    revoke_device,
+    revoke_all_devices,
+    delete_device,
+    get_device_stats,
+)
+
+bp = Blueprint("device_trust", __name__)
+
+
+@bp.route("/register", methods=["POST"])
+@jwt_required()
+def register_device_endpoint():
+    """Register or update a trusted device.
+
+    JSON body:
+    - device_name: optional friendly name
+    - trust_level: full | standard | limited (default: standard)
+    - expires_days: days until expiry (default: 90, 0 = no expiry)
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+    user_agent = request.headers.get("User-Agent", "")
+    ip_address = request.remote_addr or ""
+
+    result = register_device(
+        user_id=user_id,
+        user_agent=user_agent,
+        ip_address=ip_address,
+        device_name=data.get("device_name"),
+        trust_level=data.get("trust_level", "standard"),
+        expires_days=data.get("expires_days", 90),
+    )
+
+    return jsonify(result), 201
+
+
+@bp.route("/recognize", methods=["POST"])
+@jwt_required()
+def recognize_device_endpoint():
+    """Check if the current device is recognized/trusted."""
+    user_id = int(get_jwt_identity())
+    user_agent = request.headers.get("User-Agent", "")
+    ip_address = request.remote_addr or ""
+
+    result = recognize_device(user_id, user_agent, ip_address)
+    status = 200 if result["recognized"] else 404
+
+    return jsonify(result), status
+
+
+@bp.route("/devices", methods=["GET"])
+@jwt_required()
+def list_devices():
+    """List all trusted devices for the current user."""
+    user_id = int(get_jwt_identity())
+    include_revoked = request.args.get("include_revoked", "false").lower() == "true"
+
+    devices = get_user_devices(user_id, include_revoked=include_revoked)
+    return jsonify({"devices": devices, "count": len(devices)}), 200
+
+
+@bp.route("/devices/<int:device_id>", methods=["PATCH"])
+@jwt_required()
+def update_device_endpoint(device_id):
+    """Update a device's name or trust level.
+
+    JSON body:
+    - device_name: new friendly name
+    - trust_level: full | standard | limited
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    result = update_device(
+        user_id=user_id,
+        device_db_id=device_id,
+        device_name=data.get("device_name"),
+        trust_level=data.get("trust_level"),
+    )
+
+    if result is None:
+        return jsonify({"error": "Device not found or invalid trust level"}), 404
+
+    return jsonify(result), 200
+
+
+@bp.route("/devices/<int:device_id>/revoke", methods=["POST"])
+@jwt_required()
+def revoke_device_endpoint(device_id):
+    """Revoke trust for a specific device."""
+    user_id = int(get_jwt_identity())
+
+    if revoke_device(user_id, device_id):
+        return jsonify({"message": "Device trust revoked"}), 200
+
+    return jsonify({"error": "Device not found"}), 404
+
+
+@bp.route("/devices/revoke-all", methods=["POST"])
+@jwt_required()
+def revoke_all_endpoint():
+    """Revoke all devices except the current one.
+
+    JSON body:
+    - except_current: boolean (default true)
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+    except_current = data.get("except_current", True)
+
+    count = revoke_all_devices(user_id, except_current=except_current)
+    return jsonify({"message": f"{count} devices revoked", "count": count}), 200
+
+
+@bp.route("/devices/<int:device_id>", methods=["DELETE"])
+@jwt_required()
+def delete_device_endpoint(device_id):
+    """Permanently delete a device record."""
+    user_id = int(get_jwt_identity())
+
+    if delete_device(user_id, device_id):
+        return jsonify({"message": "Device deleted"}), 200
+
+    return jsonify({"error": "Device not found"}), 404
+
+
+@bp.route("/stats", methods=["GET"])
+@jwt_required()
+def device_stats():
+    """Get device trust statistics."""
+    user_id = int(get_jwt_identity())
+    stats = get_device_stats(user_id)
+    return jsonify(stats), 200

--- a/packages/backend/app/services/device_trust.py
+++ b/packages/backend/app/services/device_trust.py
@@ -1,0 +1,374 @@
+"""Device trust management and recognition service.
+
+Provides:
+- Device fingerprinting and registration
+- Trust level management (full, standard, limited)
+- Device activity tracking
+- Trust revocation and expiration
+- Device recognition for login flows
+"""
+
+import hashlib
+import re
+from datetime import datetime, timedelta
+from typing import Optional
+
+from app.extensions import db
+from app.models import TrustedDevice
+
+
+# ─── Device Fingerprinting ──────────────────────────────────────────
+
+
+def generate_device_id(user_agent: str, ip_address: str = "",
+                       extra: str = "") -> str:
+    """Generate a deterministic device fingerprint.
+
+    Combines user-agent, IP prefix, and optional extra data.
+    """
+    # Use first 3 octets of IP for stability (ignore last octet changes)
+    ip_prefix = ".".join(ip_address.split(".")[:3]) if ip_address else ""
+    raw = f"{user_agent}|{ip_prefix}|{extra}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:32]
+
+
+def parse_user_agent(user_agent: str) -> dict:
+    """Extract device info from User-Agent string.
+
+    Returns dict with device_type, browser, os.
+    """
+    ua = user_agent.lower() if user_agent else ""
+
+    # Detect device type
+    if any(k in ua for k in ("mobile", "android", "iphone", "ipad")):
+        if "ipad" in ua or "tablet" in ua:
+            device_type = "tablet"
+        else:
+            device_type = "mobile"
+    else:
+        device_type = "desktop"
+
+    # Detect browser
+    browser = "Unknown"
+    if "firefox" in ua:
+        browser = "Firefox"
+    elif "edg" in ua:
+        browser = "Edge"
+    elif "chrome" in ua:
+        browser = "Chrome"
+    elif "safari" in ua:
+        browser = "Safari"
+    elif "opera" in ua or "opr" in ua:
+        browser = "Opera"
+
+    # Detect OS (check mobile-specific first to avoid false matches)
+    os_name = "Unknown"
+    if "iphone" in ua or "ipad" in ua:
+        os_name = "iOS"
+    elif "android" in ua:
+        os_name = "Android"
+    elif "windows" in ua:
+        os_name = "Windows"
+    elif "mac os" in ua or "macintosh" in ua:
+        os_name = "macOS"
+    elif "linux" in ua:
+        os_name = "Linux"
+
+    return {"device_type": device_type, "browser": browser, "os": os_name}
+
+
+# ─── Device Registration ────────────────────────────────────────────
+
+
+def register_device(user_id: int, user_agent: str,
+                    ip_address: str = "",
+                    device_name: str | None = None,
+                    trust_level: str = "standard",
+                    expires_days: int = 90) -> dict:
+    """Register or update a trusted device.
+
+    Args:
+        user_id: User ID
+        user_agent: HTTP User-Agent header
+        ip_address: Client IP address
+        device_name: Optional friendly name
+        trust_level: full, standard, or limited
+        expires_days: Days until trust expires (0 = no expiry)
+
+    Returns:
+        Dict with device info
+    """
+    device_id = generate_device_id(user_agent, ip_address)
+    ua_info = parse_user_agent(user_agent)
+
+    # Check if device already exists
+    existing = TrustedDevice.query.filter_by(
+        user_id=user_id, device_id=device_id
+    ).first()
+
+    if existing:
+        # Update existing device
+        existing.last_active_at = datetime.utcnow()
+        existing.ip_address = ip_address
+        existing.is_current = True
+        existing.revoked = False
+        existing.revoked_at = None
+        if device_name:
+            existing.device_name = device_name
+        if trust_level:
+            existing.trust_level = trust_level
+        db.session.commit()
+        return _device_to_dict(existing)
+
+    # Reset is_current on other devices
+    TrustedDevice.query.filter_by(user_id=user_id, is_current=True).update(
+        {"is_current": False}
+    )
+
+    # Create new device
+    expires_at = (datetime.utcnow() + timedelta(days=expires_days)
+                  if expires_days > 0 else None)
+
+    device = TrustedDevice(
+        user_id=user_id,
+        device_id=device_id,
+        device_name=device_name or f"{ua_info['browser']} on {ua_info['os']}",
+        device_type=ua_info["device_type"],
+        browser=ua_info["browser"],
+        os=ua_info["os"],
+        ip_address=ip_address,
+        trust_level=trust_level,
+        is_current=True,
+        last_active_at=datetime.utcnow(),
+        expires_at=expires_at,
+    )
+    db.session.add(device)
+    db.session.commit()
+
+    return _device_to_dict(device)
+
+
+def recognize_device(user_id: int, user_agent: str,
+                     ip_address: str = "") -> dict:
+    """Check if a device is recognized/trusted.
+
+    Args:
+        user_id: User ID
+        user_agent: HTTP User-Agent header
+        ip_address: Client IP address
+
+    Returns:
+        Dict with recognition status and device info if found
+    """
+    device_id = generate_device_id(user_agent, ip_address)
+
+    device = TrustedDevice.query.filter_by(
+        user_id=user_id, device_id=device_id
+    ).first()
+
+    if not device:
+        return {"recognized": False, "device": None, "reason": "unknown_device"}
+
+    if device.revoked:
+        return {"recognized": False, "device": _device_to_dict(device),
+                "reason": "device_revoked"}
+
+    if device.expires_at and device.expires_at < datetime.utcnow():
+        return {"recognized": False, "device": _device_to_dict(device),
+                "reason": "trust_expired"}
+
+    # Update activity
+    device.last_active_at = datetime.utcnow()
+    device.ip_address = ip_address
+    db.session.commit()
+
+    return {
+        "recognized": True,
+        "device": _device_to_dict(device),
+        "trust_level": device.trust_level,
+    }
+
+
+# ─── Device Management ──────────────────────────────────────────────
+
+
+def get_user_devices(user_id: int, include_revoked: bool = False) -> list[dict]:
+    """Get all trusted devices for a user.
+
+    Args:
+        user_id: User ID
+        include_revoked: Whether to include revoked devices
+
+    Returns:
+        List of device dicts
+    """
+    query = TrustedDevice.query.filter_by(user_id=user_id)
+    if not include_revoked:
+        query = query.filter_by(revoked=False)
+
+    devices = query.order_by(TrustedDevice.last_active_at.desc()).all()
+    return [_device_to_dict(d) for d in devices]
+
+
+def update_device(user_id: int, device_db_id: int,
+                  device_name: str | None = None,
+                  trust_level: str | None = None) -> dict | None:
+    """Update device properties.
+
+    Args:
+        user_id: User ID (authorization)
+        device_db_id: Database ID of the device
+        device_name: New friendly name
+        trust_level: New trust level
+
+    Returns:
+        Updated device dict or None if not found
+    """
+    device = TrustedDevice.query.filter_by(
+        id=device_db_id, user_id=user_id
+    ).first()
+
+    if not device:
+        return None
+
+    if device_name is not None:
+        device.device_name = device_name
+    if trust_level is not None:
+        if trust_level not in ("full", "standard", "limited"):
+            return None
+        device.trust_level = trust_level
+
+    device.updated_at = datetime.utcnow()
+    db.session.commit()
+
+    return _device_to_dict(device)
+
+
+def revoke_device(user_id: int, device_db_id: int) -> bool:
+    """Revoke trust for a device.
+
+    Args:
+        user_id: User ID (authorization)
+        device_db_id: Database ID of the device
+
+    Returns:
+        True if revoked, False if not found
+    """
+    device = TrustedDevice.query.filter_by(
+        id=device_db_id, user_id=user_id
+    ).first()
+
+    if not device:
+        return False
+
+    device.revoked = True
+    device.revoked_at = datetime.utcnow()
+    device.is_current = False
+    db.session.commit()
+
+    return True
+
+
+def revoke_all_devices(user_id: int, except_current: bool = True) -> int:
+    """Revoke all trusted devices for a user.
+
+    Args:
+        user_id: User ID
+        except_current: Keep the current device trusted
+
+    Returns:
+        Number of devices revoked
+    """
+    query = TrustedDevice.query.filter_by(user_id=user_id, revoked=False)
+    if except_current:
+        query = query.filter_by(is_current=False)
+
+    devices = query.all()
+    count = 0
+    for d in devices:
+        d.revoked = True
+        d.revoked_at = datetime.utcnow()
+        d.is_current = False
+        count += 1
+
+    db.session.commit()
+    return count
+
+
+def delete_device(user_id: int, device_db_id: int) -> bool:
+    """Permanently delete a device record.
+
+    Args:
+        user_id: User ID (authorization)
+        device_db_id: Database ID
+
+    Returns:
+        True if deleted, False if not found
+    """
+    device = TrustedDevice.query.filter_by(
+        id=device_db_id, user_id=user_id
+    ).first()
+
+    if not device:
+        return False
+
+    db.session.delete(device)
+    db.session.commit()
+    return True
+
+
+def get_device_stats(user_id: int) -> dict:
+    """Get device trust statistics for a user.
+
+    Returns:
+        Dict with counts and breakdown
+    """
+    all_devices = TrustedDevice.query.filter_by(user_id=user_id).all()
+
+    total = len(all_devices)
+    active = sum(1 for d in all_devices if not d.revoked)
+    revoked = sum(1 for d in all_devices if d.revoked)
+    expired = sum(
+        1 for d in all_devices
+        if d.expires_at and d.expires_at < datetime.utcnow() and not d.revoked
+    )
+
+    by_type = {}
+    by_trust = {}
+    for d in all_devices:
+        if not d.revoked:
+            by_type[d.device_type] = by_type.get(d.device_type, 0) + 1
+            by_trust[d.trust_level] = by_trust.get(d.trust_level, 0) + 1
+
+    return {
+        "total": total,
+        "active": active,
+        "revoked": revoked,
+        "expired": expired,
+        "by_type": by_type,
+        "by_trust_level": by_trust,
+    }
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────
+
+
+def _device_to_dict(device: TrustedDevice) -> dict:
+    """Convert TrustedDevice model to dict."""
+    return {
+        "id": device.id,
+        "device_id": device.device_id,
+        "device_name": device.device_name,
+        "device_type": device.device_type,
+        "browser": device.browser,
+        "os": device.os,
+        "ip_address": device.ip_address,
+        "location": device.location,
+        "trust_level": device.trust_level,
+        "is_current": device.is_current,
+        "last_active_at": device.last_active_at.isoformat() if device.last_active_at else None,
+        "trusted_at": device.trusted_at.isoformat() if device.trusted_at else None,
+        "expires_at": device.expires_at.isoformat() if device.expires_at else None,
+        "revoked": device.revoked,
+        "revoked_at": device.revoked_at.isoformat() if device.revoked_at else None,
+    }

--- a/packages/backend/commit-msg.txt
+++ b/packages/backend/commit-msg.txt
@@ -1,0 +1,12 @@
+feat(devices): add device trust management & recognition
+
+Implements issue #125 — trusted device management system.
+
+Changes:
+- Add trusted_devices migration (031_device_trust.sql)
+- Add TrustedDevice model
+- Add device trust service with fingerprinting, UA parsing,
+  registration, recognition, trust levels, revocation
+- Add 8 REST endpoints under /devices/*
+- Add 51 passing tests
+- Add documentation

--- a/packages/backend/docs/device-trust.md
+++ b/packages/backend/docs/device-trust.md
@@ -1,0 +1,102 @@
+# Device Trust Management & Recognition
+
+## Overview
+
+Device trust system for managing trusted devices, fingerprinting devices
+via User-Agent analysis, and controlling access levels per device.
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Device fingerprinting** | SHA-256 based fingerprint from UA + IP prefix |
+| **User-Agent parsing** | Detect device type, browser, OS from UA string |
+| **Trust levels** | Full, standard, limited — per-device access control |
+| **Device recognition** | Check if current device is trusted on login |
+| **Trust revocation** | Revoke individual or all devices |
+| **Expiration** | Configurable trust expiry (default 90 days) |
+| **Statistics** | Device counts by type, trust level, status |
+
+## API Endpoints
+
+All endpoints require JWT authentication. Base path: `/devices`
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/devices/register` | Register or update trusted device |
+| POST | `/devices/recognize` | Check if device is recognized |
+| GET | `/devices/devices` | List all trusted devices |
+| PATCH | `/devices/devices/:id` | Update device name or trust level |
+| POST | `/devices/devices/:id/revoke` | Revoke trust for a device |
+| POST | `/devices/devices/revoke-all` | Revoke all devices |
+| DELETE | `/devices/devices/:id` | Delete device record |
+| GET | `/devices/stats` | Get device trust statistics |
+
+### POST /devices/register
+
+```json
+{
+  "device_name": "My MacBook",
+  "trust_level": "standard",
+  "expires_days": 90
+}
+```
+
+### PATCH /devices/devices/:id
+
+```json
+{
+  "device_name": "Office PC",
+  "trust_level": "full"
+}
+```
+
+## Device Fingerprinting
+
+The device ID is generated from:
+- User-Agent string
+- First 3 octets of IP address (for stability)
+- Optional extra data
+
+This means:
+- Same device on same network segment = same fingerprint
+- Different browsers = different fingerprints
+- Minor IP changes (last octet) don't affect recognition
+
+## Trust Levels
+
+| Level | Description |
+|-------|-------------|
+| **full** | Full access, no additional verification needed |
+| **standard** | Normal access (default) |
+| **limited** | Restricted access, may require additional verification |
+
+## Database
+
+### trusted_devices table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER | Primary key |
+| user_id | INTEGER | FK → users.id |
+| device_id | VARCHAR(64) | Device fingerprint hash |
+| device_name | VARCHAR(128) | User-friendly name |
+| device_type | VARCHAR(20) | mobile, desktop, tablet |
+| browser | VARCHAR(64) | Detected browser |
+| os | VARCHAR(64) | Detected OS |
+| ip_address | VARCHAR(45) | Last known IP |
+| trust_level | VARCHAR(20) | full, standard, limited |
+| is_current | BOOLEAN | Currently active device |
+| expires_at | TIMESTAMP | Trust expiration |
+| revoked | BOOLEAN | Trust revoked flag |
+
+## Testing
+
+51 tests covering:
+- Device fingerprint generation and determinism
+- User-Agent parsing (Chrome, Firefox, Safari, Android, empty)
+- Device registration (new, update, name, trust level)
+- Device recognition (known, unknown, revoked, expired)
+- Device management (list, update, revoke, delete)
+- Statistics aggregation
+- All route endpoints with auth checks

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,21 @@
 import os
 import pytest
+import fakeredis
 from app import create_app
 from app.config import Settings
 from app.extensions import db
 from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+@pytest.fixture(autouse=True)
+def _patch_redis(monkeypatch):
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr("app.extensions.redis_client", fake)
+    monkeypatch.setattr("app.routes.auth.redis_client", fake)
+    monkeypatch.setattr("app.services.cache.redis_client", fake)
+    yield
+    fake.flushall()
 
 
 class TestSettings(Settings):

--- a/packages/backend/tests/test_device_trust.py
+++ b/packages/backend/tests/test_device_trust.py
@@ -1,0 +1,502 @@
+"""Tests for device trust management and recognition."""
+
+import pytest
+from datetime import datetime, timedelta
+from app.extensions import db
+from app.models import TrustedDevice
+
+
+CHROME_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+FIREFOX_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0"
+SAFARI_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+ANDROID_UA = "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Service unit tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDeviceFingerprint:
+    """Test generate_device_id and parse_user_agent."""
+
+    def test_generate_device_id_deterministic(self, app_fixture):
+        from app.services.device_trust import generate_device_id
+
+        id1 = generate_device_id(CHROME_UA, "192.168.1.100")
+        id2 = generate_device_id(CHROME_UA, "192.168.1.100")
+        assert id1 == id2
+
+    def test_different_agents_different_ids(self, app_fixture):
+        from app.services.device_trust import generate_device_id
+
+        id1 = generate_device_id(CHROME_UA, "192.168.1.100")
+        id2 = generate_device_id(FIREFOX_UA, "192.168.1.100")
+        assert id1 != id2
+
+    def test_same_ip_prefix_same_id(self, app_fixture):
+        from app.services.device_trust import generate_device_id
+
+        # Last octet changes don't affect fingerprint
+        id1 = generate_device_id(CHROME_UA, "192.168.1.100")
+        id2 = generate_device_id(CHROME_UA, "192.168.1.200")
+        assert id1 == id2
+
+    def test_device_id_length(self, app_fixture):
+        from app.services.device_trust import generate_device_id
+
+        did = generate_device_id(CHROME_UA, "10.0.0.1")
+        assert len(did) == 32
+
+    def test_parse_chrome_desktop(self, app_fixture):
+        from app.services.device_trust import parse_user_agent
+
+        info = parse_user_agent(CHROME_UA)
+        assert info["device_type"] == "desktop"
+        assert info["browser"] == "Chrome"
+        assert info["os"] == "macOS"
+
+    def test_parse_firefox_windows(self, app_fixture):
+        from app.services.device_trust import parse_user_agent
+
+        info = parse_user_agent(FIREFOX_UA)
+        assert info["device_type"] == "desktop"
+        assert info["browser"] == "Firefox"
+        assert info["os"] == "Windows"
+
+    def test_parse_safari_iphone(self, app_fixture):
+        from app.services.device_trust import parse_user_agent
+
+        info = parse_user_agent(SAFARI_UA)
+        assert info["device_type"] == "mobile"
+        assert info["browser"] == "Safari"
+        assert info["os"] == "iOS"
+
+    def test_parse_android(self, app_fixture):
+        from app.services.device_trust import parse_user_agent
+
+        info = parse_user_agent(ANDROID_UA)
+        assert info["device_type"] == "mobile"
+        assert info["browser"] == "Chrome"
+        assert info["os"] == "Android"
+
+    def test_parse_empty_ua(self, app_fixture):
+        from app.services.device_trust import parse_user_agent
+
+        info = parse_user_agent("")
+        assert info["device_type"] == "desktop"
+        assert info["browser"] == "Unknown"
+        assert info["os"] == "Unknown"
+
+
+class TestRegisterDevice:
+    """Test register_device service function."""
+
+    def test_register_new_device(self, client, auth_header):
+        from app.services.device_trust import register_device
+
+        with client.application.app_context():
+            result = register_device(1, CHROME_UA, "192.168.1.100")
+
+        assert result["device_type"] == "desktop"
+        assert result["browser"] == "Chrome"
+        assert result["os"] == "macOS"
+        assert result["is_current"] is True
+        assert result["trust_level"] == "standard"
+
+    def test_register_with_custom_name(self, client, auth_header):
+        from app.services.device_trust import register_device
+
+        with client.application.app_context():
+            result = register_device(1, CHROME_UA, "10.0.0.1",
+                                     device_name="My MacBook")
+
+        assert result["device_name"] == "My MacBook"
+
+    def test_register_same_device_updates(self, client, auth_header):
+        from app.services.device_trust import register_device
+
+        with client.application.app_context():
+            r1 = register_device(1, CHROME_UA, "192.168.1.100")
+            r2 = register_device(1, CHROME_UA, "192.168.1.100",
+                                 device_name="Updated Name")
+
+        assert r1["id"] == r2["id"]  # Same record
+        assert r2["device_name"] == "Updated Name"
+
+    def test_register_resets_current_flag(self, client, auth_header):
+        from app.services.device_trust import register_device, get_user_devices
+
+        with client.application.app_context():
+            register_device(1, CHROME_UA, "10.0.0.1")
+            register_device(1, FIREFOX_UA, "10.0.0.2")
+
+            devices = get_user_devices(1)
+            current = [d for d in devices if d["is_current"]]
+            assert len(current) == 1
+            assert current[0]["browser"] == "Firefox"
+
+    def test_register_with_full_trust(self, client, auth_header):
+        from app.services.device_trust import register_device
+
+        with client.application.app_context():
+            result = register_device(1, CHROME_UA, "10.0.0.1",
+                                     trust_level="full")
+
+        assert result["trust_level"] == "full"
+
+    def test_register_no_expiry(self, client, auth_header):
+        from app.services.device_trust import register_device
+
+        with client.application.app_context():
+            result = register_device(1, CHROME_UA, "10.0.0.1",
+                                     expires_days=0)
+
+        assert result["expires_at"] is None
+
+
+class TestRecognizeDevice:
+    """Test recognize_device service function."""
+
+    def test_recognize_known_device(self, client, auth_header):
+        from app.services.device_trust import register_device, recognize_device
+
+        with client.application.app_context():
+            register_device(1, CHROME_UA, "192.168.1.100")
+            result = recognize_device(1, CHROME_UA, "192.168.1.100")
+
+        assert result["recognized"] is True
+        assert result["trust_level"] == "standard"
+
+    def test_unrecognized_device(self, client, auth_header):
+        from app.services.device_trust import recognize_device
+
+        with client.application.app_context():
+            result = recognize_device(1, CHROME_UA, "10.0.0.1")
+
+        assert result["recognized"] is False
+        assert result["reason"] == "unknown_device"
+
+    def test_revoked_device_not_recognized(self, client, auth_header):
+        from app.services.device_trust import register_device, revoke_device, recognize_device
+
+        with client.application.app_context():
+            reg = register_device(1, CHROME_UA, "10.0.0.1")
+            revoke_device(1, reg["id"])
+            result = recognize_device(1, CHROME_UA, "10.0.0.1")
+
+        assert result["recognized"] is False
+        assert result["reason"] == "device_revoked"
+
+    def test_expired_device_not_recognized(self, client, auth_header):
+        from app.services.device_trust import register_device, recognize_device
+
+        with client.application.app_context():
+            reg = register_device(1, CHROME_UA, "10.0.0.1", expires_days=1)
+            # Manually expire
+            device = TrustedDevice.query.get(reg["id"])
+            device.expires_at = datetime.utcnow() - timedelta(days=1)
+            db.session.commit()
+
+            result = recognize_device(1, CHROME_UA, "10.0.0.1")
+
+        assert result["recognized"] is False
+        assert result["reason"] == "trust_expired"
+
+
+class TestDeviceManagement:
+    """Test device listing, update, revoke, delete."""
+
+    def test_list_devices(self, client, auth_header):
+        from app.services.device_trust import register_device, get_user_devices
+
+        with client.application.app_context():
+            register_device(1, CHROME_UA, "10.0.0.1")
+            register_device(1, FIREFOX_UA, "10.0.0.2")
+            devices = get_user_devices(1)
+
+        assert len(devices) == 2
+
+    def test_list_excludes_revoked(self, client, auth_header):
+        from app.services.device_trust import register_device, revoke_device, get_user_devices
+
+        with client.application.app_context():
+            r1 = register_device(1, CHROME_UA, "10.0.0.1")
+            register_device(1, FIREFOX_UA, "10.0.0.2")
+            revoke_device(1, r1["id"])
+            devices = get_user_devices(1, include_revoked=False)
+
+        assert len(devices) == 1
+
+    def test_list_includes_revoked(self, client, auth_header):
+        from app.services.device_trust import register_device, revoke_device, get_user_devices
+
+        with client.application.app_context():
+            r1 = register_device(1, CHROME_UA, "10.0.0.1")
+            register_device(1, FIREFOX_UA, "10.0.0.2")
+            revoke_device(1, r1["id"])
+            devices = get_user_devices(1, include_revoked=True)
+
+        assert len(devices) == 2
+
+    def test_update_device_name(self, client, auth_header):
+        from app.services.device_trust import register_device, update_device
+
+        with client.application.app_context():
+            reg = register_device(1, CHROME_UA, "10.0.0.1")
+            result = update_device(1, reg["id"], device_name="Work PC")
+
+        assert result["device_name"] == "Work PC"
+
+    def test_update_trust_level(self, client, auth_header):
+        from app.services.device_trust import register_device, update_device
+
+        with client.application.app_context():
+            reg = register_device(1, CHROME_UA, "10.0.0.1")
+            result = update_device(1, reg["id"], trust_level="full")
+
+        assert result["trust_level"] == "full"
+
+    def test_update_invalid_trust(self, client, auth_header):
+        from app.services.device_trust import register_device, update_device
+
+        with client.application.app_context():
+            reg = register_device(1, CHROME_UA, "10.0.0.1")
+            result = update_device(1, reg["id"], trust_level="invalid")
+
+        assert result is None
+
+    def test_update_nonexistent(self, client, auth_header):
+        from app.services.device_trust import update_device
+
+        with client.application.app_context():
+            result = update_device(1, 9999, device_name="test")
+
+        assert result is None
+
+    def test_revoke_device(self, client, auth_header):
+        from app.services.device_trust import register_device, revoke_device
+
+        with client.application.app_context():
+            reg = register_device(1, CHROME_UA, "10.0.0.1")
+            result = revoke_device(1, reg["id"])
+
+        assert result is True
+
+    def test_revoke_nonexistent(self, client, auth_header):
+        from app.services.device_trust import revoke_device
+
+        with client.application.app_context():
+            assert revoke_device(1, 9999) is False
+
+    def test_revoke_all_except_current(self, client, auth_header):
+        from app.services.device_trust import register_device, revoke_all_devices, get_user_devices
+
+        with client.application.app_context():
+            register_device(1, CHROME_UA, "10.0.0.1")
+            register_device(1, FIREFOX_UA, "10.0.0.2")  # This becomes current
+            count = revoke_all_devices(1, except_current=True)
+
+        assert count == 1
+
+    def test_revoke_all_including_current(self, client, auth_header):
+        from app.services.device_trust import register_device, revoke_all_devices, get_user_devices
+
+        with client.application.app_context():
+            register_device(1, CHROME_UA, "10.0.0.1")
+            register_device(1, FIREFOX_UA, "10.0.0.2")
+            count = revoke_all_devices(1, except_current=False)
+
+        assert count == 2
+
+    def test_delete_device(self, client, auth_header):
+        from app.services.device_trust import register_device, delete_device, get_user_devices
+
+        with client.application.app_context():
+            reg = register_device(1, CHROME_UA, "10.0.0.1")
+            assert delete_device(1, reg["id"]) is True
+            assert get_user_devices(1) == []
+
+    def test_delete_nonexistent(self, client, auth_header):
+        from app.services.device_trust import delete_device
+
+        with client.application.app_context():
+            assert delete_device(1, 9999) is False
+
+
+class TestDeviceStats:
+    """Test get_device_stats."""
+
+    def test_empty_stats(self, client, auth_header):
+        from app.services.device_trust import get_device_stats
+
+        with client.application.app_context():
+            stats = get_device_stats(1)
+
+        assert stats["total"] == 0
+        assert stats["active"] == 0
+
+    def test_stats_with_devices(self, client, auth_header):
+        from app.services.device_trust import register_device, revoke_device, get_device_stats
+
+        with client.application.app_context():
+            r1 = register_device(1, CHROME_UA, "10.0.0.1")
+            register_device(1, FIREFOX_UA, "10.0.0.2")
+            register_device(1, SAFARI_UA, "10.0.0.3")
+            revoke_device(1, r1["id"])
+
+            stats = get_device_stats(1)
+
+        assert stats["total"] == 3
+        assert stats["active"] == 2
+        assert stats["revoked"] == 1
+        assert "desktop" in stats["by_type"]
+        assert "mobile" in stats["by_type"]
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Route integration tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestDeviceTrustRoutes:
+    """Integration tests for /devices/* endpoints."""
+
+    # ── POST /devices/register ──
+    def test_register_device_route(self, client, auth_header):
+        r = client.post("/devices/register", json={},
+                        headers={**auth_header, "User-Agent": CHROME_UA})
+        assert r.status_code == 201
+        body = r.get_json()
+        assert body["is_current"] is True
+        assert body["trust_level"] == "standard"
+
+    def test_register_with_name(self, client, auth_header):
+        r = client.post("/devices/register",
+                        json={"device_name": "My Laptop"},
+                        headers={**auth_header, "User-Agent": CHROME_UA})
+        assert r.status_code == 201
+        assert r.get_json()["device_name"] == "My Laptop"
+
+    def test_register_unauthorized(self, client):
+        r = client.post("/devices/register", json={})
+        assert r.status_code == 401
+
+    # ── POST /devices/recognize ──
+    def test_recognize_known(self, client, auth_header):
+        client.post("/devices/register", json={},
+                    headers={**auth_header, "User-Agent": CHROME_UA})
+        r = client.post("/devices/recognize", json={},
+                        headers={**auth_header, "User-Agent": CHROME_UA})
+        assert r.status_code == 200
+        assert r.get_json()["recognized"] is True
+
+    def test_recognize_unknown(self, client, auth_header):
+        r = client.post("/devices/recognize", json={},
+                        headers={**auth_header, "User-Agent": FIREFOX_UA})
+        assert r.status_code == 404
+        assert r.get_json()["recognized"] is False
+
+    # ── GET /devices/devices ──
+    def test_list_devices_empty(self, client, auth_header):
+        r = client.get("/devices/devices", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["count"] == 0
+
+    def test_list_devices_with_data(self, client, auth_header):
+        client.post("/devices/register", json={},
+                    headers={**auth_header, "User-Agent": CHROME_UA})
+        client.post("/devices/register", json={},
+                    headers={**auth_header, "User-Agent": FIREFOX_UA})
+        r = client.get("/devices/devices", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["count"] == 2
+
+    def test_list_with_revoked(self, client, auth_header):
+        cr = client.post("/devices/register", json={},
+                         headers={**auth_header, "User-Agent": CHROME_UA})
+        did = cr.get_json()["id"]
+        client.post(f"/devices/devices/{did}/revoke", json={}, headers=auth_header)
+
+        r = client.get("/devices/devices?include_revoked=true", headers=auth_header)
+        assert r.get_json()["count"] == 1
+
+        r2 = client.get("/devices/devices", headers=auth_header)
+        assert r2.get_json()["count"] == 0
+
+    # ── PATCH /devices/devices/<id> ──
+    def test_update_device_route(self, client, auth_header):
+        cr = client.post("/devices/register", json={},
+                         headers={**auth_header, "User-Agent": CHROME_UA})
+        did = cr.get_json()["id"]
+
+        r = client.patch(f"/devices/devices/{did}",
+                         json={"device_name": "Office PC", "trust_level": "full"},
+                         headers=auth_header)
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["device_name"] == "Office PC"
+        assert body["trust_level"] == "full"
+
+    def test_update_nonexistent_route(self, client, auth_header):
+        r = client.patch("/devices/devices/9999",
+                         json={"device_name": "test"},
+                         headers=auth_header)
+        assert r.status_code == 404
+
+    # ── POST /devices/devices/<id>/revoke ──
+    def test_revoke_device_route(self, client, auth_header):
+        cr = client.post("/devices/register", json={},
+                         headers={**auth_header, "User-Agent": CHROME_UA})
+        did = cr.get_json()["id"]
+
+        r = client.post(f"/devices/devices/{did}/revoke", json={},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert "revoked" in r.get_json()["message"]
+
+    def test_revoke_nonexistent_route(self, client, auth_header):
+        r = client.post("/devices/devices/9999/revoke", json={},
+                        headers=auth_header)
+        assert r.status_code == 404
+
+    # ── POST /devices/devices/revoke-all ──
+    def test_revoke_all_route(self, client, auth_header):
+        client.post("/devices/register", json={},
+                    headers={**auth_header, "User-Agent": CHROME_UA})
+        client.post("/devices/register", json={},
+                    headers={**auth_header, "User-Agent": FIREFOX_UA})
+
+        r = client.post("/devices/devices/revoke-all", json={},
+                        headers=auth_header)
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["count"] >= 1
+
+    # ── DELETE /devices/devices/<id> ──
+    def test_delete_device_route(self, client, auth_header):
+        cr = client.post("/devices/register", json={},
+                         headers={**auth_header, "User-Agent": CHROME_UA})
+        did = cr.get_json()["id"]
+
+        r = client.delete(f"/devices/devices/{did}", headers=auth_header)
+        assert r.status_code == 200
+        assert "deleted" in r.get_json()["message"]
+
+    def test_delete_nonexistent_route(self, client, auth_header):
+        r = client.delete("/devices/devices/9999", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_delete_unauthorized(self, client):
+        r = client.delete("/devices/devices/1")
+        assert r.status_code == 401
+
+    # ── GET /devices/stats ──
+    def test_stats_route(self, client, auth_header):
+        client.post("/devices/register", json={},
+                    headers={**auth_header, "User-Agent": CHROME_UA})
+        r = client.get("/devices/stats", headers=auth_header)
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["total"] == 1
+        assert body["active"] == 1


### PR DESCRIPTION
## Device Trust Management & Recognition

Implements **issue #125** — trusted device management and fingerprinting system.

### Features
- **Device fingerprinting** — SHA-256 based fingerprint from UA + IP prefix
- **User-Agent parsing** — detect device type, browser, OS (Chrome, Firefox, Safari, Edge, Opera; Windows, macOS, Linux, iOS, Android)
- **Trust levels** — full, standard, limited per-device access control
- **Device recognition** — check if current device is trusted on login
- **Trust revocation** — revoke individual or all devices (with "except current" option)
- **Auto-expiration** — configurable trust expiry (default 90 days)
- **Statistics** — device counts by type, trust level, and status

### Implementation

| Component | Details |
|-----------|---------|
| Migration | `031_device_trust.sql` — trusted_devices table with indexes |
| Model | `TrustedDevice` with fingerprint, UA info, trust level, expiry, revocation |
| Service | `device_trust.py` — fingerprinting, registration, recognition, management, stats |
| Routes | 8 endpoints: register, recognize, list, update, revoke, revoke-all, delete, stats |
| Tests | **51 passing tests** covering all service functions and routes |
| Docs | `docs/device-trust.md` |

### API Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/devices/register` | Register/update trusted device |
| POST | `/devices/recognize` | Check device recognition |
| GET | `/devices/devices` | List trusted devices |
| PATCH | `/devices/devices/:id` | Update name/trust level |
| POST | `/devices/devices/:id/revoke` | Revoke trust |
| POST | `/devices/devices/revoke-all` | Revoke all devices |
| DELETE | `/devices/devices/:id` | Delete device record |
| GET | `/devices/stats` | Device statistics |

### Stats
- **1,194 lines** added across 9 files
- **51 tests** — all passing
- Zero external dependencies added

Closes #125
