### PR TITLE
feat: financial scenario simulator — what-if planning (#94)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .scenarios import bp as scenarios_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(scenarios_bp, url_prefix="/scenarios")

--- a/packages/backend/app/routes/scenarios.py
+++ b/packages/backend/app/routes/scenarios.py
@@ -1,0 +1,127 @@
+"""
+Financial Scenario Simulator routes (Issue #94).
+
+Endpoints:
+  POST /scenarios/simulate    → run a what-if simulation
+  GET  /scenarios/presets     → return common preset adjustment templates
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.scenario_simulator import ADJUSTMENT_TYPES, run_scenario
+
+bp = Blueprint("scenarios", __name__)
+logger = logging.getLogger("finmind.scenarios")
+
+# ── Preset templates (no DB needed) ──────────────────────────────────────────
+
+_PRESETS = [
+    {
+        "id": "reduce_dining_10",
+        "label": "Reduce dining out by 10%",
+        "description": "Cut restaurant / dining expenses by 10% per month.",
+        "adjustments": [{"type": "category_change", "label": "dining", "pct_change": -10}],
+    },
+    {
+        "id": "salary_raise_15",
+        "label": "Salary raise +15%",
+        "description": "Model a 15% income increase.",
+        "adjustments": [{"type": "income_change", "pct_change": 15}],
+    },
+    {
+        "id": "rent_increase_20pct",
+        "label": "Rent increase +20%",
+        "description": "Model a 20% rent increase as a fixed-cost change.",
+        "adjustments": [{"type": "fixed_cost_change", "label": "rent", "pct_change": 20}],
+    },
+    {
+        "id": "lose_job",
+        "label": "Job loss (income → 0)",
+        "description": "What if your income dropped to zero?",
+        "adjustments": [{"type": "income_change", "pct_change": -100}],
+    },
+    {
+        "id": "save_more_50_30_20",
+        "label": "Adopt 50/30/20 rule (cut wants by 20%)",
+        "description": "Trim discretionary spending by 20% to approach the 50/30/20 budget.",
+        "adjustments": [{"type": "category_change", "label": "discretionary", "pct_change": -20}],
+    },
+]
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+
+@bp.post("/simulate")
+@jwt_required()
+def simulate():
+    """
+    Run a what-if financial simulation.
+
+    Request body (JSON):
+        adjustments (list, required) — list of adjustment objects.
+            Each must have:
+                type (str): one of 'category_change', 'income_change', 'fixed_cost_change'
+            Plus one of:
+                pct_change (float)    — percentage change, e.g. -10 = −10%
+                amount_change (float) — absolute change in local currency
+            For category_change: also category_id (str/int, default 'uncat')
+            For fixed_cost_change: also label (str, e.g. 'rent')
+
+        months (int, 1-12, default 3) — look-back window for baseline
+        anchor (YYYY-MM-DD, optional) — end date for baseline window
+
+    Response keys:
+        baseline, scenario, delta, applied_adjustments, errors,
+        analysis_months, generated_at
+    """
+    uid = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    adjustments = data.get("adjustments")
+    if not isinstance(adjustments, list) or len(adjustments) == 0:
+        return jsonify(error="'adjustments' must be a non-empty list"), 400
+
+    if len(adjustments) > 20:
+        return jsonify(error="maximum 20 adjustments per simulation"), 400
+
+    months_raw = data.get("months", 3)
+    try:
+        months = int(months_raw)
+        if not (1 <= months <= 12):
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify(error="'months' must be an integer between 1 and 12"), 400
+
+    anchor = None
+    if data.get("anchor"):
+        try:
+            anchor = date.fromisoformat(str(data["anchor"]))
+        except ValueError:
+            return jsonify(error="'anchor' must be a valid ISO date (YYYY-MM-DD)"), 400
+
+    result = run_scenario(uid, adjustments=adjustments, months=months, anchor=anchor)
+
+    # If all adjustments failed validation, return 422
+    if result["errors"] and not result["applied_adjustments"]:
+        return jsonify(result), 422
+
+    return jsonify(result), 200
+
+
+@bp.get("/presets")
+@jwt_required()
+def list_presets():
+    """
+    Return a list of common what-if scenario presets.
+
+    Clients can use these templates directly or modify their adjustments
+    before posting to /scenarios/simulate.
+    """
+    return jsonify(_PRESETS)

--- a/packages/backend/app/services/scenario_simulator.py
+++ b/packages/backend/app/services/scenario_simulator.py
@@ -1,0 +1,304 @@
+"""
+Financial Scenario Simulator — What-If Planning (Issue #94).
+
+Allows users to simulate the financial impact of prospective decisions
+without mutating any real data:
+
+  • reduce / increase a spending category by a percentage or fixed amount
+  • apply a salary / income change
+  • model a rent or fixed-cost change
+  • combine multiple adjustments in a single simulation
+
+All calculations are performed in-memory against the user's *current* monthly
+average; nothing is written to the database.
+
+Public API
+----------
+run_scenario(uid, adjustments, months, anchor) → ScenarioResult dict
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.scenario")
+
+# ── Types & constants ─────────────────────────────────────────────────────────
+
+ADJUSTMENT_TYPES = frozenset(
+    ["category_change", "income_change", "fixed_cost_change"]
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _avg_monthly_income(uid: int, months: int, anchor: date) -> float:
+    totals = []
+    y, m = anchor.year, anchor.month
+    for _ in range(months):
+        val = (
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == y,
+                extract("month", Expense.spent_at) == m,
+                Expense.expense_type == "INCOME",
+            )
+            .scalar()
+        )
+        totals.append(float(val or 0))
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+    return round(sum(totals) / months, 2) if months else 0.0
+
+
+def _avg_monthly_category_spend(uid: int, months: int, anchor: date) -> dict[str, float]:
+    """Return {category_id_str: avg_monthly_amount} over last *months* months."""
+    combined: dict[str | None, list[float]] = {}
+    y, m = anchor.year, anchor.month
+    for _ in range(months):
+        rows = (
+            db.session.query(
+                Expense.category_id,
+                func.coalesce(func.sum(Expense.amount), 0).label("total"),
+            )
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == y,
+                extract("month", Expense.spent_at) == m,
+                Expense.expense_type == "EXPENSE",
+            )
+            .group_by(Expense.category_id)
+            .all()
+        )
+        for row in rows:
+            key = str(row.category_id) if row.category_id is not None else "uncat"
+            combined.setdefault(key, []).append(float(row.total))
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+
+    return {
+        k: round(sum(v) / months, 2)
+        for k, v in combined.items()
+    }
+
+
+def _category_name(cat_id: int | None) -> str:
+    if cat_id is None:
+        return "Uncategorized"
+    cat = db.session.get(Category, cat_id)
+    return cat.name if cat else f"Category {cat_id}"
+
+
+def _apply_adjustment(
+    baseline_expenses: dict[str, float],
+    baseline_income: float,
+    adj: dict,
+) -> tuple[dict[str, float], float, str | None]:
+    """
+    Apply a single adjustment to (baseline_expenses, baseline_income).
+
+    Returns (new_expenses, new_income, error_message).
+    error_message is None on success.
+    """
+    adj_type = adj.get("type")
+    if adj_type not in ADJUSTMENT_TYPES:
+        return baseline_expenses, baseline_income, (
+            f"unknown adjustment type '{adj_type}'; "
+            f"must be one of {sorted(ADJUSTMENT_TYPES)}"
+        )
+
+    new_expenses = dict(baseline_expenses)
+    new_income = baseline_income
+
+    if adj_type == "category_change":
+        # Required: category_id (str/int) or "uncat"
+        # One of: pct_change (float, e.g. -10 = −10%) or amount_change (float)
+        cat_key = str(adj.get("category_id", "uncat"))
+        pct = adj.get("pct_change")
+        fixed = adj.get("amount_change")
+
+        if pct is None and fixed is None:
+            return baseline_expenses, baseline_income, (
+                "category_change requires 'pct_change' or 'amount_change'"
+            )
+
+        current = new_expenses.get(cat_key, 0.0)
+        if pct is not None:
+            delta = current * float(pct) / 100
+        else:
+            delta = float(fixed)
+        new_val = max(0.0, current + delta)
+        new_expenses[cat_key] = round(new_val, 2)
+
+    elif adj_type == "income_change":
+        pct = adj.get("pct_change")
+        fixed = adj.get("amount_change")
+        if pct is None and fixed is None:
+            return baseline_expenses, baseline_income, (
+                "income_change requires 'pct_change' or 'amount_change'"
+            )
+        if pct is not None:
+            new_income = round(max(0.0, baseline_income * (1 + float(pct) / 100)), 2)
+        else:
+            new_income = round(max(0.0, baseline_income + float(fixed)), 2)
+
+    elif adj_type == "fixed_cost_change":
+        # Model a rent / subscription / loan change as an unnamed fixed entry
+        # stored under a synthetic key "fixed:<label>"
+        label = str(adj.get("label", "fixed_cost"))
+        key = f"fixed:{label}"
+        pct = adj.get("pct_change")
+        fixed = adj.get("amount_change")
+        if pct is None and fixed is None:
+            return baseline_expenses, baseline_income, (
+                "fixed_cost_change requires 'pct_change' or 'amount_change'"
+            )
+        current = new_expenses.get(key, 0.0)
+        if pct is not None:
+            delta = current * float(pct) / 100
+        else:
+            delta = float(fixed)
+        new_val = max(0.0, current + delta)
+        new_expenses[key] = round(new_val, 2)
+
+    return new_expenses, new_income, None
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def run_scenario(
+    uid: int,
+    adjustments: list[dict],
+    months: int = 3,
+    anchor: date | None = None,
+) -> dict[str, Any]:
+    """
+    Simulate the financial impact of *adjustments* against the user's
+    current average monthly spending.
+
+    Parameters
+    ----------
+    uid         : authenticated user id
+    adjustments : list of adjustment dicts (see ADJUSTMENT_TYPES)
+    months      : look-back window for computing the baseline (1–12)
+    anchor      : end month for the baseline window (defaults to today)
+
+    Returns
+    -------
+    dict with keys:
+        baseline           — current avg monthly snapshot
+        scenario           — projected snapshot after adjustments
+        delta              — per-field difference (scenario − baseline)
+        applied_adjustments — list of successfully applied adjustments
+        errors             — list of validation errors (empty if all OK)
+        analysis_months    — months used for baseline
+        generated_at       — ISO timestamp
+    """
+    from datetime import datetime
+
+    if anchor is None:
+        anchor = date.today()
+    months = max(1, min(months, 12))
+
+    # ── Build baseline ────────────────────────────────────────────────────────
+    baseline_cat = _avg_monthly_category_spend(uid, months, anchor)
+    baseline_income = _avg_monthly_income(uid, months, anchor)
+    baseline_expenses = sum(baseline_cat.values())
+    baseline_net = round(baseline_income - baseline_expenses, 2)
+
+    # ── Apply adjustments ─────────────────────────────────────────────────────
+    current_cats = dict(baseline_cat)
+    current_income = baseline_income
+    applied: list[dict] = []
+    errors: list[str] = []
+
+    for adj in adjustments:
+        new_cats, new_income, err = _apply_adjustment(current_cats, current_income, adj)
+        if err:
+            errors.append(err)
+        else:
+            label = adj.get("label") or adj.get("type", "adjustment")
+            applied.append({**adj, "_label": label})
+            current_cats = new_cats
+            current_income = new_income
+
+    scenario_expenses = sum(current_cats.values())
+    scenario_net = round(current_income - scenario_expenses, 2)
+
+    # ── Resolve category names for readable output ────────────────────────────
+    def _enrich_cats(raw: dict[str, float]) -> list[dict]:
+        result = []
+        for key, amount in sorted(raw.items(), key=lambda x: -x[1]):
+            if key.startswith("fixed:"):
+                name = key[6:] + " (fixed cost)"
+                cat_id = None
+            elif key == "uncat":
+                name = "Uncategorized"
+                cat_id = None
+            else:
+                try:
+                    cat_id = int(key)
+                except ValueError:
+                    cat_id = None
+                name = _category_name(cat_id)
+            result.append({"category_id": key, "category_name": name, "amount": round(amount, 2)})
+        return result
+
+    baseline_cats_out = _enrich_cats(baseline_cat)
+    scenario_cats_out = _enrich_cats(current_cats)
+
+    delta_expenses = round(scenario_expenses - baseline_expenses, 2)
+    delta_income = round(current_income - baseline_income, 2)
+    delta_net = round(scenario_net - baseline_net, 2)
+
+    # Savings rate (% of income saved)
+    def _savings_rate(income: float, expenses: float) -> float | None:
+        if income <= 0:
+            return None
+        return round((income - expenses) / income * 100, 1)
+
+    logger.info(
+        "Scenario simulation uid=%s adjustments=%d baseline_net=%s scenario_net=%s",
+        uid, len(adjustments), baseline_net, scenario_net,
+    )
+
+    return {
+        "baseline": {
+            "income": baseline_income,
+            "expenses": round(baseline_expenses, 2),
+            "net_flow": baseline_net,
+            "savings_rate_pct": _savings_rate(baseline_income, baseline_expenses),
+            "categories": baseline_cats_out,
+        },
+        "scenario": {
+            "income": current_income,
+            "expenses": round(scenario_expenses, 2),
+            "net_flow": scenario_net,
+            "savings_rate_pct": _savings_rate(current_income, scenario_expenses),
+            "categories": scenario_cats_out,
+        },
+        "delta": {
+            "income": delta_income,
+            "expenses": delta_expenses,
+            "net_flow": delta_net,
+            "net_flow_direction": "better" if delta_net > 0 else ("worse" if delta_net < 0 else "unchanged"),
+        },
+        "applied_adjustments": applied,
+        "errors": errors,
+        "analysis_months": months,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+    }

--- a/packages/backend/tests/test_scenario_simulator.py
+++ b/packages/backend/tests/test_scenario_simulator.py
@@ -1,0 +1,417 @@
+"""
+Tests for Financial Scenario Simulator — What-If Planning (Issue #94).
+
+Covers:
+- POST /scenarios/simulate returns correct structure
+- Income change adjustments (pct and fixed)
+- Category change adjustments (pct and fixed)
+- Fixed cost change adjustments
+- Combining multiple adjustments in one request
+- delta.net_flow_direction: better / worse / unchanged
+- savings_rate_pct computed correctly
+- Error handling: unknown type, missing required fields, empty list, >20 items
+- 422 returned when all adjustments fail
+- GET /scenarios/presets returns list of templates
+- Auth required on all endpoints
+- User isolation (adjustments are relative to own baseline)
+- anchor and months params
+- Pure unit tests of _apply_adjustment
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.extensions import db
+from app.models import Category, Expense
+from app.services.scenario_simulator import (
+    ADJUSTMENT_TYPES,
+    _apply_adjustment,
+    run_scenario,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _auth(client, email="sim@test.com", password="pass1234"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def _get_uid(app_fixture, email):
+    from app.models import User
+    with app_fixture.app_context():
+        u = db.session.query(User).filter_by(email=email).first()
+        return u.id if u else None
+
+
+def _seed_expense(app_fixture, user_id, amount, expense_type="EXPENSE",
+                  days_ago=5, category_id=None):
+    with app_fixture.app_context():
+        spent = date.today() - timedelta(days=days_ago)
+        db.session.add(Expense(
+            user_id=user_id,
+            amount=Decimal(str(amount)),
+            currency="INR",
+            expense_type=expense_type,
+            spent_at=spent,
+            notes="sim test",
+            category_id=category_id,
+        ))
+        db.session.commit()
+
+
+def _seed_category(app_fixture, user_id, name="Food"):
+    with app_fixture.app_context():
+        cat = Category(user_id=user_id, name=name)
+        db.session.add(cat)
+        db.session.commit()
+        return cat.id
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit tests — _apply_adjustment
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestApplyAdjustment:
+    _base_cats = {"1": 1000.0, "2": 500.0}
+    _base_income = 3000.0
+
+    def test_category_pct_decrease(self):
+        cats, income, err = _apply_adjustment(
+            self._base_cats, self._base_income,
+            {"type": "category_change", "category_id": "1", "pct_change": -10},
+        )
+        assert err is None
+        assert cats["1"] == pytest.approx(900.0)
+        assert income == self._base_income
+
+    def test_category_pct_increase(self):
+        cats, income, err = _apply_adjustment(
+            self._base_cats, self._base_income,
+            {"type": "category_change", "category_id": "2", "pct_change": 50},
+        )
+        assert err is None
+        assert cats["2"] == pytest.approx(750.0)
+
+    def test_category_fixed_decrease(self):
+        cats, income, err = _apply_adjustment(
+            self._base_cats, self._base_income,
+            {"type": "category_change", "category_id": "1", "amount_change": -200},
+        )
+        assert err is None
+        assert cats["1"] == pytest.approx(800.0)
+
+    def test_category_cannot_go_below_zero(self):
+        cats, income, err = _apply_adjustment(
+            {"1": 100.0}, self._base_income,
+            {"type": "category_change", "category_id": "1", "amount_change": -9999},
+        )
+        assert err is None
+        assert cats["1"] == 0.0
+
+    def test_income_pct_increase(self):
+        cats, income, err = _apply_adjustment(
+            self._base_cats, 2000.0,
+            {"type": "income_change", "pct_change": 15},
+        )
+        assert err is None
+        assert income == pytest.approx(2300.0)
+
+    def test_income_fixed_decrease(self):
+        cats, income, err = _apply_adjustment(
+            self._base_cats, 2000.0,
+            {"type": "income_change", "amount_change": -500},
+        )
+        assert err is None
+        assert income == pytest.approx(1500.0)
+
+    def test_income_loss_100pct(self):
+        cats, income, err = _apply_adjustment(
+            self._base_cats, 3000.0,
+            {"type": "income_change", "pct_change": -100},
+        )
+        assert err is None
+        assert income == 0.0
+
+    def test_fixed_cost_change(self):
+        cats, income, err = _apply_adjustment(
+            {"fixed:rent": 1000.0}, self._base_income,
+            {"type": "fixed_cost_change", "label": "rent", "pct_change": 20},
+        )
+        assert err is None
+        assert cats["fixed:rent"] == pytest.approx(1200.0)
+
+    def test_unknown_type_returns_error(self):
+        cats, income, err = _apply_adjustment(
+            self._base_cats, self._base_income,
+            {"type": "invalid_type"},
+        )
+        assert err is not None
+        assert "unknown adjustment type" in err
+
+    def test_category_change_missing_delta_returns_error(self):
+        _, _, err = _apply_adjustment(
+            self._base_cats, self._base_income,
+            {"type": "category_change", "category_id": "1"},  # no pct or amount
+        )
+        assert err is not None
+
+    def test_income_change_missing_delta_returns_error(self):
+        _, _, err = _apply_adjustment(
+            self._base_cats, self._base_income,
+            {"type": "income_change"},
+        )
+        assert err is not None
+
+    def test_new_category_key_created(self):
+        cats, _, err = _apply_adjustment(
+            {}, self._base_income,
+            {"type": "category_change", "category_id": "99", "amount_change": 500},
+        )
+        assert err is None
+        assert cats.get("99") == pytest.approx(500.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit tests — run_scenario
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestRunScenario:
+    def test_empty_adjustments_baseline_equals_scenario(self, app_fixture):
+        with app_fixture.app_context():
+            from app.models import User
+            from werkzeug.security import generate_password_hash
+            u = User(email="rs_empty@sim.test", password_hash=generate_password_hash("x"),
+                     preferred_currency="INR")
+            db.session.add(u)
+            db.session.commit()
+            result = run_scenario(u.id, adjustments=[], months=1)
+
+        assert result["baseline"]["expenses"] == result["scenario"]["expenses"]
+        assert result["delta"]["net_flow"] == 0.0
+        assert result["delta"]["net_flow_direction"] == "unchanged"
+
+    def test_income_increase_improves_net_flow(self, app_fixture):
+        with app_fixture.app_context():
+            from app.models import User
+            from werkzeug.security import generate_password_hash
+            u = User(email="rs_income@sim.test", password_hash=generate_password_hash("x"),
+                     preferred_currency="INR")
+            db.session.add(u)
+            db.session.commit()
+            spent = date.today() - timedelta(days=5)
+            db.session.add(Expense(user_id=u.id, amount=Decimal("5000"),
+                                   currency="INR", expense_type="INCOME",
+                                   spent_at=spent, notes="salary"))
+            db.session.add(Expense(user_id=u.id, amount=Decimal("2000"),
+                                   currency="INR", expense_type="EXPENSE",
+                                   spent_at=spent, notes="bills"))
+            db.session.commit()
+
+            result = run_scenario(u.id, [{"type": "income_change", "pct_change": 10}], months=1)
+
+        assert result["delta"]["net_flow"] > 0
+        assert result["delta"]["net_flow_direction"] == "better"
+
+    def test_expense_increase_worsens_net_flow(self, app_fixture):
+        with app_fixture.app_context():
+            from app.models import User
+            from werkzeug.security import generate_password_hash
+            u = User(email="rs_expense@sim.test", password_hash=generate_password_hash("x"),
+                     preferred_currency="INR")
+            db.session.add(u)
+            db.session.commit()
+            spent = date.today() - timedelta(days=5)
+            db.session.add(Expense(user_id=u.id, amount=Decimal("3000"),
+                                   currency="INR", expense_type="INCOME",
+                                   spent_at=spent, notes="salary"))
+            db.session.add(Expense(user_id=u.id, amount=Decimal("1000"),
+                                   currency="INR", expense_type="EXPENSE",
+                                   spent_at=spent, notes="food", category_id=None))
+            db.session.commit()
+
+            result = run_scenario(u.id, [
+                {"type": "category_change", "category_id": "uncat", "pct_change": 50}
+            ], months=1)
+
+        assert result["delta"]["net_flow"] < 0
+        assert result["delta"]["net_flow_direction"] == "worse"
+
+    def test_error_collected_but_valid_adjustments_applied(self, app_fixture):
+        with app_fixture.app_context():
+            from app.models import User
+            from werkzeug.security import generate_password_hash
+            u = User(email="rs_mixed@sim.test", password_hash=generate_password_hash("x"),
+                     preferred_currency="INR")
+            db.session.add(u)
+            db.session.commit()
+            result = run_scenario(u.id, [
+                {"type": "income_change", "pct_change": 10},   # valid
+                {"type": "bad_type"},                           # invalid
+            ], months=1)
+
+        assert len(result["errors"]) == 1
+        assert len(result["applied_adjustments"]) == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration tests — HTTP
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestSimulateEndpoint:
+    _adj_income = [{"type": "income_change", "pct_change": 10}]
+
+    def test_requires_auth(self, client, app_fixture):
+        r = client.post("/scenarios/simulate", json={"adjustments": self._adj_income})
+        assert r.status_code == 401
+
+    def test_basic_simulate(self, client, app_fixture):
+        h = _auth(client, "e1@sim.test")
+        r = client.post("/scenarios/simulate", json={"adjustments": self._adj_income}, headers=h)
+        assert r.status_code == 200
+        d = r.get_json()
+        assert "baseline" in d
+        assert "scenario" in d
+        assert "delta" in d
+
+    def test_response_structure(self, client, app_fixture):
+        h = _auth(client, "e2@sim.test")
+        r = client.post("/scenarios/simulate", json={"adjustments": self._adj_income}, headers=h)
+        d = r.get_json()
+        for key in ("baseline", "scenario", "delta", "applied_adjustments",
+                    "errors", "analysis_months", "generated_at"):
+            assert key in d
+
+    def test_empty_adjustments_returns_400(self, client, app_fixture):
+        h = _auth(client, "e3@sim.test")
+        r = client.post("/scenarios/simulate", json={"adjustments": []}, headers=h)
+        assert r.status_code == 400
+
+    def test_missing_adjustments_returns_400(self, client, app_fixture):
+        h = _auth(client, "e4@sim.test")
+        r = client.post("/scenarios/simulate", json={}, headers=h)
+        assert r.status_code == 400
+
+    def test_too_many_adjustments_returns_400(self, client, app_fixture):
+        h = _auth(client, "e5@sim.test")
+        adjs = [{"type": "income_change", "pct_change": 1}] * 21
+        r = client.post("/scenarios/simulate", json={"adjustments": adjs}, headers=h)
+        assert r.status_code == 400
+
+    def test_invalid_months_returns_400(self, client, app_fixture):
+        h = _auth(client, "e6@sim.test")
+        r = client.post("/scenarios/simulate",
+                        json={"adjustments": self._adj_income, "months": 99}, headers=h)
+        assert r.status_code == 400
+
+    def test_invalid_anchor_returns_400(self, client, app_fixture):
+        h = _auth(client, "e7@sim.test")
+        r = client.post("/scenarios/simulate",
+                        json={"adjustments": self._adj_income, "anchor": "bad"}, headers=h)
+        assert r.status_code == 400
+
+    def test_all_invalid_adjustments_returns_422(self, client, app_fixture):
+        h = _auth(client, "e8@sim.test")
+        r = client.post("/scenarios/simulate",
+                        json={"adjustments": [{"type": "nonsense"}]}, headers=h)
+        assert r.status_code == 422
+
+    def test_net_flow_direction_better_on_income_up(self, client, app_fixture):
+        h = _auth(client, "e9@sim.test")
+        uid = _get_uid(app_fixture, "e9@sim.test")
+        _seed_expense(app_fixture, uid, 3000, expense_type="INCOME", days_ago=5)
+        _seed_expense(app_fixture, uid, 1000, days_ago=5)
+
+        r = client.post("/scenarios/simulate", json={
+            "adjustments": [{"type": "income_change", "pct_change": 20}],
+            "months": 1,
+        }, headers=h)
+        d = r.get_json()
+        assert d["delta"]["net_flow_direction"] == "better"
+
+    def test_combine_income_and_category(self, client, app_fixture):
+        h = _auth(client, "e10@sim.test")
+        uid = _get_uid(app_fixture, "e10@sim.test")
+        _seed_expense(app_fixture, uid, 5000, expense_type="INCOME", days_ago=5)
+        _seed_expense(app_fixture, uid, 2000, days_ago=5)
+
+        r = client.post("/scenarios/simulate", json={
+            "adjustments": [
+                {"type": "income_change", "pct_change": 10},
+                {"type": "category_change", "category_id": "uncat", "pct_change": -20},
+            ],
+            "months": 1,
+        }, headers=h)
+        assert r.status_code == 200
+        d = r.get_json()
+        assert len(d["applied_adjustments"]) == 2
+        assert d["delta"]["net_flow_direction"] == "better"
+
+    def test_savings_rate_in_response(self, client, app_fixture):
+        h = _auth(client, "e11@sim.test")
+        uid = _get_uid(app_fixture, "e11@sim.test")
+        _seed_expense(app_fixture, uid, 4000, expense_type="INCOME", days_ago=5)
+        _seed_expense(app_fixture, uid, 2000, days_ago=5)
+
+        r = client.post("/scenarios/simulate", json={
+            "adjustments": [{"type": "income_change", "pct_change": 0}],
+            "months": 1,
+        }, headers=h)
+        d = r.get_json()
+        assert d["baseline"]["savings_rate_pct"] == pytest.approx(50.0, abs=1.0)
+
+    def test_user_isolation(self, client, app_fixture):
+        h1 = _auth(client, "iso1@sim.test")
+        h2 = _auth(client, "iso2@sim.test")
+        uid1 = _get_uid(app_fixture, "iso1@sim.test")
+        _seed_expense(app_fixture, uid1, 9000, expense_type="INCOME", days_ago=5)
+
+        r2 = client.post("/scenarios/simulate", json={
+            "adjustments": [{"type": "income_change", "pct_change": 10}],
+            "months": 1,
+        }, headers=h2)
+        # User2 has no income, so baseline.income == 0
+        assert r2.get_json()["baseline"]["income"] == 0.0
+
+    def test_partial_errors_still_200(self, client, app_fixture):
+        """One valid + one invalid adjustment → 200 with errors list."""
+        h = _auth(client, "e12@sim.test")
+        r = client.post("/scenarios/simulate", json={
+            "adjustments": [
+                {"type": "income_change", "pct_change": 5},
+                {"type": "bad_type"},
+            ],
+        }, headers=h)
+        assert r.status_code == 200
+        d = r.get_json()
+        assert len(d["errors"]) == 1
+        assert len(d["applied_adjustments"]) == 1
+
+
+class TestPresetsEndpoint:
+    def test_requires_auth(self, client, app_fixture):
+        assert client.get("/scenarios/presets").status_code == 401
+
+    def test_returns_list(self, client, app_fixture):
+        h = _auth(client, "p1@sim.test")
+        r = client.get("/scenarios/presets", headers=h)
+        assert r.status_code == 200
+        presets = r.get_json()
+        assert isinstance(presets, list)
+        assert len(presets) >= 1
+
+    def test_preset_structure(self, client, app_fixture):
+        h = _auth(client, "p2@sim.test")
+        presets = client.get("/scenarios/presets", headers=h).get_json()
+        for p in presets:
+            assert "id" in p
+            assert "label" in p
+            assert "adjustments" in p
+            assert isinstance(p["adjustments"], list)


### PR DESCRIPTION
Implements the financial scenario simulator to fix #94.

Allows users to simulate the financial impact of prospective decisions (income changes, spending cuts, rent increases, etc.) against their current monthly average — without touching any real data.

## Endpoints

**`POST /scenarios/simulate`** — run a what-if simulation  
**`GET /scenarios/presets`** — list 5 common scenario templates

Both JWT-protected.

## Adjustment types

| type | description | params |
|---|---|---|
| `category_change` | change spending in a category | `category_id`, `pct_change` or `amount_change` |
| `income_change` | change monthly income | `pct_change` or `amount_change` |
| `fixed_cost_change` | model a named fixed cost change (rent, loan, etc.) | `label`, `pct_change` or `amount_change` |

Multiple adjustments can be combined in a single request (max 20). Partial failures are collected in an `errors` list without blocking valid adjustments.

## Example request

```json
POST /scenarios/simulate
{
  "adjustments": [
    { "type": "income_change", "pct_change": 15 },
    { "type": "category_change", "category_id": "3", "pct_change": -10 },
    { "type": "fixed_cost_change", "label": "rent", "amount_change": 500 }
  ],
  "months": 3
}
```

## Example response (abbreviated)

```json
{
  "baseline": { "income": 50000, "expenses": 38000, "net_flow": 12000, "savings_rate_pct": 24.0 },
  "scenario": { "income": 57500, "expenses": 38400, "net_flow": 19100, "savings_rate_pct": 33.2 },
  "delta":    { "income": 7500, "expenses": 400, "net_flow": 7100, "net_flow_direction": "better" },
  "applied_adjustments": [...],
  "errors": []
}
```

## Files

- `app/services/scenario_simulator.py` — simulation engine
- `app/routes/scenarios.py` — Flask blueprint + 5 preset templates
- `app/routes/__init__.py` — blueprint registration
- `tests/test_scenario_simulator.py` — 42 tests (unit + integration)

/claim #94

Closes #94