### PR TITLE
feat: Smart Weekly Digest with AI Narrative (#121)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import { Digest } from "./pages/Digest";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="digest"
+              element={
+                <ProtectedRoute>
+                  <Digest />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/digest.ts
+++ b/app/src/api/digest.ts
@@ -1,0 +1,26 @@
+import { api } from './client';
+
+export type WeeklyDigest = {
+  week: string;
+  period: { start: string; end: string };
+  summary: {
+    total_income: number;
+    total_expenses: number;
+    net_flow: number;
+    transaction_count: number;
+  };
+  week_over_week_change_pct: number;
+  category_breakdown: Array<{ category: string; amount: number }>;
+  top_expense: { amount: number; notes: string; date: string } | null;
+  upcoming_bills: Array<{ name: string; amount: number; due_date: string }>;
+  narrative: string;
+};
+
+export async function getWeeklyDigest(week?: string): Promise<WeeklyDigest> {
+  const query = week ? `?week=${encodeURIComponent(week)}` : '';
+  return api<WeeklyDigest>(`/digest/weekly${query}`);
+}
+
+export async function getDigestHistory(count = 4): Promise<WeeklyDigest[]> {
+  return api<WeeklyDigest[]>(`/digest/weekly/history?count=${count}`);
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Digest', href: '/digest' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/Digest.tsx
+++ b/app/src/pages/Digest.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardDescription,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { useToast } from '@/hooks/use-toast';
+import { getWeeklyDigest, getDigestHistory, type WeeklyDigest } from '@/api/digest';
+import { formatMoney } from '@/lib/currency';
+
+function currentISOWeek(): string {
+  const now = new Date();
+  const jan4 = new Date(now.getFullYear(), 0, 4);
+  const daysSinceJan4 = Math.floor((now.getTime() - jan4.getTime()) / 86400000);
+  const weekNum = Math.ceil((daysSinceJan4 + jan4.getDay() + 1) / 7);
+  return `${now.getFullYear()}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+export function Digest() {
+  const { toast } = useToast();
+  const [week, setWeek] = useState(currentISOWeek);
+  const [digest, setDigest] = useState<WeeklyDigest | null>(null);
+  const [history, setHistory] = useState<WeeklyDigest[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const [d, h] = await Promise.all([
+        getWeeklyDigest(week),
+        getDigestHistory(4),
+      ]);
+      setDigest(d);
+      setHistory(h);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to load digest';
+      toast({ title: 'Error', description: msg });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [week]);
+
+  const wowColor =
+    digest && digest.week_over_week_change_pct > 0
+      ? 'text-destructive'
+      : digest && digest.week_over_week_change_pct < 0
+        ? 'text-green-600'
+        : '';
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header">
+        <div className="relative flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div>
+            <h1 className="page-title">Weekly Digest</h1>
+            <p className="page-subtitle">
+              Your smart weekly financial summary powered by AI insights.
+            </p>
+          </div>
+          <div className="flex gap-2 items-end">
+            <div>
+              <Label htmlFor="digest-week">Week</Label>
+              <Input
+                id="digest-week"
+                type="week"
+                value={week}
+                onChange={(e) => setWeek(e.target.value)}
+                className="w-44"
+              />
+            </div>
+            <Button variant="hero" onClick={() => void load()} disabled={loading}>
+              {loading ? 'Loading…' : 'Refresh'}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {digest && (
+        <>
+          {/* Summary cards */}
+          <div className="grid gap-4 md:grid-cols-4">
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Income</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <p className="text-2xl font-bold text-green-600">
+                  {formatMoney(digest.summary.total_income)}
+                </p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Expenses</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <p className="text-2xl font-bold text-destructive">
+                  {formatMoney(digest.summary.total_expenses)}
+                </p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant={digest.summary.net_flow >= 0 ? 'success' : 'destructive'}>
+              <FinancialCardHeader>
+                <FinancialCardTitle>Net Flow</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <p className="text-2xl font-bold">
+                  {formatMoney(digest.summary.net_flow)}
+                </p>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Week-over-Week</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <p className={`text-2xl font-bold ${wowColor}`}>
+                  {digest.week_over_week_change_pct > 0 ? '+' : ''}
+                  {digest.week_over_week_change_pct.toFixed(1)}%
+                </p>
+              </FinancialCardContent>
+            </FinancialCard>
+          </div>
+
+          {/* AI Narrative */}
+          <FinancialCard variant="premium">
+            <FinancialCardHeader>
+              <FinancialCardTitle>AI Weekly Insights</FinancialCardTitle>
+              <FinancialCardDescription>
+                {digest.period.start} → {digest.period.end}
+              </FinancialCardDescription>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <p className="text-sm leading-relaxed">{digest.narrative}</p>
+            </FinancialCardContent>
+          </FinancialCard>
+
+          {/* Category breakdown & Top expense */}
+          <div className="grid gap-4 md:grid-cols-2">
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle>Category Breakdown</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                {digest.category_breakdown.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No expenses this week.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {digest.category_breakdown.map((c) => (
+                      <div key={c.category} className="flex justify-between text-sm">
+                        <span>{c.category}</span>
+                        <span className="font-medium">{formatMoney(c.amount)}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard>
+              <FinancialCardHeader>
+                <FinancialCardTitle>Upcoming Bills</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                {digest.upcoming_bills.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No bills due this week.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {digest.upcoming_bills.map((b) => (
+                      <div key={b.name} className="flex justify-between text-sm">
+                        <span>{b.name} <span className="text-muted-foreground">({b.due_date})</span></span>
+                        <span className="font-medium">{formatMoney(b.amount)}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </FinancialCardContent>
+            </FinancialCard>
+          </div>
+
+          {/* Top expense */}
+          {digest.top_expense && (
+            <FinancialCard variant="warning">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Biggest Expense</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <p className="text-lg font-bold">{formatMoney(digest.top_expense.amount)}</p>
+                <p className="text-sm text-muted-foreground">
+                  {digest.top_expense.notes} — {digest.top_expense.date}
+                </p>
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+        </>
+      )}
+
+      {/* History */}
+      {history.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold">Recent Weeks</h2>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {history.map((h) => (
+              <FinancialCard
+                key={h.week}
+                className="cursor-pointer"
+                onClick={() => setWeek(h.week)}
+              >
+                <FinancialCardHeader>
+                  <FinancialCardTitle className="text-sm">{h.week}</FinancialCardTitle>
+                  <FinancialCardDescription>
+                    {h.period.start} → {h.period.end}
+                  </FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  <div className="flex justify-between text-xs">
+                    <span className="text-green-600">{formatMoney(h.summary.total_income)}</span>
+                    <span className="text-destructive">{formatMoney(h.summary.total_expenses)}</span>
+                  </div>
+                  <p className="mt-1 text-xs font-semibold">
+                    Net: {formatMoney(h.summary.net_flow)}
+                  </p>
+                </FinancialCardContent>
+              </FinancialCard>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {loading && !digest && (
+        <div className="flex items-center justify-center py-20">
+          <p className="text-muted-foreground">Loading your weekly digest…</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,72 @@
+"""Weekly digest endpoints."""
+
+from datetime import date
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.digest import compute_digest, generate_narrative
+from ..services.cache import cache_get, cache_set
+
+bp = Blueprint("digest", __name__)
+
+
+def _current_iso_week() -> str:
+    y, w, _ = date.today().isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+def _is_valid_week(w: str) -> bool:
+    try:
+        year_s, week_s = w.split("-W")
+        year, week = int(year_s), int(week_s)
+        return 2000 <= year <= 2100 and 1 <= week <= 53
+    except Exception:
+        return False
+
+
+@bp.get("/weekly")
+@jwt_required()
+def weekly_digest():
+    """Return the weekly financial digest for the authenticated user."""
+    uid = int(get_jwt_identity())
+    week = (request.args.get("week") or _current_iso_week()).strip()
+    if not _is_valid_week(week):
+        return jsonify(error="invalid week, expected YYYY-Wnn (e.g. 2026-W11)"), 400
+
+    cache_key = f"user:{uid}:weekly_digest:{week}"
+    cached = cache_get(cache_key)
+    if cached:
+        return jsonify(cached)
+
+    digest = compute_digest(uid, week)
+    narrative = generate_narrative(digest)
+    digest["narrative"] = narrative
+
+    cache_set(cache_key, digest, ttl_seconds=3600)
+    return jsonify(digest)
+
+
+@bp.get("/weekly/history")
+@jwt_required()
+def digest_history():
+    """Return digests for the last *n* weeks (default 4)."""
+    uid = int(get_jwt_identity())
+    count = min(int(request.args.get("count", 4)), 12)
+
+    results = []
+    week = _current_iso_week()
+    for _ in range(count):
+        d = compute_digest(uid, week)
+        d["narrative"] = generate_narrative(d)
+        results.append(d)
+        # Navigate to previous week
+        year_s, week_s = week.split("-W")
+        y, w = int(year_s), int(week_s)
+        if w == 1:
+            y -= 1
+            w = 52
+        else:
+            w -= 1
+        week = f"{y}-W{w:02d}"
+
+    return jsonify(results)

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,220 @@
+"""Weekly financial digest service.
+
+Computes a spending / income summary for a given ISO week and optionally
+generates a short AI narrative via the Gemini API.
+"""
+
+import json
+import logging
+from datetime import date, timedelta
+from urllib import request as url_request
+
+from sqlalchemy import func
+
+from ..config import Settings
+from ..extensions import db
+from ..models import Bill, Category, Expense
+
+logger = logging.getLogger("finmind.digest")
+_settings = Settings()
+
+
+def _week_bounds(iso_week: str) -> tuple[date, date]:
+    """Return (monday, sunday) for an ISO week string like '2026-W11'."""
+    year, week = iso_week.split("-W")
+    monday = date.fromisocalendar(int(year), int(week), 1)
+    sunday = monday + timedelta(days=6)
+    return monday, sunday
+
+
+def _previous_week(iso_week: str) -> str:
+    monday, _ = _week_bounds(iso_week)
+    prev_monday = monday - timedelta(days=7)
+    y, w, _ = prev_monday.isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+def compute_digest(user_id: int, iso_week: str) -> dict:
+    """Build the weekly digest payload for *user_id* and *iso_week*."""
+    monday, sunday = _week_bounds(iso_week)
+
+    income = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= monday,
+            Expense.spent_at <= sunday,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+
+    expenses = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= monday,
+            Expense.spent_at <= sunday,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+
+    # Category breakdown
+    cat_rows = (
+        db.session.query(
+            Category.name,
+            func.coalesce(func.sum(Expense.amount), 0),
+        )
+        .outerjoin(Category, Expense.category_id == Category.id)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= monday,
+            Expense.spent_at <= sunday,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Category.name)
+        .all()
+    )
+    category_breakdown = [
+        {"category": name or "Uncategorized", "amount": round(float(amt), 2)}
+        for name, amt in sorted(cat_rows, key=lambda r: float(r[1]), reverse=True)
+    ]
+
+    # Bills due this week
+    bills_due = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == user_id,
+            Bill.active.is_(True),
+            Bill.next_due_date >= monday,
+            Bill.next_due_date <= sunday,
+        )
+        .all()
+    )
+    upcoming_bills = [
+        {
+            "name": b.name,
+            "amount": float(b.amount),
+            "due_date": b.next_due_date.isoformat(),
+        }
+        for b in bills_due
+    ]
+
+    # Week-over-week comparison
+    prev = _previous_week(iso_week)
+    prev_mon, prev_sun = _week_bounds(prev)
+    prev_expenses = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= prev_mon,
+            Expense.spent_at <= prev_sun,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+    if prev_expenses > 0:
+        wow_change = round(((expenses - prev_expenses) / prev_expenses) * 100, 2)
+    else:
+        wow_change = 0.0
+
+    # Top transaction
+    top_tx = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= monday,
+            Expense.spent_at <= sunday,
+            Expense.expense_type != "INCOME",
+        )
+        .order_by(Expense.amount.desc())
+        .first()
+    )
+    top_expense = None
+    if top_tx:
+        top_expense = {
+            "amount": float(top_tx.amount),
+            "notes": top_tx.notes or "N/A",
+            "date": top_tx.spent_at.isoformat(),
+        }
+
+    return {
+        "week": iso_week,
+        "period": {"start": monday.isoformat(), "end": sunday.isoformat()},
+        "summary": {
+            "total_income": round(income, 2),
+            "total_expenses": round(expenses, 2),
+            "net_flow": round(income - expenses, 2),
+            "transaction_count": _tx_count(user_id, monday, sunday),
+        },
+        "week_over_week_change_pct": wow_change,
+        "category_breakdown": category_breakdown,
+        "top_expense": top_expense,
+        "upcoming_bills": upcoming_bills,
+    }
+
+
+def _tx_count(uid: int, start: date, end: date) -> int:
+    return (
+        db.session.query(func.count(Expense.id))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .scalar()
+        or 0
+    )
+
+
+def generate_narrative(digest: dict) -> str:
+    """Call Gemini to produce a short plain-text narrative for the digest."""
+    api_key = _settings.gemini_api_key
+    model = _settings.gemini_model or "gemini-1.5-flash"
+    if not api_key:
+        return _fallback_narrative(digest)
+
+    prompt = (
+        "You are FinMind's financial coach. Write a concise 3-4 sentence "
+        "weekly financial summary from this data. Be encouraging and "
+        "action-oriented. Do not use markdown.\n\n"
+        f"{json.dumps(digest, indent=2)}"
+    )
+    body = json.dumps(
+        {"contents": [{"parts": [{"text": prompt}]}]}
+    ).encode()
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent?key={api_key}"
+    )
+    req = url_request.Request(
+        url, data=body, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with url_request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+        return (
+            data.get("candidates", [{}])[0]
+            .get("content", {})
+            .get("parts", [{}])[0]
+            .get("text", _fallback_narrative(digest))
+        )
+    except Exception:
+        logger.warning("Gemini digest narrative failed, using fallback")
+        return _fallback_narrative(digest)
+
+
+def _fallback_narrative(d: dict) -> str:
+    s = d["summary"]
+    wow = d.get("week_over_week_change_pct", 0)
+    direction = "up" if wow > 0 else "down" if wow < 0 else "unchanged"
+    return (
+        f"This week you earned {s['total_income']:.2f} and spent "
+        f"{s['total_expenses']:.2f}, resulting in a net flow of "
+        f"{s['net_flow']:.2f}. Your spending is {direction} "
+        f"{abs(wow):.1f}% compared to last week."
+    )

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,147 @@
+"""Tests for the weekly digest endpoints."""
+
+from datetime import date, timedelta
+
+
+def _current_iso_week() -> str:
+    y, w, _ = date.today().isocalendar()
+    return f"{y}-W{w:02d}"
+
+
+def _seed_data(client, auth_header):
+    """Seed income, expenses, and a bill for the current week."""
+    today = date.today()
+
+    # Category
+    r = client.post("/categories", json={"name": "Food"}, headers=auth_header)
+    assert r.status_code == 201
+    food_id = r.get_json()["id"]
+
+    # Income
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 5000,
+            "description": "Salary",
+            "date": today.isoformat(),
+            "expense_type": "INCOME",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Expense
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "Groceries",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": food_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Bill due this week
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 49.99,
+            "next_due_date": today.isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+
+def test_weekly_digest_empty(client, auth_header):
+    """An empty account should still return a valid digest."""
+    week = _current_iso_week()
+    r = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["week"] == week
+    assert payload["summary"]["total_income"] == 0
+    assert payload["summary"]["total_expenses"] == 0
+    assert payload["summary"]["net_flow"] == 0
+    assert payload["summary"]["transaction_count"] == 0
+    assert isinstance(payload["category_breakdown"], list)
+    assert isinstance(payload["upcoming_bills"], list)
+    assert "narrative" in payload
+
+
+def test_weekly_digest_with_data(client, auth_header):
+    """After seeding data, the digest should reflect income and expenses."""
+    _seed_data(client, auth_header)
+    week = _current_iso_week()
+    r = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["summary"]["total_income"] >= 5000
+    assert payload["summary"]["total_expenses"] >= 200
+    assert payload["summary"]["net_flow"] >= 4800
+    assert payload["summary"]["transaction_count"] >= 2
+
+    # Category breakdown should contain "Food"
+    cats = [c["category"] for c in payload["category_breakdown"]]
+    assert "Food" in cats
+
+    # Upcoming bills
+    bills = [b["name"] for b in payload["upcoming_bills"]]
+    assert "Internet" in bills
+
+    # Narrative is a string
+    assert isinstance(payload["narrative"], str)
+    assert len(payload["narrative"]) > 0
+
+
+def test_weekly_digest_invalid_week(client, auth_header):
+    """Invalid week format should return 400."""
+    r = client.get("/digest/weekly?week=bad", headers=auth_header)
+    assert r.status_code == 400
+    assert "error" in r.get_json()
+
+
+def test_weekly_digest_week_over_week(client, auth_header):
+    """Week-over-week change should be 0 when there's no prior week data."""
+    _seed_data(client, auth_header)
+    week = _current_iso_week()
+    r = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["week_over_week_change_pct"] == 0.0
+
+
+def test_digest_history(client, auth_header):
+    """History endpoint should return a list of digests."""
+    _seed_data(client, auth_header)
+    r = client.get("/digest/weekly/history?count=2", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    # First item is current week
+    assert data[0]["week"] == _current_iso_week()
+
+
+def test_digest_requires_auth(client):
+    """Digest endpoints require authentication."""
+    r = client.get("/digest/weekly")
+    assert r.status_code == 401
+
+    r = client.get("/digest/weekly/history")
+    assert r.status_code == 401
+
+
+def test_weekly_digest_caching(client, auth_header):
+    """Second request should return cached data."""
+    week = _current_iso_week()
+    r1 = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r1.status_code == 200
+    r2 = client.get(f"/digest/weekly?week={week}", headers=auth_header)
+    assert r2.status_code == 200
+    assert r1.get_json()["summary"] == r2.get_json()["summary"]


### PR DESCRIPTION
## Summary

Implements the **Smart Weekly Digest** feature as described in #121.

### Backend
- **services/digest.py** – Computes weekly financial summary: total income, total expenses, net flow, transaction count, category breakdown, top expense, upcoming bills, and week-over-week spending change percentage.
- **outes/digest.py** – Two endpoints:
  - \GET /digest/weekly?week=YYYY-Wnn\ – Returns the digest for a specific ISO week (defaults to current week). Responses are cached in Redis for 1 hour.
  - \GET /digest/weekly/history?count=N\ – Returns digests for the last N weeks (max 12, default 4).
- **AI Narrative** – Uses Google Gemini to generate a 3-4 sentence plain-text coaching summary from the digest data. Falls back gracefully to a heuristic narrative when no API key is configured.
- Blueprint registered at \/digest\ prefix.

### Frontend
- **\pi/digest.ts\** – Typed API client with \getWeeklyDigest()\ and \getDigestHistory()\.
- **\pages/Digest.tsx\** – Full-featured dashboard page:
  - Summary cards (Income, Expenses, Net Flow, Week-over-Week change)
  - AI Insights card with period range
  - Category breakdown and upcoming bills panels
  - Biggest expense highlight
  - Clickable weekly history cards to navigate between weeks
  - Week picker input for arbitrary week selection
- Route added at \/digest\ (protected), nav link in Navbar.

### Tests
- **\	est_digest.py\** – 7 tests covering:
  - Empty state returns valid structure
  - Seeded data reflects in summary
  - Invalid week format returns 400
  - Week-over-week is 0 with no prior data
  - History endpoint returns correct count
  - Auth required (401 without token)
  - Caching consistency

### Tech Stack Alignment
- Flask Blueprint + \@jwt_required()\ + \get_jwt_identity()\
- SQLAlchemy queries following existing dashboard pattern
- Redis caching with \cache_get\/\cache_set\
- React 18 + TypeScript + shadcn/ui \FinancialCard\ components
- \ormatMoney()\ for currency formatting

/claim #121