### PR TITLE
feat(notifications): implement notification priority & grouping system

### DIFF
--- a/packages/backend/app/db/034_notification_priority.sql
+++ b/packages/backend/app/db/034_notification_priority.sql
@@ -1,0 +1,27 @@
+-- Migration: Notification priority & grouping system
+-- Issue #122
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    title VARCHAR(200) NOT NULL,
+    message TEXT NOT NULL,
+    priority VARCHAR(20) DEFAULT 'normal',
+    category VARCHAR(50) DEFAULT 'general',
+    group_key VARCHAR(100),
+    is_read BOOLEAN DEFAULT FALSE,
+    is_dismissed BOOLEAN DEFAULT FALSE,
+    action_url VARCHAR(500),
+    action_type VARCHAR(50),
+    extra_data JSONB DEFAULT '{}',
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX idx_notifications_priority ON notifications(priority);
+CREATE INDEX idx_notifications_category ON notifications(category);
+CREATE INDEX idx_notifications_group_key ON notifications(group_key);
+CREATE INDEX idx_notifications_is_read ON notifications(is_read);
+CREATE INDEX idx_notifications_created_at ON notifications(created_at);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,25 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class Notification(db.Model):
+    __tablename__ = "notifications"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    message = db.Column(db.Text, nullable=False)
+    priority = db.Column(db.String(20), default="normal")
+    category = db.Column(db.String(50), default="general")
+    group_key = db.Column(db.String(100))
+    is_read = db.Column(db.Boolean, default=False)
+    is_dismissed = db.Column(db.Boolean, default=False)
+    action_url = db.Column(db.String(500))
+    action_type = db.Column(db.String(50))
+    extra_data = db.Column(db.JSON, default=dict)
+    expires_at = db.Column(db.DateTime)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .notification_priority import bp as notification_priority_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(notification_priority_bp, url_prefix="/notifications")

