### PR TITLE
feat: add weekly financial digest endpoint and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See `backend/app/db/schema.sql`. Key tables:
   - `user:{id}:categories` — 24h TTL
   - `user:{id}:upcoming_bills` — 15 min TTL
   - `insights:{id}` — 24h TTL (invalidate on new expense/bill)
+  - `user:{id}:weekly_digest:{week}` — 10 min TTL (invalidate on expense create/update/delete)
 - Invalidation
   - On expense/bill create/update/delete -> delete affected monthly_summary, upcoming_bills, insights
 - Rate limiting (optional): `rl:{userId}:{endpoint}:{minute}` with short TTL
@@ -66,6 +67,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Digest: GET `/digest/weekly?week=YYYY-WNN` — weekly spending summary with category breakdown, WoW change, trends, and insights
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.
@@ -73,6 +75,7 @@ OpenAPI: `backend/app/openapi.yaml`
   - Monthly spend chart, category breakdown donut.
   - Upcoming bills list with due dates and pay status.
   - AI budget suggestion card.
+- Digest page: weekly spending summary, category progress bars, WoW change badge, trends and insights, week navigation (← →).
 - Expenses page: add expense (amount, category, notes, date), list & filter.
 - Bills page: create bill (name, amount, cadence, due date, channel), toggle WhatsApp/email.
 - Settings: profile, categories, reminders default channel, export (premium).

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Digest from "./pages/Digest";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -94,6 +95,14 @@ const App = () => (
           </Route>
           <Route path="/signin" element={<SignIn />} />
           <Route path="/register" element={<Register />} />
+            <Route
+              path="digest"
+              element={
+                <ProtectedRoute>
+                  <Digest />
+                </ProtectedRoute>
+              }
+            />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/app/src/api/digest.ts
+++ b/app/src/api/digest.ts
@@ -1,0 +1,25 @@
+import { api } from './client';
+
+export type WeeklyDigest = {
+  week: string;
+  period: {
+    start: string;
+    end: string;
+  };
+  total_spent: number;
+  total_income: number;
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    share_pct: number;
+  }>;
+  week_over_week_change: number;
+  trends: string[];
+  insights: string[];
+};
+
+export async function getWeeklyDigest(week?: string): Promise<WeeklyDigest> {
+  const query = week ? `?week=${encodeURIComponent(week)}` : '';
+  return api<WeeklyDigest>(`/digest/weekly${query}`);
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Digest', href: '/digest' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/Digest.tsx
+++ b/app/src/pages/Digest.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { Badge } from '@/components/ui/badge';
+import {
+  ArrowLeft,
+  ArrowRight,
+  TrendingDown,
+  TrendingUp,
+  Minus,
+  Lightbulb,
+  BarChart3,
+} from 'lucide-react';
+import { getWeeklyDigest, type WeeklyDigest } from '@/api/digest';
+import { formatMoney } from '@/lib/currency';
+
+function isoWeek(d: Date): string {
+  const tmp = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate()));
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - (tmp.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
+  const wk = Math.ceil(((tmp.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `${tmp.getUTCFullYear()}-W${String(wk).padStart(2, '0')}`;
+}
+
+function shiftWeek(week: string, delta: number): string {
+  const [yearStr, wStr] = week.split('-W');
+  const year = parseInt(yearStr, 10);
+  const w = parseInt(wStr, 10);
+  const monday = new Date(Date.UTC(year, 0, 4));
+  monday.setUTCDate(monday.getUTCDate() - (monday.getUTCDay() || 7) + 1 + (w - 1) * 7 + delta * 7);
+  return isoWeek(monday);
+}
+
+export default function Digest() {
+  const [week, setWeek] = useState(() => isoWeek(new Date()));
+  const [data, setData] = useState<WeeklyDigest | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await getWeeklyDigest(week);
+        setData(res);
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : 'Failed to load digest');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [week]);
+
+  const wowChange = data?.week_over_week_change ?? 0;
+  const WowIcon = wowChange > 0 ? TrendingUp : wowChange < 0 ? TrendingDown : Minus;
+  const wowColor = wowChange > 0 ? 'text-red-500' : wowChange < 0 ? 'text-green-500' : 'text-muted-foreground';
+  const wowBadgeVariant = wowChange > 0 ? 'destructive' : wowChange < 0 ? 'default' : 'secondary';
+
+  return (
+    <div className="container mx-auto p-4 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Weekly Digest</h1>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="icon" onClick={() => setWeek((w) => shiftWeek(w, -1))}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm font-medium min-w-[90px] text-center">{week}</span>
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={() => setWeek((w) => shiftWeek(w, 1))}
+            disabled={week >= isoWeek(new Date())}
+          >
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {data?.period && (
+        <p className="text-sm text-muted-foreground">
+          {data.period.start} — {data.period.end}
+        </p>
+      )}
+
+      {loading && <p className="text-muted-foreground">Loading...</p>}
+      {error && <p className="text-destructive">{error}</p>}
+
+      {!loading && data && (
+        <>
+          <div className="grid gap-4 md:grid-cols-3">
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle>Total Spent</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <p className="text-2xl font-bold">{formatMoney(data.total_spent)}</p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle>Total Income</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <p className="text-2xl font-bold">{formatMoney(data.total_income)}</p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle>Week-over-Week</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="flex items-center gap-2">
+                  <WowIcon className={`h-5 w-5 ${wowColor}`} />
+                  <Badge variant={wowBadgeVariant as 'default' | 'secondary' | 'destructive' | 'outline'}>
+                    {wowChange > 0 ? '+' : ''}{wowChange}%
+                  </Badge>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          </div>
+
+          {data.category_breakdown.length > 0 && (
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle className="flex items-center gap-2">
+                  <BarChart3 className="h-5 w-5" /> Category Breakdown
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="space-y-3">
+                  {data.category_breakdown.map((cat) => (
+                    <div key={cat.category_id ?? 'uncat'} className="space-y-1">
+                      <div className="flex justify-between text-sm">
+                        <span>{cat.category_name}</span>
+                        <span className="text-muted-foreground">
+                          {formatMoney(cat.amount)} ({cat.share_pct}%)
+                        </span>
+                      </div>
+                      <Progress value={cat.share_pct} className="h-2" />
+                    </div>
+                  ))}
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+
+          {data.trends.length > 0 && (
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle className="flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5" /> Trends
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <ul className="space-y-2">
+                  {data.trends.map((t, i) => (
+                    <li key={i} className="text-sm text-muted-foreground">
+                      • {t}
+                    </li>
+                  ))}
+                </ul>
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+
+          {data.insights.length > 0 && (
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle className="flex items-center gap-2">
+                  <Lightbulb className="h-5 w-5" /> Insights
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <ul className="space-y-2">
+                  {data.insights.map((ins, i) => (
+                    <li key={i} className="text-sm text-muted-foreground">
+                      • {ins}
+                    </li>
+                  ))}
+                </ul>
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,182 @@
+from datetime import date, timedelta
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Category, Expense
+from ..services.cache import cache_get, cache_set
+import logging
+
+bp = Blueprint("digest", __name__)
+logger = logging.getLogger("finmind.digest")
+
+
+def _parse_week(raw: str) -> tuple[date, date] | None:
+    try:
+        year_str, week_str = raw.split("-W")
+        year = int(year_str)
+        week = int(week_str)
+        if not (1 <= week <= 53):
+            return None
+        start = date.fromisocalendar(year, week, 1)
+        end = start + timedelta(days=6)
+        return start, end
+    except (ValueError, AttributeError):
+        return None
+
+
+def _week_key(d: date) -> str:
+    iso = d.isocalendar()
+    return f"{iso[0]}-W{iso[1]:02d}"
+
+
+def _digest_cache_key(uid: int, week: str) -> str:
+    return f"user:{uid}:weekly_digest:{week}"
+
+
+@bp.get("/weekly")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    week_param = (request.args.get("week") or "").strip()
+    if not week_param:
+        today = date.today()
+        week_param = _week_key(today)
+
+    parsed = _parse_week(week_param)
+    if parsed is None:
+        return jsonify(error="invalid week, expected YYYY-WNN"), 400
+
+    start, end = parsed
+
+    cached = cache_get(_digest_cache_key(uid, week_param))
+    if cached:
+        return jsonify(cached)
+
+    total_spent = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+
+    total_income = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+
+    category_rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(Category.name, "Uncategorized").label("category_name"),
+            func.coalesce(func.sum(Expense.amount), 0).label("total_amount"),
+        )
+        .outerjoin(
+            Category,
+            (Category.id == Expense.category_id) & (Category.user_id == uid),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id, Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .all()
+    )
+
+    category_breakdown = []
+    for r in category_rows:
+        amt = float(r.total_amount or 0)
+        pct = round((amt / total_spent) * 100, 2) if total_spent > 0 else 0
+        category_breakdown.append(
+            {
+                "category_id": r.category_id,
+                "category_name": r.category_name,
+                "amount": amt,
+                "share_pct": pct,
+            }
+        )
+
+    prev_start = start - timedelta(days=7)
+    prev_end = end - timedelta(days=7)
+
+    prev_spent = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= prev_start,
+            Expense.spent_at <= prev_end,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+
+    if prev_spent > 0:
+        wow_change = round(((total_spent - prev_spent) / prev_spent) * 100, 2)
+    elif total_spent > 0:
+        wow_change = 100.0
+    else:
+        wow_change = 0.0
+
+    trends = []
+    if len(category_breakdown) > 0:
+        top = category_breakdown[0]
+        trends.append(
+            f"Top spending category: {top['category_name']}"
+            f" ({top['share_pct']}% of total)"
+        )
+    if wow_change > 10:
+        trends.append(f"Spending increased {wow_change}% compared to previous week")
+    elif wow_change < -10:
+        trends.append(
+            f"Spending decreased {abs(wow_change)}% compared to previous week"
+        )
+    else:
+        trends.append("Spending is roughly stable week-over-week")
+
+    insights = []
+    if total_spent > total_income and total_income > 0:
+        insights.append("You spent more than you earned this week")
+    if total_spent == 0:
+        insights.append("No expenses recorded this week")
+    if len(category_breakdown) == 1 and total_spent > 0:
+        insights.append(
+            "All spending is in one category — consider diversifying tracking"
+        )
+    if len(category_breakdown) > 5:
+        insights.append("Spending spread across many categories this week")
+
+    payload = {
+        "week": week_param,
+        "period": {
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        },
+        "total_spent": total_spent,
+        "total_income": total_income,
+        "category_breakdown": category_breakdown,
+        "week_over_week_change": wow_change,
+        "trends": trends,
+        "insights": insights,
+    }
+
+    cache_set(_digest_cache_key(uid, week_param), payload, ttl_seconds=600)
+    logger.info("Weekly digest served user=%s week=%s", uid, week_param)
+    return jsonify(payload)

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,127 @@
+from datetime import date, timedelta
+
+
+def _current_week_str():
+    today = date.today()
+    iso = today.isocalendar()
+    return f"{iso[0]}-W{iso[1]:02d}"
+
+
+def _seed_expense(
+    client,
+    auth_header,
+    amount,
+    description,
+    spent_at,
+    expense_type="EXPENSE",
+    category_id=None,
+):
+    payload = {
+        "amount": amount,
+        "description": description,
+        "date": spent_at.isoformat(),
+        "expense_type": expense_type,
+    }
+    if category_id is not None:
+        payload["category_id"] = category_id
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def test_digest_empty_week(client, auth_header):
+    r = client.get("/digest/weekly?week=2020-W01", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_spent"] == 0
+    assert data["total_income"] == 0
+    assert data["category_breakdown"] == []
+    assert data["week_over_week_change"] == 0.0
+    assert isinstance(data["trends"], list)
+    assert isinstance(data["insights"], list)
+
+
+def test_digest_populated_week(client, auth_header):
+    today = date.today()
+    iso = today.isocalendar()
+    monday = date.fromisocalendar(iso[0], iso[1], 1)
+
+    r = client.post("/categories", json={"name": "Food"}, headers=auth_header)
+    assert r.status_code == 201
+    food_id = r.get_json()["id"]
+
+    _seed_expense(client, auth_header, 500, "Groceries", monday, category_id=food_id)
+    _seed_expense(
+        client,
+        auth_header,
+        200,
+        "Dining out",
+        monday + timedelta(days=1),
+        category_id=food_id,
+    )
+    _seed_expense(client, auth_header, 1000, "Salary", monday, expense_type="INCOME")
+
+    week = f"{iso[0]}-W{iso[1]:02d}"
+    r = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_spent"] == 700
+    assert data["total_income"] == 1000
+    assert len(data["category_breakdown"]) >= 1
+    assert data["category_breakdown"][0]["category_name"] == "Food"
+    assert isinstance(data["trends"], list)
+    assert len(data["trends"]) > 0
+
+
+def test_digest_week_over_week_comparison(client, auth_header):
+    today = date.today()
+    iso = today.isocalendar()
+    monday = date.fromisocalendar(iso[0], iso[1], 1)
+    prev_monday = monday - timedelta(days=7)
+
+    _seed_expense(client, auth_header, 100, "Prev week item", prev_monday)
+    _seed_expense(client, auth_header, 300, "This week item", monday)
+
+    week = f"{iso[0]}-W{iso[1]:02d}"
+    r = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["week_over_week_change"] == 200.0
+
+
+def test_digest_requires_auth(client):
+    r = client.get("/digest/weekly")
+    assert r.status_code in (401, 422)
+
+
+def test_digest_invalid_week_format(client, auth_header):
+    r = client.get("/digest/weekly?week=invalid", headers=auth_header)
+    assert r.status_code == 400
+    assert "invalid week" in r.get_json()["error"]
+
+
+def test_digest_defaults_to_current_week(client, auth_header):
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["week"] == _current_week_str()
+    assert "period" in data
+    assert "start" in data["period"]
+    assert "end" in data["period"]
+
+
+def test_digest_insights_overspend(client, auth_header):
+    today = date.today()
+    iso = today.isocalendar()
+    monday = date.fromisocalendar(iso[0], iso[1], 1)
+
+    _seed_expense(client, auth_header, 500, "Big purchase", monday)
+    _seed_expense(
+        client, auth_header, 100, "Small income", monday, expense_type="INCOME"
+    )
+
+    week = f"{iso[0]}-W{iso[1]:02d}"
+    r = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert any("more than you earned" in i for i in data["insights"])


### PR DESCRIPTION
## Summary
- What changed: Added `GET /digest/weekly?week=YYYY-WNN` endpoint and a React Digest page with week navigation, category breakdown, WoW comparison, trends, and insights.
- Why: Closes #121. Users need a weekly summary highlighting spending trends and patterns.

/claim #121

## Validation
- [x] Frontend lint: `cd app && npm run lint`
- [x] Frontend tests: `cd app && npm test -- --runInBand`
- [x] Backend tests: `./scripts/test-backend.ps1`
- [x] Updated docs if needed

## Security and Ownership
- [x] PR opened from a fork (not direct push to `main`)
- [x] CODEOWNERS review requested

## Checklist
- [x] No secrets added
- [x] No unrelated files changed
- [x] Breaking changes documented