### PR TITLE
feat: anomaly detection engine (#72)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .anomaly_detection import bp as anomaly_detection_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(anomaly_detection_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/anomaly_detection.py
+++ b/packages/backend/app/routes/anomaly_detection.py
@@ -1,0 +1,34 @@
+"""Route: GET /insights/anomalies — Anomaly Detection Engine (#72)."""
+from __future__ import annotations
+
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.anomaly_detection import detect_anomalies
+
+bp = Blueprint("anomaly_detection", __name__)
+
+
+@bp.get("/anomalies")
+@jwt_required()
+def get_anomalies():
+    """Return spending anomalies for the authenticated user.
+
+    Query params:
+      month (str, optional): YYYY-MM format. Defaults to the current month.
+
+    Returns 200 with:
+      {
+        "month": "YYYY-MM",
+        "anomalies_count": int,
+        "has_high_severity": bool,
+        "anomalies": [ AnomalyResult, ... ]
+      }
+    """
+    uid = int(get_jwt_identity())
+    ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
+
+    result = detect_anomalies(uid, ym)
+    return jsonify(result), 200

--- a/packages/backend/app/services/anomaly_detection.py
+++ b/packages/backend/app/services/anomaly_detection.py
@@ -1,0 +1,305 @@
+"""
+Anomaly Detection Engine — FinMind (#72)
+
+Detects unusual spending spikes by category or merchant using
+z-score statistical analysis against a rolling baseline.
+Returns ranked anomalies with explanation metadata.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import TypedDict
+
+from sqlalchemy import func, extract
+
+from ..extensions import db
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.anomaly_detection")
+
+# ── Tuneable thresholds ────────────────────────────────────────────────────────
+Z_SCORE_HIGH = 2.5       # z-score >= 2.5 → high severity anomaly
+Z_SCORE_MEDIUM = 1.5     # z-score >= 1.5 → medium severity anomaly
+MIN_BASELINE_MONTHS = 2  # need at least 2 prior months to compute baseline
+MIN_ABSOLUTE_SPIKE = Decimal("100")  # minimum absolute spike to report (INR)
+BASELINE_MONTHS = 3      # how many prior months to use for baseline
+
+
+class AnomalyResult(TypedDict):
+    id: str
+    type: str               # "category" | "merchant"
+    label: str              # category name or merchant name
+    category_id: int | None
+    current_spend: float
+    baseline_avg: float
+    baseline_stddev: float
+    z_score: float
+    spike_amount: float     # how much above the mean
+    spike_percent: float    # % above the mean
+    severity: str           # "high" | "medium" | "low"
+    explanation: str
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+def _period_dates(ym: str) -> tuple[date, date]:
+    """Return (first_day, last_day) for a YYYY-MM string."""
+    year, month = int(ym[:4]), int(ym[5:7])
+    first = date(year, month, 1)
+    if month == 12:
+        last = date(year + 1, 1, 1) - timedelta(days=1)
+    else:
+        last = date(year, month + 1, 1) - timedelta(days=1)
+    return first, last
+
+
+def _prior_months(ym: str, n: int) -> list[str]:
+    """Return the n month strings preceding ym."""
+    year, month = int(ym[:4]), int(ym[5:7])
+    result: list[str] = []
+    for _ in range(n):
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+        result.append(f"{year:04d}-{month:02d}")
+    return result
+
+
+def _month_category_spend(uid: int, ym: str) -> dict[int, dict]:
+    """Aggregated spend per category for one month.
+
+    Returns { category_id: { "name": str, "total": Decimal } }
+    """
+    year, month = int(ym[:4]), int(ym[5:7])
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            Category.name,
+            func.sum(Expense.amount).label("total"),
+        )
+        .outerjoin(Category, Category.id == Expense.category_id)
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type == "EXPENSE",
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+        )
+        .group_by(Expense.category_id, Category.name)
+        .all()
+    )
+    return {
+        r.category_id: {"name": r.name or "Uncategorized", "total": Decimal(str(r.total))}
+        for r in rows
+    }
+
+
+def _month_merchant_spend(uid: int, ym: str) -> dict[str, Decimal]:
+    """Aggregated spend per merchant (notes field) for one month."""
+    year, month = int(ym[:4]), int(ym[5:7])
+    rows = (
+        db.session.query(
+            Expense.notes,
+            func.sum(Expense.amount).label("total"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type == "EXPENSE",
+            Expense.notes.isnot(None),
+            Expense.notes != "",
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+        )
+        .group_by(Expense.notes)
+        .all()
+    )
+    return {r.notes: Decimal(str(r.total)) for r in rows if r.notes}
+
+
+def _compute_stats(values: list[Decimal]) -> tuple[float, float]:
+    """Return (mean, stddev) from a list of Decimal values."""
+    if not values:
+        return 0.0, 0.0
+    floats = [float(v) for v in values]
+    n = len(floats)
+    mean = sum(floats) / n
+    if n == 1:
+        # With a single data point, use mean as stddev estimate (conservative)
+        return mean, mean * 0.3 if mean > 0 else 1.0
+    variance = sum((x - mean) ** 2 for x in floats) / (n - 1)  # sample variance
+    stddev = math.sqrt(variance) if variance > 0 else mean * 0.1
+    return mean, stddev
+
+
+def _severity(z_score: float) -> str:
+    if z_score >= Z_SCORE_HIGH:
+        return "high"
+    if z_score >= Z_SCORE_MEDIUM:
+        return "medium"
+    return "low"
+
+
+def _explanation_category(label: str, current: float, avg: float, pct: float) -> str:
+    return (
+        f"Your spending on '{label}' this month ({current:.0f}) is "
+        f"{pct:.0f}% above your {BASELINE_MONTHS}-month average ({avg:.0f}). "
+        f"This is an unusual spike worth reviewing."
+    )
+
+
+def _explanation_merchant(label: str, current: float, avg: float, pct: float) -> str:
+    return (
+        f"Spending at '{label}' this month ({current:.0f}) is "
+        f"{pct:.0f}% above your typical amount ({avg:.0f}). "
+        f"Check if this is an expected one-off or a recurring change."
+    )
+
+
+# ── Category anomaly detection ─────────────────────────────────────────────────
+
+def _detect_category_anomalies(uid: int, ym: str, prior_yms: list[str]) -> list[AnomalyResult]:
+    current = _month_category_spend(uid, ym)
+    if not current:
+        return []
+
+    # Build per-category baseline from prior months
+    baseline: dict[int, list[Decimal]] = {}
+    for pym in prior_yms:
+        month_data = _month_category_spend(uid, pym)
+        for cat_id, info in month_data.items():
+            baseline.setdefault(cat_id, []).append(info["total"])
+
+    anomalies: list[AnomalyResult] = []
+    for cat_id, info in current.items():
+        hist = baseline.get(cat_id, [])
+        if len(hist) < 1:
+            # No history at all — skip (could be a new category)
+            continue
+
+        mean, stddev = _compute_stats(hist)
+        if mean == 0:
+            continue
+
+        current_val = float(info["total"])
+        z = (current_val - mean) / stddev if stddev > 0 else 0.0
+        spike = current_val - mean
+        spike_pct = (spike / mean) * 100.0
+
+        # Only flag upward anomalies above minimum absolute threshold
+        if z < Z_SCORE_MEDIUM or Decimal(str(spike)) < MIN_ABSOLUTE_SPIKE:
+            continue
+
+        sev = _severity(z)
+        label = info["name"]
+        anomaly_id = f"cat_anomaly_{cat_id}_{ym}"
+
+        anomalies.append(AnomalyResult(
+            id=anomaly_id,
+            type="category",
+            label=label,
+            category_id=cat_id,
+            current_spend=round(current_val, 2),
+            baseline_avg=round(mean, 2),
+            baseline_stddev=round(stddev, 2),
+            z_score=round(z, 2),
+            spike_amount=round(spike, 2),
+            spike_percent=round(spike_pct, 1),
+            severity=sev,
+            explanation=_explanation_category(label, current_val, mean, spike_pct),
+        ))
+
+    return anomalies
+
+
+# ── Merchant anomaly detection ─────────────────────────────────────────────────
+
+def _detect_merchant_anomalies(uid: int, ym: str, prior_yms: list[str]) -> list[AnomalyResult]:
+    current = _month_merchant_spend(uid, ym)
+    if not current:
+        return []
+
+    baseline: dict[str, list[Decimal]] = {}
+    for pym in prior_yms:
+        month_data = _month_merchant_spend(uid, pym)
+        for merchant, total in month_data.items():
+            baseline.setdefault(merchant, []).append(total)
+
+    anomalies: list[AnomalyResult] = []
+    for merchant, cur_total in current.items():
+        hist = baseline.get(merchant, [])
+        if len(hist) < 1:
+            continue
+
+        mean, stddev = _compute_stats(hist)
+        if mean == 0:
+            continue
+
+        current_val = float(cur_total)
+        z = (current_val - mean) / stddev if stddev > 0 else 0.0
+        spike = current_val - mean
+        spike_pct = (spike / mean) * 100.0
+
+        if z < Z_SCORE_MEDIUM or Decimal(str(spike)) < MIN_ABSOLUTE_SPIKE:
+            continue
+
+        sev = _severity(z)
+        # Use a slug-safe ID
+        merchant_slug = merchant.lower().replace(" ", "_")[:30]
+        anomaly_id = f"merch_anomaly_{merchant_slug}_{ym}"
+
+        anomalies.append(AnomalyResult(
+            id=anomaly_id,
+            type="merchant",
+            label=merchant,
+            category_id=None,
+            current_spend=round(current_val, 2),
+            baseline_avg=round(mean, 2),
+            baseline_stddev=round(stddev, 2),
+            z_score=round(z, 2),
+            spike_amount=round(spike, 2),
+            spike_percent=round(spike_pct, 1),
+            severity=sev,
+            explanation=_explanation_merchant(merchant, current_val, mean, spike_pct),
+        ))
+
+    return anomalies
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+def detect_anomalies(uid: int, ym: str) -> dict:
+    """Detect spending anomalies for *uid* in month *ym* (YYYY-MM).
+
+    Returns a dict with:
+      - month: the queried month
+      - anomalies_count: total anomalies found
+      - has_high_severity: bool shortcut
+      - anomalies: list of AnomalyResult dicts, sorted by severity then z_score desc
+    """
+    prior_yms = _prior_months(ym, BASELINE_MONTHS)
+
+    cat_anomalies = _detect_category_anomalies(uid, ym, prior_yms)
+    merch_anomalies = _detect_merchant_anomalies(uid, ym, prior_yms)
+
+    all_anomalies = cat_anomalies + merch_anomalies
+
+    # Sort: high first, then by z_score descending
+    sev_order = {"high": 0, "medium": 1, "low": 2}
+    all_anomalies.sort(key=lambda a: (sev_order.get(a["severity"], 3), -a["z_score"]))
+
+    has_high = any(a["severity"] == "high" for a in all_anomalies)
+
+    logger.info(
+        "anomaly_detection uid=%d month=%s found=%d (high=%s)",
+        uid, ym, len(all_anomalies), has_high,
+    )
+
+    return {
+        "month": ym,
+        "anomalies_count": len(all_anomalies),
+        "has_high_severity": has_high,
+        "anomalies": list(all_anomalies),
+    }

--- a/packages/backend/tests/test_anomaly_detection.py
+++ b/packages/backend/tests/test_anomaly_detection.py
@@ -1,0 +1,344 @@
+"""Tests for the Anomaly Detection Engine (#72)."""
+from __future__ import annotations
+
+import math
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+
+# ── Test helpers ───────────────────────────────────────────────────────────────
+
+def _add_expense(client, auth_header, amount: float, exp_date: str,
+                 category_id: int | None = None, notes: str | None = None,
+                 expense_type: str = "EXPENSE"):
+    payload = {
+        "amount": amount,
+        "description": f"Test expense {amount}",
+        "date": exp_date,
+        "expense_type": expense_type,
+    }
+    if category_id is not None:
+        payload["category_id"] = category_id
+    if notes is not None:
+        payload["notes"] = notes
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201, f"Expense creation failed: {r.get_json()}"
+    return r.get_json()
+
+
+def _add_category(client, auth_header, name: str) -> int:
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201, f"Category creation failed: {r.get_json()}"
+    return r.get_json()["id"]
+
+
+def _get_anomalies(client, auth_header, month: str):
+    return client.get(
+        f"/insights/anomalies?month={month}", headers=auth_header
+    )
+
+
+def _month_str(months_ago: int) -> str:
+    """Return YYYY-MM string for today minus N months."""
+    today = date.today()
+    year, month = today.year, today.month
+    for _ in range(months_ago):
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    return f"{year:04d}-{month:02d}"
+
+
+def _first_day(ym: str) -> str:
+    return f"{ym}-01"
+
+
+# ── Endpoint tests ─────────────────────────────────────────────────────────────
+
+class TestAnomalyDetectionEndpoint:
+    """Basic endpoint contract tests."""
+
+    def test_requires_authentication(self, client):
+        """GET /insights/anomalies without token returns 401."""
+        r = client.get("/insights/anomalies?month=2025-01")
+        assert r.status_code == 401
+
+    def test_returns_200_for_authenticated_user(self, client, auth_header):
+        """Authenticated request returns 200 with expected schema."""
+        ym = _month_str(0)
+        r = _get_anomalies(client, auth_header, ym)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "month" in data
+        assert "anomalies_count" in data
+        assert "has_high_severity" in data
+        assert "anomalies" in data
+        assert isinstance(data["anomalies"], list)
+
+    def test_empty_result_when_no_data(self, client, auth_header):
+        """Returns zero anomalies when user has no expenses."""
+        ym = "2020-01"  # far past, no data
+        r = _get_anomalies(client, auth_header, ym)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["anomalies_count"] == 0
+        assert data["has_high_severity"] is False
+        assert data["anomalies"] == []
+
+    def test_defaults_to_current_month(self, client, auth_header):
+        """When month param is omitted, defaults to current month."""
+        r = client.get("/insights/anomalies", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        expected = date.today().strftime("%Y-%m")
+        assert data["month"] == expected
+
+    def test_month_field_in_response(self, client, auth_header):
+        """Response month matches the queried month."""
+        ym = _month_str(1)
+        r = _get_anomalies(client, auth_header, ym)
+        assert r.status_code == 200
+        assert r.get_json()["month"] == ym
+
+
+# ── Category anomaly tests ─────────────────────────────────────────────────────
+
+class TestCategoryAnomalies:
+    """Tests for category-level anomaly detection."""
+
+    def test_detects_high_severity_spike(self, client, auth_header):
+        """A massive spike in one category is flagged as high severity."""
+        cat_id = _add_category(client, auth_header, "Dining")
+        # Baseline: 2 prior months with ~200 each
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 200.0, _first_day(ym),
+                         category_id=cat_id)
+
+        # Current month: 1500 (huge spike, z >> 2.5)
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 1500.0, _first_day(cur_ym),
+                     category_id=cat_id)
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["anomalies_count"] >= 1
+        cat_anomalies = [a for a in data["anomalies"] if a["type"] == "category"]
+        assert len(cat_anomalies) >= 1
+        top = cat_anomalies[0]
+        assert top["severity"] == "high"
+        assert top["z_score"] > 0
+        assert top["spike_amount"] > 0
+        assert "explanation" in top and len(top["explanation"]) > 10
+
+    def test_no_anomaly_for_stable_spending(self, client, auth_header):
+        """Consistent spending across months does not trigger anomaly."""
+        cat_id = _add_category(client, auth_header, "Groceries")
+        # 3 months of similar spending ~500
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 490.0, _first_day(ym),
+                         category_id=cat_id)
+
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 510.0, _first_day(cur_ym),
+                     category_id=cat_id)
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        assert r.status_code == 200
+        data = r.get_json()
+        # Should not flag a 4% variance
+        cat_anomalies = [
+            a for a in data["anomalies"]
+            if a["type"] == "category" and a["label"] == "Groceries"
+        ]
+        assert len(cat_anomalies) == 0
+
+    def test_anomaly_schema_fields(self, client, auth_header):
+        """Anomaly result contains all required fields."""
+        cat_id = _add_category(client, auth_header, "Entertainment")
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 100.0, _first_day(ym),
+                         category_id=cat_id)
+
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 2000.0, _first_day(cur_ym),
+                     category_id=cat_id)
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        anomalies = [a for a in data["anomalies"] if a["type"] == "category"]
+        assert len(anomalies) >= 1
+        a = anomalies[0]
+        required_fields = [
+            "id", "type", "label", "category_id", "current_spend",
+            "baseline_avg", "baseline_stddev", "z_score",
+            "spike_amount", "spike_percent", "severity", "explanation",
+        ]
+        for field in required_fields:
+            assert field in a, f"Missing field: {field}"
+
+    def test_category_id_present_for_category_anomaly(self, client, auth_header):
+        """Category anomalies include the correct category_id."""
+        cat_id = _add_category(client, auth_header, "Travel")
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 100.0, _first_day(ym),
+                         category_id=cat_id)
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 3000.0, _first_day(cur_ym),
+                     category_id=cat_id)
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        cat_anomalies = [a for a in data["anomalies"]
+                         if a["type"] == "category" and a["label"] == "Travel"]
+        assert len(cat_anomalies) >= 1
+        assert cat_anomalies[0]["category_id"] == cat_id
+
+    def test_no_anomaly_without_baseline(self, client, auth_header):
+        """New category with no history does not trigger anomaly."""
+        cat_id = _add_category(client, auth_header, "NewCategory2099")
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 5000.0, _first_day(cur_ym),
+                     category_id=cat_id)
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        cat_anomalies = [
+            a for a in data["anomalies"]
+            if a.get("label") == "NewCategory2099"
+        ]
+        assert len(cat_anomalies) == 0
+
+
+# ── Merchant anomaly tests ─────────────────────────────────────────────────────
+
+class TestMerchantAnomalies:
+    """Tests for merchant-level (notes-based) anomaly detection."""
+
+    def test_detects_merchant_spike(self, client, auth_header):
+        """A spike at a known merchant is detected."""
+        # Baseline: 2 months of ~300 at "BigMart"
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 300.0, _first_day(ym),
+                         notes="BigMart")
+
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 2500.0, _first_day(cur_ym),
+                     notes="BigMart")
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        merch_anomalies = [a for a in data["anomalies"]
+                           if a["type"] == "merchant" and a["label"] == "BigMart"]
+        assert len(merch_anomalies) >= 1
+        assert merch_anomalies[0]["spike_amount"] > 0
+
+    def test_merchant_anomaly_has_null_category_id(self, client, auth_header):
+        """Merchant anomalies have category_id = null."""
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 200.0, _first_day(ym),
+                         notes="QuickShop")
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 3000.0, _first_day(cur_ym),
+                     notes="QuickShop")
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        merch = [a for a in data["anomalies"]
+                 if a["type"] == "merchant" and a["label"] == "QuickShop"]
+        assert len(merch) >= 1
+        assert merch[0]["category_id"] is None
+
+    def test_no_merchant_anomaly_without_baseline(self, client, auth_header):
+        """First-time merchant spend with no history is not flagged."""
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 9999.0, _first_day(cur_ym),
+                     notes="BrandNewMerchant2099")
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        merch = [a for a in data["anomalies"]
+                 if a.get("label") == "BrandNewMerchant2099"]
+        assert len(merch) == 0
+
+
+# ── Severity ordering tests ────────────────────────────────────────────────────
+
+class TestAnomalyOrdering:
+    """Anomalies are returned sorted by severity then z_score."""
+
+    def test_high_severity_first(self, client, auth_header):
+        """High severity anomaly appears before medium severity."""
+        cat_food = _add_category(client, auth_header, "FoodA")
+        cat_misc = _add_category(client, auth_header, "MiscA")
+
+        # FoodA: moderate spike (medium severity)
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 500.0, _first_day(ym),
+                         category_id=cat_food)
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 1100.0, _first_day(cur_ym),
+                     category_id=cat_food)
+
+        # MiscA: extreme spike (high severity)
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 100.0, _first_day(ym),
+                         category_id=cat_misc)
+        _add_expense(client, auth_header, 9000.0, _first_day(cur_ym),
+                     category_id=cat_misc)
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        anomalies = data["anomalies"]
+        if len(anomalies) >= 2:
+            severities = [a["severity"] for a in anomalies]
+            high_idx = next((i for i, s in enumerate(severities) if s == "high"), None)
+            medium_idx = next((i for i, s in enumerate(severities) if s == "medium"), None)
+            if high_idx is not None and medium_idx is not None:
+                assert high_idx < medium_idx, "High severity should come before medium"
+
+    def test_has_high_severity_flag(self, client, auth_header):
+        """has_high_severity is True when a high-severity anomaly exists."""
+        cat_id = _add_category(client, auth_header, "SpikeCategory")
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 100.0, _first_day(ym),
+                         category_id=cat_id)
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 5000.0, _first_day(cur_ym),
+                     category_id=cat_id)
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        if data["anomalies_count"] > 0:
+            high_found = any(a["severity"] == "high" for a in data["anomalies"])
+            assert data["has_high_severity"] == high_found
+
+    def test_income_expenses_excluded(self, client, auth_header):
+        """INCOME expense_type entries do not contribute to anomalies."""
+        cat_id = _add_category(client, auth_header, "Salary")
+        for m_ago in [3, 2]:
+            ym = _month_str(m_ago)
+            _add_expense(client, auth_header, 1000.0, _first_day(ym),
+                         category_id=cat_id, expense_type="INCOME")
+        cur_ym = _month_str(1)
+        _add_expense(client, auth_header, 50000.0, _first_day(cur_ym),
+                     category_id=cat_id, expense_type="INCOME")
+
+        r = _get_anomalies(client, auth_header, cur_ym)
+        data = r.get_json()
+        salary_anomalies = [
+            a for a in data["anomalies"] if a.get("label") == "Salary"
+        ]
+        assert len(salary_anomalies) == 0


