### PR TITLE
feat: PII Export & Delete Workflow (GDPR-ready) (#76)

### DIFF
--- a/app/src/api/privacy.ts
+++ b/app/src/api/privacy.ts
@@ -1,0 +1,40 @@
+import { api } from './client';
+
+export type PIIExport = {
+  export_version: string;
+  exported_at: string;
+  profile: {
+    id: number;
+    email: string;
+    preferred_currency: string;
+    role: string;
+    created_at: string;
+  };
+  categories: Array<{ id: number; name: string; created_at: string }>;
+  expenses: Array<{
+    id: number;
+    amount: number;
+    currency: string;
+    expense_type: string;
+    notes: string | null;
+    spent_at: string;
+    category_id: number | null;
+    created_at: string;
+  }>;
+  recurring_expenses: Array<Record<string, unknown>>;
+  bills: Array<Record<string, unknown>>;
+  reminders: Array<Record<string, unknown>>;
+  subscriptions: Array<Record<string, unknown>>;
+  audit_logs: Array<Record<string, unknown>>;
+};
+
+export async function exportPII(): Promise<PIIExport> {
+  return api<PIIExport>('/privacy/export');
+}
+
+export async function deletePII(): Promise<{ message: string }> {
+  return api<{ message: string }>('/privacy/delete', {
+    method: 'POST',
+    body: { confirm: true },
+  });
+}

--- a/app/src/pages/Account.tsx
+++ b/app/src/pages/Account.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { me, updateMe } from '@/api/auth';
-import { setCurrency } from '@/lib/auth';
+import { setCurrency, clearToken, clearRefreshToken } from '@/lib/auth';
+import { exportPII, deletePII } from '@/api/privacy';
 
 const SUPPORTED_CURRENCIES = [
   { code: 'INR', label: 'Indian Rupee (INR)' },
@@ -19,10 +21,14 @@ const SUPPORTED_CURRENCIES = [
 
 export default function Account() {
   const { toast } = useToast();
+  const nav = useNavigate();
   const [email, setEmail] = useState('');
   const [currency, setCurrencyState] = useState('INR');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -57,6 +63,50 @@ export default function Account() {
       toast({ title: 'Failed to update account', description: message });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const onExport = async () => {
+    setExporting(true);
+    try {
+      const data = await exportPII();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `finmind-export-${new Date().toISOString().slice(0, 10)}.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+      toast({ title: 'Export complete', description: 'Your data has been downloaded.' });
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to export data';
+      toast({ title: 'Export failed', description: message });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const onDelete = async () => {
+    setDeleting(true);
+    try {
+      await deletePII();
+      clearToken();
+      clearRefreshToken();
+      toast({
+        title: 'Account deleted',
+        description: 'All your personal data has been permanently removed.',
+      });
+      nav('/signin');
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to delete account';
+      toast({ title: 'Deletion failed', description: message });
+    } finally {
+      setDeleting(false);
+      setShowDeleteConfirm(false);
     }
   };
 
@@ -107,6 +157,54 @@ export default function Account() {
             </div>
           </>
         )}
+      </div>
+
+      {/* GDPR Data Privacy Section */}
+      <div className="card card-interactive space-y-5 fade-in-up">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">Data Privacy</h2>
+          <p className="text-sm text-muted-foreground">
+            Export or delete your personal data in compliance with GDPR.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Button
+            variant="outline"
+            onClick={() => void onExport()}
+            disabled={exporting}
+          >
+            {exporting ? 'Exporting…' : 'Export My Data'}
+          </Button>
+
+          {!showDeleteConfirm ? (
+            <Button
+              variant="destructive"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              Delete My Account
+            </Button>
+          ) : (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-destructive font-medium">
+                This action is permanent and cannot be undone.
+              </span>
+              <Button
+                variant="destructive"
+                onClick={() => void onDelete()}
+                disabled={deleting}
+              >
+                {deleting ? 'Deleting…' : 'Confirm Delete'}
+              </Button>
+              <Button
+                variant="ghost"
+                onClick={() => setShowDeleteConfirm(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .privacy import bp as privacy_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(privacy_bp, url_prefix="/privacy")

--- a/packages/backend/app/routes/privacy.py
+++ b/packages/backend/app/routes/privacy.py
@@ -1,0 +1,43 @@
+"""GDPR privacy endpoints: PII export and account deletion."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.privacy import delete_user_data, export_user_data
+from ..services.cache import cache_delete_patterns
+
+bp = Blueprint("privacy", __name__)
+
+
+@bp.get("/export")
+@jwt_required()
+def pii_export():
+    """Export all personal data for the authenticated user (GDPR Art. 20)."""
+    uid = int(get_jwt_identity())
+    data = export_user_data(uid)
+    if not data:
+        return jsonify(error="user not found"), 404
+    return jsonify(data)
+
+
+@bp.post("/delete")
+@jwt_required()
+def pii_delete():
+    """Permanently delete all personal data (GDPR Art. 17 – Right to Erasure).
+
+    Requires `{"confirm": true}` in the request body to prevent accidental
+    deletion.
+    """
+    uid = int(get_jwt_identity())
+    body = request.get_json(silent=True) or {}
+    if not body.get("confirm"):
+        return jsonify(error="send {\"confirm\": true} to confirm deletion"), 400
+
+    success = delete_user_data(uid)
+    if not success:
+        return jsonify(error="user not found"), 404
+
+    # Invalidate all cached data for this user
+    cache_delete_patterns([f"user:{uid}:*"])
+
+    return jsonify(message="All personal data has been permanently deleted."), 200

--- a/packages/backend/app/services/privacy.py
+++ b/packages/backend/app/services/privacy.py
@@ -1,0 +1,173 @@
+"""GDPR-ready PII export and deletion service.
+
+Collects all user-owned data across every model and returns it as a
+serialisable dictionary. Also provides irreversible account deletion
+with full audit-trail logging.
+"""
+
+import logging
+from datetime import datetime
+
+from ..extensions import db
+from ..models import (
+    AuditLog,
+    Bill,
+    Category,
+    Expense,
+    RecurringExpense,
+    Reminder,
+    User,
+    UserSubscription,
+)
+
+logger = logging.getLogger("finmind.privacy")
+
+
+def _serialize_date(d):
+    if d is None:
+        return None
+    if isinstance(d, datetime):
+        return d.isoformat()
+    return d.isoformat()
+
+
+def export_user_data(user_id: int) -> dict:
+    """Return a JSON-serialisable dict of ALL personal data for *user_id*."""
+    user = db.session.get(User, user_id)
+    if not user:
+        return {}
+
+    profile = {
+        "id": user.id,
+        "email": user.email,
+        "preferred_currency": user.preferred_currency,
+        "role": user.role,
+        "created_at": _serialize_date(user.created_at),
+    }
+
+    categories = [
+        {"id": c.id, "name": c.name, "created_at": _serialize_date(c.created_at)}
+        for c in Category.query.filter_by(user_id=user_id).all()
+    ]
+
+    expenses = [
+        {
+            "id": e.id,
+            "amount": float(e.amount),
+            "currency": e.currency,
+            "expense_type": e.expense_type,
+            "notes": e.notes,
+            "spent_at": _serialize_date(e.spent_at),
+            "category_id": e.category_id,
+            "created_at": _serialize_date(e.created_at),
+        }
+        for e in Expense.query.filter_by(user_id=user_id).all()
+    ]
+
+    recurring = [
+        {
+            "id": r.id,
+            "amount": float(r.amount),
+            "currency": r.currency,
+            "expense_type": r.expense_type,
+            "notes": r.notes,
+            "cadence": r.cadence.value if r.cadence else None,
+            "start_date": _serialize_date(r.start_date),
+            "end_date": _serialize_date(r.end_date),
+            "active": r.active,
+            "category_id": r.category_id,
+            "created_at": _serialize_date(r.created_at),
+        }
+        for r in RecurringExpense.query.filter_by(user_id=user_id).all()
+    ]
+
+    bills = [
+        {
+            "id": b.id,
+            "name": b.name,
+            "amount": float(b.amount),
+            "currency": b.currency,
+            "next_due_date": _serialize_date(b.next_due_date),
+            "cadence": b.cadence.value if b.cadence else None,
+            "autopay_enabled": b.autopay_enabled,
+            "active": b.active,
+            "created_at": _serialize_date(b.created_at),
+        }
+        for b in Bill.query.filter_by(user_id=user_id).all()
+    ]
+
+    reminders = [
+        {
+            "id": rm.id,
+            "bill_id": rm.bill_id,
+            "message": rm.message,
+            "send_at": _serialize_date(rm.send_at),
+            "sent": rm.sent,
+            "channel": rm.channel,
+        }
+        for rm in Reminder.query.filter_by(user_id=user_id).all()
+    ]
+
+    subscriptions = [
+        {
+            "id": s.id,
+            "plan_id": s.plan_id,
+            "active": s.active,
+            "started_at": _serialize_date(s.started_at),
+        }
+        for s in UserSubscription.query.filter_by(user_id=user_id).all()
+    ]
+
+    audit_logs = [
+        {
+            "id": a.id,
+            "action": a.action,
+            "created_at": _serialize_date(a.created_at),
+        }
+        for a in AuditLog.query.filter_by(user_id=user_id).all()
+    ]
+
+    return {
+        "export_version": "1.0",
+        "exported_at": datetime.utcnow().isoformat(),
+        "profile": profile,
+        "categories": categories,
+        "expenses": expenses,
+        "recurring_expenses": recurring,
+        "bills": bills,
+        "reminders": reminders,
+        "subscriptions": subscriptions,
+        "audit_logs": audit_logs,
+    }
+
+
+def delete_user_data(user_id: int) -> bool:
+    """Permanently and irreversibly delete all data for *user_id*.
+
+    Creates a final audit log entry (anonymised) before removing
+    the user row (cascades handle child records).
+    Returns True on success, False if user not found.
+    """
+    user = db.session.get(User, user_id)
+    if not user:
+        return False
+
+    # Log the deletion request before wiping data
+    db.session.add(
+        AuditLog(user_id=None, action=f"GDPR_DELETE:user_id={user_id}")
+    )
+
+    # Delete child records explicitly for databases without CASCADE support
+    Reminder.query.filter_by(user_id=user_id).delete()
+    Expense.query.filter_by(user_id=user_id).delete()
+    RecurringExpense.query.filter_by(user_id=user_id).delete()
+    Bill.query.filter_by(user_id=user_id).delete()
+    Category.query.filter_by(user_id=user_id).delete()
+    UserSubscription.query.filter_by(user_id=user_id).delete()
+    AuditLog.query.filter_by(user_id=user_id).delete()
+
+    db.session.delete(user)
+    db.session.commit()
+
+    logger.info("GDPR delete completed for user_id=%s", user_id)
+    return True

--- a/packages/backend/tests/test_privacy.py
+++ b/packages/backend/tests/test_privacy.py
@@ -1,0 +1,145 @@
+"""Tests for GDPR privacy endpoints (PII export & delete)."""
+
+from datetime import date, timedelta
+
+
+def _seed_full_profile(client, auth_header):
+    """Seed a rich user profile with categories, expenses, bills, etc."""
+    # Category
+    r = client.post("/categories", json={"name": "Transport"}, headers=auth_header)
+    assert r.status_code == 201
+    cat_id = r.get_json()["id"]
+
+    # Expenses
+    for desc, etype in [("Salary", "INCOME"), ("Bus fare", "EXPENSE")]:
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": 1000 if etype == "INCOME" else 50,
+                "description": desc,
+                "date": date.today().isoformat(),
+                "expense_type": etype,
+                "category_id": cat_id if etype == "EXPENSE" else None,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    # Bill
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Electricity",
+            "amount": 120,
+            "next_due_date": (date.today() + timedelta(days=5)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+
+# ── Export tests ──────────────────────────────────────────────────────────────
+
+
+def test_export_empty_user(client, auth_header):
+    """A freshly registered user should still return a valid export."""
+    r = client.get("/privacy/export", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["export_version"] == "1.0"
+    assert "exported_at" in data
+    assert "profile" in data
+    assert data["profile"]["email"] == "test@example.com"
+    assert isinstance(data["categories"], list)
+    assert isinstance(data["expenses"], list)
+    assert isinstance(data["bills"], list)
+
+
+def test_export_with_data(client, auth_header):
+    """After seeding data, the export should contain all records."""
+    _seed_full_profile(client, auth_header)
+    r = client.get("/privacy/export", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+
+    assert len(data["categories"]) >= 1
+    assert len(data["expenses"]) >= 2
+    assert len(data["bills"]) >= 1
+
+    # Verify expense fields are present
+    expense = data["expenses"][0]
+    assert "amount" in expense
+    assert "currency" in expense
+    assert "spent_at" in expense
+
+    # Verify bill fields
+    bill = data["bills"][0]
+    assert bill["name"] == "Electricity"
+
+
+def test_export_requires_auth(client):
+    """Export endpoint should return 401 without auth."""
+    r = client.get("/privacy/export")
+    assert r.status_code == 401
+
+
+# ── Delete tests ──────────────────────────────────────────────────────────────
+
+
+def test_delete_requires_confirmation(client, auth_header):
+    """Delete should reject requests without explicit confirmation."""
+    r = client.post("/privacy/delete", json={}, headers=auth_header)
+    assert r.status_code == 400
+    assert "confirm" in r.get_json()["error"]
+
+
+def test_delete_without_body(client, auth_header):
+    """Delete should handle missing body gracefully."""
+    r = client.post(
+        "/privacy/delete",
+        headers={**auth_header, "Content-Type": "application/json"},
+    )
+    assert r.status_code == 400
+
+
+def test_delete_user_data(client, auth_header):
+    """After deletion, user data should be completely removed."""
+    _seed_full_profile(client, auth_header)
+
+    # Verify data exists first
+    r = client.get("/privacy/export", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()["expenses"]) >= 2
+
+    # Perform deletion
+    r = client.post(
+        "/privacy/delete", json={"confirm": True}, headers=auth_header
+    )
+    assert r.status_code == 200
+    assert "permanently deleted" in r.get_json()["message"].lower()
+
+    # Token is still valid but user no longer exists, so export should fail
+    r = client.get("/privacy/export", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_delete_requires_auth(client):
+    """Delete endpoint should return 401 without auth."""
+    r = client.post("/privacy/delete", json={"confirm": True})
+    assert r.status_code == 401
+
+
+def test_delete_is_irreversible(client, auth_header):
+    """After deletion, login should fail."""
+    r = client.post(
+        "/privacy/delete", json={"confirm": True}, headers=auth_header
+    )
+    assert r.status_code == 200
+
+    # Attempt login — should fail
+    r = client.post(
+        "/auth/login",
+        json={"email": "test@example.com", "password": "password123"},
+    )
+    assert r.status_code in (401, 404)


### PR DESCRIPTION
## Summary

Implements the **GDPR PII Export & Delete Workflow** as described in #76.

### Acceptance Criteria
- Export package generation
- Irreversible deletion workflow
- Audit trail logging

### Backend

#### services/privacy.py
- **export_user_data(user_id)** - Collects ALL personal records across every model: profile, categories, expenses, recurring expenses, bills, reminders, subscriptions, and audit logs. Returns a versioned JSON-serialisable dictionary.
- **delete_user_data(user_id)** - Permanently deletes all user data. Creates an anonymised GDPR_DELETE audit log entry before removal. Explicitly deletes child records for compatibility with databases that don't support CASCADE.

#### routes/privacy.py
- GET /privacy/export - GDPR Art. 20 (Right to Data Portability). Returns all user data as JSON.
- POST /privacy/delete - GDPR Art. 17 (Right to Erasure). Requires confirm:true in the body to prevent accidental deletion. Invalidates Redis cache for the user.
- Both endpoints require JWT authentication.

### Frontend

#### api/privacy.ts
- exportPII() - Fetches the export JSON
- deletePII() - Sends confirmed deletion request

#### Account Page Updates
- **Export My Data** button - Downloads a timestamped JSON file
- **Delete My Account** - Two-step confirmation (click once to reveal confirmation, click again to execute). Shows permanent warning. Clears local auth tokens and redirects to sign-in on success.

### Tests (test_privacy.py)
8 tests covering:
- Export: empty user, seeded data, auth required
- Delete: confirmation required, missing body, full deletion, auth required, irreversibility (login fails after delete)

/claim #76
