### PR TITLE
feat(tracking): implement reminder delivery tracking & reliability metrics

### DIFF
--- a/packages/backend/app/db/033_reminder_tracking.sql
+++ b/packages/backend/app/db/033_reminder_tracking.sql
@@ -1,0 +1,26 @@
+-- Migration: Reminder reliability tracking
+-- Track delivery status and metrics for reminders
+
+CREATE TABLE IF NOT EXISTS reminder_deliveries (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    reminder_id     INTEGER NOT NULL REFERENCES reminders(id) ON DELETE CASCADE,
+    user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel         VARCHAR(20)  NOT NULL DEFAULT 'email',  -- email, push, sms, in_app
+    status          VARCHAR(20)  NOT NULL DEFAULT 'pending', -- pending, sent, delivered, failed, bounced
+    attempt_number  INTEGER      DEFAULT 1,
+    sent_at         TIMESTAMP,
+    delivered_at    TIMESTAMP,
+    failed_at       TIMESTAMP,
+    failure_reason  VARCHAR(256),
+    response_code   VARCHAR(10),
+    latency_ms      INTEGER,     -- delivery latency in milliseconds
+    opened          BOOLEAN      DEFAULT FALSE,
+    opened_at       TIMESTAMP,
+    clicked         BOOLEAN      DEFAULT FALSE,
+    clicked_at      TIMESTAMP,
+    created_at      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_reminder_deliveries_reminder ON reminder_deliveries(reminder_id);
+CREATE INDEX idx_reminder_deliveries_user     ON reminder_deliveries(user_id, created_at);
+CREATE INDEX idx_reminder_deliveries_status   ON reminder_deliveries(status);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,24 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ReminderDelivery(db.Model):
+    __tablename__ = "reminder_deliveries"
+    id = db.Column(db.Integer, primary_key=True)
+    reminder_id = db.Column(db.Integer, db.ForeignKey("reminders.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    channel = db.Column(db.String(20), nullable=False, default="email")
+    status = db.Column(db.String(20), nullable=False, default="pending")
+    attempt_number = db.Column(db.Integer, default=1)
+    sent_at = db.Column(db.DateTime)
+    delivered_at = db.Column(db.DateTime)
+    failed_at = db.Column(db.DateTime)
+    failure_reason = db.Column(db.String(256))
+    response_code = db.Column(db.String(10))
+    latency_ms = db.Column(db.Integer)
+    opened = db.Column(db.Boolean, default=False)
+    opened_at = db.Column(db.DateTime)
+    clicked = db.Column(db.Boolean, default=False)
+    clicked_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .reminder_tracking import bp as reminder_tracking_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(reminder_tracking_bp, url_prefix="/tracking")

--- a/packages/backend/app/routes/reminder_tracking.py
+++ b/packages/backend/app/routes/reminder_tracking.py
@@ -1,0 +1,201 @@
+"""Routes for reminder reliability tracking and delivery metrics."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.services.reminder_tracking import (
+    record_delivery_attempt,
+    mark_sent,
+    mark_delivered,
+    mark_failed,
+    mark_bounced,
+    record_opened,
+    record_clicked,
+    get_delivery_history,
+    get_reminder_deliveries,
+    get_reliability_metrics,
+    get_channel_performance,
+)
+
+bp = Blueprint("reminder_tracking", __name__)
+
+
+@bp.route("/record", methods=["POST"])
+@jwt_required()
+def record_attempt():
+    """Record a delivery attempt.
+
+    JSON body:
+    - reminder_id: int (required)
+    - channel: email | push | sms | in_app (default: email)
+    - status: pending | sent (default: pending)
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    reminder_id = data.get("reminder_id")
+    if not reminder_id:
+        return jsonify({"error": "reminder_id is required"}), 400
+
+    result = record_delivery_attempt(
+        reminder_id=reminder_id,
+        user_id=user_id,
+        channel=data.get("channel", "email"),
+        status=data.get("status", "pending"),
+    )
+
+    return jsonify(result), 201
+
+
+@bp.route("/<int:delivery_id>/sent", methods=["POST"])
+@jwt_required()
+def sent(delivery_id):
+    """Mark delivery as sent.
+
+    JSON body:
+    - response_code: server response code (optional)
+    """
+    data = request.get_json(silent=True) or {}
+    result = mark_sent(delivery_id, data.get("response_code", "200"))
+
+    if result is None:
+        return jsonify({"error": "Delivery not found"}), 404
+
+    return jsonify(result), 200
+
+
+@bp.route("/<int:delivery_id>/delivered", methods=["POST"])
+@jwt_required()
+def delivered(delivery_id):
+    """Mark delivery as delivered.
+
+    JSON body:
+    - latency_ms: delivery latency in ms (optional)
+    """
+    data = request.get_json(silent=True) or {}
+    result = mark_delivered(delivery_id, data.get("latency_ms", 0))
+
+    if result is None:
+        return jsonify({"error": "Delivery not found"}), 404
+
+    return jsonify(result), 200
+
+
+@bp.route("/<int:delivery_id>/failed", methods=["POST"])
+@jwt_required()
+def failed(delivery_id):
+    """Mark delivery as failed.
+
+    JSON body:
+    - reason: failure reason
+    - response_code: server response code
+    """
+    data = request.get_json(silent=True) or {}
+    result = mark_failed(
+        delivery_id,
+        reason=data.get("reason", ""),
+        response_code=data.get("response_code", ""),
+    )
+
+    if result is None:
+        return jsonify({"error": "Delivery not found"}), 404
+
+    return jsonify(result), 200
+
+
+@bp.route("/<int:delivery_id>/bounced", methods=["POST"])
+@jwt_required()
+def bounced(delivery_id):
+    """Mark delivery as bounced.
+
+    JSON body:
+    - reason: bounce reason
+    """
+    data = request.get_json(silent=True) or {}
+    result = mark_bounced(delivery_id, data.get("reason", ""))
+
+    if result is None:
+        return jsonify({"error": "Delivery not found"}), 404
+
+    return jsonify(result), 200
+
+
+@bp.route("/<int:delivery_id>/opened", methods=["POST"])
+@jwt_required()
+def opened(delivery_id):
+    """Record that delivery was opened."""
+    result = record_opened(delivery_id)
+
+    if result is None:
+        return jsonify({"error": "Delivery not found"}), 404
+
+    return jsonify(result), 200
+
+
+@bp.route("/<int:delivery_id>/clicked", methods=["POST"])
+@jwt_required()
+def clicked(delivery_id):
+    """Record that delivery link was clicked."""
+    result = record_clicked(delivery_id)
+
+    if result is None:
+        return jsonify({"error": "Delivery not found"}), 404
+
+    return jsonify(result), 200
+
+
+@bp.route("/history", methods=["GET"])
+@jwt_required()
+def delivery_history():
+    """Get delivery history.
+
+    Query params:
+    - limit: max records (default 50)
+    - channel: filter by channel
+    - status: filter by status
+    """
+    user_id = int(get_jwt_identity())
+    limit = request.args.get("limit", 50, type=int)
+    channel = request.args.get("channel")
+    status = request.args.get("status")
+
+    deliveries = get_delivery_history(user_id, limit, channel, status)
+    return jsonify({"deliveries": deliveries, "count": len(deliveries)}), 200
+
+
+@bp.route("/reminder/<int:reminder_id>", methods=["GET"])
+@jwt_required()
+def reminder_deliveries(reminder_id):
+    """Get all delivery attempts for a reminder."""
+    deliveries = get_reminder_deliveries(reminder_id)
+    return jsonify({"deliveries": deliveries, "count": len(deliveries)}), 200
+
+
+@bp.route("/metrics", methods=["GET"])
+@jwt_required()
+def reliability_metrics():
+    """Get reliability metrics.
+
+    Query params:
+    - days: lookback period (default 30)
+    """
+    user_id = int(get_jwt_identity())
+    days = request.args.get("days", 30, type=int)
+
+    metrics = get_reliability_metrics(user_id, days)
+    return jsonify(metrics), 200
+
+
+@bp.route("/channels", methods=["GET"])
+@jwt_required()
+def channel_perf():
+    """Get channel performance breakdown.
+
+    Query params:
+    - days: lookback period (default 30)
+    """
+    user_id = int(get_jwt_identity())
+    days = request.args.get("days", 30, type=int)
+
+    performance = get_channel_performance(user_id, days)
+    return jsonify({"channels": performance}), 200

--- a/packages/backend/app/services/reminder_tracking.py
+++ b/packages/backend/app/services/reminder_tracking.py
@@ -1,0 +1,390 @@
+"""Reminder reliability tracking and delivery metrics.
+
+Provides:
+- Delivery event recording (sent, delivered, failed, bounced)
+- Multi-channel tracking (email, push, SMS, in-app)
+- Retry management with attempt counting
+- Open/click engagement tracking
+- Reliability metrics and statistics
+- Channel performance analysis
+"""
+
+import json
+from datetime import datetime, timedelta
+from typing import Optional
+
+from app.extensions import db
+from app.models import ReminderDelivery, Reminder
+
+
+# ─── Delivery Recording ─────────────────────────────────────────────
+
+
+def record_delivery_attempt(reminder_id: int, user_id: int,
+                            channel: str = "email",
+                            status: str = "pending") -> dict:
+    """Record a new delivery attempt.
+
+    Args:
+        reminder_id: Reminder ID
+        user_id: User ID
+        channel: Delivery channel (email, push, sms, in_app)
+        status: Initial status
+
+    Returns:
+        Dict with delivery record info
+    """
+    # Count previous attempts
+    prev_attempts = ReminderDelivery.query.filter_by(
+        reminder_id=reminder_id, channel=channel
+    ).count()
+
+    delivery = ReminderDelivery(
+        reminder_id=reminder_id,
+        user_id=user_id,
+        channel=channel,
+        status=status,
+        attempt_number=prev_attempts + 1,
+    )
+    db.session.add(delivery)
+    db.session.commit()
+
+    return _delivery_to_dict(delivery)
+
+
+def mark_sent(delivery_id: int, response_code: str = "200") -> dict | None:
+    """Mark a delivery as sent.
+
+    Args:
+        delivery_id: Delivery record ID
+        response_code: Server response code
+
+    Returns:
+        Updated delivery dict or None
+    """
+    delivery = db.session.get(ReminderDelivery, delivery_id)
+    if not delivery:
+        return None
+
+    delivery.status = "sent"
+    delivery.sent_at = datetime.utcnow()
+    delivery.response_code = response_code
+    db.session.commit()
+
+    return _delivery_to_dict(delivery)
+
+
+def mark_delivered(delivery_id: int, latency_ms: int = 0) -> dict | None:
+    """Mark a delivery as delivered.
+
+    Args:
+        delivery_id: Delivery record ID
+        latency_ms: Delivery latency in milliseconds
+
+    Returns:
+        Updated delivery dict or None
+    """
+    delivery = db.session.get(ReminderDelivery, delivery_id)
+    if not delivery:
+        return None
+
+    delivery.status = "delivered"
+    delivery.delivered_at = datetime.utcnow()
+    delivery.latency_ms = latency_ms
+    if not delivery.sent_at:
+        delivery.sent_at = datetime.utcnow()
+    db.session.commit()
+
+    return _delivery_to_dict(delivery)
+
+
+def mark_failed(delivery_id: int, reason: str = "",
+                response_code: str = "") -> dict | None:
+    """Mark a delivery as failed.
+
+    Args:
+        delivery_id: Delivery record ID
+        reason: Failure reason
+        response_code: Server response code
+
+    Returns:
+        Updated delivery dict or None
+    """
+    delivery = db.session.get(ReminderDelivery, delivery_id)
+    if not delivery:
+        return None
+
+    delivery.status = "failed"
+    delivery.failed_at = datetime.utcnow()
+    delivery.failure_reason = reason[:256] if reason else None
+    delivery.response_code = response_code or None
+    db.session.commit()
+
+    return _delivery_to_dict(delivery)
+
+
+def mark_bounced(delivery_id: int, reason: str = "") -> dict | None:
+    """Mark a delivery as bounced.
+
+    Args:
+        delivery_id: Delivery record ID
+        reason: Bounce reason
+
+    Returns:
+        Updated delivery dict or None
+    """
+    delivery = db.session.get(ReminderDelivery, delivery_id)
+    if not delivery:
+        return None
+
+    delivery.status = "bounced"
+    delivery.failed_at = datetime.utcnow()
+    delivery.failure_reason = reason[:256] if reason else None
+    db.session.commit()
+
+    return _delivery_to_dict(delivery)
+
+
+def record_opened(delivery_id: int) -> dict | None:
+    """Record that a delivered message was opened.
+
+    Args:
+        delivery_id: Delivery record ID
+
+    Returns:
+        Updated delivery dict or None
+    """
+    delivery = db.session.get(ReminderDelivery, delivery_id)
+    if not delivery:
+        return None
+
+    delivery.opened = True
+    delivery.opened_at = datetime.utcnow()
+    db.session.commit()
+
+    return _delivery_to_dict(delivery)
+
+
+def record_clicked(delivery_id: int) -> dict | None:
+    """Record that a delivered message link was clicked.
+
+    Args:
+        delivery_id: Delivery record ID
+
+    Returns:
+        Updated delivery dict or None
+    """
+    delivery = db.session.get(ReminderDelivery, delivery_id)
+    if not delivery:
+        return None
+
+    delivery.clicked = True
+    delivery.clicked_at = datetime.utcnow()
+    if not delivery.opened:
+        delivery.opened = True
+        delivery.opened_at = datetime.utcnow()
+    db.session.commit()
+
+    return _delivery_to_dict(delivery)
+
+
+# ─── Query Functions ─────────────────────────────────────────────────
+
+
+def get_delivery_history(user_id: int, limit: int = 50,
+                         channel: str | None = None,
+                         status: str | None = None) -> list[dict]:
+    """Get delivery history for a user.
+
+    Args:
+        user_id: User ID
+        limit: Max records
+        channel: Filter by channel
+        status: Filter by status
+
+    Returns:
+        List of delivery dicts
+    """
+    query = ReminderDelivery.query.filter_by(user_id=user_id)
+
+    if channel:
+        query = query.filter_by(channel=channel)
+    if status:
+        query = query.filter_by(status=status)
+
+    deliveries = (query.order_by(ReminderDelivery.created_at.desc())
+                  .limit(limit).all())
+
+    return [_delivery_to_dict(d) for d in deliveries]
+
+
+def get_reminder_deliveries(reminder_id: int) -> list[dict]:
+    """Get all delivery attempts for a specific reminder.
+
+    Args:
+        reminder_id: Reminder ID
+
+    Returns:
+        List of delivery dicts
+    """
+    deliveries = (ReminderDelivery.query
+                  .filter_by(reminder_id=reminder_id)
+                  .order_by(ReminderDelivery.attempt_number)
+                  .all())
+
+    return [_delivery_to_dict(d) for d in deliveries]
+
+
+def get_reliability_metrics(user_id: int, days: int = 30) -> dict:
+    """Calculate reliability metrics for a user.
+
+    Args:
+        user_id: User ID
+        days: Lookback period
+
+    Returns:
+        Dict with reliability metrics
+    """
+    since = datetime.utcnow() - timedelta(days=days)
+    deliveries = ReminderDelivery.query.filter(
+        ReminderDelivery.user_id == user_id,
+        ReminderDelivery.created_at >= since,
+    ).all()
+
+    total = len(deliveries)
+    if total == 0:
+        return {
+            "period_days": days,
+            "total_attempts": 0,
+            "delivery_rate": 0.0,
+            "failure_rate": 0.0,
+            "bounce_rate": 0.0,
+            "open_rate": 0.0,
+            "click_rate": 0.0,
+            "avg_latency_ms": 0,
+            "by_channel": {},
+            "by_status": {},
+        }
+
+    delivered = sum(1 for d in deliveries if d.status == "delivered")
+    failed = sum(1 for d in deliveries if d.status == "failed")
+    bounced = sum(1 for d in deliveries if d.status == "bounced")
+    opened = sum(1 for d in deliveries if d.opened)
+    clicked = sum(1 for d in deliveries if d.clicked)
+
+    latencies = [d.latency_ms for d in deliveries if d.latency_ms]
+    avg_latency = int(sum(latencies) / len(latencies)) if latencies else 0
+
+    # By channel
+    by_channel = {}
+    for d in deliveries:
+        ch = d.channel or "unknown"
+        if ch not in by_channel:
+            by_channel[ch] = {"total": 0, "delivered": 0, "failed": 0}
+        by_channel[ch]["total"] += 1
+        if d.status == "delivered":
+            by_channel[ch]["delivered"] += 1
+        elif d.status in ("failed", "bounced"):
+            by_channel[ch]["failed"] += 1
+
+    # By status
+    by_status = {}
+    for d in deliveries:
+        by_status[d.status] = by_status.get(d.status, 0) + 1
+
+    return {
+        "period_days": days,
+        "total_attempts": total,
+        "delivery_rate": round(delivered / total, 3) if total else 0.0,
+        "failure_rate": round((failed + bounced) / total, 3) if total else 0.0,
+        "bounce_rate": round(bounced / total, 3) if total else 0.0,
+        "open_rate": round(opened / delivered, 3) if delivered else 0.0,
+        "click_rate": round(clicked / delivered, 3) if delivered else 0.0,
+        "avg_latency_ms": avg_latency,
+        "by_channel": by_channel,
+        "by_status": by_status,
+    }
+
+
+def get_channel_performance(user_id: int, days: int = 30) -> list[dict]:
+    """Get performance breakdown by delivery channel.
+
+    Args:
+        user_id: User ID
+        days: Lookback period
+
+    Returns:
+        List of channel performance dicts
+    """
+    since = datetime.utcnow() - timedelta(days=days)
+    deliveries = ReminderDelivery.query.filter(
+        ReminderDelivery.user_id == user_id,
+        ReminderDelivery.created_at >= since,
+    ).all()
+
+    channels = {}
+    for d in deliveries:
+        ch = d.channel or "unknown"
+        if ch not in channels:
+            channels[ch] = {
+                "channel": ch,
+                "total": 0,
+                "delivered": 0,
+                "failed": 0,
+                "bounced": 0,
+                "opened": 0,
+                "clicked": 0,
+                "latencies": [],
+            }
+        channels[ch]["total"] += 1
+        if d.status == "delivered":
+            channels[ch]["delivered"] += 1
+        elif d.status == "failed":
+            channels[ch]["failed"] += 1
+        elif d.status == "bounced":
+            channels[ch]["bounced"] += 1
+        if d.opened:
+            channels[ch]["opened"] += 1
+        if d.clicked:
+            channels[ch]["clicked"] += 1
+        if d.latency_ms:
+            channels[ch]["latencies"].append(d.latency_ms)
+
+    result = []
+    for ch_data in channels.values():
+        lats = ch_data.pop("latencies")
+        ch_data["avg_latency_ms"] = int(sum(lats) / len(lats)) if lats else 0
+        total = ch_data["total"]
+        ch_data["delivery_rate"] = round(ch_data["delivered"] / total, 3) if total else 0.0
+        ch_data["open_rate"] = round(
+            ch_data["opened"] / ch_data["delivered"], 3
+        ) if ch_data["delivered"] else 0.0
+        result.append(ch_data)
+
+    return sorted(result, key=lambda x: x["total"], reverse=True)
+
+
+# ─── Helpers ─────────────────────────────────────────────────────────
+
+
+def _delivery_to_dict(d: ReminderDelivery) -> dict:
+    """Convert ReminderDelivery model to dict."""
+    return {
+        "id": d.id,
+        "reminder_id": d.reminder_id,
+        "user_id": d.user_id,
+        "channel": d.channel,
+        "status": d.status,
+        "attempt_number": d.attempt_number,
+        "sent_at": d.sent_at.isoformat() if d.sent_at else None,
+        "delivered_at": d.delivered_at.isoformat() if d.delivered_at else None,
+        "failed_at": d.failed_at.isoformat() if d.failed_at else None,
+        "failure_reason": d.failure_reason,
+        "response_code": d.response_code,
+        "latency_ms": d.latency_ms,
+        "opened": d.opened,
+        "opened_at": d.opened_at.isoformat() if d.opened_at else None,
+        "clicked": d.clicked,
+        "clicked_at": d.clicked_at.isoformat() if d.clicked_at else None,
+        "created_at": d.created_at.isoformat() if d.created_at else None,
+    }

--- a/packages/backend/commit-msg.txt
+++ b/packages/backend/commit-msg.txt
@@ -1,0 +1,25 @@
+feat(tracking): implement reminder delivery tracking & reliability metrics
+
+Resolves #123
+
+Add comprehensive reminder delivery tracking with full lifecycle
+observability — from initial send through delivery confirmation,
+bounce handling, and user engagement tracking.
+
+Changes:
+- Add reminder_deliveries table migration (033_reminder_tracking.sql)
+- Add ReminderDelivery model with 17 columns
+- Add reminder tracking service with delivery lifecycle management
+- Add 11 REST endpoints under /tracking blueprint
+- Add 36 tests covering service logic and route integration
+- Add documentation (docs/reminder-tracking.md)
+
+Features:
+- Record delivery attempts with auto-incrementing attempt numbers
+- Track full delivery lifecycle: pending → sent → delivered/failed/bounced
+- Engagement tracking: open and click events with timestamps
+- Per-user delivery history with channel/status filtering
+- Reliability metrics: delivery/failure/bounce/open/click rates
+- Channel performance comparison (email, push, SMS, in-app)
+- Latency tracking per delivery
+- Configurable time period for metrics (default 30 days)

--- a/packages/backend/docs/reminder-tracking.md
+++ b/packages/backend/docs/reminder-tracking.md
@@ -1,0 +1,189 @@
+# Reminder Reliability Tracking & Delivery Metrics
+
+Track every reminder delivery attempt with full lifecycle visibility — from initial send through delivery confirmation, bounce handling, and engagement tracking.
+
+## Overview
+
+The reminder tracking system provides comprehensive delivery observability:
+
+- **Delivery lifecycle** — Record attempts, confirmations, failures, and bounces
+- **Engagement tracking** — Track opens and clicks for each delivery
+- **Reliability metrics** — Calculate delivery rates, failure rates, and latency
+- **Channel performance** — Compare effectiveness across email, push, SMS, and in-app channels
+
+## Database Schema
+
+```sql
+CREATE TABLE reminder_deliveries (
+    id SERIAL PRIMARY KEY,
+    reminder_id INTEGER NOT NULL REFERENCES reminders(id),
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    channel VARCHAR(20) DEFAULT 'email',
+    status VARCHAR(20) DEFAULT 'pending',
+    attempt_number INTEGER DEFAULT 1,
+    sent_at TIMESTAMP,
+    delivered_at TIMESTAMP,
+    failed_at TIMESTAMP,
+    failure_reason TEXT,
+    response_code VARCHAR(10),
+    latency_ms INTEGER,
+    opened BOOLEAN DEFAULT FALSE,
+    opened_at TIMESTAMP,
+    clicked BOOLEAN DEFAULT FALSE,
+    clicked_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+## API Endpoints
+
+All endpoints require JWT authentication.
+
+### Record Delivery Attempt
+
+```http
+POST /tracking/record
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+    "reminder_id": 42,
+    "channel": "email"
+}
+```
+
+**Response** `201 Created`:
+
+```json
+{
+    "id": 1,
+    "reminder_id": 42,
+    "status": "pending",
+    "attempt_number": 1,
+    "channel": "email"
+}
+```
+
+### Update Delivery Status
+
+```http
+POST /tracking/<delivery_id>/sent
+POST /tracking/<delivery_id>/delivered
+POST /tracking/<delivery_id>/failed
+POST /tracking/<delivery_id>/bounced
+```
+
+Each accepts optional JSON body:
+
+| Endpoint     | Optional Fields                    |
+|-------------|-----------------------------------|
+| `/sent`     | `response_code`                   |
+| `/delivered`| `latency_ms`                      |
+| `/failed`   | `reason`, `response_code`         |
+| `/bounced`  | `reason`                          |
+
+### Track Engagement
+
+```http
+POST /tracking/<delivery_id>/opened
+POST /tracking/<delivery_id>/clicked
+```
+
+Clicking automatically marks as opened.
+
+### Query Delivery History
+
+```http
+GET /tracking/history?channel=email&status=delivered&limit=50
+```
+
+Returns all deliveries for the authenticated user with optional filters.
+
+### Get Reminder Deliveries
+
+```http
+GET /tracking/reminder/<reminder_id>
+```
+
+Returns all delivery attempts for a specific reminder.
+
+### Reliability Metrics
+
+```http
+GET /tracking/metrics?days=30
+```
+
+**Response**:
+
+```json
+{
+    "total_attempts": 150,
+    "delivered": 142,
+    "failed": 5,
+    "bounced": 3,
+    "delivery_rate": 0.947,
+    "failure_rate": 0.033,
+    "bounce_rate": 0.02,
+    "open_rate": 0.65,
+    "click_rate": 0.12,
+    "avg_latency_ms": 245,
+    "period_days": 30,
+    "by_channel": { "email": 100, "push": 50 },
+    "by_status": { "delivered": 142, "failed": 5, "bounced": 3 }
+}
+```
+
+### Channel Performance
+
+```http
+GET /tracking/channels?days=30
+```
+
+**Response**:
+
+```json
+{
+    "channels": [
+        {
+            "channel": "email",
+            "total": 100,
+            "delivered": 95,
+            "delivery_rate": 0.95,
+            "avg_latency_ms": 320
+        },
+        {
+            "channel": "push",
+            "total": 50,
+            "delivered": 47,
+            "delivery_rate": 0.94,
+            "avg_latency_ms": 85
+        }
+    ],
+    "period_days": 30
+}
+```
+
+## Delivery Status Flow
+
+```
+pending → sent → delivered
+                ↘ failed
+                ↘ bounced
+```
+
+## Architecture
+
+| Component | File |
+|-----------|------|
+| Migration | `app/db/033_reminder_tracking.sql` |
+| Model | `app/models.py` → `ReminderDelivery` |
+| Service | `app/services/reminder_tracking.py` |
+| Routes | `app/routes/reminder_tracking.py` |
+| Tests | `tests/test_reminder_tracking.py` |
+
+## Testing
+
+```bash
+python -m pytest tests/test_reminder_tracking.py -v
+# 36 tests covering service logic, status transitions, engagement tracking, and route integration
+```

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,21 @@
 import os
 import pytest
+import fakeredis
 from app import create_app
 from app.config import Settings
 from app.extensions import db
 from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+@pytest.fixture(autouse=True)
+def _patch_redis(monkeypatch):
+    fake = fakeredis.FakeRedis()
+    monkeypatch.setattr("app.extensions.redis_client", fake)
+    monkeypatch.setattr("app.routes.auth.redis_client", fake)
+    monkeypatch.setattr("app.services.cache.redis_client", fake)
+    yield
+    fake.flushall()
 
 
 class TestSettings(Settings):

--- a/packages/backend/tests/test_reminder_tracking.py
+++ b/packages/backend/tests/test_reminder_tracking.py
@@ -1,0 +1,433 @@
+"""Tests for reminder reliability tracking and delivery metrics."""
+
+import pytest
+from datetime import datetime, timedelta
+from app.extensions import db
+from app.models import Reminder, ReminderDelivery
+
+
+def _create_reminder(user_id=1, message="Test reminder"):
+    """Helper to create a test reminder."""
+    r = Reminder(
+        user_id=user_id,
+        message=message,
+        send_at=datetime.utcnow() + timedelta(hours=1),
+        channel="email",
+    )
+    db.session.add(r)
+    db.session.commit()
+    return r
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Service unit tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestRecordDelivery:
+    """Test delivery recording functions."""
+
+    def test_record_attempt(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            result = record_delivery_attempt(reminder.id, 1)
+
+        assert result["status"] == "pending"
+        assert result["attempt_number"] == 1
+        assert result["channel"] == "email"
+
+    def test_record_multiple_attempts(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r1 = record_delivery_attempt(reminder.id, 1, channel="email")
+            r2 = record_delivery_attempt(reminder.id, 1, channel="email")
+
+        assert r1["attempt_number"] == 1
+        assert r2["attempt_number"] == 2
+
+    def test_record_different_channels(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r1 = record_delivery_attempt(reminder.id, 1, channel="email")
+            r2 = record_delivery_attempt(reminder.id, 1, channel="push")
+
+        assert r1["channel"] == "email"
+        assert r2["channel"] == "push"
+        assert r2["attempt_number"] == 1  # New channel starts at 1
+
+
+class TestStatusTransitions:
+    """Test status marking functions."""
+
+    def test_mark_sent(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, mark_sent
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r = record_delivery_attempt(reminder.id, 1)
+            result = mark_sent(r["id"], "200")
+
+        assert result["status"] == "sent"
+        assert result["sent_at"] is not None
+        assert result["response_code"] == "200"
+
+    def test_mark_delivered(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, mark_delivered
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r = record_delivery_attempt(reminder.id, 1)
+            result = mark_delivered(r["id"], latency_ms=150)
+
+        assert result["status"] == "delivered"
+        assert result["delivered_at"] is not None
+        assert result["latency_ms"] == 150
+
+    def test_mark_failed(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, mark_failed
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r = record_delivery_attempt(reminder.id, 1)
+            result = mark_failed(r["id"], reason="Timeout", response_code="504")
+
+        assert result["status"] == "failed"
+        assert result["failure_reason"] == "Timeout"
+        assert result["response_code"] == "504"
+
+    def test_mark_bounced(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, mark_bounced
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r = record_delivery_attempt(reminder.id, 1)
+            result = mark_bounced(r["id"], reason="Mailbox full")
+
+        assert result["status"] == "bounced"
+        assert result["failure_reason"] == "Mailbox full"
+
+    def test_mark_nonexistent_returns_none(self, client, auth_header):
+        from app.services.reminder_tracking import mark_sent, mark_delivered, mark_failed, mark_bounced
+
+        with client.application.app_context():
+            assert mark_sent(9999) is None
+            assert mark_delivered(9999) is None
+            assert mark_failed(9999) is None
+            assert mark_bounced(9999) is None
+
+
+class TestEngagementTracking:
+    """Test open/click tracking."""
+
+    def test_record_opened(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, record_opened
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r = record_delivery_attempt(reminder.id, 1)
+            result = record_opened(r["id"])
+
+        assert result["opened"] is True
+        assert result["opened_at"] is not None
+
+    def test_record_clicked(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, record_clicked
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r = record_delivery_attempt(reminder.id, 1)
+            result = record_clicked(r["id"])
+
+        assert result["clicked"] is True
+        assert result["opened"] is True  # Click implies open
+
+    def test_engagement_nonexistent(self, client, auth_header):
+        from app.services.reminder_tracking import record_opened, record_clicked
+
+        with client.application.app_context():
+            assert record_opened(9999) is None
+            assert record_clicked(9999) is None
+
+
+class TestDeliveryHistory:
+    """Test query functions."""
+
+    def test_empty_history(self, client, auth_header):
+        from app.services.reminder_tracking import get_delivery_history
+
+        with client.application.app_context():
+            result = get_delivery_history(1)
+
+        assert result == []
+
+    def test_history_returns_records(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, get_delivery_history
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            record_delivery_attempt(reminder.id, 1, channel="email")
+            record_delivery_attempt(reminder.id, 1, channel="push")
+            result = get_delivery_history(1)
+
+        assert len(result) == 2
+
+    def test_history_filter_by_channel(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, get_delivery_history
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            record_delivery_attempt(reminder.id, 1, channel="email")
+            record_delivery_attempt(reminder.id, 1, channel="push")
+            result = get_delivery_history(1, channel="push")
+
+        assert len(result) == 1
+        assert result[0]["channel"] == "push"
+
+    def test_history_filter_by_status(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, mark_delivered, get_delivery_history
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r1 = record_delivery_attempt(reminder.id, 1)
+            r2 = record_delivery_attempt(reminder.id, 1)
+            mark_delivered(r1["id"])
+            result = get_delivery_history(1, status="delivered")
+
+        assert len(result) == 1
+
+    def test_history_limit(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, get_delivery_history
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            for _ in range(5):
+                record_delivery_attempt(reminder.id, 1)
+            result = get_delivery_history(1, limit=3)
+
+        assert len(result) == 3
+
+    def test_reminder_deliveries(self, client, auth_header):
+        from app.services.reminder_tracking import record_delivery_attempt, get_reminder_deliveries
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            record_delivery_attempt(reminder.id, 1, channel="email")
+            record_delivery_attempt(reminder.id, 1, channel="push")
+            result = get_reminder_deliveries(reminder.id)
+
+        assert len(result) == 2
+
+
+class TestReliabilityMetrics:
+    """Test reliability metrics calculation."""
+
+    def test_empty_metrics(self, client, auth_header):
+        from app.services.reminder_tracking import get_reliability_metrics
+
+        with client.application.app_context():
+            metrics = get_reliability_metrics(1)
+
+        assert metrics["total_attempts"] == 0
+        assert metrics["delivery_rate"] == 0.0
+
+    def test_metrics_with_data(self, client, auth_header):
+        from app.services.reminder_tracking import (
+            record_delivery_attempt, mark_delivered, mark_failed,
+            record_opened, get_reliability_metrics,
+        )
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r1 = record_delivery_attempt(reminder.id, 1)
+            r2 = record_delivery_attempt(reminder.id, 1)
+            r3 = record_delivery_attempt(reminder.id, 1)
+            mark_delivered(r1["id"], latency_ms=100)
+            mark_delivered(r2["id"], latency_ms=200)
+            mark_failed(r3["id"], reason="error")
+            record_opened(r1["id"])
+
+            metrics = get_reliability_metrics(1)
+
+        assert metrics["total_attempts"] == 3
+        assert metrics["delivery_rate"] == round(2 / 3, 3)
+        assert metrics["failure_rate"] == round(1 / 3, 3)
+        assert metrics["open_rate"] == 0.5
+        assert metrics["avg_latency_ms"] == 150
+
+    def test_channel_performance(self, client, auth_header):
+        from app.services.reminder_tracking import (
+            record_delivery_attempt, mark_delivered, get_channel_performance,
+        )
+
+        with client.application.app_context():
+            reminder = _create_reminder()
+            r1 = record_delivery_attempt(reminder.id, 1, channel="email")
+            r2 = record_delivery_attempt(reminder.id, 1, channel="push")
+            mark_delivered(r1["id"])
+            mark_delivered(r2["id"])
+
+            perf = get_channel_performance(1)
+
+        assert len(perf) == 2
+        assert all(p["delivery_rate"] == 1.0 for p in perf)
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Route integration tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestTrackingRoutes:
+    """Integration tests for /tracking/* endpoints."""
+
+    def _create_reminder_via_db(self, client):
+        """Helper to create reminder in app context."""
+        with client.application.app_context():
+            r = _create_reminder()
+            return r.id
+
+    # ── POST /tracking/record ──
+    def test_record_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        r = client.post("/tracking/record",
+                        json={"reminder_id": rid, "channel": "email"},
+                        headers=auth_header)
+        assert r.status_code == 201
+        assert r.get_json()["status"] == "pending"
+
+    def test_record_missing_reminder_id(self, client, auth_header):
+        r = client.post("/tracking/record", json={}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_record_unauthorized(self, client):
+        r = client.post("/tracking/record", json={"reminder_id": 1})
+        assert r.status_code == 401
+
+    # ── POST /tracking/<id>/sent ──
+    def test_sent_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        cr = client.post("/tracking/record",
+                         json={"reminder_id": rid},
+                         headers=auth_header)
+        did = cr.get_json()["id"]
+
+        r = client.post(f"/tracking/{did}/sent", json={}, headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["status"] == "sent"
+
+    def test_sent_nonexistent(self, client, auth_header):
+        r = client.post("/tracking/9999/sent", json={}, headers=auth_header)
+        assert r.status_code == 404
+
+    # ── POST /tracking/<id>/delivered ──
+    def test_delivered_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        cr = client.post("/tracking/record",
+                         json={"reminder_id": rid},
+                         headers=auth_header)
+        did = cr.get_json()["id"]
+
+        r = client.post(f"/tracking/{did}/delivered",
+                        json={"latency_ms": 250},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["latency_ms"] == 250
+
+    # ── POST /tracking/<id>/failed ──
+    def test_failed_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        cr = client.post("/tracking/record",
+                         json={"reminder_id": rid},
+                         headers=auth_header)
+        did = cr.get_json()["id"]
+
+        r = client.post(f"/tracking/{did}/failed",
+                        json={"reason": "Network error"},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["failure_reason"] == "Network error"
+
+    # ── POST /tracking/<id>/bounced ──
+    def test_bounced_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        cr = client.post("/tracking/record",
+                         json={"reminder_id": rid},
+                         headers=auth_header)
+        did = cr.get_json()["id"]
+
+        r = client.post(f"/tracking/{did}/bounced",
+                        json={"reason": "Mailbox full"},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["status"] == "bounced"
+
+    # ── POST /tracking/<id>/opened ──
+    def test_opened_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        cr = client.post("/tracking/record",
+                         json={"reminder_id": rid},
+                         headers=auth_header)
+        did = cr.get_json()["id"]
+
+        r = client.post(f"/tracking/{did}/opened", json={}, headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["opened"] is True
+
+    # ── POST /tracking/<id>/clicked ──
+    def test_clicked_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        cr = client.post("/tracking/record",
+                         json={"reminder_id": rid},
+                         headers=auth_header)
+        did = cr.get_json()["id"]
+
+        r = client.post(f"/tracking/{did}/clicked", json={}, headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["clicked"] is True
+
+    # ── GET /tracking/history ──
+    def test_history_route(self, client, auth_header):
+        r = client.get("/tracking/history", headers=auth_header)
+        assert r.status_code == 200
+        assert "deliveries" in r.get_json()
+
+    def test_history_with_filters(self, client, auth_header):
+        r = client.get("/tracking/history?channel=email&status=pending&limit=10",
+                        headers=auth_header)
+        assert r.status_code == 200
+
+    # ── GET /tracking/reminder/<id> ──
+    def test_reminder_deliveries_route(self, client, auth_header):
+        rid = self._create_reminder_via_db(client)
+        client.post("/tracking/record",
+                    json={"reminder_id": rid},
+                    headers=auth_header)
+
+        r = client.get(f"/tracking/reminder/{rid}", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["count"] >= 1
+
+    # ── GET /tracking/metrics ──
+    def test_metrics_route(self, client, auth_header):
+        r = client.get("/tracking/metrics", headers=auth_header)
+        assert r.status_code == 200
+        body = r.get_json()
+        assert "delivery_rate" in body
+        assert "by_channel" in body
+
+    def test_metrics_with_days(self, client, auth_header):
+        r = client.get("/tracking/metrics?days=7", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["period_days"] == 7
+
+    # ── GET /tracking/channels ──
+    def test_channels_route(self, client, auth_header):
+        r = client.get("/tracking/channels", headers=auth_header)
+        assert r.status_code == 200
+        assert "channels" in r.get_json()


### PR DESCRIPTION
## Reminder Reliability Tracking & Delivery Metrics

Resolves #123

### Summary
Comprehensive reminder delivery tracking system with full lifecycle observability — from initial send through delivery confirmation, bounce handling, and user engagement tracking.

### Changes
| File | Description |
|------|-------------|
| `app/db/033_reminder_tracking.sql` | Migration — `reminder_deliveries` table with 17 columns + 3 indexes |
| `app/models.py` | `ReminderDelivery` SQLAlchemy model |
| `app/services/reminder_tracking.py` | Delivery lifecycle management & metrics calculation |
| `app/routes/reminder_tracking.py` | 11 REST endpoints under `/tracking` |
| `tests/test_reminder_tracking.py` | 36 tests (service + route integration) |
| `docs/reminder-tracking.md` | API documentation |

### Features

**Delivery Lifecycle**
- Record delivery attempts with auto-incrementing attempt numbers per channel
- Full status tracking: `pending` → `sent` → `delivered` / `failed` / `bounced`
- Failure reason and response code capture

**Engagement Tracking**
- Open tracking with timestamps
- Click tracking (automatically marks as opened)

**Reliability Metrics**
- Delivery, failure, bounce, open, and click rates
- Average latency calculation
- Breakdown by channel and status
- Configurable time period (default 30 days)

**Channel Performance**
- Per-channel delivery rates and latency
- Compare effectiveness across email, push, SMS, in-app

### API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/tracking/record` | Record new delivery attempt |
| POST | `/tracking/<id>/sent` | Mark as sent |
| POST | `/tracking/<id>/delivered` | Mark as delivered |
| POST | `/tracking/<id>/failed` | Mark as failed |
| POST | `/tracking/<id>/bounced` | Mark as bounced |
| POST | `/tracking/<id>/opened` | Record open event |
| POST | `/tracking/<id>/clicked` | Record click event |
| GET | `/tracking/history` | User delivery history |
| GET | `/tracking/reminder/<id>` | Reminder-specific deliveries |
| GET | `/tracking/metrics` | Reliability metrics dashboard |
| GET | `/tracking/channels` | Channel performance comparison |

### Testing
```
36 passed in 4.44s
```
All endpoints tested with JWT authentication, error handling, and edge cases.
