### PR TITLE
feat: Predictive Financial Health Score (#90)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import { HealthScorePage } from "./pages/HealthScore";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="health-score"
+              element={
+                <ProtectedRoute>
+                  <HealthScorePage />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/health-score.ts
+++ b/app/src/api/health-score.ts
@@ -1,0 +1,57 @@
+import { api } from './client';
+
+export type MetricDetail = Record<string, number | string | null | undefined>;
+
+export type Metric = {
+  points: number;
+  max: number;
+  detail?: MetricDetail;
+};
+
+export type HealthScoreBreakdown = {
+  savings_rate: Metric;
+  spending_stability: Metric;
+  bill_reliability: Metric;
+  trend: Metric;
+};
+
+export type HealthScore = {
+  score: number;
+  grade: string;
+  computed_at: string;
+  period: string;
+  breakdown: HealthScoreBreakdown;
+};
+
+export type HealthScoreHistoryItem = {
+  period: string;
+  score: number;
+  grade: string;
+  breakdown: {
+    savings_rate_pts: number;
+    spending_stability_pts: number;
+    bill_reliability_pts: number;
+    trend_pts: number;
+  };
+};
+
+export type HealthScoreHistory = {
+  history: HealthScoreHistoryItem[];
+};
+
+export type HealthScoreTips = {
+  tips: string[];
+  count: number;
+};
+
+export async function getHealthScore(): Promise<HealthScore> {
+  return api<HealthScore>('/health-score');
+}
+
+export async function getHealthScoreHistory(): Promise<HealthScoreHistory> {
+  return api<HealthScoreHistory>('/health-score/history');
+}
+
+export async function getHealthScoreTips(): Promise<HealthScoreTips> {
+  return api<HealthScoreTips>('/health-score/tips');
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Health Score', href: '/health-score' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/HealthScore.tsx
+++ b/app/src/pages/HealthScore.tsx
@@ -1,0 +1,452 @@
+import { useEffect, useState } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardDescription,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import {
+  getHealthScore,
+  getHealthScoreHistory,
+  getHealthScoreTips,
+  type HealthScore,
+  type HealthScoreHistory,
+  type HealthScoreTips,
+} from '@/api/health-score';
+import { useToast } from '@/hooks/use-toast';
+import { TrendingUp, TrendingDown, Minus, RefreshCw, Lightbulb } from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Grade ring colours
+// ---------------------------------------------------------------------------
+
+function gradeColor(grade: string): string {
+  switch (grade) {
+    case 'A': return '#22c55e'; // green-500
+    case 'B': return '#84cc16'; // lime-500
+    case 'C': return '#eab308'; // yellow-500
+    case 'D': return '#f97316'; // orange-500
+    default:  return '#ef4444'; // red-500
+  }
+}
+
+function gradeLabel(grade: string): string {
+  switch (grade) {
+    case 'A': return 'Excellent';
+    case 'B': return 'Good';
+    case 'C': return 'Fair';
+    case 'D': return 'Needs Work';
+    default:  return 'Critical';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SVG gauge / ring
+// ---------------------------------------------------------------------------
+
+interface ScoreRingProps {
+  score: number;
+  grade: string;
+}
+
+function ScoreRing({ score, grade }: ScoreRingProps) {
+  const r = 54;
+  const circumference = 2 * Math.PI * r;
+  const filled = (score / 100) * circumference;
+  const color = gradeColor(grade);
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <svg width="140" height="140" viewBox="0 0 140 140" aria-label={`Health score: ${score} out of 100`}>
+        {/* track */}
+        <circle
+          cx="70" cy="70" r={r}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="12"
+          className="text-muted/30"
+        />
+        {/* filled arc — rotated so it starts at 12 o'clock */}
+        <circle
+          cx="70" cy="70" r={r}
+          fill="none"
+          stroke={color}
+          strokeWidth="12"
+          strokeLinecap="round"
+          strokeDasharray={`${filled} ${circumference}`}
+          transform="rotate(-90 70 70)"
+          style={{ transition: 'stroke-dasharray 0.6s ease' }}
+        />
+        <text x="70" y="66" textAnchor="middle" fontSize="28" fontWeight="700" fill={color}>
+          {Math.round(score)}
+        </text>
+        <text x="70" y="84" textAnchor="middle" fontSize="12" fill="currentColor" opacity="0.6">
+          / 100
+        </text>
+      </svg>
+      <div className="flex items-center gap-2">
+        <span
+          className="inline-flex h-7 w-7 items-center justify-center rounded-full text-sm font-extrabold text-white"
+          style={{ backgroundColor: color }}
+        >
+          {grade}
+        </span>
+        <span className="text-sm font-semibold text-foreground">{gradeLabel(grade)}</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Metric bar
+// ---------------------------------------------------------------------------
+
+interface MetricBarProps {
+  label: string;
+  points: number;
+  max: number;
+  colorClass?: string;
+}
+
+function MetricBar({ label, points, max, colorClass = 'bg-primary' }: MetricBarProps) {
+  const pct = max > 0 ? Math.min(100, (points / max) * 100) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-foreground font-medium">{label}</span>
+        <span className="text-muted-foreground">
+          {points.toFixed(1)} / {max}
+        </span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-muted/40 overflow-hidden">
+        <div
+          className={`h-2 rounded-full ${colorClass}`}
+          style={{ width: `${pct}%`, transition: 'width 0.5s ease' }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function metricColor(points: number, max: number): string {
+  const ratio = max > 0 ? points / max : 0;
+  if (ratio >= 0.8) return 'bg-green-500';
+  if (ratio >= 0.6) return 'bg-lime-500';
+  if (ratio >= 0.4) return 'bg-yellow-500';
+  if (ratio >= 0.2) return 'bg-orange-500';
+  return 'bg-red-500';
+}
+
+// ---------------------------------------------------------------------------
+// Trend icon
+// ---------------------------------------------------------------------------
+
+interface TrendIconProps {
+  changePct: number | null | undefined;
+}
+
+function TrendIcon({ changePct }: TrendIconProps) {
+  if (changePct == null) return <Minus className="w-4 h-4 text-muted-foreground" />;
+  if (changePct < 0) return <TrendingDown className="w-4 h-4 text-green-500" />;
+  if (changePct > 0) return <TrendingUp className="w-4 h-4 text-red-500" />;
+  return <Minus className="w-4 h-4 text-muted-foreground" />;
+}
+
+// ---------------------------------------------------------------------------
+// History mini-bar chart
+// ---------------------------------------------------------------------------
+
+interface HistoryChartProps {
+  history: HealthScoreHistory['history'];
+}
+
+function HistoryChart({ history }: HistoryChartProps) {
+  if (!history.length) return null;
+  const max = 100;
+
+  return (
+    <div className="flex items-end gap-2 h-20">
+      {history.map((item) => {
+        const heightPct = (item.score / max) * 100;
+        const color = gradeColor(item.grade);
+        return (
+          <div key={item.period} className="flex flex-1 flex-col items-center gap-1">
+            <div
+              className="w-full rounded-t"
+              style={{
+                height: `${Math.max(4, heightPct * 0.7)}px`,
+                backgroundColor: color,
+                transition: 'height 0.4s ease',
+              }}
+              title={`${item.period}: ${item.score}`}
+            />
+            <span className="text-[10px] text-muted-foreground truncate">{item.period.slice(5)}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function HealthScorePage() {
+  const { toast } = useToast();
+  const [score, setScore] = useState<HealthScore | null>(null);
+  const [history, setHistory] = useState<HealthScoreHistory | null>(null);
+  const [tips, setTips] = useState<HealthScoreTips | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [s, h, t] = await Promise.all([
+        getHealthScore(),
+        getHealthScoreHistory(),
+        getHealthScoreTips(),
+      ]);
+      setScore(s);
+      setHistory(h);
+      setTips(t);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to load health score';
+      setError(msg);
+      toast({ title: 'Error', description: msg });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="page-wrap space-y-6">
+      {/* Header */}
+      <div className="page-header">
+        <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div>
+            <h1 className="page-title">Financial Health Score</h1>
+            <p className="page-subtitle">
+              A 0–100 composite of your savings, spending stability, bill reliability and trend.
+            </p>
+          </div>
+          <Button onClick={() => { void load(); }} disabled={loading} variant="outline" size="sm">
+            <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {loading && <div className="card text-muted-foreground">Computing your score…</div>}
+      {error && !loading && <div className="card text-red-600">{error}</div>}
+
+      {!loading && !error && score && (
+        <div className="grid gap-6 lg:grid-cols-3">
+
+          {/* Score ring + breakdown */}
+          <FinancialCard variant="financial" className="lg:col-span-1">
+            <FinancialCardHeader>
+              <FinancialCardTitle>Overall Score</FinancialCardTitle>
+              <FinancialCardDescription>Period: {score.period}</FinancialCardDescription>
+            </FinancialCardHeader>
+            <FinancialCardContent className="flex flex-col items-center gap-6">
+              <ScoreRing score={score.score} grade={score.grade} />
+
+              <div className="w-full space-y-3">
+                <MetricBar
+                  label="Savings Rate"
+                  points={score.breakdown.savings_rate.points}
+                  max={score.breakdown.savings_rate.max}
+                  colorClass={metricColor(score.breakdown.savings_rate.points, score.breakdown.savings_rate.max)}
+                />
+                <MetricBar
+                  label="Spending Stability"
+                  points={score.breakdown.spending_stability.points}
+                  max={score.breakdown.spending_stability.max}
+                  colorClass={metricColor(score.breakdown.spending_stability.points, score.breakdown.spending_stability.max)}
+                />
+                <MetricBar
+                  label="Bill Reliability"
+                  points={score.breakdown.bill_reliability.points}
+                  max={score.breakdown.bill_reliability.max}
+                  colorClass={metricColor(score.breakdown.bill_reliability.points, score.breakdown.bill_reliability.max)}
+                />
+                <MetricBar
+                  label="Trend"
+                  points={score.breakdown.trend.points}
+                  max={score.breakdown.trend.max}
+                  colorClass={metricColor(score.breakdown.trend.points, score.breakdown.trend.max)}
+                />
+              </div>
+            </FinancialCardContent>
+          </FinancialCard>
+
+          {/* Detail cards */}
+          <div className="lg:col-span-2 space-y-4">
+            {/* Metric detail grid */}
+            <div className="grid gap-4 sm:grid-cols-2">
+
+              {/* Savings Rate */}
+              <FinancialCard variant="financial">
+                <FinancialCardHeader className="pb-2">
+                  <FinancialCardTitle className="text-sm">Savings Rate</FinancialCardTitle>
+                  <FinancialCardDescription>{score.breakdown.savings_rate.points.toFixed(1)} / 25 pts</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent className="space-y-1 text-sm">
+                  {score.breakdown.savings_rate.detail && (
+                    <>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Income</span>
+                        <span>{Number(score.breakdown.savings_rate.detail['income'] ?? 0).toLocaleString()}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Expenses</span>
+                        <span>{Number(score.breakdown.savings_rate.detail['expenses'] ?? 0).toLocaleString()}</span>
+                      </div>
+                      <div className="flex justify-between font-semibold">
+                        <span className="text-muted-foreground">Savings Rate</span>
+                        <span>{score.breakdown.savings_rate.detail['savings_rate_pct']}%</span>
+                      </div>
+                    </>
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+
+              {/* Spending Stability */}
+              <FinancialCard variant="financial">
+                <FinancialCardHeader className="pb-2">
+                  <FinancialCardTitle className="text-sm">Spending Stability</FinancialCardTitle>
+                  <FinancialCardDescription>{score.breakdown.spending_stability.points.toFixed(1)} / 25 pts</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent className="space-y-1 text-sm">
+                  {score.breakdown.spending_stability.detail && (
+                    <>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Days with data</span>
+                        <span>{score.breakdown.spending_stability.detail['days_with_data'] ?? '—'}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Avg daily spend</span>
+                        <span>{score.breakdown.spending_stability.detail['mean_daily_spend'] ?? '—'}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Variability (CV)</span>
+                        <span>{score.breakdown.spending_stability.detail['cv'] != null
+                          ? Number(score.breakdown.spending_stability.detail['cv']).toFixed(2)
+                          : '—'}</span>
+                      </div>
+                    </>
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+
+              {/* Bill Reliability */}
+              <FinancialCard variant="financial">
+                <FinancialCardHeader className="pb-2">
+                  <FinancialCardTitle className="text-sm">Bill Reliability</FinancialCardTitle>
+                  <FinancialCardDescription>{score.breakdown.bill_reliability.points.toFixed(1)} / 25 pts</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent className="space-y-1 text-sm">
+                  {score.breakdown.bill_reliability.detail && (
+                    <>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Total bills</span>
+                        <span>{score.breakdown.bill_reliability.detail['total']}</span>
+                      </div>
+                      <div className="flex justify-between text-green-600">
+                        <span>On time</span>
+                        <span>{score.breakdown.bill_reliability.detail['on_time']}</span>
+                      </div>
+                      <div className="flex justify-between text-red-500">
+                        <span>Overdue</span>
+                        <span>{score.breakdown.bill_reliability.detail['overdue']}</span>
+                      </div>
+                    </>
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+
+              {/* Trend */}
+              <FinancialCard variant="financial">
+                <FinancialCardHeader className="pb-2">
+                  <FinancialCardTitle className="text-sm">Month-over-Month Trend</FinancialCardTitle>
+                  <FinancialCardDescription>{score.breakdown.trend.points.toFixed(1)} / 25 pts</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent className="space-y-1 text-sm">
+                  {score.breakdown.trend.detail && (
+                    <>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">This month expenses</span>
+                        <span>{Number(score.breakdown.trend.detail['current_month_expenses'] ?? 0).toLocaleString()}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Last month expenses</span>
+                        <span>{Number(score.breakdown.trend.detail['previous_month_expenses'] ?? 0).toLocaleString()}</span>
+                      </div>
+                      <div className="flex justify-between font-semibold items-center">
+                        <span className="text-muted-foreground">Change</span>
+                        <span className="flex items-center gap-1">
+                          <TrendIcon changePct={score.breakdown.trend.detail['change_pct'] as number | null} />
+                          {score.breakdown.trend.detail['change_pct'] != null
+                            ? `${Number(score.breakdown.trend.detail['change_pct']) > 0 ? '+' : ''}${Number(score.breakdown.trend.detail['change_pct']).toFixed(1)}%`
+                            : 'No prior data'}
+                        </span>
+                      </div>
+                    </>
+                  )}
+                </FinancialCardContent>
+              </FinancialCard>
+            </div>
+
+            {/* History */}
+            {history && history.history.length > 0 && (
+              <FinancialCard variant="financial">
+                <FinancialCardHeader>
+                  <FinancialCardTitle>Score History</FinancialCardTitle>
+                  <FinancialCardDescription>Last {history.history.length} months</FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  <HistoryChart history={history.history} />
+                </FinancialCardContent>
+              </FinancialCard>
+            )}
+
+            {/* Tips */}
+            {tips && tips.tips.length > 0 && (
+              <FinancialCard variant="financial">
+                <FinancialCardHeader>
+                  <FinancialCardTitle className="flex items-center gap-2">
+                    <Lightbulb className="w-4 h-4 text-yellow-500" />
+                    Actionable Tips
+                  </FinancialCardTitle>
+                  <FinancialCardDescription>
+                    Focused on your lowest-scoring areas
+                  </FinancialCardDescription>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  <ul className="space-y-2">
+                    {tips.tips.map((tip, i) => (
+                      <li key={i} className="flex items-start gap-2 text-sm text-foreground">
+                        <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-primary" />
+                        {tip}
+                      </li>
+                    ))}
+                  </ul>
+                </FinancialCardContent>
+              </FinancialCard>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .health_score import bp as health_score_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(health_score_bp, url_prefix="/health-score")

--- a/packages/backend/app/routes/health_score.py
+++ b/packages/backend/app/routes/health_score.py
@@ -1,0 +1,400 @@
+"""
+Financial Health Score — computes a 0-100 composite score from four metrics:
+
+  1. Savings Rate      (0-25 pts) – (income - expenses) / income for the month
+  2. Spending Stability (0-25 pts) – inverse of daily-spend std-dev over 30 days
+  3. Bill Reliability  (0-25 pts) – fraction of bills not overdue / total active
+  4. Trend Score       (0-25 pts) – month-over-month expense improvement
+
+Grades: A (>=80), B (>=65), C (>=50), D (>=35), F (<35)
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+from typing import Any
+
+from flask import Blueprint, jsonify
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Bill, Expense
+from ..services.cache import cache_get, cache_set
+
+bp = Blueprint("health_score", __name__)
+
+# ---------------------------------------------------------------------------
+# Cache helpers
+# ---------------------------------------------------------------------------
+
+_TTL = 300  # 5 minutes
+
+
+def _score_key(user_id: int) -> str:
+    return f"health_score:{user_id}:current"
+
+
+def _history_key(user_id: int) -> str:
+    return f"health_score:{user_id}:history"
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+def _grade(score: float) -> str:
+    if score >= 80:
+        return "A"
+    if score >= 65:
+        return "B"
+    if score >= 50:
+        return "C"
+    if score >= 35:
+        return "D"
+    return "F"
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 25.0) -> float:
+    return max(lo, min(hi, value))
+
+
+# ---------------------------------------------------------------------------
+# Per-metric calculators
+# ---------------------------------------------------------------------------
+
+def _savings_rate_score(uid: int, year: int, month: int) -> dict[str, Any]:
+    """0-25 pts. Scales linearly from 0% savings (0 pts) to >=20% savings (25 pts)."""
+    income = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+    expenses = float(
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+        or 0
+    )
+    if income <= 0:
+        rate = 0.0
+        points = 0.0
+    else:
+        rate = max(0.0, (income - expenses) / income)
+        # Full marks at 20% savings rate
+        points = _clamp(rate / 0.20 * 25)
+    return {
+        "points": round(points, 2),
+        "max": 25,
+        "detail": {
+            "income": income,
+            "expenses": expenses,
+            "savings_rate_pct": round(rate * 100, 2),
+        },
+    }
+
+
+def _spending_stability_score(uid: int) -> dict[str, Any]:
+    """0-25 pts. Lower daily-spend std-dev relative to mean → higher score."""
+    today = date.today()
+    start = today - timedelta(days=29)
+
+    rows = (
+        db.session.query(
+            Expense.spent_at,
+            func.coalesce(func.sum(Expense.amount), 0).label("day_total"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= today,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.spent_at)
+        .all()
+    )
+
+    if not rows:
+        return {"points": 12.5, "max": 25, "detail": {"cv": None, "days_with_data": 0}}
+
+    daily_totals = [float(r.day_total) for r in rows]
+    mean = sum(daily_totals) / len(daily_totals)
+
+    if mean <= 0:
+        return {"points": 25.0, "max": 25, "detail": {"cv": 0.0, "days_with_data": len(daily_totals)}}
+
+    variance = sum((x - mean) ** 2 for x in daily_totals) / len(daily_totals)
+    std_dev = math.sqrt(variance)
+    cv = std_dev / mean  # coefficient of variation
+
+    # CV=0 → 25 pts, CV>=1.5 → 0 pts
+    points = _clamp(max(0.0, (1 - cv / 1.5)) * 25)
+    return {
+        "points": round(points, 2),
+        "max": 25,
+        "detail": {
+            "cv": round(cv, 4),
+            "mean_daily_spend": round(mean, 2),
+            "std_dev": round(std_dev, 2),
+            "days_with_data": len(daily_totals),
+        },
+    }
+
+
+def _bill_reliability_score(uid: int) -> dict[str, Any]:
+    """0-25 pts. Fraction of active bills with next_due_date >= today (on time)."""
+    today = date.today()
+    bills = (
+        db.session.query(Bill)
+        .filter(Bill.user_id == uid, Bill.active.is_(True))
+        .all()
+    )
+    if not bills:
+        return {"points": 25.0, "max": 25, "detail": {"on_time": 0, "overdue": 0, "total": 0}}
+
+    overdue = sum(1 for b in bills if b.next_due_date < today)
+    on_time = len(bills) - overdue
+    fraction = on_time / len(bills)
+    points = _clamp(fraction * 25)
+    return {
+        "points": round(points, 2),
+        "max": 25,
+        "detail": {
+            "on_time": on_time,
+            "overdue": overdue,
+            "total": len(bills),
+        },
+    }
+
+
+def _trend_score(uid: int, year: int, month: int) -> dict[str, Any]:
+    """0-25 pts. Month-over-month expense change; improvement = higher score."""
+
+    def _monthly_expenses(y: int, m: int) -> float:
+        return float(
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == y,
+                extract("month", Expense.spent_at) == m,
+                Expense.expense_type != "INCOME",
+            )
+            .scalar()
+            or 0
+        )
+
+    # Previous month
+    if month == 1:
+        prev_year, prev_month = year - 1, 12
+    else:
+        prev_year, prev_month = year, month - 1
+
+    current = _monthly_expenses(year, month)
+    previous = _monthly_expenses(prev_year, prev_month)
+
+    if previous <= 0:
+        # No data for previous month — neutral score
+        points = 12.5
+        change_pct = None
+    else:
+        change_pct = (current - previous) / previous
+        # -20% or better → 25 pts; +20% or worse → 0 pts
+        # Linear interpolation across [-0.20, +0.20]
+        normalized = (-change_pct + 0.20) / 0.40  # 0..1
+        points = _clamp(normalized * 25)
+
+    return {
+        "points": round(points, 2),
+        "max": 25,
+        "detail": {
+            "current_month_expenses": round(current, 2),
+            "previous_month_expenses": round(previous, 2),
+            "change_pct": round(change_pct * 100, 2) if change_pct is not None else None,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core computation
+# ---------------------------------------------------------------------------
+
+def _compute_score(uid: int) -> dict[str, Any]:
+    today = date.today()
+    year, month = today.year, today.month
+
+    savings = _savings_rate_score(uid, year, month)
+    stability = _spending_stability_score(uid)
+    reliability = _bill_reliability_score(uid)
+    trend = _trend_score(uid, year, month)
+
+    total = savings["points"] + stability["points"] + reliability["points"] + trend["points"]
+
+    return {
+        "score": round(total, 1),
+        "grade": _grade(total),
+        "computed_at": today.isoformat(),
+        "period": f"{year}-{month:02d}",
+        "breakdown": {
+            "savings_rate": savings,
+            "spending_stability": stability,
+            "bill_reliability": reliability,
+            "trend": trend,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tips engine
+# ---------------------------------------------------------------------------
+
+_TIPS: dict[str, list[str]] = {
+    "savings_rate": [
+        "Try to save at least 20% of your monthly income — even small steps count.",
+        "Review your largest expense categories and find one to reduce by 10%.",
+        "Set up an automatic transfer to savings on pay-day to remove temptation.",
+    ],
+    "spending_stability": [
+        "Large swings in daily spending often signal impulse purchases — review them.",
+        "Creating a weekly spending budget can smooth out unpredictable days.",
+        "Try a 24-hour rule before any non-essential purchase over a set threshold.",
+    ],
+    "bill_reliability": [
+        "Enable autopay for recurring bills to avoid missed or late payments.",
+        "Set a reminder 3 days before each bill's due date.",
+        "Consolidate bill due-dates to the same week each month for easier tracking.",
+    ],
+    "trend": [
+        "Your expenses are rising month-over-month — identify the main driver and act.",
+        "Benchmark this month against your 3-month average to spot spending creep.",
+        "Try a no-spend day once a week to reduce the overall monthly total.",
+    ],
+}
+
+_GENERAL_TIPS = [
+    "Keep up the great work — your financial health is on track.",
+    "Consider reviewing your financial goals quarterly.",
+]
+
+
+def _generate_tips(breakdown: dict[str, Any]) -> list[str]:
+    """Return tips focused on the worst-scoring areas (below 60% of max)."""
+    tips: list[str] = []
+    sorted_metrics = sorted(
+        breakdown.items(),
+        key=lambda kv: kv[1]["points"] / kv[1]["max"],
+    )
+    for metric_key, metric_data in sorted_metrics:
+        ratio = metric_data["points"] / metric_data["max"]
+        if ratio < 0.60 and metric_key in _TIPS:
+            tips.extend(_TIPS[metric_key][:2])
+    if not tips:
+        tips = _GENERAL_TIPS
+    return tips[:6]
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@bp.get("")
+@jwt_required()
+def get_health_score():
+    """Return the current financial health score with a full breakdown."""
+    uid = int(get_jwt_identity())
+    key = _score_key(uid)
+    cached = cache_get(key)
+    if cached:
+        return jsonify(cached)
+
+    result = _compute_score(uid)
+    cache_set(key, result, ttl_seconds=_TTL)
+    return jsonify(result)
+
+
+@bp.get("/history")
+@jwt_required()
+def get_health_score_history():
+    """Return monthly health scores for the past 6 months."""
+    uid = int(get_jwt_identity())
+    key = _history_key(uid)
+    cached = cache_get(key)
+    if cached:
+        return jsonify(cached)
+
+    today = date.today()
+    history = []
+    for delta in range(6):
+        # Walk backwards month by month
+        if today.month - delta < 1:
+            m = today.month - delta + 12
+            y = today.year - 1
+        else:
+            m = today.month - delta
+            y = today.year
+
+        savings = _savings_rate_score(uid, y, m)
+        trend = _trend_score(uid, y, m)
+        # For history use current stability/reliability (rolling 30 days)
+        if delta == 0:
+            stability = _spending_stability_score(uid)
+            reliability = _bill_reliability_score(uid)
+        else:
+            # Approximate for past months — stability/reliability are rolling
+            stability = {"points": 12.5, "max": 25}
+            reliability = {"points": 12.5, "max": 25}
+
+        total = (
+            savings["points"]
+            + stability["points"]
+            + reliability["points"]
+            + trend["points"]
+        )
+        history.append(
+            {
+                "period": f"{y}-{m:02d}",
+                "score": round(total, 1),
+                "grade": _grade(total),
+                "breakdown": {
+                    "savings_rate_pts": savings["points"],
+                    "spending_stability_pts": stability["points"],
+                    "bill_reliability_pts": reliability["points"],
+                    "trend_pts": trend["points"],
+                },
+            }
+        )
+
+    history.reverse()  # oldest → newest
+    payload = {"history": history}
+    cache_set(key, payload, ttl_seconds=_TTL)
+    return jsonify(payload)
+
+
+@bp.get("/tips")
+@jwt_required()
+def get_health_score_tips():
+    """Return actionable tips based on the lowest-scoring areas."""
+    uid = int(get_jwt_identity())
+    # Reuse cached score if available
+    key = _score_key(uid)
+    cached = cache_get(key)
+    if cached:
+        breakdown = cached["breakdown"]
+    else:
+        result = _compute_score(uid)
+        cache_set(key, result, ttl_seconds=_TTL)
+        breakdown = result["breakdown"]
+
+    tips = _generate_tips(breakdown)
+    return jsonify({"tips": tips, "count": len(tips)})

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -15,6 +15,7 @@ pypdf==4.3.1
 openai==1.37.1
 twilio==9.3.2
 pytest==8.2.2
+fakeredis==2.23.3
 black==24.8.0
 flake8==7.0.0
 bandit==1.7.9

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
 import pytest
+import fakeredis
+from unittest.mock import patch
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
 
 
@@ -28,21 +29,20 @@ def app_fixture():
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
-    app = create_app(settings)
-    app.config.update(TESTING=True)
-    _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
-    yield app
-    with app.app_context():
-        db.session.remove()
-        db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis = fakeredis.FakeRedis(decode_responses=True)
+    # Patch both the module-level redis_client in auth (direct import)
+    # and the one used by services.cache (used by all other routes).
+    with patch("app.routes.auth.redis_client", fake_redis), \
+         patch("app.services.cache.redis_client", fake_redis):
+        app = create_app(settings)
+        app.config.update(TESTING=True)
+        _setup_db(app)
+        fake_redis.flushdb()
+        yield app
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+        fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_health_score.py
+++ b/packages/backend/tests/test_health_score.py
@@ -1,0 +1,196 @@
+"""Tests for the Financial Health Score endpoints."""
+
+from datetime import date, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_expense(client, auth_header, amount, expense_type="EXPENSE", days_ago=0):
+    spent_at = (date.today() - timedelta(days=days_ago)).isoformat()
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": amount,
+            "expense_type": expense_type,
+            "description": "test txn",
+            "date": spent_at,
+            "currency": "USD",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201, r.get_json()
+    return r.get_json()
+
+
+def _make_bill(client, auth_header, name="Electric", amount=50.0, due_days=10):
+    due = (date.today() + timedelta(days=due_days)).isoformat()
+    r = client.post(
+        "/bills",
+        json={
+            "name": name,
+            "amount": amount,
+            "currency": "USD",
+            "next_due_date": due,
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201, r.get_json()
+    return r.get_json()
+
+
+# ---------------------------------------------------------------------------
+# GET /health-score
+# ---------------------------------------------------------------------------
+
+class TestGetHealthScore:
+    def test_returns_200_with_expected_structure(self, client, auth_header):
+        r = client.get("/health-score", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "score" in data
+        assert "grade" in data
+        assert "breakdown" in data
+        assert "period" in data
+        assert "computed_at" in data
+
+    def test_score_in_valid_range(self, client, auth_header):
+        r = client.get("/health-score", headers=auth_header)
+        data = r.get_json()
+        assert 0 <= data["score"] <= 100
+
+    def test_grade_is_valid(self, client, auth_header):
+        r = client.get("/health-score", headers=auth_header)
+        data = r.get_json()
+        assert data["grade"] in ("A", "B", "C", "D", "F")
+
+    def test_breakdown_has_four_metrics(self, client, auth_header):
+        r = client.get("/health-score", headers=auth_header)
+        bd = r.get_json()["breakdown"]
+        assert "savings_rate" in bd
+        assert "spending_stability" in bd
+        assert "bill_reliability" in bd
+        assert "trend" in bd
+
+    def test_each_metric_within_range(self, client, auth_header):
+        r = client.get("/health-score", headers=auth_header)
+        bd = r.get_json()["breakdown"]
+        for metric, data in bd.items():
+            assert 0 <= data["points"] <= data["max"], (
+                f"{metric}: {data['points']} not in [0, {data['max']}]"
+            )
+
+    def test_requires_authentication(self, client):
+        r = client.get("/health-score")
+        assert r.status_code == 401
+
+    def test_savings_rate_reflects_income_expenses(self, client, auth_header):
+        # Add income and expenses for current month
+        _make_expense(client, auth_header, 1000, expense_type="INCOME", days_ago=0)
+        _make_expense(client, auth_header, 500, expense_type="EXPENSE", days_ago=1)
+
+        r = client.get("/health-score", headers=auth_header)
+        bd = r.get_json()["breakdown"]
+        detail = bd["savings_rate"]["detail"]
+        assert detail["income"] == 1000.0
+        assert detail["expenses"] == 500.0
+        assert detail["savings_rate_pct"] == 50.0
+        # 50% savings → full 25 pts
+        assert bd["savings_rate"]["points"] == 25.0
+
+    def test_bill_reliability_reflects_overdue(self, client, auth_header):
+        # A bill already overdue
+        overdue_date = (date.today() - timedelta(days=5)).isoformat()
+        client.post(
+            "/bills",
+            json={
+                "name": "Late Bill",
+                "amount": 30.0,
+                "currency": "USD",
+                "next_due_date": overdue_date,
+                "cadence": "MONTHLY",
+            },
+            headers=auth_header,
+        )
+        r = client.get("/health-score", headers=auth_header)
+        bd = r.get_json()["breakdown"]
+        detail = bd["bill_reliability"]["detail"]
+        assert detail["overdue"] >= 1
+
+    def test_grade_a_with_perfect_metrics(self, client, auth_header):
+        # High income, low expenses — should yield a good grade
+        _make_expense(client, auth_header, 5000, expense_type="INCOME", days_ago=0)
+        _make_expense(client, auth_header, 500, expense_type="EXPENSE", days_ago=1)
+        _make_bill(client, auth_header, due_days=15)
+
+        r = client.get("/health-score", headers=auth_header)
+        data = r.get_json()
+        # At 5000 income / 500 expense, savings rate is 90% → full 25 pts.
+        # With no historical data, trend defaults to neutral (12.5) and
+        # spending stability also gets a fair score.
+        assert data["score"] > 50, data
+
+
+# ---------------------------------------------------------------------------
+# GET /health-score/history
+# ---------------------------------------------------------------------------
+
+class TestGetHealthScoreHistory:
+    def test_returns_200_with_history_key(self, client, auth_header):
+        r = client.get("/health-score/history", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "history" in data
+
+    def test_history_has_up_to_six_periods(self, client, auth_header):
+        r = client.get("/health-score/history", headers=auth_header)
+        history = r.get_json()["history"]
+        assert 1 <= len(history) <= 6
+
+    def test_history_periods_are_sorted_oldest_first(self, client, auth_header):
+        r = client.get("/health-score/history", headers=auth_header)
+        periods = [item["period"] for item in r.get_json()["history"]]
+        assert periods == sorted(periods)
+
+    def test_history_items_have_required_fields(self, client, auth_header):
+        r = client.get("/health-score/history", headers=auth_header)
+        for item in r.get_json()["history"]:
+            assert "period" in item
+            assert "score" in item
+            assert "grade" in item
+            assert "breakdown" in item
+
+    def test_requires_authentication(self, client):
+        r = client.get("/health-score/history")
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /health-score/tips
+# ---------------------------------------------------------------------------
+
+class TestGetHealthScoreTips:
+    def test_returns_200_with_tips_list(self, client, auth_header):
+        r = client.get("/health-score/tips", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "tips" in data
+        assert isinstance(data["tips"], list)
+        assert data["count"] == len(data["tips"])
+
+    def test_tips_list_not_empty(self, client, auth_header):
+        r = client.get("/health-score/tips", headers=auth_header)
+        assert len(r.get_json()["tips"]) > 0
+
+    def test_requires_authentication(self, client):
+        r = client.get("/health-score/tips")
+        assert r.status_code == 401
+
+    def test_tips_target_weak_areas(self, client, auth_header):
+        # No income → savings_rate = 0 → tips should mention savings
+        r = client.get("/health-score/tips", headers=auth_header)
+        tips = r.get_json()["tips"]
+        # At least one tip should be a non-empty string
+        assert all(isinstance(t, str) and len(t) > 0 for t in tips)


### PR DESCRIPTION
## Summary

Implements a dynamic, real-time **Financial Health Score** (0–100) made up of four equally-weighted metrics, each worth 25 points:

| Metric | How it's scored |
|---|---|
| **Savings Rate** | `(income - expenses) / income` — full marks at ≥20% savings |
| **Spending Stability** | Inverse of coefficient of variation of daily spend over 30 days |
| **Bill Reliability** | Fraction of active bills not overdue |
| **Trend Score** | Month-over-month expense change — improvement earns higher score |

A letter grade is derived from the total: **A** (≥80), **B** (≥65), **C** (≥50), **D** (≥35), **F** (<35).

## Backend (`packages/backend`)

- **New blueprint** `app/routes/health_score.py` registered at `/health-score`
  - `GET /health-score` — current score with full breakdown + detail per metric
  - `GET /health-score/history` — month-by-month scores for the last 6 months
  - `GET /health-score/tips` — actionable tips targeted at the lowest-scoring areas
- All endpoints are JWT-protected and Redis-cached (5 min TTL)
- No new models or migrations needed — computed entirely from existing `expenses` and `bills` tables

## Frontend (`app/src`)

- **New page** `src/pages/HealthScore.tsx` at `/health-score`
  - SVG score ring with animated fill coloured by grade
  - Progress bars for each metric, coloured green → red by performance
  - Detail cards: savings rate, spending stability, bill reliability, trend (with MoM change)
  - 6-month bar chart history
  - Actionable tips list from the API
- **API client** `src/api/health-score.ts` with full TypeScript types
- Route added to `App.tsx`, "Health Score" nav link added to `Navbar.tsx`

## Tests

- **18 new backend tests** in `tests/test_health_score.py` covering all three endpoints
- Updated `conftest.py` to use `fakeredis` so the entire test suite runs without a live Redis instance — **all 40 tests pass**
- `fakeredis` added to `requirements.txt`

## Test plan

- [ ] `GET /health-score` returns `score`, `grade`, `breakdown`, `period`, `computed_at`
- [ ] Score is always in 0–100, grade is one of A/B/C/D/F
- [ ] Savings rate correctly reflects income/expense entries
- [ ] Overdue bills lower the bill reliability score
- [ ] History returns up to 6 periods sorted oldest → newest
- [ ] Tips are non-empty strings targeting the weakest area
- [ ] All endpoints return 401 without a JWT
- [ ] Frontend `/health-score` page renders ring, bars, history chart and tips
- [ ] `pytest` full suite: 40/40 pass

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)