### PR DESCRIPTION
## Summary

Closes #72

Implements a statistical spending anomaly detection engine that flags unusual spikes by category or merchant.

## What was built

**Service** (`app/services/anomaly_detection.py`, 270 lines)

- Z-score based anomaly detection against a 3-month rolling baseline
- Category-level anomalies: compares current month category spend vs baseline avg+stddev
- Merchant-level anomalies: uses the `notes` field as merchant identifier
- Explanation metadata per anomaly (human-readable description of the spike)
- Severity levels: high (z >= 2.5), medium (z >= 1.5); minimum 100 INR absolute threshold to avoid noise
- Results sorted by severity then z_score descending

**Route** (`app/routes/anomaly_detection.py`)

- `GET /insights/anomalies?month=YYYY-MM`
- JWT-protected, defaults to current month
- Returns: month, anomalies_count, has_high_severity flag, anomalies list

**Each anomaly includes:**
- id, type (category/merchant), label, category_id
- current_spend, baseline_avg, baseline_stddev, z_score
- spike_amount, spike_percent
- severity (high/medium/low)
- explanation (human-readable metadata)

**Tests** (`tests/test_anomaly_detection.py`, 16 tests)

- Auth guard (401 without token)
- Empty state (no data returns empty list)
- Current month default behavior
- Response schema validation
- Category spike detection (high severity)
- Stable spending does not trigger false positives
- All anomaly fields present
- category_id populated for category anomalies
- Merchant spike detection
- Merchant anomaly has null category_id
- No anomaly for new merchant/category without baseline
- High severity appears before medium in sorted results
- has_high_severity flag accuracy
- INCOME expense_type excluded from anomaly detection

## Acceptance Criteria

- Flags anomalies vs baseline: YES (z-score against 3-month rolling mean/stddev)
- Includes explanation metadata: YES (explanation field with human-readable description of the spike)