### PR TITLE
feat(dashboard): add customizable dashboard widgets (#103)

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,20 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class DashboardWidget(db.Model):
+    __tablename__ = "dashboard_widgets"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    widget_key = db.Column(db.String(50), nullable=False)
+    display_name = db.Column(db.String(100), nullable=False)
+    visible = db.Column(db.Boolean, default=True)
+    position = db.Column(db.Integer, default=0, nullable=False)
+    config = db.Column(db.JSON, default=dict)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "widget_key", name="uq_user_widget"),
+    )

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .dashboard_widgets import bp as dashboard_widgets_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(dashboard_widgets_bp, url_prefix="/widgets")

--- a/packages/backend/app/routes/dashboard_widgets.py
+++ b/packages/backend/app/routes/dashboard_widgets.py
@@ -1,0 +1,117 @@
+"""Customizable dashboard widgets routes."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.services.dashboard_widgets import (
+    get_layout,
+    initialize_layout,
+    reset_layout,
+    toggle_visibility,
+    bulk_update_visibility,
+    reorder_widgets,
+    update_widget_config,
+    get_widget,
+    get_available_widgets,
+)
+
+bp = Blueprint("dashboard_widgets", __name__)
+
+
+@bp.get("")
+@jwt_required()
+def get_layout_route():
+    """Get dashboard widget layout."""
+    user_id = int(get_jwt_identity())
+    result = get_layout(user_id)
+    return jsonify(result), 200
+
+
+@bp.post("/initialize")
+@jwt_required()
+def initialize_route():
+    """Initialize default widget layout."""
+    user_id = int(get_jwt_identity())
+    result = initialize_layout(user_id)
+    return jsonify(result), 201
+
+
+@bp.post("/reset")
+@jwt_required()
+def reset_route():
+    """Reset layout to defaults."""
+    user_id = int(get_jwt_identity())
+    result = reset_layout(user_id)
+    return jsonify(result), 200
+
+
+@bp.put("/<widget_key>/visibility")
+@jwt_required()
+def toggle_route(widget_key):
+    """Toggle widget visibility."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or "visible" not in data:
+        return jsonify({"error": "visible field is required"}), 400
+
+    result = toggle_visibility(user_id, widget_key, data["visible"])
+    if "error" in result:
+        return jsonify(result), 404
+    return jsonify(result), 200
+
+
+@bp.put("/visibility")
+@jwt_required()
+def bulk_visibility_route():
+    """Update visibility for multiple widgets."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No data provided"}), 400
+    result = bulk_update_visibility(user_id, data)
+    return jsonify(result), 200
+
+
+@bp.put("/reorder")
+@jwt_required()
+def reorder_route():
+    """Reorder dashboard widgets."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json()
+    if not data or "order" not in data:
+        return jsonify({"error": "order array is required"}), 400
+    result = reorder_widgets(user_id, data["order"])
+    return jsonify(result), 200
+
+
+@bp.put("/<widget_key>/config")
+@jwt_required()
+def config_route(widget_key):
+    """Update widget configuration."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No config data provided"}), 400
+    result = update_widget_config(user_id, widget_key, data)
+    if "error" in result:
+        return jsonify(result), 404
+    return jsonify(result), 200
+
+
+@bp.get("/<widget_key>")
+@jwt_required()
+def get_widget_route(widget_key):
+    """Get single widget details."""
+    user_id = int(get_jwt_identity())
+    result = get_widget(user_id, widget_key)
+    if "error" in result:
+        return jsonify(result), 404
+    return jsonify(result), 200
+
+
+@bp.get("/available")
+@jwt_required()
+def available_route():
+    """List all available widget types."""
+    result = get_available_widgets()
+    return jsonify(result), 200

--- a/packages/backend/app/services/dashboard_widgets.py
+++ b/packages/backend/app/services/dashboard_widgets.py
@@ -1,0 +1,204 @@
+"""Customizable dashboard widgets service.
+
+Allows users to show/hide, reorder, and configure dashboard sections.
+Provides default widget layouts and per-user customization.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from app.extensions import db
+from app.models import DashboardWidget
+
+
+# Default widgets available to all users
+DEFAULT_WIDGETS = [
+    {"widget_key": "spending_overview", "display_name": "Spending Overview", "position": 0},
+    {"widget_key": "recent_transactions", "display_name": "Recent Transactions", "position": 1},
+    {"widget_key": "budget_progress", "display_name": "Budget Progress", "position": 2},
+    {"widget_key": "upcoming_bills", "display_name": "Upcoming Bills", "position": 3},
+    {"widget_key": "category_breakdown", "display_name": "Category Breakdown", "position": 4},
+    {"widget_key": "savings_goals", "display_name": "Savings Goals", "position": 5},
+    {"widget_key": "recurring_expenses", "display_name": "Recurring Expenses", "position": 6},
+    {"widget_key": "financial_health", "display_name": "Financial Health Score", "position": 7},
+]
+
+
+# ── Widget Layout ─────────────────────────────────────────────────
+
+
+def get_layout(user_id: int) -> list:
+    """Get the dashboard layout for a user.
+
+    Returns user's custom layout or defaults if none configured.
+    """
+    widgets = (
+        DashboardWidget.query
+        .filter_by(user_id=user_id)
+        .order_by(DashboardWidget.position)
+        .all()
+    )
+
+    if not widgets:
+        return [
+            {**w, "visible": True, "config": {}}
+            for w in DEFAULT_WIDGETS
+        ]
+
+    return [_serialize_widget(w) for w in widgets]
+
+
+def initialize_layout(user_id: int) -> list:
+    """Initialize default widget layout for a user.
+
+    Creates widget records from defaults. Idempotent — skips
+    if layout already exists.
+    """
+    existing = DashboardWidget.query.filter_by(user_id=user_id).count()
+    if existing > 0:
+        return get_layout(user_id)
+
+    for w in DEFAULT_WIDGETS:
+        widget = DashboardWidget(
+            user_id=user_id,
+            widget_key=w["widget_key"],
+            display_name=w["display_name"],
+            position=w["position"],
+            visible=True,
+        )
+        db.session.add(widget)
+
+    db.session.commit()
+    return get_layout(user_id)
+
+
+def reset_layout(user_id: int) -> list:
+    """Reset layout to defaults by deleting all custom widgets."""
+    DashboardWidget.query.filter_by(user_id=user_id).delete()
+    db.session.commit()
+    return initialize_layout(user_id)
+
+
+# ── Widget Visibility ─────────────────────────────────────────────
+
+
+def toggle_visibility(user_id: int, widget_key: str, visible: bool) -> dict:
+    """Show or hide a dashboard widget."""
+    widget = _get_or_create(user_id, widget_key)
+    if not widget:
+        return {"error": f"Unknown widget: {widget_key}"}
+
+    widget.visible = visible
+    widget.updated_at = datetime.utcnow()
+    db.session.commit()
+    return _serialize_widget(widget)
+
+
+def bulk_update_visibility(user_id: int, updates: dict) -> list:
+    """Update visibility for multiple widgets at once.
+
+    Args:
+        updates: dict of {widget_key: visible_bool}
+    """
+    _ensure_layout(user_id)
+    for key, visible in updates.items():
+        widget = DashboardWidget.query.filter_by(
+            user_id=user_id, widget_key=key
+        ).first()
+        if widget:
+            widget.visible = visible
+            widget.updated_at = datetime.utcnow()
+
+    db.session.commit()
+    return get_layout(user_id)
+
+
+# ── Widget Reordering ─────────────────────────────────────────────
+
+
+def reorder_widgets(user_id: int, order: list) -> list:
+    """Reorder dashboard widgets.
+
+    Args:
+        order: list of widget_keys in desired order
+    """
+    _ensure_layout(user_id)
+    for position, key in enumerate(order):
+        widget = DashboardWidget.query.filter_by(
+            user_id=user_id, widget_key=key
+        ).first()
+        if widget:
+            widget.position = position
+            widget.updated_at = datetime.utcnow()
+
+    db.session.commit()
+    return get_layout(user_id)
+
+
+# ── Widget Configuration ──────────────────────────────────────────
+
+
+def update_widget_config(user_id: int, widget_key: str, config: dict) -> dict:
+    """Update widget-specific configuration."""
+    widget = _get_or_create(user_id, widget_key)
+    if not widget:
+        return {"error": f"Unknown widget: {widget_key}"}
+
+    widget.config = config
+    widget.updated_at = datetime.utcnow()
+    db.session.commit()
+    return _serialize_widget(widget)
+
+
+def get_widget(user_id: int, widget_key: str) -> dict:
+    """Get a single widget's details."""
+    widget = DashboardWidget.query.filter_by(
+        user_id=user_id, widget_key=widget_key
+    ).first()
+    if not widget:
+        # Check if it's a known default
+        default = next((w for w in DEFAULT_WIDGETS if w["widget_key"] == widget_key), None)
+        if default:
+            return {**default, "visible": True, "config": {}}
+        return {"error": f"Unknown widget: {widget_key}"}
+    return _serialize_widget(widget)
+
+
+# ── Available Widgets ─────────────────────────────────────────────
+
+
+def get_available_widgets() -> list:
+    """List all available widget types."""
+    return [
+        {"widget_key": w["widget_key"], "display_name": w["display_name"]}
+        for w in DEFAULT_WIDGETS
+    ]
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _ensure_layout(user_id: int):
+    """Ensure user has a layout initialized."""
+    if DashboardWidget.query.filter_by(user_id=user_id).count() == 0:
+        initialize_layout(user_id)
+
+
+def _get_or_create(user_id: int, widget_key: str) -> Optional[DashboardWidget]:
+    """Get a widget or create it from defaults."""
+    _ensure_layout(user_id)
+    widget = DashboardWidget.query.filter_by(
+        user_id=user_id, widget_key=widget_key
+    ).first()
+    return widget
+
+
+def _serialize_widget(w: DashboardWidget) -> dict:
+    return {
+        "id": w.id,
+        "widget_key": w.widget_key,
+        "display_name": w.display_name,
+        "visible": w.visible,
+        "position": w.position,
+        "config": w.config or {},
+    }

