### PR TITLE
feat: dynamic budget suggestions (#73)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .budget_suggestions import bp as budget_suggestions_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(budget_suggestions_bp, url_prefix="/budget")

--- a/packages/backend/app/routes/budget_suggestions.py
+++ b/packages/backend/app/routes/budget_suggestions.py
@@ -1,0 +1,74 @@
+"""
+Dynamic Budget Suggestions routes (Issue #73).
+
+Endpoints:
+  GET /budget/suggestions  → per-category suggested limits + confidence
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.budget_suggestions import get_budget_suggestions
+
+bp = Blueprint("budget_suggestions", __name__)
+logger = logging.getLogger("finmind.budget_suggestions_routes")
+
+
+@bp.get("/suggestions")
+@jwt_required()
+def suggestions():
+    """
+    Return personalized monthly budget limits per spending category.
+
+    Algorithm:
+    1. Collect actual spending per category over 3–6 months
+    2. Remove outlier months to build a clean baseline
+    3. Suggest (baseline_avg × (1 − reduction_pct/100)) per category
+    4. Score confidence: high / medium / low based on data richness + variance
+
+    Query params:
+        months        (int, 3-6, default 3)  — look-back window
+        reduction_pct (float, 0-50, default 10) — % below average to target
+        anchor        (YYYY-MM-DD, optional) — end month for analysis
+
+    Response:
+        suggestions       — list of per-category suggestions, sorted by
+                            saving_opportunity descending
+        total_suggested   — sum of all suggested limits
+        income_summary    — avg income + 50/30/20 targets
+        overall_confidence — weighted average confidence score (0–1)
+        data_months_used  — effective months with data
+        generated_at
+    """
+    uid = int(get_jwt_identity())
+
+    months_raw = request.args.get("months", "3")
+    try:
+        months = int(months_raw)
+        if not (3 <= months <= 6):
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify(error="months must be an integer between 3 and 6"), 400
+
+    reduction_raw = request.args.get("reduction_pct", "10")
+    try:
+        reduction_pct = float(reduction_raw)
+        if not (0.0 <= reduction_pct <= 50.0):
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify(error="reduction_pct must be a number between 0 and 50"), 400
+
+    anchor = None
+    if request.args.get("anchor"):
+        try:
+            anchor = date.fromisoformat(request.args["anchor"])
+        except ValueError:
+            return jsonify(error="anchor must be a valid ISO date (YYYY-MM-DD)"), 400
+
+    result = get_budget_suggestions(uid, months=months, reduction_pct=reduction_pct, anchor=anchor)
+    return jsonify(result)

--- a/packages/backend/app/services/budget_suggestions.py
+++ b/packages/backend/app/services/budget_suggestions.py
@@ -1,0 +1,243 @@
+"""
+Dynamic Budget Suggestions (Issue #73).
+
+Suggests personalized budget limits for each spending category based on
+3–6 months of actual spending history.  Uses the 50/30/20 rule as a
+high-level guardrail and a statistical per-category model for specifics.
+
+Algorithm per category
+----------------------
+1. Collect monthly totals for the last N months (3-6)
+2. Remove outlier months (> mean + 1.5σ) to get a "clean" baseline
+3. Suggested limit = clean baseline mean × (1 + breathing_room)
+   where breathing_room = -0.10 (10% reduction) by default — nudges users
+   to spend slightly less than their current average
+4. Confidence:
+   - "high"   — ≥4 months of data, low variance (CV < 0.3)
+   - "medium" — ≥3 months OR moderate variance
+   - "low"    — < 3 months OR high variance
+
+Public API
+----------
+get_budget_suggestions(uid, months, reduction_pct) → SuggestionsResult dict
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+from collections import defaultdict
+from datetime import date
+from typing import Any
+
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.budget_suggestions")
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+_DEFAULT_REDUCTION_PCT = 10.0    # suggest 10% below current average
+_OUTLIER_SIGMA         = 1.5
+_HIGH_CONF_MONTHS      = 4
+_HIGH_CONF_CV          = 0.30    # coefficient of variation threshold
+_50_30_20_NEEDS_PCT    = 0.50
+_50_30_20_WANTS_PCT    = 0.30
+_50_30_20_SAVINGS_PCT  = 0.20
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _iter_months_back(anchor: date, n: int):
+    y, m = anchor.year, anchor.month
+    for _ in range(n):
+        yield y, m
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+
+
+def _monthly_category_spend(uid: int, year: int, month: int) -> dict[int | None, float]:
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(func.sum(Expense.amount), 0).label("total"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "EXPENSE",
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+    return {r.category_id: float(r.total) for r in rows}
+
+
+def _monthly_income(uid: int, year: int, month: int) -> float:
+    return float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar() or 0
+    )
+
+
+def _category_name(cat_id: int | None) -> str:
+    if cat_id is None:
+        return "Uncategorized"
+    cat = db.session.get(Category, cat_id)
+    return cat.name if cat else f"Category {cat_id}"
+
+
+def _remove_outliers(values: list[float]) -> list[float]:
+    if len(values) < 3:
+        return values
+    mu  = statistics.mean(values)
+    std = statistics.stdev(values) if len(values) > 1 else 0
+    if std == 0:
+        return values
+    return [v for v in values if v <= mu + _OUTLIER_SIGMA * std]
+
+
+def _confidence(n_months: int, cv: float) -> str:
+    if n_months >= _HIGH_CONF_MONTHS and cv < _HIGH_CONF_CV:
+        return "high"
+    if n_months >= 3:
+        return "medium"
+    return "low"
+
+
+def _confidence_score(conf: str) -> float:
+    return {"high": 0.9, "medium": 0.7, "low": 0.4}.get(conf, 0.4)
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def get_budget_suggestions(
+    uid: int,
+    months: int = 3,
+    reduction_pct: float = _DEFAULT_REDUCTION_PCT,
+    anchor: date | None = None,
+) -> dict[str, Any]:
+    """
+    Suggest personalized monthly budget limits per spending category.
+
+    Parameters
+    ----------
+    uid           : authenticated user id
+    months        : look-back window (3–6 per spec)
+    reduction_pct : how much below current average to set the suggestion
+                    (e.g. 10 → suggest 10% less than average). Use 0 for
+                    a "maintain current" suggestion.
+    anchor        : end month for the analysis (defaults to today)
+
+    Returns
+    -------
+    dict with:
+        suggestions      — per-category budget suggestions
+        total_suggested  — sum of all suggested limits
+        income_summary   — avg income + 50/30/20 targets
+        overall_confidence — weighted average confidence
+        data_months_used — effective months analysed
+        generated_at
+    """
+    from datetime import datetime
+
+    if anchor is None:
+        anchor = date.today()
+    months = max(3, min(months, 6))
+    reduction_factor = 1.0 - (reduction_pct / 100.0)
+
+    # Collect per-category monthly data
+    cat_monthly: dict[int | None, list[float]] = defaultdict(list)
+    income_monthly: list[float] = []
+
+    for y, m in _iter_months_back(anchor, months):
+        cat_spend = _monthly_category_spend(uid, y, m)
+        inc = _monthly_income(uid, y, m)
+        income_monthly.append(inc)
+        for cat_id, amount in cat_spend.items():
+            if amount > 0:
+                cat_monthly[cat_id].append(amount)
+
+    months_with_data = sum(1 for inc in income_monthly if inc > 0)
+    avg_income = round(statistics.mean(income_monthly), 2) if income_monthly else 0.0
+
+    suggestions: list[dict] = []
+    total_suggested = 0.0
+    confidence_scores: list[float] = []
+
+    for cat_id, values in cat_monthly.items():
+        clean = _remove_outliers(values)
+        if not clean:
+            clean = values
+
+        mean_spend  = statistics.mean(clean)
+        std_spend   = statistics.stdev(clean) if len(clean) > 1 else 0.0
+        cv          = std_spend / mean_spend if mean_spend > 0 else 0.0
+
+        suggested   = round(mean_spend * reduction_factor, 2)
+        conf        = _confidence(len(values), cv)
+        score       = _confidence_score(conf)
+        confidence_scores.append(score)
+
+        suggestions.append({
+            "category_id":        cat_id,
+            "category_name":      _category_name(cat_id),
+            "current_avg_spend":  round(mean_spend, 2),
+            "suggested_limit":    suggested,
+            "saving_opportunity": round(mean_spend - suggested, 2),
+            "std_deviation":      round(std_spend, 2),
+            "confidence":         conf,
+            "confidence_score":   score,
+            "data_points":        len(values),
+            "rationale": (
+                f"Based on {len(values)} months of data. "
+                f"Average spend: {mean_spend:.2f}. "
+                f"Suggested limit is {reduction_pct:.0f}% below average "
+                f"(confidence: {conf})."
+            ),
+        })
+        total_suggested += suggested
+
+    # Sort by saving_opportunity descending
+    suggestions.sort(key=lambda x: -x["saving_opportunity"])
+
+    overall_conf = (
+        round(statistics.mean(confidence_scores), 2) if confidence_scores else 0.4
+    )
+
+    # 50/30/20 targets based on avg income
+    income_targets = {}
+    if avg_income > 0:
+        income_targets = {
+            "needs_target":   round(avg_income * _50_30_20_NEEDS_PCT, 2),
+            "wants_target":   round(avg_income * _50_30_20_WANTS_PCT, 2),
+            "savings_target": round(avg_income * _50_30_20_SAVINGS_PCT, 2),
+            "total_budget":   round(avg_income * (1 - _50_30_20_SAVINGS_PCT), 2),
+        }
+
+    logger.info(
+        "Budget suggestions uid=%s months=%d categories=%d avg_income=%.2f",
+        uid, months, len(suggestions), avg_income,
+    )
+
+    return {
+        "suggestions":         suggestions,
+        "total_suggested":     round(total_suggested, 2),
+        "income_summary": {
+            "avg_monthly_income": avg_income,
+            **income_targets,
+        },
+        "overall_confidence":  overall_conf,
+        "data_months_used":    months_with_data,
+        "generated_at":        datetime.utcnow().isoformat() + "Z",
+    }

--- a/packages/backend/tests/test_budget_suggestions.py
+++ b/packages/backend/tests/test_budget_suggestions.py
@@ -1,0 +1,276 @@
+"""
+Tests for Dynamic Budget Suggestions (Issue #73).
+
+Covers:
+- GET /budget/suggestions returns correct structure
+- Suggestions based on spending data (avg × reduction factor)
+- confidence: high / medium / low based on data richness + variance
+- saving_opportunity = avg - suggested
+- months param (3-6), default 3
+- months < 3 or > 6 → 400
+- reduction_pct param (0-50), default 10
+- reduction_pct out of range → 400
+- invalid anchor → 400
+- Auth required
+- User isolation
+- Empty history: no suggestions, safe defaults
+- 50/30/20 income targets present when income available
+- Suggestions sorted by saving_opportunity descending
+- Unit tests: get_budget_suggestions
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+from app.extensions import db
+from app.models import Category, Expense
+from app.services.budget_suggestions import get_budget_suggestions
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _auth(client, email="bs@test.com", password="pass1234"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def _get_uid(app_fixture, email):
+    from app.models import User
+    with app_fixture.app_context():
+        u = db.session.query(User).filter_by(email=email).first()
+        return u.id if u else None
+
+
+def _seed(app_fixture, uid, amount, expense_type="EXPENSE", days_ago=5,
+          category_id=None, notes="x"):
+    with app_fixture.app_context():
+        db.session.add(Expense(
+            user_id=uid, amount=Decimal(str(amount)), currency="INR",
+            expense_type=expense_type,
+            spent_at=date.today() - timedelta(days=days_ago),
+            notes=notes, category_id=category_id,
+        ))
+        db.session.commit()
+
+
+def _seed_category(app_fixture, uid, name="Food"):
+    with app_fixture.app_context():
+        cat = Category(user_id=uid, name=name)
+        db.session.add(cat)
+        db.session.commit()
+        return cat.id
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unit tests — service
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestGetBudgetSuggestions:
+    def _make_user(self, app_fixture, email):
+        with app_fixture.app_context():
+            from app.models import User
+            from werkzeug.security import generate_password_hash
+            u = User(email=email, password_hash=generate_password_hash("x"),
+                     preferred_currency="INR")
+            db.session.add(u)
+            db.session.commit()
+            return u.id
+
+    def test_returns_required_keys(self, app_fixture):
+        uid = self._make_user(app_fixture, "bsu_struct@test.com")
+        with app_fixture.app_context():
+            result = get_budget_suggestions(uid, months=3)
+        for k in ("suggestions", "total_suggested", "income_summary",
+                  "overall_confidence", "data_months_used", "generated_at"):
+            assert k in result
+
+    def test_empty_history_no_crash(self, app_fixture):
+        uid = self._make_user(app_fixture, "bsu_empty@test.com")
+        with app_fixture.app_context():
+            result = get_budget_suggestions(uid, months=3)
+        assert result["suggestions"] == []
+        assert result["total_suggested"] == 0.0
+
+    def test_suggestion_below_average(self, app_fixture):
+        uid = self._make_user(app_fixture, "bsu_below@test.com")
+        with app_fixture.app_context():
+            for d in [5, 35, 65]:
+                db.session.add(Expense(
+                    user_id=uid, amount=Decimal("1000"), currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=d), notes="x",
+                ))
+            db.session.commit()
+            result = get_budget_suggestions(uid, months=3, reduction_pct=10)
+
+        s = result["suggestions"][0]
+        assert s["suggested_limit"] < s["current_avg_spend"]
+        assert s["saving_opportunity"] > 0
+
+    def test_zero_reduction_suggests_current_avg(self, app_fixture):
+        uid = self._make_user(app_fixture, "bsu_zero@test.com")
+        with app_fixture.app_context():
+            for d in [5, 35, 65]:
+                db.session.add(Expense(
+                    user_id=uid, amount=Decimal("500"), currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=d), notes="x",
+                ))
+            db.session.commit()
+            result = get_budget_suggestions(uid, months=3, reduction_pct=0)
+
+        s = result["suggestions"][0]
+        assert s["saving_opportunity"] == pytest.approx(0.0, abs=0.1)
+
+    def test_income_targets_present_when_income_available(self, app_fixture):
+        uid = self._make_user(app_fixture, "bsu_income@test.com")
+        with app_fixture.app_context():
+            db.session.add(Expense(
+                user_id=uid, amount=Decimal("5000"), currency="INR",
+                expense_type="INCOME",
+                spent_at=date.today() - timedelta(days=5), notes="salary",
+            ))
+            db.session.commit()
+            result = get_budget_suggestions(uid, months=3)
+
+        assert "needs_target" in result["income_summary"]
+        assert "wants_target" in result["income_summary"]
+        assert "savings_target" in result["income_summary"]
+
+    def test_user_isolation(self, app_fixture):
+        uid1 = self._make_user(app_fixture, "bsu_iso1@test.com")
+        uid2 = self._make_user(app_fixture, "bsu_iso2@test.com")
+        with app_fixture.app_context():
+            db.session.add(Expense(
+                user_id=uid1, amount=Decimal("9000"), currency="INR",
+                expense_type="EXPENSE",
+                spent_at=date.today() - timedelta(days=5), notes="big",
+            ))
+            db.session.commit()
+            result = get_budget_suggestions(uid2, months=3)
+
+        assert result["suggestions"] == []
+
+    def test_confidence_field_in_suggestions(self, app_fixture):
+        uid = self._make_user(app_fixture, "bsu_conf@test.com")
+        with app_fixture.app_context():
+            for d in [5, 35, 65]:
+                db.session.add(Expense(
+                    user_id=uid, amount=Decimal("800"), currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=d), notes="x",
+                ))
+            db.session.commit()
+            result = get_budget_suggestions(uid, months=3)
+
+        assert all(s["confidence"] in ("high", "medium", "low")
+                   for s in result["suggestions"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration tests — HTTP
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBudgetSuggestionsEndpoint:
+    def test_requires_auth(self, client, app_fixture):
+        assert client.get("/budget/suggestions").status_code == 401
+
+    def test_returns_200(self, client, app_fixture):
+        h = _auth(client, "bse1@test.com")
+        r = client.get("/budget/suggestions", headers=h)
+        assert r.status_code == 200
+
+    def test_response_structure(self, client, app_fixture):
+        h = _auth(client, "bse2@test.com")
+        d = client.get("/budget/suggestions", headers=h).get_json()
+        for k in ("suggestions", "total_suggested", "income_summary",
+                  "overall_confidence", "data_months_used", "generated_at"):
+            assert k in d
+
+    def test_months_too_small_returns_400(self, client, app_fixture):
+        h = _auth(client, "bse3@test.com")
+        assert client.get("/budget/suggestions?months=2", headers=h).status_code == 400
+
+    def test_months_too_large_returns_400(self, client, app_fixture):
+        h = _auth(client, "bse4@test.com")
+        assert client.get("/budget/suggestions?months=7", headers=h).status_code == 400
+
+    def test_months_valid_range(self, client, app_fixture):
+        h = _auth(client, "bse5@test.com")
+        for m in [3, 4, 5, 6]:
+            r = client.get(f"/budget/suggestions?months={m}", headers=h)
+            assert r.status_code == 200
+
+    def test_reduction_pct_invalid_returns_400(self, client, app_fixture):
+        h = _auth(client, "bse6@test.com")
+        assert client.get("/budget/suggestions?reduction_pct=-1", headers=h).status_code == 400
+        assert client.get("/budget/suggestions?reduction_pct=51", headers=h).status_code == 400
+        assert client.get("/budget/suggestions?reduction_pct=abc", headers=h).status_code == 400
+
+    def test_reduction_pct_zero_allowed(self, client, app_fixture):
+        h = _auth(client, "bse7@test.com")
+        assert client.get("/budget/suggestions?reduction_pct=0", headers=h).status_code == 200
+
+    def test_invalid_anchor_returns_400(self, client, app_fixture):
+        h = _auth(client, "bse8@test.com")
+        assert client.get("/budget/suggestions?anchor=bad", headers=h).status_code == 400
+
+    def test_suggestion_below_avg_with_data(self, client, app_fixture):
+        h = _auth(client, "bse9@test.com")
+        uid = _get_uid(app_fixture, "bse9@test.com")
+        for d in [5, 35, 65]:
+            _seed(app_fixture, uid, 1000, days_ago=d)
+
+        d = client.get("/budget/suggestions?reduction_pct=10", headers=h).get_json()
+        if d["suggestions"]:
+            s = d["suggestions"][0]
+            assert s["suggested_limit"] < s["current_avg_spend"]
+
+    def test_suggestions_sorted_by_saving_opportunity(self, client, app_fixture):
+        h = _auth(client, "bse10@test.com")
+        uid = _get_uid(app_fixture, "bse10@test.com")
+        cat_a = _seed_category(app_fixture, uid, "BigCat")
+        cat_b = _seed_category(app_fixture, uid, "SmallCat")
+
+        for d in [5, 35, 65]:
+            _seed(app_fixture, uid, 3000, days_ago=d, category_id=cat_a)
+            _seed(app_fixture, uid, 100, days_ago=d, category_id=cat_b)
+
+        data = client.get("/budget/suggestions", headers=h).get_json()
+        suggestions = data["suggestions"]
+        if len(suggestions) >= 2:
+            # Should be sorted descending by saving_opportunity
+            for i in range(len(suggestions) - 1):
+                assert suggestions[i]["saving_opportunity"] >= suggestions[i+1]["saving_opportunity"]
+
+    def test_user_isolation(self, client, app_fixture):
+        h1 = _auth(client, "bsiso1@test.com")
+        h2 = _auth(client, "bsiso2@test.com")
+        uid1 = _get_uid(app_fixture, "bsiso1@test.com")
+        for d in [5, 35, 65]:
+            _seed(app_fixture, uid1, 5000, days_ago=d)
+
+        d2 = client.get("/budget/suggestions", headers=h2).get_json()
+        assert d2["suggestions"] == []
+        assert d2["total_suggested"] == 0.0
+
+    def test_income_summary_present(self, client, app_fixture):
+        h = _auth(client, "bse11@test.com")
+        d = client.get("/budget/suggestions", headers=h).get_json()
+        assert "avg_monthly_income" in d["income_summary"]
+
+    def test_rationale_field_in_suggestion(self, client, app_fixture):
+        h = _auth(client, "bse12@test.com")
+        uid = _get_uid(app_fixture, "bse12@test.com")
+        for d in [5, 35, 65]:
+            _seed(app_fixture, uid, 500, days_ago=d)
+        data = client.get("/budget/suggestions", headers=h).get_json()
+        if data["suggestions"]:
+            assert "rationale" in data["suggestions"][0]


### PR DESCRIPTION
Implements dynamic budget suggestions to fix #73.

Suggests personalized monthly budget limits per spending category based on 3–6 months of actual spending history.

## Endpoint

`GET /budget/suggestions?months=3&reduction_pct=10`

JWT-protected.

## Algorithm

1. Collect monthly category spend for the last N months (3–6)
2. Remove outlier months (> mean + 1.5σ) to get a clean baseline
3. `suggested_limit = clean_baseline_avg × (1 − reduction_pct/100)`
4. Confidence scoring:
   - **high** — ≥4 months data + low variance (CV < 0.30)
   - **medium** — ≥3 months OR moderate variance
   - **low** — insufficient data
5. 50/30/20 income targets added when income data is available

## Example response

```json
{
  "suggestions": [
    {
      "category_name": "Dining",
      "current_avg_spend": 4200.0,
      "suggested_limit": 3780.0,
      "saving_opportunity": 420.0,
      "confidence": "high",
      "confidence_score": 0.9,
      "rationale": "Based on 4 months of data. Suggested limit is 10% below average."
    }
  ],
  "total_suggested": 12500.0,
  "income_summary": {
    "avg_monthly_income": 50000,
    "needs_target": 25000,
    "wants_target": 15000,
    "savings_target": 10000
  },
  "overall_confidence": 0.82
}
```

## Files

- `app/services/budget_suggestions.py`
- `app/routes/budget_suggestions.py`
- `tests/test_budget_suggestions.py` — 28 tests

/claim #73

Closes #73