### PR TITLE
feat: dynamic budget suggestions using 3-6 month baseline (#73)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .budget_suggestions import bp as budget_suggestions_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(budget_suggestions_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/budget_suggestions.py
+++ b/packages/backend/app/routes/budget_suggestions.py
@@ -1,0 +1,34 @@
+"""Route: GET /insights/budget-suggestions — Dynamic Budget Suggestions (#73)."""
+from __future__ import annotations
+
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.budget_suggestions import get_budget_suggestions
+
+bp = Blueprint("budget_suggestions", __name__)
+
+
+@bp.get("/budget-suggestions")
+@jwt_required()
+def get_suggestions():
+    """Return dynamic budget suggestions for the authenticated user.
+
+    Query params:
+      month (str, optional): YYYY-MM anchor month. Defaults to current month.
+        The service analyses the MAX_MONTHS (6) months prior to this anchor.
+
+    Returns 200 with:
+      {
+        "reference_months": ["YYYY-MM", ...],
+        "suggestions_count": int,
+        "suggestions": [ BudgetSuggestion, ... ]
+      }
+    """
+    uid = int(get_jwt_identity())
+    anchor = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
+
+    result = get_budget_suggestions(uid, anchor)
+    return jsonify(result), 200

--- a/packages/backend/app/services/budget_suggestions.py
+++ b/packages/backend/app/services/budget_suggestions.py
@@ -1,0 +1,201 @@
+"""
+Dynamic Budget Suggestions — FinMind (#73)
+
+Suggests monthly budget limits per category using 3-6 months of
+historical spending data. Includes a confidence score based on
+data completeness.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from decimal import Decimal
+from typing import TypedDict
+
+from sqlalchemy import func, extract
+
+from ..extensions import db
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.budget_suggestions")
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+MIN_MONTHS = 3         # minimum months of data to generate a suggestion
+MAX_MONTHS = 6         # maximum months used for baseline
+BUFFER_RATIO = 1.10    # suggested budget = avg * 1.10 (10% buffer)
+STDDEV_BUFFER = 0.5    # suggested budget += 0.5 * stddev for variance
+
+
+class BudgetSuggestion(TypedDict):
+    category_id: int | None
+    category_name: str
+    avg_monthly_spend: float
+    stddev_monthly_spend: float
+    suggested_budget: float
+    confidence_score: float      # 0.0 - 1.0 based on months of data
+    months_of_data: int
+    rationale: str
+
+
+class BudgetSuggestionsResult(TypedDict):
+    reference_months: list[str]
+    suggestions_count: int
+    suggestions: list[BudgetSuggestion]
+
+
+# ── Internal helpers ───────────────────────────────────────────────────────────
+
+def _prior_months(anchor_ym: str, n: int) -> list[str]:
+    """Return the n months preceding anchor_ym (oldest first)."""
+    year, month = int(anchor_ym[:4]), int(anchor_ym[5:7])
+    result: list[str] = []
+    for _ in range(n):
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+        result.append(f"{year:04d}-{month:02d}")
+    return list(reversed(result))  # oldest first
+
+
+def _category_monthly_spend(uid: int, months: list[str]) -> dict[int, dict]:
+    """Return per-category monthly totals across the given month list.
+
+    Returns {
+      category_id: {
+        "name": str,
+        "monthly": {ym: Decimal}   # only months with data
+      }
+    }
+    """
+    categories: dict[int, dict] = {}
+    for ym in months:
+        year, month = int(ym[:4]), int(ym[5:7])
+        rows = (
+            db.session.query(
+                Expense.category_id,
+                Category.name,
+                func.sum(Expense.amount).label("total"),
+            )
+            .outerjoin(Category, Category.id == Expense.category_id)
+            .filter(
+                Expense.user_id == uid,
+                Expense.expense_type == "EXPENSE",
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+            )
+            .group_by(Expense.category_id, Category.name)
+            .all()
+        )
+        for row in rows:
+            if row.category_id not in categories:
+                categories[row.category_id] = {
+                    "name": row.name or "Uncategorized",
+                    "monthly": {},
+                }
+            categories[row.category_id]["monthly"][ym] = Decimal(str(row.total))
+    return categories
+
+
+def _compute_suggestion(cat_info: dict, months: list[str]) -> tuple[float, float, float, float, int]:
+    """Return (avg, stddev, suggested_budget, confidence, months_of_data)."""
+    monthly = cat_info["monthly"]
+    # Fill zero for months with no data
+    values = [float(monthly.get(ym, Decimal("0"))) for ym in months]
+    # Count non-zero months
+    non_zero = [v for v in values if v > 0]
+    months_of_data = len(non_zero)
+
+    if months_of_data == 0:
+        return 0.0, 0.0, 0.0, 0.0, 0
+
+    n = len(non_zero)
+    avg = sum(non_zero) / n
+    if n == 1:
+        stddev = avg * 0.2  # conservative estimate for single data point
+    else:
+        variance = sum((x - avg) ** 2 for x in non_zero) / (n - 1)
+        stddev = math.sqrt(variance)
+
+    # Suggested budget: avg * buffer + partial stddev
+    suggested = avg * BUFFER_RATIO + stddev * STDDEV_BUFFER
+    # Round up to nearest 100 for cleanliness
+    suggested = math.ceil(suggested / 100) * 100 if suggested > 100 else math.ceil(suggested / 10) * 10
+
+    # Confidence: based on months of data vs MAX_MONTHS
+    # Full confidence (1.0) requires MAX_MONTHS data points
+    confidence = min(months_of_data / MAX_MONTHS, 1.0)
+
+    return round(avg, 2), round(stddev, 2), round(float(suggested), 2), round(confidence, 2), months_of_data
+
+
+def _rationale(avg: float, stddev: float, confidence: float, months: int) -> str:
+    """Generate a human-readable rationale for the suggestion."""
+    cv = stddev / avg if avg > 0 else 0  # coefficient of variation
+    if confidence < 0.5:
+        stability = "limited data"
+    elif cv < 0.15:
+        stability = "highly consistent"
+    elif cv < 0.35:
+        stability = "moderately variable"
+    else:
+        stability = "highly variable"
+
+    conf_pct = int(confidence * 100)
+    return (
+        f"Based on {months} month(s) of data ({stability} spending). "
+        f"Average: {avg:.0f}, variance buffer applied. "
+        f"Confidence: {conf_pct}%."
+    )
+
+
+# ── Public API ─────────────────────────────────────────────────────────────────
+
+def get_budget_suggestions(uid: int, anchor_ym: str) -> BudgetSuggestionsResult:
+    """Generate dynamic budget suggestions for user *uid*.
+
+    Uses up to MAX_MONTHS (6) months of data prior to *anchor_ym* (YYYY-MM).
+    Only suggests budgets for categories with at least MIN_MONTHS data points.
+
+    Returns BudgetSuggestionsResult with sorted list of suggestions (highest
+    avg spend first) and confidence scores.
+    """
+    reference_months = _prior_months(anchor_ym, MAX_MONTHS)
+    category_data = _category_monthly_spend(uid, reference_months)
+
+    suggestions: list[BudgetSuggestion] = []
+
+    for cat_id, cat_info in category_data.items():
+        avg, stddev, suggested, confidence, months_of_data = _compute_suggestion(
+            cat_info, reference_months
+        )
+        if months_of_data < MIN_MONTHS:
+            # Not enough data for a reliable suggestion
+            continue
+        if avg <= 0:
+            continue
+
+        suggestions.append(BudgetSuggestion(
+            category_id=cat_id,
+            category_name=cat_info["name"],
+            avg_monthly_spend=avg,
+            stddev_monthly_spend=stddev,
+            suggested_budget=suggested,
+            confidence_score=confidence,
+            months_of_data=months_of_data,
+            rationale=_rationale(avg, stddev, confidence, months_of_data),
+        ))
+
+    # Sort by avg_monthly_spend descending (highest spend categories first)
+    suggestions.sort(key=lambda s: -s["avg_monthly_spend"])
+
+    logger.info(
+        "budget_suggestions uid=%d anchor=%s months=%d suggestions=%d",
+        uid, anchor_ym, len(reference_months), len(suggestions),
+    )
+
+    return BudgetSuggestionsResult(
+        reference_months=reference_months,
+        suggestions_count=len(suggestions),
+        suggestions=suggestions,
+    )

--- a/packages/backend/tests/test_budget_suggestions.py
+++ b/packages/backend/tests/test_budget_suggestions.py
@@ -1,0 +1,234 @@
+"""Tests for Dynamic Budget Suggestions (#73)."""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _add_expense(client, auth_header, amount: float, exp_date: str,
+                 category_id: int | None = None, expense_type: str = "EXPENSE"):
+    payload = {
+        "amount": amount,
+        "description": f"Test expense {amount}",
+        "date": exp_date,
+        "expense_type": expense_type,
+    }
+    if category_id is not None:
+        payload["category_id"] = category_id
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201, r.get_json()
+    return r.get_json()
+
+
+def _add_category(client, auth_header, name: str) -> int:
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201, r.get_json()
+    return r.get_json()["id"]
+
+
+def _get_suggestions(client, auth_header, month: str):
+    return client.get(
+        f"/insights/budget-suggestions?month={month}", headers=auth_header
+    )
+
+
+def _month_str(months_ago: int = 0) -> str:
+    today = date.today()
+    year, month = today.year, today.month
+    for _ in range(months_ago):
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    return f"{year:04d}-{month:02d}"
+
+
+def _first_day(ym: str) -> str:
+    return f"{ym}-01"
+
+
+# ── Endpoint tests ─────────────────────────────────────────────────────────────
+
+class TestBudgetSuggestionsEndpoint:
+
+    def test_requires_authentication(self, client):
+        """Without token, returns 401."""
+        r = client.get("/insights/budget-suggestions")
+        assert r.status_code == 401
+
+    def test_returns_200_for_authenticated_user(self, client, auth_header):
+        """Authenticated request returns 200 with expected schema."""
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "reference_months" in data
+        assert "suggestions_count" in data
+        assert "suggestions" in data
+        assert isinstance(data["suggestions"], list)
+        assert isinstance(data["reference_months"], list)
+
+    def test_no_suggestions_without_enough_data(self, client, auth_header):
+        """Returns empty suggestions when user has fewer than MIN_MONTHS of data."""
+        # Add data for only 1 month (min is 3)
+        cat_id = _add_category(client, auth_header, "GroceriesTest99")
+        _add_expense(client, auth_header, 500.0, _first_day(_month_str(1)),
+                     category_id=cat_id)
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        assert r.status_code == 200
+        data = r.get_json()
+        # Category with only 1 month of data should NOT produce a suggestion
+        cat_suggestions = [
+            s for s in data["suggestions"] if s["category_name"] == "GroceriesTest99"
+        ]
+        assert len(cat_suggestions) == 0
+
+    def test_defaults_to_current_month(self, client, auth_header):
+        """Omitting month param uses current month as anchor."""
+        r = client.get("/insights/budget-suggestions", headers=auth_header)
+        assert r.status_code == 200
+
+    def test_reference_months_has_six_entries(self, client, auth_header):
+        """reference_months always contains exactly 6 entries (MAX_MONTHS)."""
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        assert len(data["reference_months"]) == 6
+
+    def test_reference_months_format(self, client, auth_header):
+        """reference_months entries are YYYY-MM strings."""
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        for ym in r.get_json()["reference_months"]:
+            assert len(ym) == 7
+            assert ym[4] == "-"
+            assert ym[:4].isdigit()
+            assert ym[5:].isdigit()
+
+
+# ── Suggestion quality tests ───────────────────────────────────────────────────
+
+class TestSuggestionQuality:
+
+    def _seed_3_months(self, client, auth_header, cat_id: int, amounts: list[float]):
+        """Seed 3 months of data (oldest to newest) for a category."""
+        for i, amount in enumerate(amounts):
+            ym = _month_str(3 - i)  # 3 months ago, 2 months ago, 1 month ago
+            _add_expense(client, auth_header, amount, _first_day(ym),
+                         category_id=cat_id)
+
+    def test_generates_suggestion_with_3_months_data(self, client, auth_header):
+        """Category with exactly 3 months of data produces a suggestion."""
+        cat_id = _add_category(client, auth_header, "FoodGen3M")
+        self._seed_3_months(client, auth_header, cat_id, [500.0, 480.0, 520.0])
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        cat_sug = [s for s in data["suggestions"] if s["category_name"] == "FoodGen3M"]
+        assert len(cat_sug) == 1
+
+    def test_suggestion_schema(self, client, auth_header):
+        """Suggestion contains all required fields."""
+        cat_id = _add_category(client, auth_header, "RentSchema")
+        self._seed_3_months(client, auth_header, cat_id, [10000.0, 10000.0, 10000.0])
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        cat_sug = [s for s in data["suggestions"] if s["category_name"] == "RentSchema"]
+        assert len(cat_sug) >= 1
+        s = cat_sug[0]
+        required = [
+            "category_id", "category_name", "avg_monthly_spend",
+            "stddev_monthly_spend", "suggested_budget", "confidence_score",
+            "months_of_data", "rationale",
+        ]
+        for field in required:
+            assert field in s, f"Missing field: {field}"
+
+    def test_suggested_budget_above_average(self, client, auth_header):
+        """Suggested budget is always >= average monthly spend (includes buffer)."""
+        cat_id = _add_category(client, auth_header, "DiningBudget")
+        self._seed_3_months(client, auth_header, cat_id, [300.0, 350.0, 320.0])
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        cat_sug = [s for s in data["suggestions"] if s["category_name"] == "DiningBudget"]
+        assert len(cat_sug) >= 1
+        s = cat_sug[0]
+        assert s["suggested_budget"] >= s["avg_monthly_spend"]
+
+    def test_confidence_score_range(self, client, auth_header):
+        """Confidence score is always between 0 and 1."""
+        cat_id = _add_category(client, auth_header, "ConfidenceTest")
+        self._seed_3_months(client, auth_header, cat_id, [200.0, 210.0, 190.0])
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        for s in data["suggestions"]:
+            assert 0.0 <= s["confidence_score"] <= 1.0, (
+                f"Confidence out of range: {s['confidence_score']}"
+            )
+
+    def test_confidence_increases_with_more_months(self, client, auth_header):
+        """3 months of data has lower confidence than 6 months."""
+        # 3 months of data -> confidence = 3/6 = 0.5
+        cat_id = _add_category(client, auth_header, "ConfLow3M")
+        self._seed_3_months(client, auth_header, cat_id, [400.0, 420.0, 410.0])
+
+        # 6 months of data -> confidence = 6/6 = 1.0
+        cat_id2 = _add_category(client, auth_header, "ConfHigh6M")
+        for i in range(1, 7):
+            ym = _month_str(i)
+            _add_expense(client, auth_header, 500.0, _first_day(ym), category_id=cat_id2)
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        low_conf = next((s for s in data["suggestions"] if s["category_name"] == "ConfLow3M"), None)
+        high_conf = next((s for s in data["suggestions"] if s["category_name"] == "ConfHigh6M"), None)
+
+        if low_conf and high_conf:
+            assert low_conf["confidence_score"] < high_conf["confidence_score"]
+
+    def test_rationale_is_non_empty_string(self, client, auth_header):
+        """Every suggestion has a non-empty rationale string."""
+        cat_id = _add_category(client, auth_header, "RationaleTest")
+        self._seed_3_months(client, auth_header, cat_id, [500.0, 480.0, 510.0])
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        for s in data["suggestions"]:
+            assert isinstance(s["rationale"], str)
+            assert len(s["rationale"]) > 0
+
+    def test_suggestions_sorted_by_avg_spend_desc(self, client, auth_header):
+        """Suggestions are sorted highest avg_monthly_spend first."""
+        cat_high = _add_category(client, auth_header, "HighSpend")
+        cat_low = _add_category(client, auth_header, "LowSpend")
+        self._seed_3_months(client, auth_header, cat_high, [2000.0, 1900.0, 2100.0])
+        self._seed_3_months(client, auth_header, cat_low, [100.0, 110.0, 90.0])
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        avgs = [s["avg_monthly_spend"] for s in data["suggestions"]]
+        # Should be in descending order
+        assert avgs == sorted(avgs, reverse=True)
+
+    def test_income_excluded_from_suggestions(self, client, auth_header):
+        """INCOME type expenses do not generate budget suggestions."""
+        cat_id = _add_category(client, auth_header, "SalaryIncome")
+        for i in range(1, 4):
+            ym = _month_str(i)
+            _add_expense(client, auth_header, 50000.0, _first_day(ym),
+                         category_id=cat_id, expense_type="INCOME")
+
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        income_sug = [s for s in data["suggestions"] if s["category_name"] == "SalaryIncome"]
+        assert len(income_sug) == 0
+
+    def test_suggestions_count_matches_list_length(self, client, auth_header):
+        """suggestions_count field equals len(suggestions)."""
+        r = _get_suggestions(client, auth_header, _month_str(0))
+        data = r.get_json()
+        assert data["suggestions_count"] == len(data["suggestions"])


### PR DESCRIPTION
## Summary

Closes #73

Implements a dynamic budget suggestion engine that analyzes 3-6 months of spending history per category and recommends monthly budget limits with confidence scores.

## What was built

**Service** (`app/services/budget_suggestions.py`, 201 lines)

- Analyses up to 6 prior months of EXPENSE data per category
- Only generates suggestions when a category has >= 3 months of data (configurable MIN_MONTHS)
- Suggested budget formula: `avg * 1.10 + 0.5 * stddev` rounded up to nearest 100 INR
- Confidence score: `months_of_data / MAX_MONTHS` (range 0.0-1.0; full confidence = 6 months)
- Human-readable rationale per suggestion (data stability, confidence %)
- Results sorted by avg_monthly_spend descending (highest-priority categories first)

**Route** (`app/routes/budget_suggestions.py`)

- `GET /insights/budget-suggestions?month=YYYY-MM`
- JWT-protected, anchor month defaults to current month
- Returns reference_months list (6 months prior to anchor), suggestions_count, suggestions

**Each suggestion includes:**
- category_id, category_name
- avg_monthly_spend, stddev_monthly_spend
- suggested_budget (always >= avg)
- confidence_score (0.0-1.0)
- months_of_data
- rationale (human-readable explanation)

**Tests** (`tests/test_budget_suggestions.py`, 14 tests)

- Auth guard, schema validation, empty state
- No suggestions without enough data (<3 months)
- 3-month threshold generates suggestion
- suggested_budget >= avg_monthly_spend (buffer always applied)
- confidence_score in [0.0, 1.0] range
- Confidence increases with more months of data (3 < 6)
- Rationale is non-empty string
- Suggestions sorted by avg_monthly_spend descending
- INCOME expense_type excluded
- suggestions_count matches len(suggestions)

## Acceptance Criteria

- Uses 3-6 month data: YES (MIN_MONTHS=3, MAX_MONTHS=6)
- Provides confidence score: YES (months_of_data / MAX_MONTHS, 0.0-1.0 range)