--- a/packages/backend/commit-msg.txt
+++ b/packages/backend/commit-msg.txt
@@ -1,0 +1,23 @@
+feat(dashboard): add customizable dashboard widgets (#103)
+
+Add widget customization system allowing users to show/hide,
+reorder, and configure dashboard sections.
+
+New features:
+- 8 default dashboard widgets (spending, transactions, budget, etc.)
+- Per-user widget layout persistence
+- Individual and bulk visibility toggling
+- Drag-and-drop style reordering via position API
+- Per-widget configuration storage (JSON)
+- Layout initialization and reset to defaults
+- Idempotent initialization
+
+Implementation:
+- Migration 041: dashboard_widgets table with unique constraint
+- DashboardWidget model with position ordering
+- Dashboard widgets service with 9 public functions
+- 9 REST endpoints under /widgets
+- 25 tests (unit + integration), all passing
+- Full API documentation
+
+Closes #103

--- a/packages/backend/docs/dashboard-widgets.md
+++ b/packages/backend/docs/dashboard-widgets.md
@@ -1,0 +1,84 @@
+# Customizable Dashboard Widgets
+
+## Overview
+
+Allows users to show/hide, reorder, and configure dashboard sections. Provides 8 default widgets with per-user customization that persists across sessions.
+
+## Default Widgets
+
+| Position | Key | Name |
+|---|---|---|
+| 0 | spending_overview | Spending Overview |
+| 1 | recent_transactions | Recent Transactions |
+| 2 | budget_progress | Budget Progress |
+| 3 | upcoming_bills | Upcoming Bills |
+| 4 | category_breakdown | Category Breakdown |
+| 5 | savings_goals | Savings Goals |
+| 6 | recurring_expenses | Recurring Expenses |
+| 7 | financial_health | Financial Health Score |
+
+## API Endpoints
+
+All endpoints require JWT authentication.
+
+### Get Layout
+```
+GET /widgets
+Response: [
+  { "id": 1, "widget_key": "spending_overview", "display_name": "Spending Overview", "visible": true, "position": 0, "config": {} }
+]
+```
+
+### Initialize Layout
+```
+POST /widgets/initialize
+```
+
+### Reset Layout
+```
+POST /widgets/reset
+```
+
+### Toggle Widget Visibility
+```
+PUT /widgets/:widget_key/visibility
+Body: { "visible": false }
+```
+
+### Bulk Update Visibility
+```
+PUT /widgets/visibility
+Body: { "spending_overview": false, "savings_goals": false }
+```
+
+### Reorder Widgets
+```
+PUT /widgets/reorder
+Body: { "order": ["upcoming_bills", "spending_overview", "recent_transactions"] }
+```
+
+### Update Widget Config
+```
+PUT /widgets/:widget_key/config
+Body: { "period": "weekly", "showChart": true }
+```
+
+### Get Single Widget
+```
+GET /widgets/:widget_key
+```
+
+### Available Widgets
+```
+GET /widgets/available
+Response: [{ "widget_key": "spending_overview", "display_name": "Spending Overview" }]
+```
+
+## Testing
+
+```bash
+cd packages/backend
+.venv/bin/python -m pytest tests/test_dashboard_widgets.py -v
+```
+
+25 tests covering layout, visibility, reordering, config, and routes.

--- a/packages/backend/migrations/041_dashboard_widgets.sql
+++ b/packages/backend/migrations/041_dashboard_widgets.sql
@@ -1,0 +1,18 @@
+-- Migration 041: Customizable dashboard widgets
+-- Allows users to show/hide and reorder dashboard sections
+
+CREATE TABLE IF NOT EXISTS dashboard_widgets (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    widget_key VARCHAR(50) NOT NULL,
+    display_name VARCHAR(100) NOT NULL,
+    visible BOOLEAN DEFAULT TRUE,
+    position INTEGER NOT NULL DEFAULT 0,
+    config JSONB DEFAULT '{}',
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW(),
+    UNIQUE(user_id, widget_key)
+);
+
+CREATE INDEX idx_widgets_user ON dashboard_widgets(user_id);
+CREATE INDEX idx_widgets_position ON dashboard_widgets(user_id, position);

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,21 @@
 import os
 import pytest
+from unittest.mock import patch
+import fakeredis
 from app import create_app
 from app.config import Settings
 from app.extensions import db
 from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+@pytest.fixture(autouse=True)
+def _patch_redis():
+    fake = fakeredis.FakeRedis()
+    with patch("app.extensions.redis_client", fake), \
+         patch("app.routes.auth.redis_client", fake), \
+         patch("app.services.cache.redis_client", fake):
+        yield
 
 
 class TestSettings(Settings):

--- a/packages/backend/tests/test_dashboard_widgets.py
+++ b/packages/backend/tests/test_dashboard_widgets.py
@@ -1,0 +1,208 @@
+"""Tests for customizable dashboard widgets."""
+
+import pytest
+from app.models import DashboardWidget
+from app.extensions import db
+from app.services.dashboard_widgets import (
+    get_layout,
+    initialize_layout,
+    reset_layout,
+    toggle_visibility,
+    bulk_update_visibility,
+    reorder_widgets,
+    update_widget_config,
+    get_widget,
+    get_available_widgets,
+    DEFAULT_WIDGETS,
+)
+
+
+# ── Service: get_layout ──────────────────────────────────────────
+
+
+class TestGetLayout:
+    def test_default_layout(self, app_fixture):
+        with app_fixture.app_context():
+            result = get_layout(1)
+            assert len(result) == len(DEFAULT_WIDGETS)
+            assert result[0]["widget_key"] == "spending_overview"
+
+    def test_custom_layout(self, app_fixture):
+        with app_fixture.app_context():
+            initialize_layout(1)
+            result = get_layout(1)
+            assert len(result) == len(DEFAULT_WIDGETS)
+            assert "id" in result[0]
+
+
+# ── Service: initialize_layout ────────────────────────────────────
+
+
+class TestInitializeLayout:
+    def test_creates_widgets(self, app_fixture):
+        with app_fixture.app_context():
+            result = initialize_layout(1)
+            assert len(result) == len(DEFAULT_WIDGETS)
+            count = DashboardWidget.query.filter_by(user_id=1).count()
+            assert count == len(DEFAULT_WIDGETS)
+
+    def test_idempotent(self, app_fixture):
+        with app_fixture.app_context():
+            initialize_layout(1)
+            initialize_layout(1)
+            count = DashboardWidget.query.filter_by(user_id=1).count()
+            assert count == len(DEFAULT_WIDGETS)
+
+
+# ── Service: reset_layout ─────────────────────────────────────────
+
+
+class TestResetLayout:
+    def test_reset(self, app_fixture):
+        with app_fixture.app_context():
+            initialize_layout(1)
+            # Modify a widget
+            toggle_visibility(1, "spending_overview", False)
+            # Reset
+            result = reset_layout(1)
+            assert all(w["visible"] for w in result)
+
+
+# ── Service: visibility ───────────────────────────────────────────
+
+
+class TestVisibility:
+    def test_hide_widget(self, app_fixture):
+        with app_fixture.app_context():
+            result = toggle_visibility(1, "spending_overview", False)
+            assert result["visible"] is False
+
+    def test_show_widget(self, app_fixture):
+        with app_fixture.app_context():
+            toggle_visibility(1, "spending_overview", False)
+            result = toggle_visibility(1, "spending_overview", True)
+            assert result["visible"] is True
+
+    def test_bulk_update(self, app_fixture):
+        with app_fixture.app_context():
+            result = bulk_update_visibility(1, {
+                "spending_overview": False,
+                "recent_transactions": False,
+            })
+            hidden = [w for w in result if not w["visible"]]
+            assert len(hidden) == 2
+
+
+# ── Service: reorder ─────────────────────────────────────────────
+
+
+class TestReorder:
+    def test_reorder_widgets(self, app_fixture):
+        with app_fixture.app_context():
+            new_order = ["upcoming_bills", "spending_overview", "recent_transactions"]
+            result = reorder_widgets(1, new_order)
+            # First 3 should be reordered
+            keys = [w["widget_key"] for w in result[:3]]
+            assert keys[0] == "upcoming_bills"
+            assert keys[1] == "spending_overview"
+
+
+# ── Service: config ───────────────────────────────────────────────
+
+
+class TestWidgetConfig:
+    def test_update_config(self, app_fixture):
+        with app_fixture.app_context():
+            result = update_widget_config(1, "spending_overview", {"period": "weekly"})
+            assert result["config"]["period"] == "weekly"
+
+    def test_get_widget(self, app_fixture):
+        with app_fixture.app_context():
+            result = get_widget(1, "spending_overview")
+            assert result["widget_key"] == "spending_overview"
+
+    def test_get_unknown_widget(self, app_fixture):
+        with app_fixture.app_context():
+            result = get_widget(1, "nonexistent_widget")
+            assert "error" in result
+
+
+# ── Service: available widgets ────────────────────────────────────
+
+
+class TestAvailableWidgets:
+    def test_list_available(self):
+        result = get_available_widgets()
+        assert len(result) == len(DEFAULT_WIDGETS)
+        assert all("widget_key" in w for w in result)
+
+
+# ── Routes ────────────────────────────────────────────────────────
+
+
+class TestDashboardWidgetRoutes:
+    def test_get_layout(self, client, auth_header):
+        r = client.get("/widgets", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert len(data) == len(DEFAULT_WIDGETS)
+
+    def test_initialize(self, client, auth_header):
+        r = client.post("/widgets/initialize", headers=auth_header)
+        assert r.status_code == 201
+
+    def test_reset(self, client, auth_header):
+        client.post("/widgets/initialize", headers=auth_header)
+        r = client.post("/widgets/reset", headers=auth_header)
+        assert r.status_code == 200
+
+    def test_toggle_visibility(self, client, auth_header):
+        r = client.put("/widgets/spending_overview/visibility",
+                       json={"visible": False},
+                       headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["visible"] is False
+
+    def test_toggle_visibility_missing_field(self, client, auth_header):
+        r = client.put("/widgets/spending_overview/visibility",
+                       json={},
+                       headers=auth_header)
+        assert r.status_code == 400
+
+    def test_bulk_visibility(self, client, auth_header):
+        r = client.put("/widgets/visibility",
+                       json={"spending_overview": False},
+                       headers=auth_header)
+        assert r.status_code == 200
+
+    def test_reorder(self, client, auth_header):
+        r = client.put("/widgets/reorder",
+                       json={"order": ["upcoming_bills", "spending_overview"]},
+                       headers=auth_header)
+        assert r.status_code == 200
+
+    def test_reorder_missing_field(self, client, auth_header):
+        r = client.put("/widgets/reorder",
+                       json={},
+                       headers=auth_header)
+        assert r.status_code == 400
+
+    def test_update_config(self, client, auth_header):
+        r = client.put("/widgets/spending_overview/config",
+                       json={"period": "weekly"},
+                       headers=auth_header)
+        assert r.status_code == 200
+
+    def test_get_widget(self, client, auth_header):
+        r = client.get("/widgets/spending_overview",
+                       headers=auth_header)
+        assert r.status_code == 200
+
+    def test_available_widgets(self, client, auth_header):
+        r = client.get("/widgets/available",
+                       headers=auth_header)
+        assert r.status_code == 200
+
+    def test_unauthorized(self, client):
+        r = client.get("/widgets")
+        assert r.status_code == 401


### PR DESCRIPTION
## Customizable Dashboard Widgets

Closes #103

### What
Widget customization system that lets users show/hide, reorder, and configure dashboard sections with persistent per-user layouts.

### Features
- **8 Default Widgets** — Spending overview, recent transactions, budget progress, upcoming bills, category breakdown, savings goals, recurring expenses, financial health
- **Visibility Control** — Individual toggle and bulk update for show/hide
- **Reordering** — Position-based ordering via API
- **Per-Widget Config** — JSON configuration storage for widget-specific settings
- **Layout Management** — Initialize defaults, reset to defaults, idempotent operations

### API Endpoints
| Method | Path | Description |
|---|---|---|
| GET | `/widgets` | Get layout |
| POST | `/widgets/initialize` | Initialize defaults |
| POST | `/widgets/reset` | Reset to defaults |
| PUT | `/widgets/:key/visibility` | Toggle visibility |
| PUT | `/widgets/visibility` | Bulk visibility |
| PUT | `/widgets/reorder` | Reorder widgets |
| PUT | `/widgets/:key/config` | Update config |
| GET | `/widgets/:key` | Get single widget |
| GET | `/widgets/available` | List available types |

### Files Changed
- `migrations/041_dashboard_widgets.sql` — dashboard_widgets table
- `app/models.py` — DashboardWidget model
- `app/services/dashboard_widgets.py` — Layout/visibility/reorder/config logic
- `app/routes/dashboard_widgets.py` — 9 REST endpoints
- `app/routes/__init__.py` — Blueprint registration
- `tests/test_dashboard_widgets.py` — 25 tests (all passing)
- `docs/dashboard-widgets.md` — API documentation

### Testing
```
25 passed in 2.15s
```
