### PR TITLE
Bounty Submission: Universal One-Click Deployment (Docker + K8s + Tilt) for FinMind

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,150 @@
+# FinMind Tiltfile - Local Kubernetes Development Workflow
+# Usage: tilt up
+# Prerequisites: Docker, kubectl, a local K8s cluster (minikube/kind/k3d)
+
+# ============================================================
+# Configuration
+# ============================================================
+load('ext://namespace', 'namespace_create')
+load('ext://helm_resource', 'helm_resource')
+
+# Allow connections from any host (for remote dev)
+allow_k8s_contexts(k8s_context())
+
+# Create namespace
+namespace_create('finmind')
+
+# ============================================================
+# Docker Builds with Live Reload
+# ============================================================
+
+# Backend: build image with live-reload via gunicorn --reload
+docker_build(
+    'finmind-backend',
+    context='./packages/backend',
+    dockerfile='./packages/backend/Dockerfile',
+    live_update=[
+        sync('./packages/backend/app', '/app/app'),
+        sync('./packages/backend/wsgi.py', '/app/wsgi.py'),
+        run('pip install -r requirements.txt', trigger=['./packages/backend/requirements.txt']),
+    ],
+)
+
+# Frontend: build image with Vite dev server hot-reload
+docker_build(
+    'finmind-frontend',
+    context='./app',
+    dockerfile='./app/Dockerfile',
+    live_update=[
+        sync('./app/src', '/app/src'),
+        sync('./app/public', '/app/public'),
+        sync('./app/index.html', '/app/index.html'),
+        run('npm install', trigger=['./app/package.json']),
+    ],
+)
+
+# ============================================================
+# Kubernetes Resources (ordered by dependency)
+# ============================================================
+
+# Secrets (must be applied before anything else)
+k8s_yaml('deploy/k8s/secrets.example.yaml')
+
+# Database layer
+k8s_yaml('deploy/k8s/namespace.yaml')
+
+# Apply the full app stack
+k8s_yaml('deploy/k8s/app-stack.yaml')
+
+# ============================================================
+# Resource Dependencies (enforce startup order)
+# ============================================================
+
+# Group resources for the Tilt UI
+k8s_resource('postgres',
+    labels=['data'],
+    port_forwards=['5432:5432'],
+)
+
+k8s_resource('redis',
+    labels=['data'],
+    port_forwards=['6379:6379'],
+    resource_deps=['postgres'],
+)
+
+k8s_resource('backend',
+    labels=['app'],
+    port_forwards=['8000:8000'],
+    resource_deps=['postgres', 'redis'],
+)
+
+k8s_resource('nginx',
+    labels=['app'],
+    port_forwards=['8080:80'],
+    resource_deps=['backend'],
+)
+
+# Monitoring stack (optional - lower priority)
+k8s_yaml('deploy/k8s/monitoring-stack.yaml')
+
+k8s_resource('postgres-exporter',
+    labels=['monitoring'],
+    resource_deps=['postgres'],
+)
+
+k8s_resource('redis-exporter',
+    labels=['monitoring'],
+    resource_deps=['redis'],
+)
+
+k8s_resource('nginx-exporter',
+    labels=['monitoring'],
+    resource_deps=['nginx'],
+)
+
+# ============================================================
+# Local Development Buttons
+# ============================================================
+
+# Button to run backend tests
+local_resource(
+    'backend-tests',
+    cmd='cd packages/backend && python -m pytest tests/ -v',
+    labels=['dev'],
+    auto_init=False,
+    trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
+# Button to run frontend tests
+local_resource(
+    'frontend-tests',
+    cmd='cd app && npm test -- --watchAll=false',
+    labels=['dev'],
+    auto_init=False,
+    trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
+# Button to initialize/reset database
+local_resource(
+    'init-db',
+    cmd='kubectl exec -n finmind deploy/backend -- python -m flask --app wsgi:app init-db',
+    labels=['dev'],
+    auto_init=False,
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    resource_deps=['backend'],
+)
+
+print("""
+===========================================
+  FinMind Local Development Environment
+===========================================
+  Frontend:  http://localhost:5173
+  Backend:   http://localhost:8000
+  Nginx:     http://localhost:8080
+  Postgres:  localhost:5432
+  Redis:     localhost:6379
+===========================================
+  Run 'tilt up' to start all services
+  Press (s) for a snapshot of all resources
+===========================================
+""")

--- a/deploy/DEPLOYMENT.md
+++ b/deploy/DEPLOYMENT.md
@@ -1,0 +1,283 @@
+# FinMind - Universal Deployment Guide
+
+One-click deployment for FinMind across all major platforms.
+
+## Quick Start
+
+```bash
+# One-command deployment (defaults to Docker Compose)
+./deploy/scripts/deploy.sh
+
+# Or specify a platform
+./deploy/scripts/deploy.sh <platform>
+```
+
+## Supported Platforms
+
+| Platform | Command | Type |
+|----------|---------|------|
+| Docker Compose | `./deploy/scripts/deploy.sh docker-compose` | Local |
+| Kubernetes (Helm) | `./deploy/scripts/deploy.sh kubernetes` | Cloud-agnostic |
+| Tilt | `./deploy/scripts/deploy.sh tilt` | Local K8s Dev |
+| Railway | `./deploy/scripts/deploy.sh railway` | PaaS |
+| Heroku | `./deploy/scripts/deploy.sh heroku` | PaaS |
+| DigitalOcean App Platform | `./deploy/scripts/deploy.sh digitalocean` | PaaS |
+| DigitalOcean Droplet | `./deploy/scripts/deploy.sh do-droplet` | VPS |
+| Render | `./deploy/scripts/deploy.sh render` | PaaS |
+| Fly.io | `./deploy/scripts/deploy.sh flyio` | PaaS |
+| AWS ECS Fargate | `./deploy/scripts/deploy.sh aws-ecs` | Cloud |
+| AWS App Runner | `./deploy/scripts/deploy.sh aws-apprunner` | Cloud |
+| GCP Cloud Run | `./deploy/scripts/deploy.sh gcp` | Cloud |
+| Azure Container Apps | `./deploy/scripts/deploy.sh azure` | Cloud |
+| Netlify | `./deploy/scripts/deploy.sh netlify` | Frontend |
+| Vercel | `./deploy/scripts/deploy.sh vercel` | Frontend |
+
+---
+
+## Docker Compose (Local Development)
+
+```bash
+# Copy environment variables
+cp .env.example .env
+# Edit .env with your values
+
+# Start all services
+./deploy/scripts/deploy.sh docker-compose
+
+# Or directly:
+docker compose up -d --build
+```
+
+**Services:**
+- Frontend: http://localhost:5173
+- Backend: http://localhost:8000
+- Nginx: http://localhost:8080
+- Grafana: http://localhost:3000
+- Prometheus: http://localhost:9090
+
+---
+
+## Kubernetes (Helm Chart)
+
+### Prerequisites
+- kubectl configured with cluster access
+- Helm 3.x installed
+
+### Install
+
+```bash
+# Quick deploy
+./deploy/scripts/deploy.sh kubernetes
+
+# Or manually with Helm
+helm upgrade --install finmind deploy/helm/finmind \
+  --namespace finmind \
+  --create-namespace \
+  --set secrets.jwtSecret="your-secret" \
+  --set secrets.geminiApiKey="your-key" \
+  --wait
+```
+
+### Features
+- HorizontalPodAutoscaler (2-10 replicas for backend)
+- NetworkPolicy (zero-trust networking)
+- PodDisruptionBudget (high availability)
+- TLS-ready Ingress with cert-manager
+- Health probes (readiness + liveness)
+- Prometheus scrape annotations
+- ConfigMap/Secret separation
+
+### Customization
+
+```bash
+# Override values
+helm upgrade --install finmind deploy/helm/finmind \
+  --set backend.replicaCount=3 \
+  --set backend.autoscaling.maxReplicas=20 \
+  --set ingress.hosts[0].host=finmind.yourdomain.com
+```
+
+---
+
+## Tilt (Local K8s Development)
+
+### Prerequisites
+- Docker
+- kubectl + local cluster (minikube, kind, or k3d)
+- [Tilt](https://docs.tilt.dev/install.html)
+
+### Start
+
+```bash
+# Start local cluster (if needed)
+minikube start  # or: kind create cluster
+
+# Start Tilt
+./deploy/scripts/deploy.sh tilt
+# Or: tilt up
+```
+
+### Features
+- Live-reload for backend (gunicorn --reload syncs Python files)
+- Live-reload for frontend (Vite HMR syncs src/ files)
+- Proper dependency ordering: postgres -> redis -> backend -> frontend
+- Port-forwarding for all services
+- Manual test triggers in Tilt UI
+- Resource grouping (app, data, monitoring, dev)
+
+---
+
+## Cloud Platforms
+
+### Railway
+
+```bash
+# Install CLI: npm install -g @railway/cli
+railway login
+./deploy/scripts/deploy.sh railway
+```
+
+Config: `deploy/platforms/railway/railway.toml`
+
+### Heroku
+
+```bash
+# Install CLI: https://devcenter.heroku.com/articles/heroku-cli
+heroku login
+heroku create finmind
+./deploy/scripts/deploy.sh heroku
+```
+
+Config: `deploy/platforms/heroku/heroku.yml`, `deploy/platforms/heroku/app.json`
+
+### DigitalOcean App Platform
+
+```bash
+# Install: https://docs.digitalocean.com/reference/doctl/how-to/install/
+doctl auth init
+./deploy/scripts/deploy.sh digitalocean
+```
+
+Config: `deploy/platforms/digitalocean/app-platform/do-app-spec.yaml`
+
+### DigitalOcean Droplet
+
+```bash
+# Run on a fresh Ubuntu droplet:
+curl -sSL https://raw.githubusercontent.com/rohitdash08/FinMind/main/deploy/platforms/digitalocean/droplet/setup.sh | bash
+
+# Or locally:
+./deploy/scripts/deploy.sh do-droplet
+```
+
+### Render
+
+```bash
+./deploy/scripts/deploy.sh render
+```
+
+Blueprint: `deploy/platforms/render/render.yaml` - Connect via Render Dashboard.
+
+### Fly.io
+
+```bash
+# Install: https://fly.io/docs/hands-on/install-flyctl/
+fly auth login
+./deploy/scripts/deploy.sh flyio
+```
+
+Config: `deploy/platforms/flyio/backend/fly.toml`, `deploy/platforms/flyio/frontend/fly.toml`
+
+### AWS ECS Fargate
+
+```bash
+export AWS_ACCOUNT_ID=123456789
+export AWS_REGION=us-east-1
+./deploy/scripts/deploy.sh aws-ecs
+```
+
+Config: `deploy/platforms/aws/ecs-fargate/task-definition.json`
+
+### AWS App Runner
+
+Config: `deploy/platforms/aws/app-runner/apprunner.yaml`
+
+### GCP Cloud Run
+
+```bash
+export GCP_PROJECT_ID=your-project
+./deploy/scripts/deploy.sh gcp
+```
+
+Config: `deploy/platforms/gcp/cloudrun.yaml`
+
+### Azure Container Apps
+
+```bash
+export AZURE_RESOURCE_GROUP=finmind-rg
+./deploy/scripts/deploy.sh azure
+```
+
+Config: `deploy/platforms/azure/container-app.yaml`
+
+### Netlify (Frontend)
+
+```bash
+# Install: npm install -g netlify-cli
+./deploy/scripts/deploy.sh netlify
+```
+
+Config: `deploy/platforms/netlify/netlify.toml`
+
+### Vercel (Frontend)
+
+```bash
+# Install: npm install -g vercel
+./deploy/scripts/deploy.sh vercel
+```
+
+Config: `deploy/platforms/vercel/vercel.json`
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `DATABASE_URL` | Yes | (auto) | PostgreSQL connection string |
+| `REDIS_URL` | Yes | (auto) | Redis connection string |
+| `JWT_SECRET` | Yes | `change-me` | JWT signing secret |
+| `GEMINI_API_KEY` | No | - | Google Gemini API key |
+| `GEMINI_MODEL` | No | `gemini-1.5-flash` | Gemini model |
+| `LOG_LEVEL` | No | `INFO` | Logging level |
+| `VITE_API_URL` | Frontend | `http://localhost:8000` | Backend URL |
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────┐
+                    │   Ingress   │
+                    │  (TLS/SSL)  │
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+        ┌─────▼─────┐ ┌───▼───┐ ┌─────▼─────┐
+        │  Frontend  │ │ Nginx │ │ Monitoring│
+        │  (React)   │ │(Proxy)│ │ (Grafana) │
+        └───────────┘ └───┬───┘ └───────────┘
+                          │
+                    ┌─────▼─────┐
+                    │  Backend  │
+                    │  (Flask)  │
+                    └─────┬─────┘
+                          │
+              ┌───────────┼───────────┐
+              │                       │
+        ┌─────▼─────┐         ┌──────▼─────┐
+        │ PostgreSQL │         │   Redis    │
+        │   (Data)   │         │  (Cache)   │
+        └───────────┘         └────────────┘
+```

--- a/deploy/helm/finmind/Chart.yaml
+++ b/deploy/helm/finmind/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: finmind
+description: FinMind - AI Finance Tracker Helm Chart
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - finmind
+  - finance
+  - ai
+  - tracker
+maintainers:
+  - name: FinMind Team
+    url: https://github.com/rohitdash08/FinMind

--- a/deploy/helm/finmind/templates/_helpers.tpl
+++ b/deploy/helm/finmind/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Common labels
+*/}}
+{{- define "finmind.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}
+
+{{/*
+Selector labels for a component
+*/}}
+{{- define "finmind.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
+Full name helper
+*/}}
+{{- define "finmind.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Database URL construction
+*/}}
+{{- define "finmind.databaseUrl" -}}
+postgresql+psycopg2://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@{{ .Release.Name }}-postgres:5432/$(POSTGRES_DB)
+{{- end }}
+
+{{/*
+Redis URL construction
+*/}}
+{{- define "finmind.redisUrl" -}}
+redis://{{ .Release.Name }}-redis:6379/0
+{{- end }}

--- a/deploy/helm/finmind/templates/backend.yaml
+++ b/deploy/helm/finmind/templates/backend.yaml
@@ -1,0 +1,121 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-backend
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8000"
+        prometheus.io/path: "/metrics"
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: POSTGRES_DB
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: JWT_SECRET
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: GEMINI_API_KEY
+            - name: DATABASE_URL
+              value: {{ include "finmind.databaseUrl" . | quote }}
+            - name: REDIS_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}-config
+                  key: REDIS_URL
+            - name: GEMINI_MODEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}-config
+                  key: GEMINI_MODEL
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}-config
+                  key: LOG_LEVEL
+          command:
+            - sh
+            - -c
+            - |
+              python -m flask --app wsgi:app init-db && \
+              export PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus_multiproc && \
+              rm -rf $PROMETHEUS_MULTIPROC_DIR && \
+              mkdir -p $PROMETHEUS_MULTIPROC_DIR && \
+              gunicorn --workers=2 --threads=4 --bind 0.0.0.0:8000 wsgi:app
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.backend.healthCheck.path }}
+              port: 8000
+            initialDelaySeconds: {{ .Values.backend.healthCheck.initialDelaySeconds }}
+            periodSeconds: {{ .Values.backend.healthCheck.periodSeconds }}
+            timeoutSeconds: {{ .Values.backend.healthCheck.timeoutSeconds }}
+            failureThreshold: {{ .Values.backend.healthCheck.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.backend.healthCheck.path }}
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-backend
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: backend
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP

--- a/deploy/helm/finmind/templates/configmap.yaml
+++ b/deploy/helm/finmind/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-config
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+data:
+  LOG_LEVEL: {{ .Values.backend.env.LOG_LEVEL | quote }}
+  GEMINI_MODEL: {{ .Values.backend.env.GEMINI_MODEL | quote }}
+  REDIS_URL: {{ include "finmind.redisUrl" . | quote }}

--- a/deploy/helm/finmind/templates/frontend.yaml
+++ b/deploy/helm/finmind/templates/frontend.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-frontend
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag }}"
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-frontend
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP

--- a/deploy/helm/finmind/templates/hpa.yaml
+++ b/deploy/helm/finmind/templates/hpa.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.backend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-backend-hpa
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-backend
+  minReplicas: {{ .Values.backend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.backend.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetCPUUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.backend.autoscaling.targetMemoryUtilization }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 25
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 60
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+{{- end }}
+---
+{{- if .Values.frontend.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-frontend-hpa
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-frontend
+  minReplicas: {{ .Values.frontend.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.frontend.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.frontend.autoscaling.targetCPUUtilization }}
+{{- end }}

--- a/deploy/helm/finmind/templates/ingress.yaml
+++ b/deploy/helm/finmind/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-ingress
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - secretName: {{ .secretName }}
+      hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                {{- if eq .service "backend" }}
+                name: {{ $.Release.Name }}-backend
+                port:
+                  number: 8000
+                {{- else }}
+                name: {{ $.Release.Name }}-frontend
+                port:
+                  number: 80
+                {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/finmind/templates/namespace.yaml
+++ b/deploy/helm/finmind/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}

--- a/deploy/helm/finmind/templates/networkpolicy.yaml
+++ b/deploy/helm/finmind/templates/networkpolicy.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.networkPolicy.enabled }}
+# Backend: allow ingress from frontend/nginx only, egress to postgres + redis
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-backend-netpol
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: backend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: nginx
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: frontend
+      ports:
+        - port: 8000
+          protocol: TCP
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: postgres
+      ports:
+        - port: 5432
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: redis
+      ports:
+        - port: 6379
+          protocol: TCP
+    # Allow DNS resolution
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Allow external HTTPS (for Gemini API, etc.)
+    - to: []
+      ports:
+        - port: 443
+          protocol: TCP
+---
+# PostgreSQL: only accept from backend
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-postgres-netpol
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: postgres
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+      ports:
+        - port: 5432
+          protocol: TCP
+---
+# Redis: only accept from backend
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-redis-netpol
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: backend
+      ports:
+        - port: 6379
+          protocol: TCP
+{{- end }}

--- a/deploy/helm/finmind/templates/pdb.yaml
+++ b/deploy/helm/finmind/templates/pdb.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-backend-pdb
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.backend.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: backend
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-frontend-pdb
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.frontend.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: frontend
+{{- end }}

--- a/deploy/helm/finmind/templates/postgres.yaml
+++ b/deploy/helm/finmind/templates/postgres.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-postgres-data
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+spec:
+  accessModes: [ReadWriteOnce]
+  {{- if .Values.postgres.storage.storageClass }}
+  storageClassName: {{ .Values.postgres.storage.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.postgres.storage.size }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-postgres
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Release.Name }}-secrets
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "finmind"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "finmind"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-postgres-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-postgres
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: postgres
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/finmind/templates/redis.yaml
+++ b/deploy/helm/finmind/templates/redis.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-redis
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+{{- end }}

--- a/deploy/helm/finmind/templates/secrets.yaml
+++ b/deploy/helm/finmind/templates/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    {{- include "finmind.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  POSTGRES_USER: {{ .Values.secrets.postgresUser | quote }}
+  POSTGRES_PASSWORD: {{ .Values.secrets.postgresPassword | quote }}
+  POSTGRES_DB: {{ .Values.secrets.postgresDb | quote }}
+  JWT_SECRET: {{ .Values.secrets.jwtSecret | quote }}
+  GEMINI_API_KEY: {{ .Values.secrets.geminiApiKey | quote }}

--- a/deploy/helm/finmind/values.yaml
+++ b/deploy/helm/finmind/values.yaml
@@ -1,0 +1,154 @@
+# FinMind Helm Chart - Default Values
+
+global:
+  namespace: finmind
+  imagePullPolicy: IfNotPresent
+
+# -- Backend configuration
+backend:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/rohitdash08/finmind-backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8000
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilization: 70
+    targetMemoryUtilization: 80
+  healthCheck:
+    path: /health
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  env:
+    LOG_LEVEL: INFO
+    GEMINI_MODEL: gemini-1.5-flash
+
+# -- Frontend configuration
+frontend:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/rohitdash08/finmind-frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: 6
+    targetCPUUtilization: 70
+
+# -- PostgreSQL configuration
+postgres:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16"
+  storage:
+    size: 10Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+# -- Redis configuration
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7"
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+
+# -- Nginx reverse proxy
+nginx:
+  enabled: true
+  image:
+    repository: nginx
+    tag: 1.27-alpine
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 80
+
+# -- Ingress configuration
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+  hosts:
+    - host: finmind.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          service: frontend
+        - path: /api
+          pathType: Prefix
+          service: backend
+  tls:
+    - secretName: finmind-tls
+      hosts:
+        - finmind.example.com
+
+# -- Secrets (override via --set or external secret manager)
+secrets:
+  postgresUser: finmind
+  postgresPassword: changeme-in-production
+  postgresDb: finmind
+  jwtSecret: changeme-in-production
+  geminiApiKey: ""
+
+# -- Observability
+monitoring:
+  enabled: true
+  prometheus:
+    enabled: true
+    scrapeInterval: 15s
+  serviceMonitor:
+    enabled: false
+
+# -- Network policies
+networkPolicy:
+  enabled: true
+
+# -- Pod disruption budgets
+podDisruptionBudget:
+  enabled: true
+  backend:
+    minAvailable: 1
+  frontend:
+    minAvailable: 1

--- a/deploy/platforms/aws/app-runner/apprunner.yaml
+++ b/deploy/platforms/aws/app-runner/apprunner.yaml
@@ -1,0 +1,30 @@
+# AWS App Runner service configuration
+# Deploy: aws apprunner create-service --cli-input-yaml file://deploy/platforms/aws/app-runner/apprunner.yaml
+ServiceName: finmind-backend
+SourceConfiguration:
+  ImageRepository:
+    ImageIdentifier: "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/finmind-backend:latest"
+    ImageRepositoryType: ECR
+    ImageConfiguration:
+      Port: "8000"
+      RuntimeEnvironmentVariables:
+        GEMINI_MODEL: gemini-1.5-flash
+        LOG_LEVEL: INFO
+      RuntimeEnvironmentSecrets:
+        DATABASE_URL: "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/DATABASE_URL"
+        REDIS_URL: "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/REDIS_URL"
+        JWT_SECRET: "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/JWT_SECRET"
+        GEMINI_API_KEY: "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/GEMINI_API_KEY"
+  AuthenticationConfiguration:
+    AccessRoleArn: "${APP_RUNNER_ECR_ACCESS_ROLE_ARN}"
+InstanceConfiguration:
+  Cpu: "0.5 vCPU"
+  Memory: "1 GB"
+HealthCheckConfiguration:
+  Protocol: HTTP
+  Path: /health
+  Interval: 10
+  Timeout: 5
+  HealthyThreshold: 1
+  UnhealthyThreshold: 5
+AutoScalingConfigurationArn: "${AUTO_SCALING_CONFIG_ARN}"

--- a/deploy/platforms/aws/ecs-fargate/deploy.sh
+++ b/deploy/platforms/aws/ecs-fargate/deploy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# FinMind - AWS ECS Fargate Deployment
+# Prerequisites: AWS CLI configured, ECR repository created
+set -euo pipefail
+
+# Configuration
+AWS_REGION="${AWS_REGION:-us-east-1}"
+AWS_ACCOUNT_ID="${AWS_ACCOUNT_ID:?Set AWS_ACCOUNT_ID}"
+CLUSTER_NAME="${CLUSTER_NAME:-finmind-cluster}"
+SERVICE_NAME="${SERVICE_NAME:-finmind-backend}"
+ECR_REPO="${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
+
+echo "=== FinMind ECS Fargate Deployment ==="
+
+# Step 1: Authenticate with ECR
+echo "Authenticating with ECR..."
+aws ecr get-login-password --region "$AWS_REGION" | docker login --username AWS --password-stdin "$ECR_REPO"
+
+# Step 2: Build and push backend image
+echo "Building backend image..."
+docker build -t finmind-backend ./packages/backend
+docker tag finmind-backend:latest "$ECR_REPO/finmind-backend:latest"
+docker push "$ECR_REPO/finmind-backend:latest"
+
+# Step 3: Build and push frontend image
+echo "Building frontend image..."
+docker build -t finmind-frontend ./app
+docker tag finmind-frontend:latest "$ECR_REPO/finmind-frontend:latest"
+docker push "$ECR_REPO/finmind-frontend:latest"
+
+# Step 4: Store secrets in SSM Parameter Store
+echo "Checking SSM parameters..."
+for param in DATABASE_URL REDIS_URL JWT_SECRET GEMINI_API_KEY; do
+    if ! aws ssm get-parameter --name "/finmind/$param" --region "$AWS_REGION" &>/dev/null; then
+        echo "WARNING: SSM parameter /finmind/$param not found. Create it with:"
+        echo "  aws ssm put-parameter --name '/finmind/$param' --type SecureString --value 'YOUR_VALUE'"
+    fi
+done
+
+# Step 5: Register task definition
+echo "Registering task definition..."
+TASK_DEF=$(envsubst < deploy/platforms/aws/ecs-fargate/task-definition.json)
+aws ecs register-task-definition --cli-input-json "$TASK_DEF" --region "$AWS_REGION"
+
+# Step 6: Create or update the service
+if aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME" --region "$AWS_REGION" | grep -q "ACTIVE"; then
+    echo "Updating existing service..."
+    aws ecs update-service \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-definition finmind \
+        --force-new-deployment \
+        --region "$AWS_REGION"
+else
+    echo "Creating new service..."
+    aws ecs create-service \
+        --cluster "$CLUSTER_NAME" \
+        --service-name "$SERVICE_NAME" \
+        --task-definition finmind \
+        --desired-count 2 \
+        --launch-type FARGATE \
+        --network-configuration "awsvpcConfiguration={subnets=[${SUBNET_IDS}],securityGroups=[${SECURITY_GROUP_IDS}],assignPublicIp=ENABLED}" \
+        --region "$AWS_REGION"
+fi
+
+echo "=== Deployment complete! ==="
+echo "Check status: aws ecs describe-services --cluster $CLUSTER_NAME --services $SERVICE_NAME"

--- a/deploy/platforms/aws/ecs-fargate/task-definition.json
+++ b/deploy/platforms/aws/ecs-fargate/task-definition.json
@@ -1,0 +1,47 @@
+{
+  "family": "finmind",
+  "networkMode": "awsvpc",
+  "requiresCompatibilities": ["FARGATE"],
+  "cpu": "512",
+  "memory": "1024",
+  "executionRoleArn": "${EXECUTION_ROLE_ARN}",
+  "taskRoleArn": "${TASK_ROLE_ARN}",
+  "containerDefinitions": [
+    {
+      "name": "backend",
+      "image": "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com/finmind-backend:latest",
+      "essential": true,
+      "portMappings": [
+        {
+          "containerPort": 8000,
+          "protocol": "tcp"
+        }
+      ],
+      "environment": [
+        { "name": "GEMINI_MODEL", "value": "gemini-1.5-flash" },
+        { "name": "LOG_LEVEL", "value": "INFO" }
+      ],
+      "secrets": [
+        { "name": "DATABASE_URL", "valueFrom": "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/DATABASE_URL" },
+        { "name": "REDIS_URL", "valueFrom": "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/REDIS_URL" },
+        { "name": "JWT_SECRET", "valueFrom": "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/JWT_SECRET" },
+        { "name": "GEMINI_API_KEY", "valueFrom": "arn:aws:ssm:${AWS_REGION}:${AWS_ACCOUNT_ID}:parameter/finmind/GEMINI_API_KEY" }
+      ],
+      "healthCheck": {
+        "command": ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"],
+        "interval": 30,
+        "timeout": 5,
+        "retries": 3,
+        "startPeriod": 30
+      },
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/finmind",
+          "awslogs-region": "${AWS_REGION}",
+          "awslogs-stream-prefix": "backend"
+        }
+      }
+    }
+  ]
+}

--- a/deploy/platforms/azure/container-app.yaml
+++ b/deploy/platforms/azure/container-app.yaml
@@ -1,0 +1,62 @@
+# Azure Container Apps deployment configuration
+# Deploy with: az containerapp create --yaml deploy/platforms/azure/container-app.yaml
+type: Microsoft.App/containerApps
+location: eastus
+properties:
+  managedEnvironmentId: /subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.App/managedEnvironments/${ENVIRONMENT_NAME}
+  configuration:
+    ingress:
+      external: true
+      targetPort: 8000
+      transport: auto
+      allowInsecure: false
+    secrets:
+      - name: database-url
+        value: "${DATABASE_URL}"
+      - name: redis-url
+        value: "${REDIS_URL}"
+      - name: jwt-secret
+        value: "${JWT_SECRET}"
+      - name: gemini-api-key
+        value: "${GEMINI_API_KEY}"
+  template:
+    containers:
+      - name: backend
+        image: ${ACR_NAME}.azurecr.io/finmind-backend:latest
+        resources:
+          cpu: 0.5
+          memory: 1Gi
+        env:
+          - name: DATABASE_URL
+            secretRef: database-url
+          - name: REDIS_URL
+            secretRef: redis-url
+          - name: JWT_SECRET
+            secretRef: jwt-secret
+          - name: GEMINI_API_KEY
+            secretRef: gemini-api-key
+          - name: GEMINI_MODEL
+            value: gemini-1.5-flash
+          - name: LOG_LEVEL
+            value: INFO
+        probes:
+          - type: readiness
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          - type: liveness
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 20
+    scale:
+      minReplicas: 1
+      maxReplicas: 10
+      rules:
+        - name: http-scaling
+          http:
+            metadata:
+              concurrentRequests: "50"

--- a/deploy/platforms/azure/deploy.sh
+++ b/deploy/platforms/azure/deploy.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# FinMind - Azure Container Apps Deployment
+# Prerequisites: az CLI logged in
+set -euo pipefail
+
+RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-finmind-rg}"
+LOCATION="${AZURE_LOCATION:-eastus}"
+ENVIRONMENT_NAME="${AZURE_ENV_NAME:-finmind-env}"
+ACR_NAME="${AZURE_ACR_NAME:-finmindacr}"
+
+echo "=== FinMind Azure Container Apps Deployment ==="
+
+# Step 1: Create resource group
+echo "Creating resource group..."
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+
+# Step 2: Create ACR
+echo "Creating Azure Container Registry..."
+az acr create --resource-group "$RESOURCE_GROUP" --name "$ACR_NAME" --sku Basic --admin-enabled true
+
+# Step 3: Build and push images
+echo "Building and pushing images..."
+az acr build --registry "$ACR_NAME" --image finmind-backend:latest ./packages/backend
+az acr build --registry "$ACR_NAME" --image finmind-frontend:latest ./app
+
+# Step 4: Create Container Apps Environment
+echo "Creating Container Apps environment..."
+az containerapp env create \
+    --name "$ENVIRONMENT_NAME" \
+    --resource-group "$RESOURCE_GROUP" \
+    --location "$LOCATION"
+
+# Step 5: Deploy backend
+echo "Deploying backend..."
+ACR_PASSWORD=$(az acr credential show --name "$ACR_NAME" --query "passwords[0].value" -o tsv)
+az containerapp create \
+    --name finmind-backend \
+    --resource-group "$RESOURCE_GROUP" \
+    --environment "$ENVIRONMENT_NAME" \
+    --image "$ACR_NAME.azurecr.io/finmind-backend:latest" \
+    --registry-server "$ACR_NAME.azurecr.io" \
+    --registry-username "$ACR_NAME" \
+    --registry-password "$ACR_PASSWORD" \
+    --target-port 8000 \
+    --ingress external \
+    --min-replicas 1 \
+    --max-replicas 10 \
+    --cpu 0.5 \
+    --memory 1Gi \
+    --env-vars "GEMINI_MODEL=gemini-1.5-flash" "LOG_LEVEL=INFO"
+
+# Step 6: Deploy frontend
+echo "Deploying frontend..."
+BACKEND_FQDN=$(az containerapp show --name finmind-backend --resource-group "$RESOURCE_GROUP" --query "properties.configuration.ingress.fqdn" -o tsv)
+az containerapp create \
+    --name finmind-frontend \
+    --resource-group "$RESOURCE_GROUP" \
+    --environment "$ENVIRONMENT_NAME" \
+    --image "$ACR_NAME.azurecr.io/finmind-frontend:latest" \
+    --registry-server "$ACR_NAME.azurecr.io" \
+    --registry-username "$ACR_NAME" \
+    --registry-password "$ACR_PASSWORD" \
+    --target-port 80 \
+    --ingress external \
+    --min-replicas 1 \
+    --max-replicas 5 \
+    --cpu 0.25 \
+    --memory 0.5Gi \
+    --env-vars "VITE_API_URL=https://$BACKEND_FQDN"
+
+FRONTEND_FQDN=$(az containerapp show --name finmind-frontend --resource-group "$RESOURCE_GROUP" --query "properties.configuration.ingress.fqdn" -o tsv)
+
+echo ""
+echo "=== Deployment complete! ==="
+echo "Backend:  https://$BACKEND_FQDN"
+echo "Frontend: https://$FRONTEND_FQDN"

--- a/deploy/platforms/digitalocean/app-platform/do-app-spec.yaml
+++ b/deploy/platforms/digitalocean/app-platform/do-app-spec.yaml
@@ -1,0 +1,68 @@
+# DigitalOcean App Platform Spec
+# Deploy: doctl apps create --spec deploy/platforms/digitalocean/app-platform/do-app-spec.yaml
+name: finmind
+region: nyc
+services:
+  - name: backend
+    dockerfile_path: packages/backend/Dockerfile
+    source_dir: /
+    github:
+      repo: rohitdash08/FinMind
+      branch: main
+      deploy_on_push: true
+    http_port: 8000
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    health_check:
+      http_path: /health
+      initial_delay_seconds: 15
+      period_seconds: 10
+    envs:
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        value: "${db.DATABASE_URL}"
+      - key: REDIS_URL
+        scope: RUN_TIME
+        value: "${redis.REDIS_URL}"
+      - key: JWT_SECRET
+        scope: RUN_TIME
+        type: SECRET
+      - key: GEMINI_API_KEY
+        scope: RUN_TIME
+        type: SECRET
+      - key: GEMINI_MODEL
+        scope: RUN_TIME
+        value: gemini-1.5-flash
+      - key: LOG_LEVEL
+        scope: RUN_TIME
+        value: INFO
+    routes:
+      - path: /api
+
+  - name: frontend
+    dockerfile_path: app/Dockerfile
+    source_dir: /app
+    github:
+      repo: rohitdash08/FinMind
+      branch: main
+      deploy_on_push: true
+    http_port: 80
+    instance_count: 1
+    instance_size_slug: basic-xxs
+    health_check:
+      http_path: /
+    routes:
+      - path: /
+
+databases:
+  - name: db
+    engine: PG
+    version: "16"
+    size: db-s-dev-database
+    num_nodes: 1
+
+  - name: redis
+    engine: REDIS
+    version: "7"
+    size: db-s-dev-database
+    num_nodes: 1

--- a/deploy/platforms/digitalocean/droplet/setup.sh
+++ b/deploy/platforms/digitalocean/droplet/setup.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# FinMind - DigitalOcean Droplet One-Click Setup
+# Usage: curl -sSL https://raw.githubusercontent.com/rohitdash08/FinMind/main/deploy/platforms/digitalocean/droplet/setup.sh | bash
+set -euo pipefail
+
+echo "=== FinMind Droplet Setup ==="
+
+# Install Docker if not present
+if ! command -v docker &>/dev/null; then
+    echo "Installing Docker..."
+    curl -fsSL https://get.docker.com | sh
+    sudo usermod -aG docker "$USER"
+    sudo systemctl enable docker
+    sudo systemctl start docker
+fi
+
+# Install Docker Compose plugin if not present
+if ! docker compose version &>/dev/null; then
+    echo "Installing Docker Compose..."
+    sudo apt-get update && sudo apt-get install -y docker-compose-plugin
+fi
+
+# Clone repo
+INSTALL_DIR="/opt/finmind"
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Updating existing installation..."
+    cd "$INSTALL_DIR" && git pull
+else
+    echo "Cloning FinMind..."
+    sudo git clone https://github.com/rohitdash08/FinMind.git "$INSTALL_DIR"
+    sudo chown -R "$USER:$USER" "$INSTALL_DIR"
+fi
+
+cd "$INSTALL_DIR"
+
+# Create .env if not exists
+if [ ! -f .env ]; then
+    cp .env.example .env
+    # Generate a random JWT secret
+    JWT_SECRET=$(openssl rand -hex 32)
+    sed -i "s/JWT_SECRET=\"change-me\"/JWT_SECRET=\"$JWT_SECRET\"/" .env
+    echo "Created .env file with generated JWT_SECRET"
+    echo "Please edit .env to add your GEMINI_API_KEY and other settings"
+fi
+
+# Setup firewall
+if command -v ufw &>/dev/null; then
+    sudo ufw allow 22/tcp
+    sudo ufw allow 80/tcp
+    sudo ufw allow 443/tcp
+    sudo ufw --force enable
+fi
+
+# Build and start
+echo "Building and starting FinMind..."
+docker compose up -d --build
+
+echo ""
+echo "=== FinMind is starting! ==="
+echo "Frontend: http://$(curl -s ifconfig.me):5173"
+echo "Backend:  http://$(curl -s ifconfig.me):8000"
+echo "Nginx:    http://$(curl -s ifconfig.me):8080"
+echo ""
+echo "To view logs: cd $INSTALL_DIR && docker compose logs -f"
+echo "To stop:      cd $INSTALL_DIR && docker compose down"

--- a/deploy/platforms/flyio/backend/fly.toml
+++ b/deploy/platforms/flyio/backend/fly.toml
@@ -1,0 +1,39 @@
+app = "finmind-backend"
+primary_region = "iad"
+kill_signal = "SIGINT"
+kill_timeout = "5s"
+
+[build]
+  dockerfile = "packages/backend/Dockerfile"
+
+[deploy]
+  release_command = "python -m flask --app wsgi:app init-db"
+
+[env]
+  GEMINI_MODEL = "gemini-1.5-flash"
+  LOG_LEVEL = "INFO"
+  PORT = "8000"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 250
+    soft_limit = 200
+
+[[http_service.checks]]
+  grace_period = "10s"
+  interval = "15s"
+  method = "GET"
+  path = "/health"
+  timeout = "5s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  cpus = 1

--- a/deploy/platforms/flyio/frontend/fly.toml
+++ b/deploy/platforms/flyio/frontend/fly.toml
@@ -1,0 +1,31 @@
+app = "finmind-frontend"
+primary_region = "iad"
+kill_signal = "SIGINT"
+kill_timeout = "5s"
+
+[build]
+  dockerfile = "app/Dockerfile"
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 500
+    soft_limit = 400
+
+[[http_service.checks]]
+  grace_period = "5s"
+  interval = "15s"
+  method = "GET"
+  path = "/"
+  timeout = "3s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"
+  cpus = 1

--- a/deploy/platforms/gcp/cloudrun.yaml
+++ b/deploy/platforms/gcp/cloudrun.yaml
@@ -1,0 +1,46 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: finmind-backend
+  annotations:
+    run.googleapis.com/launch-stage: GA
+    run.googleapis.com/ingress: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/maxScale: "10"
+        run.googleapis.com/cpu-throttling: "false"
+        run.googleapis.com/startup-cpu-boost: "true"
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 300
+      containers:
+        - image: gcr.io/PROJECT_ID/finmind-backend:latest
+          ports:
+            - containerPort: 8000
+          env:
+            - name: GEMINI_MODEL
+              value: gemini-1.5-flash
+            - name: LOG_LEVEL
+              value: INFO
+          envFrom:
+            - secretRef:
+                name: finmind-secrets
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15

--- a/deploy/platforms/gcp/deploy.sh
+++ b/deploy/platforms/gcp/deploy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# FinMind - Google Cloud Run Deployment
+# Prerequisites: gcloud CLI configured, project selected
+set -euo pipefail
+
+PROJECT_ID="${GCP_PROJECT_ID:?Set GCP_PROJECT_ID}"
+REGION="${GCP_REGION:-us-central1}"
+
+echo "=== FinMind GCP Cloud Run Deployment ==="
+
+# Step 1: Enable required APIs
+echo "Enabling APIs..."
+gcloud services enable run.googleapis.com containerregistry.googleapis.com sqladmin.googleapis.com redis.googleapis.com --project="$PROJECT_ID"
+
+# Step 2: Build and push images
+echo "Building backend image..."
+gcloud builds submit --tag "gcr.io/$PROJECT_ID/finmind-backend" ./packages/backend --project="$PROJECT_ID"
+
+echo "Building frontend image..."
+gcloud builds submit --tag "gcr.io/$PROJECT_ID/finmind-frontend" ./app --project="$PROJECT_ID"
+
+# Step 3: Create secrets (if not exists)
+for secret in DATABASE_URL REDIS_URL JWT_SECRET GEMINI_API_KEY; do
+    if ! gcloud secrets describe "finmind-$secret" --project="$PROJECT_ID" &>/dev/null; then
+        echo "Creating secret: finmind-$secret (set value manually)"
+        echo -n "placeholder" | gcloud secrets create "finmind-$secret" --data-file=- --project="$PROJECT_ID"
+    fi
+done
+
+# Step 4: Deploy backend
+echo "Deploying backend to Cloud Run..."
+gcloud run deploy finmind-backend \
+    --image "gcr.io/$PROJECT_ID/finmind-backend:latest" \
+    --region "$REGION" \
+    --platform managed \
+    --port 8000 \
+    --min-instances 1 \
+    --max-instances 10 \
+    --memory 512Mi \
+    --cpu 1 \
+    --set-env-vars "GEMINI_MODEL=gemini-1.5-flash,LOG_LEVEL=INFO" \
+    --set-secrets "DATABASE_URL=finmind-DATABASE_URL:latest,REDIS_URL=finmind-REDIS_URL:latest,JWT_SECRET=finmind-JWT_SECRET:latest,GEMINI_API_KEY=finmind-GEMINI_API_KEY:latest" \
+    --allow-unauthenticated \
+    --project="$PROJECT_ID"
+
+# Step 5: Deploy frontend
+echo "Deploying frontend to Cloud Run..."
+BACKEND_URL=$(gcloud run services describe finmind-backend --region "$REGION" --format="value(status.url)" --project="$PROJECT_ID")
+gcloud run deploy finmind-frontend \
+    --image "gcr.io/$PROJECT_ID/finmind-frontend:latest" \
+    --region "$REGION" \
+    --platform managed \
+    --port 80 \
+    --min-instances 1 \
+    --max-instances 5 \
+    --memory 256Mi \
+    --cpu 1 \
+    --set-env-vars "VITE_API_URL=$BACKEND_URL" \
+    --allow-unauthenticated \
+    --project="$PROJECT_ID"
+
+FRONTEND_URL=$(gcloud run services describe finmind-frontend --region "$REGION" --format="value(status.url)" --project="$PROJECT_ID")
+
+echo ""
+echo "=== Deployment complete! ==="
+echo "Backend:  $BACKEND_URL"
+echo "Frontend: $FRONTEND_URL"

--- a/deploy/platforms/heroku/Procfile
+++ b/deploy/platforms/heroku/Procfile
@@ -1,0 +1,1 @@
+web: python -m flask --app wsgi:app init-db && gunicorn --workers=2 --threads=4 --bind 0.0.0.0:$PORT wsgi:app

--- a/deploy/platforms/heroku/app.json
+++ b/deploy/platforms/heroku/app.json
@@ -1,0 +1,41 @@
+{
+  "name": "FinMind",
+  "description": "AI Finance Tracker - Manage expenses, budgets, and insights",
+  "keywords": ["finance", "ai", "tracker", "python", "flask"],
+  "stack": "container",
+  "addons": [
+    {
+      "plan": "heroku-postgresql:essential-0"
+    },
+    {
+      "plan": "heroku-redis:mini"
+    }
+  ],
+  "env": {
+    "JWT_SECRET": {
+      "description": "Secret key for JWT token signing",
+      "generator": "secret"
+    },
+    "GEMINI_API_KEY": {
+      "description": "Google Gemini API key for AI features",
+      "required": false
+    },
+    "GEMINI_MODEL": {
+      "description": "Gemini model to use",
+      "value": "gemini-1.5-flash"
+    },
+    "LOG_LEVEL": {
+      "description": "Logging level",
+      "value": "INFO"
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "basic"
+    }
+  },
+  "buildpacks": [
+    { "url": "heroku/python" }
+  ]
+}

--- a/deploy/platforms/heroku/heroku.yml
+++ b/deploy/platforms/heroku/heroku.yml
@@ -1,0 +1,12 @@
+build:
+  docker:
+    web: packages/backend/Dockerfile
+    frontend: app/Dockerfile
+run:
+  web: python -m flask --app wsgi:app init-db && gunicorn --workers=2 --threads=4 --bind 0.0.0.0:$PORT wsgi:app
+release:
+  command:
+    - python -m flask --app wsgi:app init-db
+addons:
+  - plan: heroku-postgresql:essential-0
+  - plan: heroku-redis:mini

--- a/deploy/platforms/netlify/netlify.toml
+++ b/deploy/platforms/netlify/netlify.toml
@@ -1,0 +1,38 @@
+[build]
+  base = "app/"
+  command = "npm ci && npm run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "20"
+  NPM_FLAGS = "--prefer-offline"
+
+# SPA fallback - all routes serve index.html
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+
+# API proxy to backend
+[[redirects]]
+  from = "/api/*"
+  to = "${VITE_API_URL}/:splat"
+  status = 200
+  force = true
+
+# Security headers
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    X-XSS-Protection = "1; mode=block"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https:;"
+
+# Cache static assets
+[[headers]]
+  for = "/assets/*"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000, immutable"

--- a/deploy/platforms/railway/railway.toml
+++ b/deploy/platforms/railway/railway.toml
@@ -1,0 +1,33 @@
+[build]
+builder = "DOCKERFILE"
+
+[build.dockerfilePath]
+backend = "packages/backend/Dockerfile"
+frontend = "app/Dockerfile"
+
+[deploy]
+startCommand = "gunicorn --workers=2 --threads=4 --bind 0.0.0.0:$PORT wsgi:app"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3
+
+[[services]]
+name = "backend"
+source = "packages/backend"
+buildCommand = "pip install -r requirements.txt"
+startCommand = "python -m flask --app wsgi:app init-db && gunicorn --workers=2 --threads=4 --bind 0.0.0.0:$PORT wsgi:app"
+
+[services.healthcheck]
+path = "/health"
+timeout = 30
+
+[[services]]
+name = "frontend"
+source = "app"
+buildCommand = "npm ci && npm run build"
+startCommand = "npx serve -s dist -l $PORT"
+
+[services.healthcheck]
+path = "/"
+timeout = 15

--- a/deploy/platforms/render/render.yaml
+++ b/deploy/platforms/render/render.yaml
@@ -1,0 +1,57 @@
+# Render Blueprint - https://render.com/docs/blueprint-spec
+services:
+  - type: web
+    name: finmind-backend
+    runtime: docker
+    dockerfilePath: packages/backend/Dockerfile
+    dockerContext: .
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: finmind-db
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          name: finmind-redis
+          type: redis
+          property: connectionString
+      - key: JWT_SECRET
+        generateValue: true
+      - key: GEMINI_API_KEY
+        sync: false
+      - key: GEMINI_MODEL
+        value: gemini-1.5-flash
+      - key: LOG_LEVEL
+        value: INFO
+    healthCheckPath: /health
+    autoDeploy: true
+    plan: starter
+
+  - type: web
+    name: finmind-frontend
+    runtime: docker
+    dockerfilePath: app/Dockerfile
+    dockerContext: ./app
+    envVars:
+      - key: VITE_API_URL
+        fromService:
+          name: finmind-backend
+          type: web
+          property: hostport
+    healthCheckPath: /
+    autoDeploy: true
+    plan: starter
+
+  - type: redis
+    name: finmind-redis
+    plan: starter
+    maxmemoryPolicy: allkeys-lru
+    ipAllowList: []
+
+databases:
+  - name: finmind-db
+    plan: starter
+    databaseName: finmind
+    user: finmind
+    postgresMajorVersion: 16
+    ipAllowList: []

--- a/deploy/platforms/vercel/vercel.json
+++ b/deploy/platforms/vercel/vercel.json
@@ -1,0 +1,27 @@
+{
+  "framework": "vite",
+  "buildCommand": "cd app && npm ci && npm run build",
+  "outputDirectory": "app/dist",
+  "installCommand": "cd app && npm ci",
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "${VITE_API_URL}/api/$1" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-XSS-Protection", "value": "1; mode=block" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# FinMind Universal One-Click Deployment Script
+# Usage: ./deploy/scripts/deploy.sh <platform>
+#
+# Supported platforms:
+#   docker-compose  - Local Docker Compose (default)
+#   kubernetes      - Kubernetes via Helm
+#   tilt            - Local K8s dev with Tilt
+#   railway         - Railway PaaS
+#   heroku          - Heroku
+#   digitalocean    - DigitalOcean App Platform
+#   do-droplet      - DigitalOcean Droplet
+#   render          - Render
+#   flyio           - Fly.io
+#   aws-ecs         - AWS ECS Fargate
+#   aws-apprunner   - AWS App Runner
+#   gcp             - Google Cloud Run
+#   azure           - Azure Container Apps
+#   netlify         - Netlify (frontend only)
+#   vercel          - Vercel (frontend only)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PLATFORM="${1:-docker-compose}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# Pre-flight checks
+preflight_check() {
+    log_info "Running pre-flight checks for: $PLATFORM"
+
+    # Check .env exists
+    if [ ! -f "$ROOT_DIR/.env" ] && [ "$PLATFORM" = "docker-compose" ]; then
+        if [ -f "$ROOT_DIR/.env.example" ]; then
+            log_warn ".env not found. Copying from .env.example..."
+            cp "$ROOT_DIR/.env.example" "$ROOT_DIR/.env"
+            log_warn "Please edit .env with your configuration before deploying to production."
+        else
+            log_error ".env.example not found"
+            exit 1
+        fi
+    fi
+}
+
+# Smoke test after deployment
+smoke_test() {
+    local url="${1:?URL required}"
+    local path="${2:-/health}"
+    local max_retries=30
+    local retry=0
+
+    log_info "Running smoke test: $url$path"
+    while [ $retry -lt $max_retries ]; do
+        if curl -sf "$url$path" >/dev/null 2>&1; then
+            log_ok "Smoke test passed: $url$path"
+            return 0
+        fi
+        retry=$((retry + 1))
+        sleep 2
+    done
+    log_error "Smoke test failed after $max_retries retries: $url$path"
+    return 1
+}
+
+deploy_docker_compose() {
+    log_info "Deploying with Docker Compose..."
+    command -v docker >/dev/null 2>&1 || { log_error "Docker not found"; exit 1; }
+
+    cd "$ROOT_DIR"
+    preflight_check
+
+    docker compose build
+    docker compose up -d
+
+    log_info "Waiting for services to start..."
+    sleep 10
+
+    smoke_test "http://localhost:8000" "/health" || true
+    smoke_test "http://localhost:5173" "/" || true
+
+    log_ok "Docker Compose deployment complete!"
+    echo ""
+    echo "  Frontend:   http://localhost:5173"
+    echo "  Backend:    http://localhost:8000"
+    echo "  Nginx:      http://localhost:8080"
+    echo "  Grafana:    http://localhost:3000"
+    echo "  Prometheus: http://localhost:9090"
+}
+
+deploy_kubernetes() {
+    log_info "Deploying to Kubernetes with Helm..."
+    command -v helm >/dev/null 2>&1 || { log_error "Helm not found. Install: https://helm.sh/docs/intro/install/"; exit 1; }
+    command -v kubectl >/dev/null 2>&1 || { log_error "kubectl not found"; exit 1; }
+
+    cd "$ROOT_DIR"
+
+    NAMESPACE="${K8S_NAMESPACE:-finmind}"
+    RELEASE="${HELM_RELEASE:-finmind}"
+
+    log_info "Installing Helm chart (namespace: $NAMESPACE, release: $RELEASE)..."
+    helm upgrade --install "$RELEASE" deploy/helm/finmind \
+        --namespace "$NAMESPACE" \
+        --create-namespace \
+        --set global.namespace="$NAMESPACE" \
+        --wait --timeout 5m
+
+    log_ok "Kubernetes deployment complete!"
+    echo ""
+    echo "  kubectl get pods -n $NAMESPACE"
+    echo "  kubectl get svc -n $NAMESPACE"
+    echo "  kubectl port-forward -n $NAMESPACE svc/$RELEASE-backend 8000:8000"
+    echo "  kubectl port-forward -n $NAMESPACE svc/$RELEASE-frontend 8080:80"
+}
+
+deploy_tilt() {
+    log_info "Starting Tilt development environment..."
+    command -v tilt >/dev/null 2>&1 || { log_error "Tilt not found. Install: https://docs.tilt.dev/install.html"; exit 1; }
+
+    cd "$ROOT_DIR"
+    tilt up
+}
+
+deploy_railway() {
+    log_info "Deploying to Railway..."
+    command -v railway >/dev/null 2>&1 || { log_error "Railway CLI not found. Install: npm install -g @railway/cli"; exit 1; }
+
+    cd "$ROOT_DIR"
+    log_info "Copy railway.toml to project root..."
+    cp deploy/platforms/railway/railway.toml .
+    railway up
+    log_ok "Railway deployment initiated!"
+}
+
+deploy_heroku() {
+    log_info "Deploying to Heroku..."
+    command -v heroku >/dev/null 2>&1 || { log_error "Heroku CLI not found. Install: https://devcenter.heroku.com/articles/heroku-cli"; exit 1; }
+
+    cd "$ROOT_DIR"
+    HEROKU_APP="${HEROKU_APP:-finmind}"
+
+    heroku container:login
+    heroku container:push web --app "$HEROKU_APP" --context-path ./packages/backend
+    heroku container:release web --app "$HEROKU_APP"
+    heroku run "python -m flask --app wsgi:app init-db" --app "$HEROKU_APP"
+
+    log_ok "Heroku deployment complete!"
+    heroku open --app "$HEROKU_APP"
+}
+
+deploy_digitalocean() {
+    log_info "Deploying to DigitalOcean App Platform..."
+    command -v doctl >/dev/null 2>&1 || { log_error "doctl not found. Install: https://docs.digitalocean.com/reference/doctl/how-to/install/"; exit 1; }
+
+    cd "$ROOT_DIR"
+    doctl apps create --spec deploy/platforms/digitalocean/app-platform/do-app-spec.yaml
+    log_ok "DigitalOcean App Platform deployment initiated!"
+}
+
+deploy_do_droplet() {
+    log_info "Deploying to DigitalOcean Droplet..."
+    bash "$ROOT_DIR/deploy/platforms/digitalocean/droplet/setup.sh"
+}
+
+deploy_render() {
+    log_info "Deploying to Render..."
+    log_info "Use the Render Blueprint: deploy/platforms/render/render.yaml"
+    log_info "1. Go to https://dashboard.render.com"
+    log_info "2. New > Blueprint Instance"
+    log_info "3. Connect your GitHub repo"
+    log_info "4. Render will auto-detect render.yaml"
+    log_ok "Render blueprint ready at: deploy/platforms/render/render.yaml"
+}
+
+deploy_flyio() {
+    log_info "Deploying to Fly.io..."
+    command -v fly >/dev/null 2>&1 || { log_error "fly CLI not found. Install: https://fly.io/docs/hands-on/install-flyctl/"; exit 1; }
+
+    cd "$ROOT_DIR"
+
+    # Create Postgres + Redis
+    log_info "Setting up Fly.io Postgres..."
+    fly postgres create --name finmind-db --region iad --initial-cluster-size 1 --vm-size shared-cpu-1x --volume-size 1 || true
+
+    log_info "Setting up Fly.io Redis..."
+    fly redis create --name finmind-redis --region iad --no-replicas || true
+
+    # Deploy backend
+    log_info "Deploying backend..."
+    fly deploy --config deploy/platforms/flyio/backend/fly.toml --app finmind-backend
+
+    # Deploy frontend
+    log_info "Deploying frontend..."
+    fly deploy --config deploy/platforms/flyio/frontend/fly.toml --app finmind-frontend
+
+    log_ok "Fly.io deployment complete!"
+}
+
+deploy_aws_ecs() {
+    log_info "Deploying to AWS ECS Fargate..."
+    bash "$ROOT_DIR/deploy/platforms/aws/ecs-fargate/deploy.sh"
+}
+
+deploy_aws_apprunner() {
+    log_info "Deploying to AWS App Runner..."
+    command -v aws >/dev/null 2>&1 || { log_error "AWS CLI not found"; exit 1; }
+    log_info "Config: deploy/platforms/aws/app-runner/apprunner.yaml"
+    log_info "Fill in environment variables and run:"
+    echo "  aws apprunner create-service --cli-input-yaml file://deploy/platforms/aws/app-runner/apprunner.yaml"
+}
+
+deploy_gcp() {
+    log_info "Deploying to GCP Cloud Run..."
+    bash "$ROOT_DIR/deploy/platforms/gcp/deploy.sh"
+}
+
+deploy_azure() {
+    log_info "Deploying to Azure Container Apps..."
+    bash "$ROOT_DIR/deploy/platforms/azure/deploy.sh"
+}
+
+deploy_netlify() {
+    log_info "Deploying frontend to Netlify..."
+    command -v netlify >/dev/null 2>&1 || { log_error "Netlify CLI not found. Install: npm install -g netlify-cli"; exit 1; }
+
+    cd "$ROOT_DIR"
+    cp deploy/platforms/netlify/netlify.toml app/netlify.toml
+    cd app
+    npm ci && npm run build
+    netlify deploy --prod --dir=dist
+    log_ok "Netlify deployment complete!"
+}
+
+deploy_vercel() {
+    log_info "Deploying frontend to Vercel..."
+    command -v vercel >/dev/null 2>&1 || { log_error "Vercel CLI not found. Install: npm install -g vercel"; exit 1; }
+
+    cd "$ROOT_DIR"
+    cp deploy/platforms/vercel/vercel.json .
+    vercel --prod
+    log_ok "Vercel deployment complete!"
+}
+
+# Main dispatcher
+echo "================================================"
+echo "  FinMind Universal Deployment"
+echo "  Platform: $PLATFORM"
+echo "================================================"
+echo ""
+
+case "$PLATFORM" in
+    docker-compose|docker|compose)  deploy_docker_compose ;;
+    kubernetes|k8s|helm)            deploy_kubernetes ;;
+    tilt|dev)                       deploy_tilt ;;
+    railway)                        deploy_railway ;;
+    heroku)                         deploy_heroku ;;
+    digitalocean|do)                deploy_digitalocean ;;
+    do-droplet|droplet)             deploy_do_droplet ;;
+    render)                         deploy_render ;;
+    flyio|fly)                      deploy_flyio ;;
+    aws-ecs|ecs|fargate)            deploy_aws_ecs ;;
+    aws-apprunner|apprunner)        deploy_aws_apprunner ;;
+    gcp|cloudrun|cloud-run)         deploy_gcp ;;
+    azure|aca|container-apps)       deploy_azure ;;
+    netlify)                        deploy_netlify ;;
+    vercel)                         deploy_vercel ;;
+    *)
+        log_error "Unknown platform: $PLATFORM"
+        echo ""
+        echo "Supported platforms:"
+        echo "  docker-compose  - Local Docker Compose (default)"
+        echo "  kubernetes      - Kubernetes via Helm"
+        echo "  tilt            - Local K8s dev with Tilt"
+        echo "  railway         - Railway PaaS"
+        echo "  heroku          - Heroku"
+        echo "  digitalocean    - DigitalOcean App Platform"
+        echo "  do-droplet      - DigitalOcean Droplet"
+        echo "  render          - Render"
+        echo "  flyio           - Fly.io"
+        echo "  aws-ecs         - AWS ECS Fargate"
+        echo "  aws-apprunner   - AWS App Runner"
+        echo "  gcp             - Google Cloud Run"
+        echo "  azure           - Azure Container Apps"
+        echo "  netlify         - Netlify (frontend only)"
+        echo "  vercel          - Vercel (frontend only)"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
/claim #144

## Summary

Complete universal one-click deployment system for FinMind covering **all 12+ mandatory platforms** with a single dispatcher script: `./deploy/scripts/deploy.sh <platform>`.

## What's Included

### Docker + Compose
- Retains existing `docker-compose.yml` production stack
- Unified deploy script with pre-flight checks and smoke tests

### Kubernetes (Production-Grade Helm Chart)
- **11 Helm templates**: backend, frontend, postgres, redis, configmap, secrets, namespace, ingress, HPA, NetworkPolicy, PDB
- **HorizontalPodAutoscaler**: 2-10 replicas for backend, 2-6 for frontend, CPU+memory targets, scale-down stabilization
- **NetworkPolicy**: Zero-trust — postgres only accepts from backend, redis only from backend, backend only from nginx/frontend
- **PodDisruptionBudget**: minAvailable=1 for backend and frontend
- **TLS-ready Ingress**: cert-manager annotations, configurable hosts
- **Health probes**: Readiness + liveness on all services
- **Prometheus annotations**: Scrape-ready backend pods
- **ConfigMap/Secret separation**: Clean environment management

### Tilt (Local K8s Dev)
- `Tiltfile` with live-reload for backend (gunicorn --reload, syncs Python files) and frontend (Vite HMR, syncs src/)
- Proper dependency ordering: `postgres → redis → backend → frontend`
- Port-forwarding for all services
- Manual trigger buttons for tests and DB init
- Resource grouping in Tilt UI (app, data, monitoring, dev)

### Cloud PaaS Platforms
- **Railway**: `railway.toml` with multi-service config
- **Heroku**: `heroku.yml`, `Procfile`, `app.json` (1-click deploy button ready)
- **Render**: Blueprint `render.yaml` with managed Postgres + Redis
- **Fly.io**: Separate backend/frontend `fly.toml` with health checks, auto-scaling, auto-stop
- **DigitalOcean App Platform**: `do-app-spec.yaml` with managed DB + Redis
- **DigitalOcean Droplet**: One-line setup script (curl | bash)

### Cloud Providers
- **AWS ECS Fargate**: Task definition (JSON) + deploy script using SSM Parameter Store for secrets
- **AWS App Runner**: Service YAML config
- **GCP Cloud Run**: Knative service YAML + gcloud deploy script with Cloud Build
- **Azure Container Apps**: Container app YAML + az CLI deploy script with ACR

### Frontend CDN
- **Netlify**: `netlify.toml` with SPA rewrite, API proxy, security headers, asset caching
- **Vercel**: `vercel.json` with rewrites, security headers, asset caching

## File Structure

```
Tiltfile                                          # Local K8s dev workflow
deploy/
  DEPLOYMENT.md                                   # Full deployment guide
  scripts/deploy.sh                               # Universal dispatcher
  helm/finmind/                                   # Production Helm chart
    Chart.yaml, values.yaml
    templates/{backend,frontend,postgres,redis,
              configmap,secrets,namespace,ingress,
              hpa,networkpolicy,pdb,_helpers}.yaml
  platforms/
    railway/railway.toml
    heroku/{Procfile,heroku.yml,app.json}
    render/render.yaml
    flyio/{backend,frontend}/fly.toml
    digitalocean/{app-platform/do-app-spec.yaml,droplet/setup.sh}
    aws/{ecs-fargate/{task-definition.json,deploy.sh},app-runner/apprunner.yaml}
    gcp/{cloudrun.yaml,deploy.sh}
    azure/{container-app.yaml,deploy.sh}
    netlify/netlify.toml
    vercel/vercel.json
```

**35 files, 2,356 lines added, 0 deletions** — purely additive, no existing code modified.

Fixes #144