--- a/packages/backend/app/routes/notification_priority.py
+++ b/packages/backend/app/routes/notification_priority.py
@@ -1,0 +1,147 @@
+"""Routes for notification priority & grouping system."""
+
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from app.services.notification_priority import (
+    create_notification,
+    get_notifications,
+    get_grouped_notifications,
+    mark_read,
+    mark_all_read,
+    dismiss_notification,
+    dismiss_group,
+    get_unread_count,
+    get_notification_stats,
+)
+
+bp = Blueprint("notification_priority", __name__)
+
+
+@bp.post("/send")
+@jwt_required()
+def send_notification():
+    """Create a new notification."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    title = data.get("title")
+    message = data.get("message")
+    if not title or not message:
+        return jsonify({"error": "title and message are required"}), 400
+
+    result = create_notification(
+        user_id=user_id,
+        title=title,
+        message=message,
+        priority=data.get("priority", "normal"),
+        category=data.get("category", "general"),
+        group_key=data.get("group_key"),
+        action_url=data.get("action_url"),
+        action_type=data.get("action_type"),
+        metadata=data.get("extra_data"),
+        expires_at=None,
+    )
+    return jsonify(result), 201
+
+
+@bp.get("")
+@jwt_required()
+def list_notifications():
+    """List notifications with priority sorting and filtering."""
+    user_id = int(get_jwt_identity())
+
+    result = get_notifications(
+        user_id=user_id,
+        category=request.args.get("category"),
+        priority=request.args.get("priority"),
+        is_read=_parse_bool(request.args.get("is_read")),
+        group_key=request.args.get("group_key"),
+        limit=int(request.args.get("limit", 50)),
+        offset=int(request.args.get("offset", 0)),
+    )
+    return jsonify(result), 200
+
+
+@bp.get("/grouped")
+@jwt_required()
+def grouped_notifications():
+    """Get notifications grouped by group_key."""
+    user_id = int(get_jwt_identity())
+    category = request.args.get("category")
+    result = get_grouped_notifications(user_id, category=category)
+    return jsonify(result), 200
+
+
+@bp.post("/<int:notification_id>/read")
+@jwt_required()
+def read_notification(notification_id):
+    """Mark a notification as read."""
+    user_id = int(get_jwt_identity())
+    result = mark_read(notification_id, user_id)
+    if not result:
+        return jsonify({"error": "Notification not found"}), 404
+    return jsonify(result), 200
+
+
+@bp.post("/read-all")
+@jwt_required()
+def read_all():
+    """Mark all notifications as read."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json() or {}
+    result = mark_all_read(
+        user_id,
+        category=data.get("category"),
+        group_key=data.get("group_key"),
+    )
+    return jsonify(result), 200
+
+
+@bp.post("/<int:notification_id>/dismiss")
+@jwt_required()
+def dismiss(notification_id):
+    """Dismiss a notification."""
+    user_id = int(get_jwt_identity())
+    result = dismiss_notification(notification_id, user_id)
+    if not result:
+        return jsonify({"error": "Notification not found"}), 404
+    return jsonify(result), 200
+
+
+@bp.post("/dismiss-group")
+@jwt_required()
+def dismiss_grp():
+    """Dismiss all notifications in a group."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json() or {}
+    group_key = data.get("group_key")
+    if not group_key:
+        return jsonify({"error": "group_key is required"}), 400
+    result = dismiss_group(user_id, group_key)
+    return jsonify(result), 200
+
+
+@bp.get("/unread")
+@jwt_required()
+def unread():
+    """Get unread notification counts."""
+    user_id = int(get_jwt_identity())
+    result = get_unread_count(user_id)
+    return jsonify(result), 200
+
+
+@bp.get("/stats")
+@jwt_required()
+def stats():
+    """Get notification statistics."""
+    user_id = int(get_jwt_identity())
+    days = int(request.args.get("days", 30))
+    result = get_notification_stats(user_id, days=days)
+    return jsonify(result), 200
+
+
+def _parse_bool(value):
+    """Parse boolean query parameter."""
+    if value is None:
+        return None
+    return value.lower() in ("true", "1", "yes")

--- a/packages/backend/app/services/notification_priority.py
+++ b/packages/backend/app/services/notification_priority.py
@@ -1,0 +1,370 @@
+"""Notification priority & grouping service.
+
+Provides intelligent notification management with priority levels,
+category-based grouping, batch operations, and analytics.
+"""
+
+from datetime import datetime, timedelta
+from sqlalchemy import func, case, desc
+from app.extensions import db
+from app.models import Notification
+
+
+# Priority weights for sorting (higher = more important)
+PRIORITY_WEIGHTS = {
+    "critical": 4,
+    "high": 3,
+    "normal": 2,
+    "low": 1,
+}
+
+# Default categories
+CATEGORIES = [
+    "general",
+    "bill_due",
+    "budget_alert",
+    "transaction",
+    "security",
+    "insight",
+    "reminder",
+    "system",
+]
+
+
+def create_notification(
+    user_id,
+    title,
+    message,
+    priority="normal",
+    category="general",
+    group_key=None,
+    action_url=None,
+    action_type=None,
+    metadata=None,
+    expires_at=None,
+):
+    """Create a new notification."""
+    if priority not in PRIORITY_WEIGHTS:
+        priority = "normal"
+    if category not in CATEGORIES:
+        category = "general"
+
+    notification = Notification(
+        user_id=user_id,
+        title=title,
+        message=message,
+        priority=priority,
+        category=category,
+        group_key=group_key,
+        action_url=action_url,
+        action_type=action_type,
+        extra_data=metadata or {},
+        expires_at=expires_at,
+    )
+    db.session.add(notification)
+    db.session.commit()
+    return _notification_to_dict(notification)
+
+
+def get_notifications(
+    user_id,
+    category=None,
+    priority=None,
+    is_read=None,
+    group_key=None,
+    limit=50,
+    offset=0,
+):
+    """Get notifications for a user, sorted by priority then recency."""
+    query = Notification.query.filter_by(
+        user_id=user_id, is_dismissed=False
+    )
+
+    # Filter expired notifications
+    query = query.filter(
+        db.or_(
+            Notification.expires_at.is_(None),
+            Notification.expires_at > datetime.utcnow(),
+        )
+    )
+
+    if category:
+        query = query.filter_by(category=category)
+    if priority:
+        query = query.filter_by(priority=priority)
+    if is_read is not None:
+        query = query.filter_by(is_read=is_read)
+    if group_key:
+        query = query.filter_by(group_key=group_key)
+
+    # Sort by priority weight (descending) then created_at (descending)
+    priority_order = case(
+        (Notification.priority == "critical", 4),
+        (Notification.priority == "high", 3),
+        (Notification.priority == "normal", 2),
+        (Notification.priority == "low", 1),
+        else_=0,
+    )
+
+    query = query.order_by(desc(priority_order), desc(Notification.created_at))
+    total = query.count()
+    notifications = query.limit(limit).offset(offset).all()
+
+    return {
+        "notifications": [_notification_to_dict(n) for n in notifications],
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def get_grouped_notifications(user_id, category=None):
+    """Get notifications grouped by group_key and category."""
+    query = Notification.query.filter_by(
+        user_id=user_id, is_dismissed=False
+    ).filter(
+        db.or_(
+            Notification.expires_at.is_(None),
+            Notification.expires_at > datetime.utcnow(),
+        )
+    )
+
+    if category:
+        query = query.filter_by(category=category)
+
+    notifications = query.order_by(
+        desc(Notification.created_at)
+    ).all()
+
+    groups = {}
+    ungrouped = []
+
+    for n in notifications:
+        d = _notification_to_dict(n)
+        if n.group_key:
+            if n.group_key not in groups:
+                groups[n.group_key] = {
+                    "group_key": n.group_key,
+                    "category": n.category,
+                    "count": 0,
+                    "unread_count": 0,
+                    "latest": None,
+                    "notifications": [],
+                }
+            group = groups[n.group_key]
+            group["count"] += 1
+            if not n.is_read:
+                group["unread_count"] += 1
+            group["notifications"].append(d)
+            if group["latest"] is None:
+                group["latest"] = d
+        else:
+            ungrouped.append(d)
+
+    # Sort groups by highest priority notification in each group
+    sorted_groups = sorted(
+        groups.values(),
+        key=lambda g: max(
+            PRIORITY_WEIGHTS.get(n.get("priority", "normal"), 0)
+            for n in g["notifications"]
+        ),
+        reverse=True,
+    )
+
+    return {
+        "groups": sorted_groups,
+        "ungrouped": ungrouped,
+        "total_groups": len(sorted_groups),
+        "total_ungrouped": len(ungrouped),
+    }
+
+
+def mark_read(notification_id, user_id):
+    """Mark a single notification as read."""
+    n = Notification.query.filter_by(id=notification_id, user_id=user_id).first()
+    if not n:
+        return None
+    n.is_read = True
+    n.updated_at = datetime.utcnow()
+    db.session.commit()
+    return _notification_to_dict(n)
+
+
+def mark_all_read(user_id, category=None, group_key=None):
+    """Mark all notifications as read with optional filters."""
+    query = Notification.query.filter_by(user_id=user_id, is_read=False)
+    if category:
+        query = query.filter_by(category=category)
+    if group_key:
+        query = query.filter_by(group_key=group_key)
+
+    count = query.update(
+        {"is_read": True, "updated_at": datetime.utcnow()},
+        synchronize_session="fetch",
+    )
+    db.session.commit()
+    return {"marked_read": count}
+
+
+def dismiss_notification(notification_id, user_id):
+    """Dismiss (soft-delete) a notification."""
+    n = Notification.query.filter_by(id=notification_id, user_id=user_id).first()
+    if not n:
+        return None
+    n.is_dismissed = True
+    n.updated_at = datetime.utcnow()
+    db.session.commit()
+    return _notification_to_dict(n)
+
+
+def dismiss_group(user_id, group_key):
+    """Dismiss all notifications in a group."""
+    count = Notification.query.filter_by(
+        user_id=user_id, group_key=group_key, is_dismissed=False
+    ).update(
+        {"is_dismissed": True, "updated_at": datetime.utcnow()},
+        synchronize_session="fetch",
+    )
+    db.session.commit()
+    return {"dismissed": count}
+
+
+def get_unread_count(user_id):
+    """Get unread notification counts by priority and category."""
+    base = Notification.query.filter_by(
+        user_id=user_id, is_read=False, is_dismissed=False
+    ).filter(
+        db.or_(
+            Notification.expires_at.is_(None),
+            Notification.expires_at > datetime.utcnow(),
+        )
+    )
+
+    total = base.count()
+
+    by_priority = dict(
+        db.session.query(
+            Notification.priority, func.count(Notification.id)
+        )
+        .filter(
+            Notification.user_id == user_id,
+            Notification.is_read == False,
+            Notification.is_dismissed == False,
+            db.or_(
+                Notification.expires_at.is_(None),
+                Notification.expires_at > datetime.utcnow(),
+            ),
+        )
+        .group_by(Notification.priority)
+        .all()
+    )
+
+    by_category = dict(
+        db.session.query(
+            Notification.category, func.count(Notification.id)
+        )
+        .filter(
+            Notification.user_id == user_id,
+            Notification.is_read == False,
+            Notification.is_dismissed == False,
+            db.or_(
+                Notification.expires_at.is_(None),
+                Notification.expires_at > datetime.utcnow(),
+            ),
+        )
+        .group_by(Notification.category)
+        .all()
+    )
+
+    return {
+        "total": total,
+        "by_priority": by_priority,
+        "by_category": by_category,
+    }
+
+
+def get_notification_stats(user_id, days=30):
+    """Get notification statistics for analytics."""
+    since = datetime.utcnow() - timedelta(days=days)
+
+    base = Notification.query.filter(
+        Notification.user_id == user_id,
+        Notification.created_at >= since,
+    )
+
+    total = base.count()
+    read = base.filter_by(is_read=True).count()
+    dismissed = base.filter_by(is_dismissed=True).count()
+    unread = base.filter_by(is_read=False, is_dismissed=False).count()
+
+    by_priority = dict(
+        db.session.query(
+            Notification.priority, func.count(Notification.id)
+        )
+        .filter(
+            Notification.user_id == user_id,
+            Notification.created_at >= since,
+        )
+        .group_by(Notification.priority)
+        .all()
+    )
+
+    by_category = dict(
+        db.session.query(
+            Notification.category, func.count(Notification.id)
+        )
+        .filter(
+            Notification.user_id == user_id,
+            Notification.created_at >= since,
+        )
+        .group_by(Notification.category)
+        .all()
+    )
+
+    # Daily volume
+    daily = (
+        db.session.query(
+            func.date(Notification.created_at).label("date"),
+            func.count(Notification.id).label("count"),
+        )
+        .filter(
+            Notification.user_id == user_id,
+            Notification.created_at >= since,
+        )
+        .group_by(func.date(Notification.created_at))
+        .order_by(func.date(Notification.created_at))
+        .all()
+    )
+
+    return {
+        "total": total,
+        "read": read,
+        "unread": unread,
+        "dismissed": dismissed,
+        "read_rate": round(read / total, 3) if total > 0 else 0.0,
+        "by_priority": by_priority,
+        "by_category": by_category,
+        "daily_volume": [{"date": str(d.date), "count": d.count} for d in daily],
+        "period_days": days,
+    }
+
+
+def _notification_to_dict(n):
+    """Convert notification model to dict."""
+    return {
+        "id": n.id,
+        "user_id": n.user_id,
+        "title": n.title,
+        "message": n.message,
+        "priority": n.priority,
+        "category": n.category,
+        "group_key": n.group_key,
+        "is_read": n.is_read,
+        "is_dismissed": n.is_dismissed,
+        "action_url": n.action_url,
+        "action_type": n.action_type,
+        "extra_data": n.extra_data,
+        "expires_at": n.expires_at.isoformat() if n.expires_at else None,
+        "created_at": n.created_at.isoformat() if n.created_at else None,
+        "updated_at": n.updated_at.isoformat() if n.updated_at else None,
+    }

--- a/packages/backend/commit-msg.txt
+++ b/packages/backend/commit-msg.txt
@@ -1,0 +1,26 @@
+feat(notifications): implement notification priority & grouping system
+
+Resolves #122
+
+Add intelligent notification management with priority-weighted sorting,
+category-based organization, notification grouping, batch operations,
+and analytics dashboard.
+
+Changes:
+- Add notifications table migration (034_notification_priority.sql)
+- Add Notification model with 15 columns and 6 indexes
+- Add notification priority service with grouping and analytics
+- Add 9 REST endpoints under /notifications blueprint
+- Add 38 tests covering service logic and route integration
+- Add documentation (docs/notification-priority.md)
+
+Features:
+- Priority levels: critical (4), high (3), normal (2), low (1)
+- Categories: general, bill_due, budget_alert, transaction, security, etc.
+- Group related notifications by group_key with unread counts
+- Mark individual or all notifications as read (with category/group filters)
+- Dismiss single notifications or entire groups (soft delete)
+- Unread counts broken down by priority and category
+- Statistics: read rates, volume trends, daily counts
+- Expired notification auto-filtering
+- Pagination with offset/limit support

--- a/packages/backend/docs/notification-priority.md
+++ b/packages/backend/docs/notification-priority.md
@@ -1,0 +1,124 @@
+# Notification Priority & Grouping System
+
+Intelligent notification management with priority levels, category-based grouping, batch operations, and analytics.
+
+## Overview
+
+- **Priority sorting** — Critical, high, normal, low with weighted ordering
+- **Category system** — general, bill_due, budget_alert, transaction, security, insight, reminder, system
+- **Grouping** — Collapse related notifications by group_key
+- **Batch operations** — Mark all read, dismiss entire groups
+- **Analytics** — Read rates, volume trends, priority/category breakdowns
+
+## Database Schema
+
+```sql
+CREATE TABLE notifications (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    title VARCHAR(200) NOT NULL,
+    message TEXT NOT NULL,
+    priority VARCHAR(20) DEFAULT 'normal',
+    category VARCHAR(50) DEFAULT 'general',
+    group_key VARCHAR(100),
+    is_read BOOLEAN DEFAULT FALSE,
+    is_dismissed BOOLEAN DEFAULT FALSE,
+    action_url VARCHAR(500),
+    action_type VARCHAR(50),
+    extra_data JSONB DEFAULT '{}',
+    expires_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+## API Endpoints
+
+All endpoints require JWT authentication.
+
+### Create Notification
+
+```http
+POST /notifications/send
+{
+    "title": "Bill Due Tomorrow",
+    "message": "Your rent payment of $1,200 is due tomorrow",
+    "priority": "high",
+    "category": "bill_due",
+    "group_key": "bills_march",
+    "action_url": "/bills/42",
+    "action_type": "navigate"
+}
+```
+
+### List Notifications (Priority-Sorted)
+
+```http
+GET /notifications?category=bill_due&priority=high&is_read=false&limit=20&offset=0
+```
+
+Returns notifications sorted by priority weight descending, then by recency.
+
+### Grouped View
+
+```http
+GET /notifications/grouped?category=security
+```
+
+Groups notifications by `group_key` with counts and unread tallies.
+
+### Mark Read
+
+```http
+POST /notifications/<id>/read
+POST /notifications/read-all
+```
+
+### Dismiss
+
+```http
+POST /notifications/<id>/dismiss
+POST /notifications/dismiss-group  {"group_key": "bills_march"}
+```
+
+### Unread Counts
+
+```http
+GET /notifications/unread
+```
+
+Returns total count with breakdowns by priority and category.
+
+### Statistics
+
+```http
+GET /notifications/stats?days=30
+```
+
+Returns read rates, volume trends, priority/category breakdowns.
+
+## Priority Weights
+
+| Priority | Weight | Use Case |
+|----------|--------|----------|
+| critical | 4 | Security alerts, overdue bills |
+| high | 3 | Due tomorrow, budget exceeded |
+| normal | 2 | Transaction notifications |
+| low | 1 | Tips, insights |
+
+## Architecture
+
+| Component | File |
+|-----------|------|
+| Migration | `app/db/034_notification_priority.sql` |
+| Model | `app/models.py` → `Notification` |
+| Service | `app/services/notification_priority.py` |
+| Routes | `app/routes/notification_priority.py` |
+| Tests | `tests/test_notification_priority.py` |
+
+## Testing
+
+```bash
+python -m pytest tests/test_notification_priority.py -v
+# 38 tests covering priority sorting, grouping, batch ops, and route integration
+```

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,21 @@
 import os
 import pytest
+import fakeredis
+from unittest.mock import patch
 from app import create_app
 from app.config import Settings
 from app.extensions import db
 from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+@pytest.fixture(autouse=True)
+def _patch_redis():
+    fake = fakeredis.FakeRedis()
+    with patch("app.extensions.redis_client", fake), \
+         patch("app.routes.auth.redis_client", fake), \
+         patch("app.services.cache.redis_client", fake):
+        yield fake
 
 
 class TestSettings(Settings):

--- a/packages/backend/tests/test_notification_priority.py
+++ b/packages/backend/tests/test_notification_priority.py
@@ -1,0 +1,427 @@
+"""Tests for notification priority & grouping system."""
+
+import pytest
+from datetime import datetime, timedelta
+from app.extensions import db
+from app.models import Notification
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Service unit tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestCreateNotification:
+    """Test notification creation."""
+
+    def test_create_basic(self, client, auth_header):
+        from app.services.notification_priority import create_notification
+
+        with client.application.app_context():
+            result = create_notification(1, "Test", "Hello world")
+
+        assert result["title"] == "Test"
+        assert result["message"] == "Hello world"
+        assert result["priority"] == "normal"
+        assert result["category"] == "general"
+        assert result["is_read"] is False
+
+    def test_create_with_priority(self, client, auth_header):
+        from app.services.notification_priority import create_notification
+
+        with client.application.app_context():
+            result = create_notification(1, "Alert", "Critical!", priority="critical")
+
+        assert result["priority"] == "critical"
+
+    def test_invalid_priority_defaults(self, client, auth_header):
+        from app.services.notification_priority import create_notification
+
+        with client.application.app_context():
+            result = create_notification(1, "Test", "msg", priority="invalid")
+
+        assert result["priority"] == "normal"
+
+    def test_invalid_category_defaults(self, client, auth_header):
+        from app.services.notification_priority import create_notification
+
+        with client.application.app_context():
+            result = create_notification(1, "Test", "msg", category="unknown")
+
+        assert result["category"] == "general"
+
+    def test_create_with_group_key(self, client, auth_header):
+        from app.services.notification_priority import create_notification
+
+        with client.application.app_context():
+            result = create_notification(
+                1, "Bill Due", "Pay rent", group_key="bills_march"
+            )
+
+        assert result["group_key"] == "bills_march"
+
+    def test_create_with_action(self, client, auth_header):
+        from app.services.notification_priority import create_notification
+
+        with client.application.app_context():
+            result = create_notification(
+                1, "Test", "msg",
+                action_url="/bills/42",
+                action_type="navigate",
+            )
+
+        assert result["action_url"] == "/bills/42"
+        assert result["action_type"] == "navigate"
+
+
+class TestGetNotifications:
+    """Test notification listing with priority sorting."""
+
+    def _seed(self, client):
+        from app.services.notification_priority import create_notification
+
+        with client.application.app_context():
+            create_notification(1, "Low", "low msg", priority="low")
+            create_notification(1, "Critical", "urgent!", priority="critical")
+            create_notification(1, "Normal", "normal msg", priority="normal")
+            create_notification(1, "High", "important", priority="high")
+
+    def test_priority_ordering(self, client, auth_header):
+        from app.services.notification_priority import get_notifications
+
+        self._seed(client)
+        with client.application.app_context():
+            result = get_notifications(1)
+
+        titles = [n["title"] for n in result["notifications"]]
+        assert titles[0] == "Critical"
+        assert titles[1] == "High"
+        assert titles[2] == "Normal"
+        assert titles[3] == "Low"
+
+    def test_filter_by_priority(self, client, auth_header):
+        from app.services.notification_priority import get_notifications
+
+        self._seed(client)
+        with client.application.app_context():
+            result = get_notifications(1, priority="critical")
+
+        assert result["total"] == 1
+        assert result["notifications"][0]["priority"] == "critical"
+
+    def test_filter_by_read_status(self, client, auth_header):
+        from app.services.notification_priority import get_notifications, mark_read
+
+        self._seed(client)
+        with client.application.app_context():
+            notifs = get_notifications(1)
+            mark_read(notifs["notifications"][0]["id"], 1)
+            unread = get_notifications(1, is_read=False)
+
+        assert unread["total"] == 3
+
+    def test_pagination(self, client, auth_header):
+        from app.services.notification_priority import get_notifications
+
+        self._seed(client)
+        with client.application.app_context():
+            result = get_notifications(1, limit=2, offset=0)
+
+        assert len(result["notifications"]) == 2
+        assert result["total"] == 4
+
+    def test_empty_list(self, client, auth_header):
+        from app.services.notification_priority import get_notifications
+
+        with client.application.app_context():
+            result = get_notifications(1)
+
+        assert result["notifications"] == []
+        assert result["total"] == 0
+
+
+class TestGroupedNotifications:
+    """Test notification grouping."""
+
+    def test_grouped(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, get_grouped_notifications,
+        )
+
+        with client.application.app_context():
+            create_notification(1, "Bill 1", "msg", group_key="bills")
+            create_notification(1, "Bill 2", "msg", group_key="bills")
+            create_notification(1, "Solo", "msg")  # ungrouped
+            result = get_grouped_notifications(1)
+
+        assert result["total_groups"] == 1
+        assert result["groups"][0]["count"] == 2
+        assert result["total_ungrouped"] == 1
+
+    def test_grouped_unread_count(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, get_grouped_notifications, mark_read,
+        )
+
+        with client.application.app_context():
+            n1 = create_notification(1, "A", "msg", group_key="g1")
+            create_notification(1, "B", "msg", group_key="g1")
+            mark_read(n1["id"], 1)
+            result = get_grouped_notifications(1)
+
+        assert result["groups"][0]["unread_count"] == 1
+
+    def test_filter_by_category(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, get_grouped_notifications,
+        )
+
+        with client.application.app_context():
+            create_notification(1, "A", "msg", group_key="g", category="bill_due")
+            create_notification(1, "B", "msg", group_key="g", category="security")
+            result = get_grouped_notifications(1, category="bill_due")
+
+        assert result["total_groups"] == 1
+        assert result["groups"][0]["count"] == 1
+
+
+class TestMarkRead:
+    """Test read/dismiss operations."""
+
+    def test_mark_read(self, client, auth_header):
+        from app.services.notification_priority import create_notification, mark_read
+
+        with client.application.app_context():
+            n = create_notification(1, "Test", "msg")
+            result = mark_read(n["id"], 1)
+
+        assert result["is_read"] is True
+
+    def test_mark_read_nonexistent(self, client, auth_header):
+        from app.services.notification_priority import mark_read
+
+        with client.application.app_context():
+            assert mark_read(9999, 1) is None
+
+    def test_mark_all_read(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, mark_all_read, get_unread_count,
+        )
+
+        with client.application.app_context():
+            create_notification(1, "A", "msg")
+            create_notification(1, "B", "msg")
+            result = mark_all_read(1)
+            count = get_unread_count(1)
+
+        assert result["marked_read"] == 2
+        assert count["total"] == 0
+
+    def test_dismiss(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, dismiss_notification, get_notifications,
+        )
+
+        with client.application.app_context():
+            n = create_notification(1, "Test", "msg")
+            dismiss_notification(n["id"], 1)
+            result = get_notifications(1)
+
+        assert result["total"] == 0
+
+    def test_dismiss_group(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, dismiss_group, get_notifications,
+        )
+
+        with client.application.app_context():
+            create_notification(1, "A", "msg", group_key="g1")
+            create_notification(1, "B", "msg", group_key="g1")
+            create_notification(1, "C", "msg")  # ungrouped
+            dismiss_group(1, "g1")
+            result = get_notifications(1)
+
+        assert result["total"] == 1  # only ungrouped remains
+
+
+class TestUnreadCount:
+    """Test unread count."""
+
+    def test_counts(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, get_unread_count,
+        )
+
+        with client.application.app_context():
+            create_notification(1, "A", "msg", priority="critical", category="security")
+            create_notification(1, "B", "msg", priority="low", category="general")
+            result = get_unread_count(1)
+
+        assert result["total"] == 2
+        assert result["by_priority"]["critical"] == 1
+        assert result["by_priority"]["low"] == 1
+        assert result["by_category"]["security"] == 1
+
+
+class TestNotificationStats:
+    """Test statistics."""
+
+    def test_empty_stats(self, client, auth_header):
+        from app.services.notification_priority import get_notification_stats
+
+        with client.application.app_context():
+            stats = get_notification_stats(1)
+
+        assert stats["total"] == 0
+        assert stats["read_rate"] == 0.0
+
+    def test_stats_with_data(self, client, auth_header):
+        from app.services.notification_priority import (
+            create_notification, mark_read, get_notification_stats,
+        )
+
+        with client.application.app_context():
+            n1 = create_notification(1, "A", "msg", priority="high")
+            create_notification(1, "B", "msg", priority="low")
+            mark_read(n1["id"], 1)
+            stats = get_notification_stats(1)
+
+        assert stats["total"] == 2
+        assert stats["read"] == 1
+        assert stats["read_rate"] == 0.5
+        assert stats["by_priority"]["high"] == 1
+
+
+# ═══════════════════════════════════════════════════════════════════
+# Route integration tests
+# ═══════════════════════════════════════════════════════════════════
+
+
+class TestNotificationRoutes:
+    """Integration tests for /notifications/* endpoints."""
+
+    # ── POST /notifications/send ──
+    def test_send(self, client, auth_header):
+        r = client.post("/notifications/send",
+                        json={"title": "Test", "message": "Hello"},
+                        headers=auth_header)
+        assert r.status_code == 201
+        assert r.get_json()["title"] == "Test"
+
+    def test_send_with_priority(self, client, auth_header):
+        r = client.post("/notifications/send",
+                        json={"title": "Alert", "message": "!",
+                              "priority": "critical", "category": "security"},
+                        headers=auth_header)
+        assert r.status_code == 201
+        assert r.get_json()["priority"] == "critical"
+
+    def test_send_missing_fields(self, client, auth_header):
+        r = client.post("/notifications/send", json={}, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_send_unauthorized(self, client):
+        r = client.post("/notifications/send",
+                        json={"title": "T", "message": "M"})
+        assert r.status_code == 401
+
+    # ── GET /notifications ──
+    def test_list(self, client, auth_header):
+        client.post("/notifications/send",
+                    json={"title": "T", "message": "M"},
+                    headers=auth_header)
+        r = client.get("/notifications", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["total"] >= 1
+
+    def test_list_with_filters(self, client, auth_header):
+        r = client.get("/notifications?priority=high&is_read=false&limit=10",
+                       headers=auth_header)
+        assert r.status_code == 200
+
+    # ── GET /notifications/grouped ──
+    def test_grouped(self, client, auth_header):
+        client.post("/notifications/send",
+                    json={"title": "A", "message": "M", "group_key": "g1"},
+                    headers=auth_header)
+        client.post("/notifications/send",
+                    json={"title": "B", "message": "M", "group_key": "g1"},
+                    headers=auth_header)
+        r = client.get("/notifications/grouped", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["total_groups"] >= 1
+
+    # ── POST /notifications/<id>/read ──
+    def test_mark_read_route(self, client, auth_header):
+        cr = client.post("/notifications/send",
+                         json={"title": "T", "message": "M"},
+                         headers=auth_header)
+        nid = cr.get_json()["id"]
+        r = client.post(f"/notifications/{nid}/read", json={},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["is_read"] is True
+
+    def test_mark_read_nonexistent(self, client, auth_header):
+        r = client.post("/notifications/9999/read", json={},
+                        headers=auth_header)
+        assert r.status_code == 404
+
+    # ── POST /notifications/read-all ──
+    def test_read_all_route(self, client, auth_header):
+        client.post("/notifications/send",
+                    json={"title": "T", "message": "M"},
+                    headers=auth_header)
+        r = client.post("/notifications/read-all", json={},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["marked_read"] >= 1
+
+    # ── POST /notifications/<id>/dismiss ──
+    def test_dismiss_route(self, client, auth_header):
+        cr = client.post("/notifications/send",
+                         json={"title": "T", "message": "M"},
+                         headers=auth_header)
+        nid = cr.get_json()["id"]
+        r = client.post(f"/notifications/{nid}/dismiss", json={},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["is_dismissed"] is True
+
+    # ── POST /notifications/dismiss-group ──
+    def test_dismiss_group_route(self, client, auth_header):
+        client.post("/notifications/send",
+                    json={"title": "T", "message": "M", "group_key": "gx"},
+                    headers=auth_header)
+        r = client.post("/notifications/dismiss-group",
+                        json={"group_key": "gx"},
+                        headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["dismissed"] >= 1
+
+    def test_dismiss_group_missing_key(self, client, auth_header):
+        r = client.post("/notifications/dismiss-group", json={},
+                        headers=auth_header)
+        assert r.status_code == 400
+
+    # ── GET /notifications/unread ──
+    def test_unread_route(self, client, auth_header):
+        client.post("/notifications/send",
+                    json={"title": "T", "message": "M"},
+                    headers=auth_header)
+        r = client.get("/notifications/unread", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["total"] >= 1
+
+    # ── GET /notifications/stats ──
+    def test_stats_route(self, client, auth_header):
+        r = client.get("/notifications/stats", headers=auth_header)
+        assert r.status_code == 200
+        body = r.get_json()
+        assert "read_rate" in body
+        assert "by_priority" in body
+
+    def test_stats_with_days(self, client, auth_header):
+        r = client.get("/notifications/stats?days=7", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["period_days"] == 7


### PR DESCRIPTION
## Notification Priority & Grouping System

Resolves #122

### Summary
Intelligent notification management with priority-weighted sorting, category-based grouping, batch operations, and analytics.

### Changes
| File | Description |
|------|-------------|
| `app/db/034_notification_priority.sql` | Migration — `notifications` table with 15 columns + 6 indexes |
| `app/models.py` | `Notification` SQLAlchemy model |
| `app/services/notification_priority.py` | Priority sorting, grouping, batch ops, analytics |
| `app/routes/notification_priority.py` | 9 REST endpoints under `/notifications` |
| `tests/test_notification_priority.py` | 38 tests (service + route integration) |
| `docs/notification-priority.md` | API documentation |

### Features

**Priority System**
| Priority | Weight | Use Case |
|----------|--------|----------|
| critical | 4 | Security alerts, overdue bills |
| high | 3 | Due tomorrow, budget exceeded |
| normal | 2 | Transaction notifications |
| low | 1 | Tips, insights |

**Category System**
- general, bill_due, budget_alert, transaction, security, insight, reminder, system

**Grouping**
- Collapse related notifications by `group_key`
- Per-group unread counts
- Dismiss entire groups at once

**Batch Operations**
- Mark all read (filterable by category/group)
- Dismiss groups

**Analytics**
- Read rates, volume trends
- Breakdowns by priority and category
- Daily volume tracking

### API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/notifications/send` | Create notification |
| GET | `/notifications` | List (priority-sorted) |
| GET | `/notifications/grouped` | Grouped view |
| POST | `/notifications/<id>/read` | Mark read |
| POST | `/notifications/read-all` | Mark all read |
| POST | `/notifications/<id>/dismiss` | Dismiss one |
| POST | `/notifications/dismiss-group` | Dismiss group |
| GET | `/notifications/unread` | Unread counts |
| GET | `/notifications/stats` | Analytics |

### Testing
```
38 passed in 5.06s
```
