### PR TITLE
fix typo: SCH[Scheduler/APSch → SCH[Scheduler/APScheduler]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ flowchart LR
     API[Flask + Gunicorn]
     JWT[PyJWT]
     AI[Insights Service]
-    SCH[Scheduler/APScheduler]
+    SCH[Scheduler/APScheduler]eduler]
   end
 
   subgraph Data


### PR DESCRIPTION
Fixes #121