### PR TITLE
feat: multi-account financial overview dashboard

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import { Accounts } from "./pages/Accounts";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="accounts"
+              element={
+                <ProtectedRoute>
+                  <Accounts />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/accounts.ts
+++ b/app/src/api/accounts.ts
@@ -1,0 +1,95 @@
+import { api } from './client';
+
+export type AccountType = 'CHECKING' | 'SAVINGS' | 'CREDIT' | 'INVESTMENT' | 'CASH' | 'OTHER';
+
+export type FinancialAccount = {
+  id: number;
+  name: string;
+  account_type: AccountType;
+  balance: number;
+  institution: string | null;
+  currency: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AccountOverview = {
+  period: { month: string };
+  net_worth: number;
+  accounts: Array<{
+    id: number;
+    name: string;
+    account_type: AccountType;
+    balance: number;
+    institution: string | null;
+    currency: string;
+  }>;
+  account_summary_by_type: Array<{
+    account_type: AccountType;
+    total_balance: number;
+  }>;
+  recent_transactions: Array<{
+    id: number;
+    description: string;
+    amount: number;
+    date: string;
+    type: string;
+    category_id: number | null;
+    currency: string;
+  }>;
+  spending_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    share_pct: number;
+  }>;
+  errors?: string[];
+};
+
+export type CreateAccountPayload = {
+  name: string;
+  account_type: AccountType;
+  balance: number;
+  institution?: string;
+  currency?: string;
+};
+
+export type UpdateAccountPayload = Partial<CreateAccountPayload & { is_active: boolean }>;
+
+export async function listAccounts(includeInactive = false): Promise<FinancialAccount[]> {
+  const q = includeInactive ? '?include_inactive=true' : '';
+  return api<FinancialAccount[]>(`/accounts${q}`);
+}
+
+export async function createAccount(payload: CreateAccountPayload): Promise<FinancialAccount> {
+  return api<FinancialAccount>('/accounts', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateAccount(id: number, payload: UpdateAccountPayload): Promise<FinancialAccount> {
+  return api<FinancialAccount>(`/accounts/${id}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteAccount(id: number): Promise<void> {
+  await api<{ message: string }>(`/accounts/${id}`, { method: 'DELETE' });
+}
+
+export async function getAccountOverview(month?: string): Promise<AccountOverview> {
+  const q = month ? `?month=${encodeURIComponent(month)}` : '';
+  return api<AccountOverview>(`/dashboard/overview${q}`);
+}
+
+export const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
+  CHECKING: 'Checking',
+  SAVINGS: 'Savings',
+  CREDIT: 'Credit Card',
+  INVESTMENT: 'Investment',
+  CASH: 'Cash',
+  OTHER: 'Other',
+};

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -8,6 +8,7 @@ import { logout as logoutApi } from '@/api/auth';
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard' },
+  { name: 'Accounts', href: '/accounts' },
   { name: 'Budgets', href: '/budgets' },
   { name: 'Bills', href: '/bills' },
   { name: 'Reminders', href: '/reminders' },

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useState } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+  FinancialCardDescription,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Building2,
+  Wallet,
+  CreditCard,
+  TrendingUp,
+  Banknote,
+  MoreHorizontal,
+} from 'lucide-react';
+import {
+  listAccounts,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  ACCOUNT_TYPE_LABELS,
+  type FinancialAccount,
+  type AccountType,
+  type CreateAccountPayload,
+} from '@/api/accounts';
+import { formatMoney } from '@/lib/currency';
+
+const ACCOUNT_TYPE_ICONS: Record<AccountType, React.ElementType> = {
+  CHECKING: Wallet,
+  SAVINGS: Building2,
+  CREDIT: CreditCard,
+  INVESTMENT: TrendingUp,
+  CASH: Banknote,
+  OTHER: MoreHorizontal,
+};
+
+const ACCOUNT_TYPES: AccountType[] = ['CHECKING', 'SAVINGS', 'CREDIT', 'INVESTMENT', 'CASH', 'OTHER'];
+
+const EMPTY_FORM: CreateAccountPayload = {
+  name: '',
+  account_type: 'CHECKING',
+  balance: 0,
+  institution: '',
+  currency: 'INR',
+};
+
+export function Accounts() {
+  const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingAccount, setEditingAccount] = useState<FinancialAccount | null>(null);
+  const [form, setForm] = useState<CreateAccountPayload>(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await listAccounts();
+      setAccounts(data);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load accounts');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  const openCreate = () => {
+    setEditingAccount(null);
+    setForm(EMPTY_FORM);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (account: FinancialAccount) => {
+    setEditingAccount(account);
+    setForm({
+      name: account.name,
+      account_type: account.account_type,
+      balance: account.balance,
+      institution: account.institution ?? '',
+      currency: account.currency,
+    });
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!form.name.trim()) return;
+    setSaving(true);
+    try {
+      if (editingAccount) {
+        await updateAccount(editingAccount.id, form);
+      } else {
+        await createAccount(form);
+      }
+      setDialogOpen(false);
+      await load();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to save account');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    setDeleteId(id);
+    try {
+      await deleteAccount(id);
+      await load();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to delete account');
+    } finally {
+      setDeleteId(null);
+    }
+  };
+
+  const totalAssets = accounts
+    .filter(a => a.account_type !== 'CREDIT')
+    .reduce((sum, a) => sum + a.balance, 0);
+  const totalCredit = accounts
+    .filter(a => a.account_type === 'CREDIT')
+    .reduce((sum, a) => sum + a.balance, 0);
+  const netWorth = totalAssets - totalCredit;
+
+  return (
+    <div className="page-wrap">
+      <div className="page-header">
+        <div className="relative flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+          <div>
+            <h1 className="page-title">Financial Accounts</h1>
+            <p className="page-subtitle">Manage your bank accounts, credit cards, and investments.</p>
+          </div>
+          <Button variant="financial" size="sm" onClick={openCreate}>
+            <Plus className="w-4 h-4" />
+            Add Account
+          </Button>
+        </div>
+      </div>
+
+      {error && <div className="error mb-6">{error}</div>}
+
+      {/* Summary row */}
+      <div className="grid gap-4 md:grid-cols-3 mb-8">
+        <FinancialCard variant="financial" className="fade-in-up">
+          <FinancialCardHeader className="pb-2">
+            <FinancialCardTitle className="text-sm font-medium text-muted-foreground">Net Worth</FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className={`metric-value ${netWorth >= 0 ? 'text-success' : 'text-destructive'}`}>
+              {loading ? '...' : formatMoney(netWorth)}
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+        <FinancialCard variant="financial" className="fade-in-up">
+          <FinancialCardHeader className="pb-2">
+            <FinancialCardTitle className="text-sm font-medium text-muted-foreground">Total Assets</FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value text-foreground">{loading ? '...' : formatMoney(totalAssets)}</div>
+          </FinancialCardContent>
+        </FinancialCard>
+        <FinancialCard variant="financial" className="fade-in-up">
+          <FinancialCardHeader className="pb-2">
+            <FinancialCardTitle className="text-sm font-medium text-muted-foreground">Total Credit Debt</FinancialCardTitle>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value text-destructive">{loading ? '...' : formatMoney(totalCredit)}</div>
+          </FinancialCardContent>
+        </FinancialCard>
+      </div>
+
+      {/* Account list */}
+      <FinancialCard variant="financial" className="fade-in-up">
+        <FinancialCardHeader>
+          <FinancialCardTitle className="section-title">Your Accounts</FinancialCardTitle>
+          <FinancialCardDescription>{accounts.length} active account{accounts.length !== 1 ? 's' : ''}</FinancialCardDescription>
+        </FinancialCardHeader>
+        <FinancialCardContent>
+          {loading ? (
+            <div className="text-sm text-muted-foreground">Loading accounts…</div>
+          ) : accounts.length === 0 ? (
+            <div className="text-center py-8">
+              <p className="text-muted-foreground mb-4">No accounts yet. Add your first account to get started.</p>
+              <Button variant="financial" onClick={openCreate}>
+                <Plus className="w-4 h-4" />
+                Add Account
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {accounts.map((account) => {
+                const Icon = ACCOUNT_TYPE_ICONS[account.account_type];
+                const isCredit = account.account_type === 'CREDIT';
+                return (
+                  <div
+                    key={account.id}
+                    className="interactive-row flex items-center justify-between gap-4"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <div className={`w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0 ${
+                        isCredit
+                          ? 'bg-destructive-light text-destructive'
+                          : 'bg-success-light text-success'
+                      }`}>
+                        <Icon className="w-5 h-5" />
+                      </div>
+                      <div className="min-w-0">
+                        <div className="font-medium text-foreground truncate">{account.name}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {ACCOUNT_TYPE_LABELS[account.account_type]}
+                          {account.institution ? ` · ${account.institution}` : ''}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3 flex-shrink-0">
+                      <div className={`text-right font-semibold ${isCredit ? 'text-destructive' : 'text-foreground'}`}>
+                        {isCredit ? '-' : ''}{formatMoney(account.balance, account.currency)}
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => openEdit(account)}
+                        aria-label={`Edit ${account.name}`}
+                      >
+                        <Pencil className="w-4 h-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 text-destructive hover:text-destructive"
+                        onClick={() => void handleDelete(account.id)}
+                        disabled={deleteId === account.id}
+                        aria-label={`Delete ${account.name}`}
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </FinancialCardContent>
+      </FinancialCard>
+
+      {/* Create/Edit Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-[480px]">
+          <DialogHeader>
+            <DialogTitle>{editingAccount ? 'Edit Account' : 'Add Account'}</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <Label htmlFor="acc-name">Account Name</Label>
+              <Input
+                id="acc-name"
+                placeholder="e.g. HDFC Savings, Chase Checking"
+                value={form.name}
+                onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="acc-type">Account Type</Label>
+              <Select
+                value={form.account_type}
+                onValueChange={v => setForm(f => ({ ...f, account_type: v as AccountType }))}
+              >
+                <SelectTrigger id="acc-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {ACCOUNT_TYPES.map(t => (
+                    <SelectItem key={t} value={t}>{ACCOUNT_TYPE_LABELS[t]}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="acc-balance">Balance</Label>
+                <Input
+                  id="acc-balance"
+                  type="number"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={form.balance}
+                  onChange={e => setForm(f => ({ ...f, balance: parseFloat(e.target.value) || 0 }))}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="acc-currency">Currency</Label>
+                <Input
+                  id="acc-currency"
+                  placeholder="INR"
+                  maxLength={10}
+                  value={form.currency ?? 'INR'}
+                  onChange={e => setForm(f => ({ ...f, currency: e.target.value.toUpperCase() }))}
+                />
+              </div>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="acc-institution">Institution (optional)</Label>
+              <Input
+                id="acc-institution"
+                placeholder="e.g. HDFC Bank, Chase, Vanguard"
+                value={form.institution ?? ''}
+                onChange={e => setForm(f => ({ ...f, institution: e.target.value }))}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button variant="financial" onClick={() => void handleSave()} disabled={saving || !form.name.trim()}>
+              {saving ? 'Saving…' : editingAccount ? 'Save Changes' : 'Add Account'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   ArrowDownRight,
   ArrowUpRight,
@@ -18,10 +19,28 @@ import {
   AlertTriangle,
   Calendar,
   Plus,
+  Building2,
+  Banknote,
+  MoreHorizontal,
 } from 'lucide-react';
 import { getDashboardSummary, type DashboardSummary } from '@/api/dashboard';
+import {
+  getAccountOverview,
+  ACCOUNT_TYPE_LABELS,
+  type AccountOverview,
+  type AccountType,
+} from '@/api/accounts';
 import { useNavigate } from 'react-router-dom';
 import { formatMoney } from '@/lib/currency';
+
+const ACCOUNT_TYPE_ICONS: Record<AccountType, React.ElementType> = {
+  CHECKING: Wallet,
+  SAVINGS: Building2,
+  CREDIT: CreditCard,
+  INVESTMENT: TrendingUp,
+  CASH: Banknote,
+  OTHER: MoreHorizontal,
+};
 
 function currency(n: number, code?: string) {
   return formatMoney(Number(n || 0), code);
@@ -34,6 +53,10 @@ export function Dashboard() {
   const [error, setError] = useState<string | null>(null);
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
 
+  const [overview, setOverview] = useState<AccountOverview | null>(null);
+  const [overviewLoading, setOverviewLoading] = useState(true);
+  const [overviewError, setOverviewError] = useState<string | null>(null);
+
   useEffect(() => {
     (async () => {
       setLoading(true);
@@ -45,6 +68,21 @@ export function Dashboard() {
         setError(error instanceof Error ? error.message : 'Failed to load dashboard');
       } finally {
         setLoading(false);
+      }
+    })();
+  }, [month]);
+
+  useEffect(() => {
+    (async () => {
+      setOverviewLoading(true);
+      setOverviewError(null);
+      try {
+        const res = await getAccountOverview(month);
+        setOverview(res);
+      } catch (err: unknown) {
+        setOverviewError(err instanceof Error ? err.message : 'Failed to load account overview');
+      } finally {
+        setOverviewLoading(false);
       }
     })();
   }, [month]);
@@ -109,7 +147,7 @@ export function Dashboard() {
             <h1 className="page-title">Financial Dashboard</h1>
             <p className="page-subtitle">Live overview for {data?.period?.month || 'current period'}.</p>
           </div>
-          <div className="flex gap-3">
+          <div className="flex gap-3 flex-wrap">
             <label className="sr-only" htmlFor="dashboard-month">Dashboard month</label>
             <input
               id="dashboard-month"
@@ -127,6 +165,10 @@ export function Dashboard() {
               <Plus className="w-4 h-4" />
               Add Transaction
             </Button>
+            <Button variant="outline" size="sm" onClick={() => navigate('/accounts')}>
+              <Building2 className="w-4 h-4" />
+              Accounts
+            </Button>
           </div>
         </div>
       </div>
@@ -141,142 +183,337 @@ export function Dashboard() {
         </div>
       )}
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-8">
-        {summaryCards.map((card, index) => (
-          <FinancialCard key={index} variant="financial" className="group card-interactive fade-in-up">
-            <FinancialCardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">{card.title}</FinancialCardTitle>
-                <card.icon className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors" />
-              </div>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              <div className="metric-value text-foreground mb-1">{loading ? '...' : card.amount}</div>
-              <div className="flex items-center text-sm">
-                {card.trend === 'up' ? (
-                  <ArrowUpRight className="w-4 h-4 text-success mr-1" />
-                ) : (
-                  <ArrowDownRight className="w-4 h-4 text-destructive mr-1" />
-                )}
-                <span className={card.trend === 'up' ? 'text-success font-medium mr-2' : 'text-destructive font-medium mr-2'}>{card.change}</span>
-                <span className="text-muted-foreground">{card.description}</span>
-              </div>
-            </FinancialCardContent>
-          </FinancialCard>
-        ))}
-      </div>
+      <Tabs defaultValue="summary" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="summary">Monthly Summary</TabsTrigger>
+          <TabsTrigger value="accounts">Accounts Overview</TabsTrigger>
+        </TabsList>
 
-      <div className="grid lg:grid-cols-3 gap-8">
-        <div className="lg:col-span-2">
-          <FinancialCard variant="financial" className="fade-in-up">
-            <FinancialCardHeader>
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="section-title">Recent Transactions</FinancialCardTitle>
-                <Button variant="ghost" size="sm" onClick={() => navigate('/expenses')}>View All</Button>
-              </div>
-              <FinancialCardDescription>Your latest financial activity</FinancialCardDescription>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              {transactions.length === 0 ? (
-                <div className="text-sm text-muted-foreground">No transactions yet.</div>
-              ) : (
-                <div className="space-y-3">
-                  {transactions.map((transaction) => {
-                    const isIncome = transaction.type === 'INCOME';
-                    return (
-                      <div key={transaction.id} className="interactive-row flex items-center justify-between">
-                        <div className="flex items-center space-x-3">
-                          <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
-                            isIncome ? 'bg-success-light text-success' : 'bg-destructive-light text-destructive'
-                          }`}>
-                            {isIncome ? <ArrowUpRight className="w-5 h-5" /> : <ArrowDownRight className="w-5 h-5" />}
+        {/* ── Monthly Summary Tab ── */}
+        <TabsContent value="summary" className="space-y-8">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {summaryCards.map((card, index) => (
+              <FinancialCard key={index} variant="financial" className="group card-interactive fade-in-up">
+                <FinancialCardHeader className="pb-3">
+                  <div className="flex items-center justify-between">
+                    <FinancialCardTitle className="text-sm font-medium text-muted-foreground">{card.title}</FinancialCardTitle>
+                    <card.icon className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors" />
+                  </div>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  <div className="metric-value text-foreground mb-1">{loading ? '...' : card.amount}</div>
+                  <div className="flex items-center text-sm">
+                    {card.trend === 'up' ? (
+                      <ArrowUpRight className="w-4 h-4 text-success mr-1" />
+                    ) : (
+                      <ArrowDownRight className="w-4 h-4 text-destructive mr-1" />
+                    )}
+                    <span className={card.trend === 'up' ? 'text-success font-medium mr-2' : 'text-destructive font-medium mr-2'}>{card.change}</span>
+                    <span className="text-muted-foreground">{card.description}</span>
+                  </div>
+                </FinancialCardContent>
+              </FinancialCard>
+            ))}
+          </div>
+
+          <div className="grid lg:grid-cols-3 gap-8">
+            <div className="lg:col-span-2">
+              <FinancialCard variant="financial" className="fade-in-up">
+                <FinancialCardHeader>
+                  <div className="flex items-center justify-between">
+                    <FinancialCardTitle className="section-title">Recent Transactions</FinancialCardTitle>
+                    <Button variant="ghost" size="sm" onClick={() => navigate('/expenses')}>View All</Button>
+                  </div>
+                  <FinancialCardDescription>Your latest financial activity</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  {transactions.length === 0 ? (
+                    <div className="text-sm text-muted-foreground">No transactions yet.</div>
+                  ) : (
+                    <div className="space-y-3">
+                      {transactions.map((transaction) => {
+                        const isIncome = transaction.type === 'INCOME';
+                        return (
+                          <div key={transaction.id} className="interactive-row flex items-center justify-between">
+                            <div className="flex items-center space-x-3">
+                              <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
+                                isIncome ? 'bg-success-light text-success' : 'bg-destructive-light text-destructive'
+                              }`}>
+                                {isIncome ? <ArrowUpRight className="w-5 h-5" /> : <ArrowDownRight className="w-5 h-5" />}
+                              </div>
+                              <div>
+                                <div className="font-medium text-foreground">{transaction.description}</div>
+                                <div className="text-sm text-muted-foreground">{new Date(transaction.date).toLocaleDateString()}</div>
+                              </div>
+                            </div>
+                            <div className={`font-semibold ${isIncome ? 'text-success' : 'text-foreground'}`}>
+                              {isIncome ? '+' : '-'}
+                              {currency(Math.abs(transaction.amount), transaction.currency)}
+                            </div>
                           </div>
-                          <div>
-                            <div className="font-medium text-foreground">{transaction.description}</div>
-                            <div className="text-sm text-muted-foreground">{new Date(transaction.date).toLocaleDateString()}</div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+            </div>
+
+            <div className="space-y-6">
+              <FinancialCard variant="financial" className="fade-in-up">
+                <FinancialCardHeader>
+                  <div className="flex items-center justify-between">
+                    <FinancialCardTitle className="section-title">Upcoming Bills</FinancialCardTitle>
+                    <Button variant="ghost" size="sm" onClick={() => navigate('/bills')}>Manage</Button>
+                  </div>
+                  <FinancialCardDescription>Active bills due soon</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  {upcomingBills.length === 0 ? (
+                    <div className="text-sm text-muted-foreground">No upcoming bills.</div>
+                  ) : (
+                    <div className="space-y-3">
+                      {upcomingBills.map((bill) => (
+                        <div key={bill.id} className="interactive-row flex items-center justify-between">
+                          <div className="flex items-center space-x-3">
+                            <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-warning-light text-warning">
+                              <AlertTriangle className="w-4 h-4" />
+                            </div>
+                            <div>
+                              <div className="font-medium text-foreground text-sm">{bill.name}</div>
+                              <div className="text-xs text-muted-foreground">Due {new Date(bill.next_due_date).toLocaleDateString()}</div>
+                            </div>
+                          </div>
+                          <div className="text-sm font-semibold text-foreground">
+                            {currency(bill.amount, bill.currency)}
                           </div>
                         </div>
-                        <div className={`font-semibold ${isIncome ? 'text-success' : 'text-foreground'}`}>
-                          {isIncome ? '+' : '-'}
-                          {currency(Math.abs(transaction.amount), transaction.currency)}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </FinancialCardContent>
-          </FinancialCard>
-        </div>
-
-        <div className="space-y-6">
-          <FinancialCard variant="financial" className="fade-in-up">
-            <FinancialCardHeader>
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="section-title">Upcoming Bills</FinancialCardTitle>
-                <Button variant="ghost" size="sm" onClick={() => navigate('/bills')}>Manage</Button>
-              </div>
-              <FinancialCardDescription>Active bills due soon</FinancialCardDescription>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              {upcomingBills.length === 0 ? (
-                <div className="text-sm text-muted-foreground">No upcoming bills.</div>
-              ) : (
-                <div className="space-y-3">
-                  {upcomingBills.map((bill) => (
-                    <div key={bill.id} className="interactive-row flex items-center justify-between">
-                      <div className="flex items-center space-x-3">
-                        <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-warning-light text-warning">
-                          <AlertTriangle className="w-4 h-4" />
-                        </div>
-                        <div>
-                          <div className="font-medium text-foreground text-sm">{bill.name}</div>
-                          <div className="text-xs text-muted-foreground">Due {new Date(bill.next_due_date).toLocaleDateString()}</div>
-                        </div>
-                      </div>
-                      <div className="text-sm font-semibold text-foreground">
-                        {currency(bill.amount, bill.currency)}
-                      </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              )}
-            </FinancialCardContent>
-            <FinancialCardFooter>
-              <Button variant="financial" size="sm" className="w-full" onClick={() => navigate('/bills')}>
-                <Plus className="w-4 h-4" />
-                Add New Bill
-              </Button>
-            </FinancialCardFooter>
-          </FinancialCard>
+                  )}
+                </FinancialCardContent>
+                <FinancialCardFooter>
+                  <Button variant="financial" size="sm" className="w-full" onClick={() => navigate('/bills')}>
+                    <Plus className="w-4 h-4" />
+                    Add New Bill
+                  </Button>
+                </FinancialCardFooter>
+              </FinancialCard>
 
-          <FinancialCard variant="financial" className="fade-in-up">
-            <FinancialCardHeader>
-              <FinancialCardTitle className="section-title">Category Breakdown</FinancialCardTitle>
-              <FinancialCardDescription>Expense mix for {data?.period?.month || month}</FinancialCardDescription>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              {categoryBreakdown.length === 0 ? (
-                <div className="text-sm text-muted-foreground">No category data for this month.</div>
-              ) : (
-                <div className="space-y-3">
-                  {categoryBreakdown.slice(0, 6).map((row) => (
-                    <div key={`${row.category_id ?? 'uncat'}-${row.category_name}`} className="space-y-1">
-                      <div className="flex items-center justify-between text-sm">
-                        <span className="text-foreground">{row.category_name}</span>
-                        <span className="text-muted-foreground">{currency(row.amount)} ({row.share_pct.toFixed(0)}%)</span>
-                      </div>
-                      <div className="chart-track h-2">
-                        <div className="chart-fill-primary h-2" style={{ width: `${Math.max(2, Math.min(100, row.share_pct))}%` }} />
-                      </div>
+              <FinancialCard variant="financial" className="fade-in-up">
+                <FinancialCardHeader>
+                  <FinancialCardTitle className="section-title">Category Breakdown</FinancialCardTitle>
+                  <FinancialCardDescription>Expense mix for {data?.period?.month || month}</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  {categoryBreakdown.length === 0 ? (
+                    <div className="text-sm text-muted-foreground">No category data for this month.</div>
+                  ) : (
+                    <div className="space-y-3">
+                      {categoryBreakdown.slice(0, 6).map((row) => (
+                        <div key={`${row.category_id ?? 'uncat'}-${row.category_name}`} className="space-y-1">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className="text-foreground">{row.category_name}</span>
+                            <span className="text-muted-foreground">{currency(row.amount)} ({row.share_pct.toFixed(0)}%)</span>
+                          </div>
+                          <div className="chart-track h-2">
+                            <div className="chart-fill-primary h-2" style={{ width: `${Math.max(2, Math.min(100, row.share_pct))}%` }} />
+                          </div>
+                        </div>
+                      ))}
                     </div>
-                  ))}
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+            </div>
+          </div>
+        </TabsContent>
+
+        {/* ── Accounts Overview Tab ── */}
+        <TabsContent value="accounts" className="space-y-8">
+          {overviewError && (
+            <div className="error mb-4">{overviewError}</div>
+          )}
+
+          {/* Net worth + type breakdown */}
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <FinancialCard variant="financial" className="group card-interactive fade-in-up lg:col-span-1">
+              <FinancialCardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <FinancialCardTitle className="text-sm font-medium text-muted-foreground">Total Net Worth</FinancialCardTitle>
+                  <Wallet className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors" />
                 </div>
-              )}
-            </FinancialCardContent>
-          </FinancialCard>
-        </div>
-      </div>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className={`metric-value mb-1 ${(overview?.net_worth ?? 0) >= 0 ? 'text-success' : 'text-destructive'}`}>
+                  {overviewLoading ? '...' : currency(overview?.net_worth ?? 0)}
+                </div>
+                <div className="text-xs text-muted-foreground">Across all accounts</div>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            {(overview?.account_summary_by_type ?? []).slice(0, 3).map((t) => {
+              const Icon = ACCOUNT_TYPE_ICONS[t.account_type] ?? Wallet;
+              return (
+                <FinancialCard key={t.account_type} variant="financial" className="group card-interactive fade-in-up">
+                  <FinancialCardHeader className="pb-3">
+                    <div className="flex items-center justify-between">
+                      <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                        {ACCOUNT_TYPE_LABELS[t.account_type]}
+                      </FinancialCardTitle>
+                      <Icon className="w-5 h-5 text-muted-foreground group-hover:text-primary transition-colors" />
+                    </div>
+                  </FinancialCardHeader>
+                  <FinancialCardContent>
+                    <div className="metric-value text-foreground mb-1">
+                      {overviewLoading ? '...' : currency(t.total_balance)}
+                    </div>
+                    <div className="text-xs text-muted-foreground">Total balance</div>
+                  </FinancialCardContent>
+                </FinancialCard>
+              );
+            })}
+          </div>
+
+          <div className="grid lg:grid-cols-3 gap-8">
+            {/* Per-account balance cards */}
+            <div className="lg:col-span-2 space-y-4">
+              <FinancialCard variant="financial" className="fade-in-up">
+                <FinancialCardHeader>
+                  <div className="flex items-center justify-between">
+                    <FinancialCardTitle className="section-title">Account Balances</FinancialCardTitle>
+                    <Button variant="ghost" size="sm" onClick={() => navigate('/accounts')}>Manage</Button>
+                  </div>
+                  <FinancialCardDescription>
+                    {overview?.accounts.length ?? 0} active account{(overview?.accounts.length ?? 0) !== 1 ? 's' : ''}
+                  </FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  {overviewLoading ? (
+                    <div className="text-sm text-muted-foreground">Loading accounts…</div>
+                  ) : (overview?.accounts ?? []).length === 0 ? (
+                    <div className="text-center py-6">
+                      <p className="text-muted-foreground mb-3 text-sm">No accounts yet.</p>
+                      <Button variant="financial" size="sm" onClick={() => navigate('/accounts')}>
+                        <Plus className="w-4 h-4" /> Add Account
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      {(overview?.accounts ?? []).map((account) => {
+                        const Icon = ACCOUNT_TYPE_ICONS[account.account_type] ?? Wallet;
+                        const isCredit = account.account_type === 'CREDIT';
+                        return (
+                          <div key={account.id} className="interactive-row flex items-center justify-between">
+                            <div className="flex items-center space-x-3">
+                              <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
+                                isCredit ? 'bg-destructive-light text-destructive' : 'bg-success-light text-success'
+                              }`}>
+                                <Icon className="w-5 h-5" />
+                              </div>
+                              <div>
+                                <div className="font-medium text-foreground">{account.name}</div>
+                                <div className="text-xs text-muted-foreground">
+                                  {ACCOUNT_TYPE_LABELS[account.account_type]}
+                                  {account.institution ? ` · ${account.institution}` : ''}
+                                </div>
+                              </div>
+                            </div>
+                            <div className={`font-semibold ${isCredit ? 'text-destructive' : 'text-foreground'}`}>
+                              {isCredit ? '-' : ''}{currency(account.balance, account.currency)}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </FinancialCardContent>
+                <FinancialCardFooter>
+                  <Button variant="financial" size="sm" className="w-full" onClick={() => navigate('/accounts')}>
+                    <Plus className="w-4 h-4" />
+                    Add Account
+                  </Button>
+                </FinancialCardFooter>
+              </FinancialCard>
+
+              {/* Combined transaction timeline */}
+              <FinancialCard variant="financial" className="fade-in-up">
+                <FinancialCardHeader>
+                  <FinancialCardTitle className="section-title">Combined Transaction Timeline</FinancialCardTitle>
+                  <FinancialCardDescription>Recent activity across all accounts</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  {overviewLoading ? (
+                    <div className="text-sm text-muted-foreground">Loading…</div>
+                  ) : (overview?.recent_transactions ?? []).length === 0 ? (
+                    <div className="text-sm text-muted-foreground">No transactions yet.</div>
+                  ) : (
+                    <div className="space-y-3">
+                      {(overview?.recent_transactions ?? []).slice(0, 10).map((txn) => {
+                        const isIncome = txn.type === 'INCOME';
+                        return (
+                          <div key={txn.id} className="interactive-row flex items-center justify-between">
+                            <div className="flex items-center space-x-3">
+                              <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${
+                                isIncome ? 'bg-success-light text-success' : 'bg-destructive-light text-destructive'
+                              }`}>
+                                {isIncome ? <ArrowUpRight className="w-5 h-5" /> : <ArrowDownRight className="w-5 h-5" />}
+                              </div>
+                              <div>
+                                <div className="font-medium text-foreground">{txn.description}</div>
+                                <div className="text-sm text-muted-foreground">{new Date(txn.date).toLocaleDateString()}</div>
+                              </div>
+                            </div>
+                            <div className={`font-semibold ${isIncome ? 'text-success' : 'text-foreground'}`}>
+                              {isIncome ? '+' : '-'}{currency(Math.abs(txn.amount), txn.currency)}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+            </div>
+
+            {/* Spending breakdown */}
+            <div>
+              <FinancialCard variant="financial" className="fade-in-up">
+                <FinancialCardHeader>
+                  <FinancialCardTitle className="section-title">Spending Breakdown</FinancialCardTitle>
+                  <FinancialCardDescription>Across all accounts for {overview?.period?.month || month}</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  {overviewLoading ? (
+                    <div className="text-sm text-muted-foreground">Loading…</div>
+                  ) : (overview?.spending_breakdown ?? []).length === 0 ? (
+                    <div className="text-sm text-muted-foreground">No spending data for this period.</div>
+                  ) : (
+                    <div className="space-y-3">
+                      {(overview?.spending_breakdown ?? []).slice(0, 8).map((row) => (
+                        <div key={`${row.category_id ?? 'uncat'}-${row.category_name}`} className="space-y-1">
+                          <div className="flex items-center justify-between text-sm">
+                            <span className="text-foreground">{row.category_name}</span>
+                            <span className="text-muted-foreground">
+                              {currency(row.amount)} ({row.share_pct.toFixed(0)}%)
+                            </span>
+                          </div>
+                          <div className="chart-track h-2">
+                            <div
+                              className="chart-fill-primary h-2"
+                              style={{ width: `${Math.max(2, Math.min(100, row.share_pct))}%` }}
+                            />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,23 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+DO $$ BEGIN
+  CREATE TYPE account_type_enum AS ENUM ('CHECKING','SAVINGS','CREDIT','INVESTMENT','CASH','OTHER');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS financial_accounts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  account_type account_type_enum NOT NULL DEFAULT 'CHECKING',
+  balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  institution VARCHAR(200),
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_financial_accounts_user ON financial_accounts(user_id, is_active);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,32 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AccountType(str, Enum):
+    CHECKING = "CHECKING"
+    SAVINGS = "SAVINGS"
+    CREDIT = "CREDIT"
+    INVESTMENT = "INVESTMENT"
+    CASH = "CASH"
+    OTHER = "OTHER"
+
+
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    account_type = db.Column(
+        SAEnum(AccountType, name="account_type_enum", create_type=False),
+        nullable=False,
+        default=AccountType.CHECKING,
+    )
+    balance = db.Column(db.Numeric(14, 2), nullable=False, default=0)
+    institution = db.Column(db.String(200), nullable=True)
+    currency = db.Column(db.String(10), nullable=False, default="INR")
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,141 @@
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import AccountType, FinancialAccount
+
+bp = Blueprint("accounts", __name__)
+
+VALID_ACCOUNT_TYPES = {t.value for t in AccountType}
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _account_to_dict(a: FinancialAccount) -> dict:
+    return {
+        "id": a.id,
+        "name": a.name,
+        "account_type": a.account_type.value if hasattr(a.account_type, "value") else str(a.account_type),
+        "balance": float(a.balance),
+        "institution": a.institution,
+        "currency": a.currency,
+        "is_active": a.is_active,
+        "created_at": a.created_at.isoformat(),
+        "updated_at": a.updated_at.isoformat(),
+    }
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    include_inactive = request.args.get("include_inactive", "false").lower() == "true"
+    q = db.session.query(FinancialAccount).filter_by(user_id=uid)
+    if not include_inactive:
+        q = q.filter(FinancialAccount.is_active.is_(True))
+    accounts = q.order_by(FinancialAccount.created_at.asc()).all()
+    return jsonify([_account_to_dict(a) for a in accounts])
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+
+    raw_type = str(data.get("account_type") or "CHECKING").upper().strip()
+    if raw_type not in VALID_ACCOUNT_TYPES:
+        return jsonify(error=f"invalid account_type, must be one of: {', '.join(sorted(VALID_ACCOUNT_TYPES))}"), 400
+
+    balance = _parse_amount(data.get("balance", 0))
+    if balance is None:
+        return jsonify(error="invalid balance"), 400
+
+    account = FinancialAccount(
+        user_id=uid,
+        name=name,
+        account_type=AccountType(raw_type),
+        balance=balance,
+        institution=(data.get("institution") or "").strip() or None,
+        currency=str(data.get("currency") or "INR")[:10],
+        is_active=True,
+    )
+    db.session.add(account)
+    db.session.commit()
+    return jsonify(_account_to_dict(account)), 201
+
+
+@bp.get("/<int:account_id>")
+@jwt_required()
+def get_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    return jsonify(_account_to_dict(account))
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+
+    if "name" in data:
+        name = (data["name"] or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        account.name = name
+
+    if "account_type" in data:
+        raw_type = str(data["account_type"] or "").upper().strip()
+        if raw_type not in VALID_ACCOUNT_TYPES:
+            return jsonify(error=f"invalid account_type, must be one of: {', '.join(sorted(VALID_ACCOUNT_TYPES))}"), 400
+        account.account_type = AccountType(raw_type)
+
+    if "balance" in data:
+        balance = _parse_amount(data["balance"])
+        if balance is None:
+            return jsonify(error="invalid balance"), 400
+        account.balance = balance
+
+    if "institution" in data:
+        account.institution = (data["institution"] or "").strip() or None
+
+    if "currency" in data:
+        account.currency = str(data["currency"] or "INR")[:10]
+
+    if "is_active" in data:
+        account.is_active = bool(data["is_active"])
+
+    account.updated_at = datetime.utcnow()
+    db.session.commit()
+    return jsonify(_account_to_dict(account))
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def delete_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(account)
+    db.session.commit()
+    return jsonify(message="deleted")

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..extensions import db
-from ..models import Bill, Expense, Category
+from ..models import Bill, Expense, Category, FinancialAccount
 from ..services.cache import cache_get, cache_set, dashboard_summary_key
 
 bp = Blueprint("dashboard", __name__)
@@ -165,6 +165,141 @@ def dashboard_summary():
         payload["errors"].append("category_breakdown_unavailable")
 
     cache_set(key, payload, ttl_seconds=300)
+    return jsonify(payload)
+
+
+@bp.get("/overview")
+@jwt_required()
+def multi_account_overview():
+    """
+    Multi-account financial overview.
+    Returns net worth, per-account balances, combined recent transactions
+    and spending breakdown across all accounts for the given month.
+    """
+    uid = int(get_jwt_identity())
+    ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
+    if not _is_valid_month(ym):
+        return jsonify(error="invalid month, expected YYYY-MM"), 400
+
+    payload = {
+        "period": {"month": ym},
+        "net_worth": 0.0,
+        "accounts": [],
+        "account_summary_by_type": [],
+        "recent_transactions": [],
+        "spending_breakdown": [],
+        "errors": [],
+    }
+
+    year, month = map(int, ym.split("-"))
+
+    # --- accounts ---
+    try:
+        accounts = (
+            db.session.query(FinancialAccount)
+            .filter_by(user_id=uid, is_active=True)
+            .order_by(FinancialAccount.created_at.asc())
+            .all()
+        )
+        account_list = [
+            {
+                "id": a.id,
+                "name": a.name,
+                "account_type": a.account_type.value if hasattr(a.account_type, "value") else str(a.account_type),
+                "balance": float(a.balance),
+                "institution": a.institution,
+                "currency": a.currency,
+            }
+            for a in accounts
+        ]
+        payload["accounts"] = account_list
+
+        # Net worth: sum all account balances (credit balances reduce net worth)
+        net_worth = 0.0
+        for a in accounts:
+            bal = float(a.balance)
+            atype = a.account_type.value if hasattr(a.account_type, "value") else str(a.account_type)
+            if atype == "CREDIT":
+                net_worth -= bal
+            else:
+                net_worth += bal
+        payload["net_worth"] = round(net_worth, 2)
+
+        # Breakdown by account type
+        type_totals: dict[str, float] = {}
+        for a in accounts:
+            atype = a.account_type.value if hasattr(a.account_type, "value") else str(a.account_type)
+            type_totals[atype] = type_totals.get(atype, 0.0) + float(a.balance)
+        payload["account_summary_by_type"] = [
+            {"account_type": t, "total_balance": round(v, 2)}
+            for t, v in sorted(type_totals.items())
+        ]
+    except Exception:
+        payload["errors"].append("accounts_unavailable")
+
+    # --- combined recent transactions ---
+    try:
+        rows = (
+            db.session.query(Expense)
+            .filter(Expense.user_id == uid)
+            .order_by(Expense.spent_at.desc(), Expense.id.desc())
+            .limit(20)
+            .all()
+        )
+        payload["recent_transactions"] = [
+            {
+                "id": e.id,
+                "description": e.notes or "Transaction",
+                "amount": float(e.amount),
+                "date": e.spent_at.isoformat(),
+                "type": e.expense_type,
+                "category_id": e.category_id,
+                "currency": e.currency,
+            }
+            for e in rows
+        ]
+    except Exception:
+        payload["errors"].append("recent_transactions_unavailable")
+
+    # --- spending breakdown by category for the period ---
+    try:
+        category_rows = (
+            db.session.query(
+                Expense.category_id,
+                func.coalesce(Category.name, "Uncategorized").label("category_name"),
+                func.coalesce(func.sum(Expense.amount), 0).label("total_amount"),
+            )
+            .outerjoin(
+                Category,
+                (Category.id == Expense.category_id) & (Category.user_id == uid),
+            )
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type != "INCOME",
+            )
+            .group_by(Expense.category_id, Category.name)
+            .order_by(func.sum(Expense.amount).desc())
+            .all()
+        )
+        total_spent = sum(float(r.total_amount or 0) for r in category_rows)
+        payload["spending_breakdown"] = [
+            {
+                "category_id": r.category_id,
+                "category_name": r.category_name,
+                "amount": float(r.total_amount or 0),
+                "share_pct": (
+                    round((float(r.total_amount or 0) / total_spent) * 100, 2)
+                    if total_spent > 0
+                    else 0
+                ),
+            }
+            for r in category_rows
+        ]
+    except Exception:
+        payload["errors"].append("spending_breakdown_unavailable")
+
     return jsonify(payload)
 
 

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,9 +1,9 @@
 import os
 import pytest
+from unittest.mock import MagicMock, patch
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
 
 
@@ -19,6 +19,19 @@ def _setup_db(app):
         db.create_all()
 
 
+def _make_redis_mock():
+    """Return a MagicMock that behaves like a simple in-memory Redis for tests."""
+    store: dict = {}
+    mock = MagicMock()
+    mock.get.side_effect = lambda key: store.get(key)
+    mock.set.side_effect = lambda key, value, **_: store.update({key: value})
+    mock.setex.side_effect = lambda key, ttl, value: store.update({key: value})
+    mock.delete.side_effect = lambda *keys: [store.pop(k, None) for k in keys]
+    mock.scan.return_value = (0, [])
+    mock.flushdb.side_effect = store.clear
+    return mock
+
+
 @pytest.fixture()
 def app_fixture():
     # Ensure a clean env for tests
@@ -28,21 +41,17 @@ def app_fixture():
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
-    app = create_app(settings)
-    app.config.update(TESTING=True)
-    _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
-    yield app
-    with app.app_context():
-        db.session.remove()
-        db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    redis_mock = _make_redis_mock()
+    with patch("app.extensions.redis_client", redis_mock), \
+         patch("app.routes.auth.redis_client", redis_mock), \
+         patch("app.services.cache.redis_client", redis_mock):
+        app = create_app(settings)
+        app.config.update(TESTING=True)
+        _setup_db(app)
+        yield app
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,288 @@
+"""Tests for /accounts CRUD and /dashboard/overview multi-account aggregation."""
+from datetime import date, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_account(client, headers, **kwargs):
+    payload = {
+        "name": kwargs.get("name", "Main Checking"),
+        "account_type": kwargs.get("account_type", "CHECKING"),
+        "balance": kwargs.get("balance", 1000),
+        "institution": kwargs.get("institution", "Test Bank"),
+        "currency": kwargs.get("currency", "INR"),
+    }
+    return client.post("/accounts", json=payload, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Account CRUD
+# ---------------------------------------------------------------------------
+
+def test_create_account_returns_201(client, auth_header):
+    r = _create_account(client, auth_header, name="Salary Account", account_type="SAVINGS", balance=5000)
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["name"] == "Salary Account"
+    assert data["account_type"] == "SAVINGS"
+    assert data["balance"] == 5000.0
+    assert data["institution"] == "Test Bank"
+    assert data["currency"] == "INR"
+    assert data["is_active"] is True
+    assert "id" in data
+    assert "created_at" in data
+    assert "updated_at" in data
+
+
+def test_create_account_invalid_type_returns_400(client, auth_header):
+    r = _create_account(client, auth_header, account_type="BOGUS")
+    assert r.status_code == 400
+    assert "account_type" in r.get_json().get("error", "")
+
+
+def test_create_account_missing_name_returns_400(client, auth_header):
+    r = client.post("/accounts", json={"account_type": "CHECKING", "balance": 100}, headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_create_account_invalid_balance_returns_400(client, auth_header):
+    r = client.post("/accounts", json={"name": "X", "balance": "not-a-number"}, headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_list_accounts_empty(client, auth_header):
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_list_accounts_returns_active_only_by_default(client, auth_header):
+    _create_account(client, auth_header, name="Active Account")
+    r1 = _create_account(client, auth_header, name="To Be Deactivated")
+    acct_id = r1.get_json()["id"]
+    # deactivate via PATCH
+    client.patch(f"/accounts/{acct_id}", json={"is_active": False}, headers=auth_header)
+
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    names = [a["name"] for a in r.get_json()]
+    assert "Active Account" in names
+    assert "To Be Deactivated" not in names
+
+
+def test_list_accounts_include_inactive(client, auth_header):
+    _create_account(client, auth_header, name="Active")
+    r1 = _create_account(client, auth_header, name="Inactive")
+    client.patch(f"/accounts/{r1.get_json()['id']}", json={"is_active": False}, headers=auth_header)
+
+    r = client.get("/accounts?include_inactive=true", headers=auth_header)
+    assert r.status_code == 200
+    names = [a["name"] for a in r.get_json()]
+    assert "Active" in names
+    assert "Inactive" in names
+
+
+def test_get_account_by_id(client, auth_header):
+    r = _create_account(client, auth_header, name="Investment Portfolio", account_type="INVESTMENT", balance=25000)
+    acct_id = r.get_json()["id"]
+
+    r2 = client.get(f"/accounts/{acct_id}", headers=auth_header)
+    assert r2.status_code == 200
+    data = r2.get_json()
+    assert data["id"] == acct_id
+    assert data["name"] == "Investment Portfolio"
+    assert data["account_type"] == "INVESTMENT"
+
+
+def test_get_account_not_found(client, auth_header):
+    r = client.get("/accounts/99999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_update_account_name_and_balance(client, auth_header):
+    r = _create_account(client, auth_header, name="Old Name", balance=100)
+    acct_id = r.get_json()["id"]
+
+    r2 = client.patch(f"/accounts/{acct_id}", json={"name": "New Name", "balance": 2500.50}, headers=auth_header)
+    assert r2.status_code == 200
+    data = r2.get_json()
+    assert data["name"] == "New Name"
+    assert data["balance"] == 2500.50
+
+
+def test_update_account_type(client, auth_header):
+    r = _create_account(client, auth_header, account_type="CHECKING")
+    acct_id = r.get_json()["id"]
+    r2 = client.patch(f"/accounts/{acct_id}", json={"account_type": "SAVINGS"}, headers=auth_header)
+    assert r2.status_code == 200
+    assert r2.get_json()["account_type"] == "SAVINGS"
+
+
+def test_update_account_not_found(client, auth_header):
+    r = client.patch("/accounts/99999", json={"name": "X"}, headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_delete_account(client, auth_header):
+    r = _create_account(client, auth_header, name="Temp Account")
+    acct_id = r.get_json()["id"]
+
+    r2 = client.delete(f"/accounts/{acct_id}", headers=auth_header)
+    assert r2.status_code == 200
+    assert r2.get_json()["message"] == "deleted"
+
+    r3 = client.get(f"/accounts/{acct_id}", headers=auth_header)
+    assert r3.status_code == 404
+
+
+def test_delete_account_not_found(client, auth_header):
+    r = client.delete("/accounts/99999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_accounts_isolated_between_users(client, app_fixture):
+    """Two users should not see each other's accounts."""
+    def _register_login(email, password):
+        client.post("/auth/register", json={"email": email, "password": password})
+        r = client.post("/auth/login", json={"email": email, "password": password})
+        return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+    h1 = _register_login("user1@test.com", "password123")
+    h2 = _register_login("user2@test.com", "password123")
+
+    _create_account(client, h1, name="User1 Account")
+    _create_account(client, h2, name="User2 Account")
+
+    r1 = client.get("/accounts", headers=h1)
+    r2 = client.get("/accounts", headers=h2)
+
+    names1 = [a["name"] for a in r1.get_json()]
+    names2 = [a["name"] for a in r2.get_json()]
+
+    assert "User1 Account" in names1
+    assert "User2 Account" not in names1
+    assert "User2 Account" in names2
+    assert "User1 Account" not in names2
+
+
+def test_all_account_types_accepted(client, auth_header):
+    for atype in ("CHECKING", "SAVINGS", "CREDIT", "INVESTMENT", "CASH", "OTHER"):
+        r = _create_account(client, auth_header, name=f"Test {atype}", account_type=atype)
+        assert r.status_code == 201, f"Expected 201 for account_type={atype}, got {r.status_code}"
+        assert r.get_json()["account_type"] == atype
+
+
+# ---------------------------------------------------------------------------
+# /dashboard/overview multi-account aggregation
+# ---------------------------------------------------------------------------
+
+def test_overview_empty(client, auth_header):
+    r = client.get("/dashboard/overview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["net_worth"] == 0.0
+    assert data["accounts"] == []
+    assert data["account_summary_by_type"] == []
+    assert data["recent_transactions"] == []
+    assert data["spending_breakdown"] == []
+
+
+def test_overview_net_worth_calculation(client, auth_header):
+    """Net worth = checking + savings + investment - credit balance."""
+    _create_account(client, auth_header, name="Checking", account_type="CHECKING", balance=2000)
+    _create_account(client, auth_header, name="Savings", account_type="SAVINGS", balance=5000)
+    _create_account(client, auth_header, name="Credit Card", account_type="CREDIT", balance=500)
+    _create_account(client, auth_header, name="Stocks", account_type="INVESTMENT", balance=10000)
+
+    r = client.get("/dashboard/overview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    # 2000 + 5000 + 10000 - 500 = 16500
+    assert data["net_worth"] == 16500.0
+    assert len(data["accounts"]) == 4
+
+
+def test_overview_account_summary_by_type(client, auth_header):
+    _create_account(client, auth_header, name="Checking 1", account_type="CHECKING", balance=1000)
+    _create_account(client, auth_header, name="Checking 2", account_type="CHECKING", balance=500)
+    _create_account(client, auth_header, name="Savings", account_type="SAVINGS", balance=3000)
+
+    r = client.get("/dashboard/overview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    by_type = {t["account_type"]: t["total_balance"] for t in data["account_summary_by_type"]}
+    assert by_type["CHECKING"] == 1500.0
+    assert by_type["SAVINGS"] == 3000.0
+
+
+def test_overview_recent_transactions(client, auth_header):
+    client.post(
+        "/expenses",
+        json={"amount": 150, "description": "Groceries", "date": date.today().isoformat(), "expense_type": "EXPENSE"},
+        headers=auth_header,
+    )
+    client.post(
+        "/expenses",
+        json={"amount": 3000, "description": "Salary", "date": date.today().isoformat(), "expense_type": "INCOME"},
+        headers=auth_header,
+    )
+
+    r = client.get("/dashboard/overview", headers=auth_header)
+    assert r.status_code == 200
+    txns = r.get_json()["recent_transactions"]
+    descriptions = [t["description"] for t in txns]
+    assert "Groceries" in descriptions
+    assert "Salary" in descriptions
+
+
+def test_overview_spending_breakdown_by_category(client, auth_header):
+    r_cat = client.post("/categories", json={"name": "Food"}, headers=auth_header)
+    food_id = r_cat.get_json()["id"]
+
+    today = date.today().isoformat()
+    client.post(
+        "/expenses",
+        json={"amount": 200, "description": "Lunch", "date": today, "expense_type": "EXPENSE", "category_id": food_id},
+        headers=auth_header,
+    )
+    client.post(
+        "/expenses",
+        json={"amount": 100, "description": "Dinner", "date": today, "expense_type": "EXPENSE", "category_id": food_id},
+        headers=auth_header,
+    )
+
+    month = date.today().strftime("%Y-%m")
+    r = client.get(f"/dashboard/overview?month={month}", headers=auth_header)
+    assert r.status_code == 200
+    breakdown = r.get_json()["spending_breakdown"]
+    assert len(breakdown) >= 1
+    food_entry = next((b for b in breakdown if b["category_name"] == "Food"), None)
+    assert food_entry is not None
+    assert food_entry["amount"] == 300.0
+    assert food_entry["share_pct"] == 100.0
+
+
+def test_overview_invalid_month_returns_400(client, auth_header):
+    r = client.get("/dashboard/overview?month=not-a-month", headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_overview_only_shows_active_accounts(client, auth_header):
+    _create_account(client, auth_header, name="Active", balance=1000)
+    r_inactive = _create_account(client, auth_header, name="Inactive", balance=9999)
+    client.patch(
+        f"/accounts/{r_inactive.get_json()['id']}",
+        json={"is_active": False},
+        headers=auth_header,
+    )
+
+    r = client.get("/dashboard/overview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    account_names = [a["name"] for a in data["accounts"]]
+    assert "Active" in account_names
+    assert "Inactive" not in account_names
+    # net worth should not include the inactive account's 9999 balance
+    assert data["net_worth"] == 1000.0


### PR DESCRIPTION
/claim #132

## Summary

- **`FinancialAccount` model** — supports `CHECKING`, `SAVINGS`, `CREDIT`, `INVESTMENT`, `CASH`, `OTHER` account types with name, balance, institution, currency, and active flag
- **CRUD API** at `/accounts` — `GET`, `POST`, `GET /:id`, `PATCH /:id`, `DELETE /:id` with full validation and per-user data isolation
- **`GET /dashboard/overview`** aggregation endpoint — returns net worth (credit balances subtract), per-account balances, account type summary, combined recent transaction timeline, and spending breakdown by category, all filterable by month
- **`/accounts` page** — full account management UI with create/edit dialog, net worth + assets + credit debt summary cards, per-account balance list with type icons
- **Dashboard enhanced** with a new "Accounts Overview" tab showing total net worth card, per-account balance cards, combined transaction timeline, and spending breakdown across accounts
- **Accounts added to Navbar** navigation
- **23 new backend tests** covering all CRUD endpoints and overview aggregation (net worth calculation, type grouping, transaction inclusion, spending breakdown, cross-user isolation)
- **Redis mock in conftest** so the full test suite (45 tests) runs without a running Redis instance — this fixed a pre-existing blocker where _all_ existing tests were also failing

## Test plan

- [x] 45 backend tests pass: `pytest tests/ -v` (23 new + 22 existing, no regressions)
- [x] TypeScript compiles clean: `tsc --noEmit`
- [ ] Create accounts of each type, verify they appear in `/dashboard` Accounts Overview tab
- [ ] Verify net worth = assets minus credit card balance
- [ ] Verify spending breakdown updates when expenses are added
- [ ] Verify per-user isolation (one user cannot see another's accounts)

> Note: a short demo video will be added as a follow-up comment as the bounty guidelines require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)