### PR TITLE
feat: explainable spending insights (#89)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .insights_explainable import bp as insights_explainable_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(insights_explainable_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/insights_explainable.py
+++ b/packages/backend/app/routes/insights_explainable.py
@@ -1,0 +1,90 @@
+"""
+Explainable Spending Insights routes (Issue #89).
+
+Endpoints:
+  GET /insights/explain         → full explainable insights (MoM changes + why)
+  GET /insights/explain/summary → top changes + overall trend only (lightweight)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.spending_insights import get_spending_insights
+
+bp = Blueprint("insights_explainable", __name__)
+logger = logging.getLogger("finmind.insights_explainable_routes")
+
+
+@bp.get("/explain")
+@jwt_required()
+def explain():
+    """
+    Return explainable month-over-month spending insights.
+
+    For each consecutive pair of months in the window, surfaces:
+    - Which categories changed significantly
+    - What changed (direction + magnitude)
+    - Why it changed (pattern-based explanation)
+    - Confidence level (high / medium / low)
+
+    Query params:
+        months (int, 2-12, default 3) — analysis window
+        anchor (YYYY-MM-DD, default today)
+
+    Response:
+        insights         — per-period list of category changes with explanations
+        top_changes      — top 3 largest changes across all periods
+        overall_trend    — 'increasing' | 'decreasing' | 'stable' | 'insufficient_data'
+        trend_confidence — confidence in overall trend
+        period_summaries — per-month income/expense/net
+        generated_at
+    """
+    uid = int(get_jwt_identity())
+
+    months_raw = request.args.get("months", "3")
+    try:
+        months = int(months_raw)
+        if not (2 <= months <= 12):
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify(error="months must be an integer between 2 and 12"), 400
+
+    anchor = None
+    if request.args.get("anchor"):
+        try:
+            anchor = date.fromisoformat(request.args["anchor"])
+        except ValueError:
+            return jsonify(error="anchor must be a valid ISO date (YYYY-MM-DD)"), 400
+
+    result = get_spending_insights(uid, months=months, anchor=anchor)
+    return jsonify(result)
+
+
+@bp.get("/explain/summary")
+@jwt_required()
+def explain_summary():
+    """
+    Lightweight version: top changes + overall trend only.
+    """
+    uid = int(get_jwt_identity())
+
+    months_raw = request.args.get("months", "3")
+    try:
+        months = int(months_raw)
+        if not (2 <= months <= 12):
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify(error="months must be an integer between 2 and 12"), 400
+
+    full = get_spending_insights(uid, months=months)
+    return jsonify({
+        "top_changes":      full["top_changes"],
+        "overall_trend":    full["overall_trend"],
+        "trend_confidence": full["trend_confidence"],
+        "generated_at":     full["generated_at"],
+    })

--- a/packages/backend/app/services/spending_insights.py
+++ b/packages/backend/app/services/spending_insights.py
@@ -1,0 +1,292 @@
+"""
+Explainable Spending Insights (Issue #89).
+
+Provides human-readable explanations of WHY spending changed month-over-month:
+- What changed (category-level delta detection)
+- Why it changed (pattern-based explanation with confidence level)
+- Confidence score based on data richness and change magnitude
+
+Public API
+----------
+get_spending_insights(uid, months, anchor) → InsightsResult dict
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.insights_explainable")
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+# Minimum % change to consider "significant"
+_SIGNIFICANT_CHANGE_PCT = 15.0
+# Minimum absolute change to surface (avoid noise on tiny amounts)
+_MIN_ABSOLUTE_CHANGE = 50.0
+# Confidence thresholds
+_HIGH_CONF_MONTHS = 4
+_MED_CONF_MONTHS  = 2
+
+
+# ── Data helpers ──────────────────────────────────────────────────────────────
+
+def _month_expense_by_category(uid: int, year: int, month: int) -> dict[int | None, float]:
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(func.sum(Expense.amount), 0).label("total"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "EXPENSE",
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+    return {r.category_id: float(r.total) for r in rows}
+
+
+def _month_totals(uid: int, year: int, month: int) -> tuple[float, float]:
+    inc = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar() or 0
+    )
+    exp = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "EXPENSE",
+        )
+        .scalar() or 0
+    )
+    return inc, exp
+
+
+def _category_name(cat_id: int | None) -> str:
+    if cat_id is None:
+        return "Uncategorized"
+    cat = db.session.get(Category, cat_id)
+    return cat.name if cat else f"Category {cat_id}"
+
+
+def _iter_months_back(anchor: date, n: int):
+    y, m = anchor.year, anchor.month
+    for _ in range(n):
+        yield y, m
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+
+
+# ── Explanation engine ────────────────────────────────────────────────────────
+
+def _explain_change(
+    cat_name: str,
+    prev: float,
+    curr: float,
+    pct_change: float,
+    history: list[float],
+) -> tuple[str, str]:
+    """
+    Return (what_changed, why_it_changed) explanations for a category delta.
+    Uses heuristics based on magnitude, direction, and historical variance.
+    """
+    direction = "increased" if curr > prev else "decreased"
+    abs_pct = abs(pct_change)
+
+    # Determine historical baseline volatility
+    if len(history) >= 3:
+        std = statistics.stdev(history)
+        mean = statistics.mean(history)
+        cv = std / mean if mean > 0 else 0  # coefficient of variation
+    else:
+        cv = 0
+
+    what = (
+        f"{cat_name} spending {direction} by {abs_pct:.1f}% "
+        f"({abs(curr - prev):.2f} more)" if curr > prev
+        else f"{cat_name} spending {direction} by {abs_pct:.1f}% "
+             f"({abs(curr - prev):.2f} less)"
+    )
+
+    # Why heuristics
+    if prev == 0 and curr > 0:
+        why = f"New spending in {cat_name} this month — no previous activity recorded."
+    elif curr == 0 and prev > 0:
+        why = f"No {cat_name} expenses recorded this month (category went quiet)."
+    elif abs_pct > 100:
+        why = f"Exceptional spike in {cat_name} — spending more than doubled. Likely a one-time large purchase or irregular event."
+    elif abs_pct > 50:
+        why = f"Large change in {cat_name}. Could indicate a seasonal pattern, a big purchase, or a change in habits."
+    elif cv > 0.4 and abs_pct > 20:
+        why = f"{cat_name} is historically volatile (high month-to-month variance), so this change may be within the normal range."
+    elif abs_pct > _SIGNIFICANT_CHANGE_PCT and cv < 0.2:
+        why = f"{cat_name} is usually stable, making this change notable. Consider reviewing recent transactions in this category."
+    else:
+        why = f"Moderate change in {cat_name}. Consistent with typical spending variation."
+
+    return what, why
+
+
+def _confidence_level(months_of_data: int, pct_change: float) -> str:
+    if months_of_data >= _HIGH_CONF_MONTHS and abs(pct_change) >= _SIGNIFICANT_CHANGE_PCT:
+        return "high"
+    if months_of_data >= _MED_CONF_MONTHS:
+        return "medium"
+    return "low"
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def get_spending_insights(
+    uid: int,
+    months: int = 3,
+    anchor: date | None = None,
+) -> dict[str, Any]:
+    """
+    Generate explainable spending insights for the last *months* months.
+
+    Returns:
+        insights           — list of month-over-month insight objects
+        top_changes        — top 3 largest changes across all periods
+        overall_trend      — 'increasing' | 'decreasing' | 'stable'
+        trend_confidence   — confidence in the overall trend
+        period_summaries   — per-month income/expense/net
+        generated_at       — ISO timestamp
+    """
+    from datetime import datetime
+
+    if anchor is None:
+        anchor = date.today()
+    months = max(2, min(months, 12))  # need at least 2 months for comparison
+
+    # Gather per-month totals
+    monthly_totals: list[dict] = []
+    for y, m in reversed(list(_iter_months_back(anchor, months))):
+        inc, exp = _month_totals(uid, y, m)
+        monthly_totals.append({
+            "year": y, "month": m,
+            "label": f"{y:04d}-{m:02d}",
+            "income": inc, "expenses": exp,
+            "net": round(inc - exp, 2),
+        })
+
+    # Build historical category data for the whole window (for volatility)
+    all_cat_history: dict[int | None, list[float]] = {}
+    for entry in monthly_totals:
+        cats = _month_expense_by_category(uid, entry["year"], entry["month"])
+        for cat_id, amount in cats.items():
+            all_cat_history.setdefault(cat_id, []).append(amount)
+
+    insights: list[dict] = []
+    all_changes: list[dict] = []
+
+    # Compare consecutive months
+    for i in range(1, len(monthly_totals)):
+        prev_m = monthly_totals[i - 1]
+        curr_m = monthly_totals[i]
+
+        prev_cats = _month_expense_by_category(uid, prev_m["year"], prev_m["month"])
+        curr_cats = _month_expense_by_category(uid, curr_m["year"], curr_m["month"])
+
+        all_cat_ids = set(prev_cats) | set(curr_cats)
+        period_changes: list[dict] = []
+
+        for cat_id in all_cat_ids:
+            prev_val = prev_cats.get(cat_id, 0.0)
+            curr_val = curr_cats.get(cat_id, 0.0)
+            delta = curr_val - prev_val
+
+            if abs(delta) < _MIN_ABSOLUTE_CHANGE:
+                continue
+
+            pct = ((curr_val - prev_val) / prev_val * 100) if prev_val > 0 else (100.0 if curr_val > 0 else 0.0)
+            if abs(pct) < _SIGNIFICANT_CHANGE_PCT and abs(delta) < _MIN_ABSOLUTE_CHANGE * 2:
+                continue
+
+            history = all_cat_history.get(cat_id, [])
+            cat_name = _category_name(cat_id)
+            what, why = _explain_change(cat_name, prev_val, curr_val, pct, history)
+            confidence = _confidence_level(len(history), pct)
+
+            change = {
+                "category_id": cat_id,
+                "category_name": cat_name,
+                "period": curr_m["label"],
+                "previous_period": prev_m["label"],
+                "previous_amount": round(prev_val, 2),
+                "current_amount": round(curr_val, 2),
+                "delta": round(delta, 2),
+                "pct_change": round(pct, 1),
+                "what_changed": what,
+                "why_it_changed": why,
+                "confidence": confidence,
+            }
+            period_changes.append(change)
+            all_changes.append(change)
+
+        # Total expense change for this period
+        total_prev = prev_m["expenses"]
+        total_curr = curr_m["expenses"]
+        total_pct = ((total_curr - total_prev) / total_prev * 100) if total_prev > 0 else 0.0
+
+        insights.append({
+            "period": curr_m["label"],
+            "previous_period": prev_m["label"],
+            "total_expense_change": round(total_curr - total_prev, 2),
+            "total_expense_pct_change": round(total_pct, 1),
+            "category_changes": sorted(period_changes, key=lambda x: -abs(x["delta"])),
+        })
+
+    # Top 3 changes across all periods
+    top_changes = sorted(all_changes, key=lambda x: -abs(x["delta"]))[:3]
+
+    # Overall trend
+    if len(monthly_totals) >= 2:
+        expense_series = [m["expenses"] for m in monthly_totals]
+        first_half_avg = statistics.mean(expense_series[:len(expense_series)//2]) if expense_series else 0
+        second_half_avg = statistics.mean(expense_series[len(expense_series)//2:]) if expense_series else 0
+        if second_half_avg > first_half_avg * 1.05:
+            overall_trend = "increasing"
+        elif second_half_avg < first_half_avg * 0.95:
+            overall_trend = "decreasing"
+        else:
+            overall_trend = "stable"
+        trend_confidence = "high" if len(monthly_totals) >= 4 else "medium"
+    else:
+        overall_trend = "insufficient_data"
+        trend_confidence = "low"
+
+    logger.info(
+        "Spending insights uid=%s months=%d insights=%d trend=%s",
+        uid, months, len(all_changes), overall_trend,
+    )
+
+    return {
+        "insights": insights,
+        "top_changes": top_changes,
+        "overall_trend": overall_trend,
+        "trend_confidence": trend_confidence,
+        "period_summaries": monthly_totals,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+    }

--- a/packages/backend/tests/test_spending_insights.py
+++ b/packages/backend/tests/test_spending_insights.py
@@ -1,0 +1,238 @@
+"""
+Tests for Explainable Spending Insights (Issue #89).
+
+Covers:
+- GET /insights/explain structure
+- Insight generated when spending increases significantly
+- Insight generated when spending decreases
+- what_changed / why_it_changed fields populated
+- confidence field present and valid
+- New category (prev=0) explanation
+- Vanishing category (curr=0) explanation
+- months=2 minimum validated
+- months=1 returns 400
+- months=13 returns 400
+- anchor param
+- invalid anchor returns 400
+- Auth required
+- User isolation
+- Overall trend: increasing / decreasing / stable
+- GET /insights/explain/summary lightweight
+- period_summaries correct
+- top_changes is a list of max 3
+- Empty history returns safe defaults (no crash)
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.extensions import db
+from app.models import Category, Expense
+from app.services.spending_insights import get_spending_insights
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _auth(client, email="exp@test.com", password="pass1234"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def _get_uid(app_fixture, email):
+    from app.models import User
+    with app_fixture.app_context():
+        u = db.session.query(User).filter_by(email=email).first()
+        return u.id if u else None
+
+
+def _seed(app_fixture, uid, amount, expense_type="EXPENSE", days_ago=5,
+          category_id=None, notes="x"):
+    with app_fixture.app_context():
+        db.session.add(Expense(
+            user_id=uid, amount=Decimal(str(amount)), currency="INR",
+            expense_type=expense_type,
+            spent_at=date.today() - timedelta(days=days_ago),
+            notes=notes, category_id=category_id,
+        ))
+        db.session.commit()
+
+
+def _seed_category(app_fixture, uid, name="Food"):
+    with app_fixture.app_context():
+        cat = Category(user_id=uid, name=name)
+        db.session.add(cat)
+        db.session.commit()
+        return cat.id
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit tests — service
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGetSpendingInsights:
+    def _make_user(self, app_fixture, email):
+        with app_fixture.app_context():
+            from app.models import User
+            from werkzeug.security import generate_password_hash
+            u = User(email=email, password_hash=generate_password_hash("x"),
+                     preferred_currency="INR")
+            db.session.add(u)
+            db.session.commit()
+            return u.id
+
+    def test_returns_required_keys(self, app_fixture):
+        uid = self._make_user(app_fixture, "si_struct@test.com")
+        with app_fixture.app_context():
+            result = get_spending_insights(uid, months=2)
+        for k in ("insights", "top_changes", "overall_trend",
+                  "trend_confidence", "period_summaries", "generated_at"):
+            assert k in result
+
+    def test_empty_history_no_crash(self, app_fixture):
+        uid = self._make_user(app_fixture, "si_empty@test.com")
+        with app_fixture.app_context():
+            result = get_spending_insights(uid, months=2)
+        assert isinstance(result["insights"], list)
+        assert result["overall_trend"] in ("stable", "insufficient_data", "increasing", "decreasing")
+
+    def test_period_summaries_count(self, app_fixture):
+        uid = self._make_user(app_fixture, "si_periods@test.com")
+        with app_fixture.app_context():
+            result = get_spending_insights(uid, months=3)
+        assert len(result["period_summaries"]) == 3
+
+    def test_top_changes_max_3(self, app_fixture):
+        uid = self._make_user(app_fixture, "si_top@test.com")
+        with app_fixture.app_context():
+            result = get_spending_insights(uid, months=3)
+        assert len(result["top_changes"]) <= 3
+
+    def test_user_isolation(self, app_fixture):
+        uid1 = self._make_user(app_fixture, "si_iso1@test.com")
+        uid2 = self._make_user(app_fixture, "si_iso2@test.com")
+        with app_fixture.app_context():
+            # Seed large change for u1
+            for days in [5, 35]:
+                db.session.add(Expense(user_id=uid1, amount=Decimal("5000"),
+                                       currency="INR", expense_type="EXPENSE",
+                                       spent_at=date.today() - timedelta(days=days),
+                                       notes="big"))
+            db.session.commit()
+            # u2 should see no insights
+            result = get_spending_insights(uid2, months=2)
+        assert len(result["top_changes"]) == 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration tests — HTTP
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestExplainEndpoint:
+    def test_requires_auth(self, client, app_fixture):
+        assert client.get("/insights/explain").status_code == 401
+
+    def test_returns_200(self, client, app_fixture):
+        h = _auth(client, "ex1@test.com")
+        r = client.get("/insights/explain", headers=h)
+        assert r.status_code == 200
+
+    def test_response_structure(self, client, app_fixture):
+        h = _auth(client, "ex2@test.com")
+        d = client.get("/insights/explain", headers=h).get_json()
+        for k in ("insights", "top_changes", "overall_trend",
+                  "trend_confidence", "period_summaries", "generated_at"):
+            assert k in d
+
+    def test_months_param_min_2(self, client, app_fixture):
+        h = _auth(client, "ex3@test.com")
+        assert client.get("/insights/explain?months=1", headers=h).status_code == 400
+
+    def test_months_param_max_12(self, client, app_fixture):
+        h = _auth(client, "ex4@test.com")
+        assert client.get("/insights/explain?months=13", headers=h).status_code == 400
+        assert client.get("/insights/explain?months=12", headers=h).status_code == 200
+
+    def test_invalid_months_type_returns_400(self, client, app_fixture):
+        h = _auth(client, "ex5@test.com")
+        assert client.get("/insights/explain?months=abc", headers=h).status_code == 400
+
+    def test_invalid_anchor_returns_400(self, client, app_fixture):
+        h = _auth(client, "ex6@test.com")
+        assert client.get("/insights/explain?anchor=bad", headers=h).status_code == 400
+
+    def test_valid_anchor(self, client, app_fixture):
+        h = _auth(client, "ex7@test.com")
+        r = client.get("/insights/explain?anchor=2026-03-01&months=2", headers=h)
+        assert r.status_code == 200
+
+    def test_insight_fields_when_change_detected(self, client, app_fixture):
+        """When spending changes significantly, insight must have explanation fields."""
+        h = _auth(client, "ex8@test.com")
+        uid = _get_uid(app_fixture, "ex8@test.com")
+        cat_id = _seed_category(app_fixture, uid, "Dining")
+
+        # Large expense in current month, nothing last month
+        _seed(app_fixture, uid, 5000, days_ago=5, category_id=cat_id)
+
+        d = client.get("/insights/explain?months=2", headers=h).get_json()
+        if d["top_changes"]:
+            change = d["top_changes"][0]
+            assert "what_changed" in change
+            assert "why_it_changed" in change
+            assert "confidence" in change
+            assert change["confidence"] in ("high", "medium", "low")
+
+    def test_period_summaries_correct_count(self, client, app_fixture):
+        h = _auth(client, "ex9@test.com")
+        d = client.get("/insights/explain?months=4", headers=h).get_json()
+        assert len(d["period_summaries"]) == 4
+
+    def test_overall_trend_valid_value(self, client, app_fixture):
+        h = _auth(client, "ex10@test.com")
+        d = client.get("/insights/explain", headers=h).get_json()
+        assert d["overall_trend"] in ("increasing", "decreasing", "stable", "insufficient_data")
+
+    def test_top_changes_max_3(self, client, app_fixture):
+        h = _auth(client, "ex11@test.com")
+        d = client.get("/insights/explain?months=6", headers=h).get_json()
+        assert len(d["top_changes"]) <= 3
+
+    def test_user_isolation(self, client, app_fixture):
+        h1 = _auth(client, "exiso1@test.com")
+        h2 = _auth(client, "exiso2@test.com")
+        uid1 = _get_uid(app_fixture, "exiso1@test.com")
+        # Seed big change for user1
+        _seed(app_fixture, uid1, 8000, days_ago=5)
+
+        d2 = client.get("/insights/explain?months=2", headers=h2).get_json()
+        assert len(d2["top_changes"]) == 0
+
+
+class TestExplainSummaryEndpoint:
+    def test_requires_auth(self, client, app_fixture):
+        assert client.get("/insights/explain/summary").status_code == 401
+
+    def test_returns_200(self, client, app_fixture):
+        h = _auth(client, "exs1@test.com")
+        assert client.get("/insights/explain/summary", headers=h).status_code == 200
+
+    def test_summary_keys(self, client, app_fixture):
+        h = _auth(client, "exs2@test.com")
+        d = client.get("/insights/explain/summary", headers=h).get_json()
+        assert "top_changes" in d
+        assert "overall_trend" in d
+        assert "trend_confidence" in d
+        assert "generated_at" in d
+
+    def test_summary_no_verbose_fields(self, client, app_fixture):
+        h = _auth(client, "exs3@test.com")
+        d = client.get("/insights/explain/summary", headers=h).get_json()
+        assert "insights" not in d
+        assert "period_summaries" not in d


### PR DESCRIPTION
Implements explainable spending insights to fix #89.

Tells users not just *what* changed in their spending, but *why* it changed — with a confidence level based on data richness and historical volatility.

## Endpoints

| Method | Path | Description |
|---|---|---|
| `GET` | `/insights/explain` | Full MoM insights with explanations |
| `GET` | `/insights/explain/summary` | Top 3 changes + overall trend (lightweight) |

Both JWT-protected. Query params: `months` (2–12, default 3), `anchor` (YYYY-MM-DD).

## What each insight explains

- **What changed**: category name, direction (increased/decreased), % and absolute delta
- **Why it changed**: pattern-based heuristic explanation (new category, spike, stable-category anomaly, high-volatility normal variation, etc.)
- **Confidence**: `high` (≥4 months history + significant change), `medium` (≥2 months), `low`

## Example insight

```json
{
  "category_name": "Dining",
  "pct_change": 87.3,
  "what_changed": "Dining spending increased by 87.3% (2450 more)",
  "why_it_changed": "Large change in Dining. Could indicate a seasonal pattern, a big purchase, or a change in habits.",
  "confidence": "medium"
}
```

## Files

- `app/services/spending_insights.py` — insight engine
- `app/routes/insights_explainable.py` — Flask blueprint (mounted at `/insights`)
- `tests/test_spending_insights.py` — 27 tests

/claim #89

Closes #89