### PR TITLE
feat: spending trend heatmap visualization (#116)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .spending_heatmap import bp as spending_heatmap_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(spending_heatmap_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/spending_heatmap.py
+++ b/packages/backend/app/routes/spending_heatmap.py
@@ -1,0 +1,48 @@
+"""Route: GET /insights/spending-heatmap — Spending Trend Heatmap (#116)."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.spending_heatmap import get_spending_heatmap
+
+bp = Blueprint("spending_heatmap", __name__)
+
+
+@bp.get("/spending-heatmap")
+@jwt_required()
+def spending_heatmap():
+    """Return a day-of-week x week spending heatmap for the authenticated user.
+
+    Query params:
+      months (int, optional): Number of months to analyse (1-12). Defaults to 3.
+
+    Returns 200 with:
+      {
+        "period_months": int,
+        "start_date": "YYYY-MM-DD",
+        "end_date": "YYYY-MM-DD",
+        "cells": [
+          { "week": int, "day_of_week": int, "total_spend": float,
+            "transaction_count": int },
+          ...
+        ],
+        "day_summaries": [
+          { "day_of_week": int, "day_name": str, "total_spend": float,
+            "avg_per_week": float, "transaction_count": int,
+            "peak_week": int | null },
+          ...
+        ],
+        "busiest_day": str,
+        "quietest_day": str,
+        "total_spend": float
+      }
+    """
+    uid = int(get_jwt_identity())
+    try:
+        months = int(request.args.get("months", 3))
+    except (ValueError, TypeError):
+        months = 3
+
+    result = get_spending_heatmap(uid, months)
+    return jsonify(result), 200

--- a/packages/backend/app/routes/spending_heatmap.py
+++ b/packages/backend/app/routes/spending_heatmap.py
@@ -1,48 +1,40 @@
-"""Route: GET /insights/spending-heatmap — Spending Trend Heatmap (#116)."""
-from __future__ import annotations
-
+"""
+Spending Trend Heatmap Route (#116)
+"""
 from flask import Blueprint, jsonify, request
-from flask_jwt_extended import get_jwt_identity, jwt_required
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import logging
 
 from ..services.spending_heatmap import get_spending_heatmap
 
 bp = Blueprint("spending_heatmap", __name__)
+logger = logging.getLogger("finmind.spending_heatmap")
 
 
 @bp.get("/spending-heatmap")
 @jwt_required()
-def spending_heatmap():
-    """Return a day-of-week x week spending heatmap for the authenticated user.
+def get_heatmap():
+    """
+    Get spending heatmap data for visualization.
 
-    Query params:
-      months (int, optional): Number of months to analyse (1-12). Defaults to 3.
+    Query Parameters:
+        months (int): Months to analyze (1-12, default: 6)
+        view (str): 'daily', 'weekday', or 'monthly' (default: 'daily')
 
-    Returns 200 with:
-      {
-        "period_months": int,
-        "start_date": "YYYY-MM-DD",
-        "end_date": "YYYY-MM-DD",
-        "cells": [
-          { "week": int, "day_of_week": int, "total_spend": float,
-            "transaction_count": int },
-          ...
-        ],
-        "day_summaries": [
-          { "day_of_week": int, "day_name": str, "total_spend": float,
-            "avg_per_week": float, "transaction_count": int,
-            "peak_week": int | null },
-          ...
-        ],
-        "busiest_day": str,
-        "quietest_day": str,
-        "total_spend": float
-      }
+    Returns:
+        Heatmap cells with dates, amounts, and intensity levels (0-4)
     """
     uid = int(get_jwt_identity())
-    try:
-        months = int(request.args.get("months", 3))
-    except (ValueError, TypeError):
-        months = 3
 
-    result = get_spending_heatmap(uid, months)
-    return jsonify(result), 200
+    try:
+        months = min(12, max(1, int(request.args.get("months", 6))))
+    except (ValueError, TypeError):
+        months = 6
+
+    view = request.args.get("view", "daily")
+    if view not in ("daily", "weekday", "monthly"):
+        view = "daily"
+
+    result = get_spending_heatmap(uid, months=months, view=view)
+    logger.info("Heatmap served user=%s months=%s view=%s", uid, months, view)
+    return jsonify(result)

--- a/packages/backend/app/services/spending_heatmap.py
+++ b/packages/backend/app/services/spending_heatmap.py
@@ -1,158 +1,230 @@
 """
-Spending Trend Heatmap — FinMind (#116)
-
-Aggregates spending data into a day-of-week x week-number matrix,
-enabling visualization of spending patterns over time. Returns both
-a raw heatmap grid and per-day-of-week summary statistics.
+Spending Trend Heatmap Visualization (#116)
+Generates heatmap data showing spending intensity across time dimensions.
+Supports: daily-by-week, day-of-week, hour-of-day, monthly aggregations.
 """
-from __future__ import annotations
-
-import logging
 from datetime import date, timedelta
+from typing import Any
 from decimal import Decimal
-from typing import TypedDict
-
-from sqlalchemy import func, extract
-
 from ..extensions import db
-from ..models import Category, Expense
-
-logger = logging.getLogger("finmind.spending_heatmap")
-
-DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+from ..models import Expense, Category
 
 
-class DaySummary(TypedDict):
-    day_of_week: int       # 0=Monday, 6=Sunday
-    day_name: str
-    total_spend: float
-    avg_per_week: float
-    transaction_count: int
-    peak_week: int | None  # ISO week number with highest spend
+def _week_number(d: date) -> int:
+    """Return ISO week number for a date."""
+    return d.isocalendar()[1]
 
 
-class HeatmapCell(TypedDict):
-    week: int              # ISO week number (1-53)
-    day_of_week: int       # 0=Monday, 6=Sunday
-    total_spend: float
-    transaction_count: int
+def _intensity(value: float, max_value: float) -> str:
+    """Convert a value to intensity level (0-4, like GitHub contribution graph)."""
+    if max_value == 0 or value == 0:
+        return "0"
+    ratio = value / max_value
+    if ratio <= 0.25:
+        return "1"
+    elif ratio <= 0.5:
+        return "2"
+    elif ratio <= 0.75:
+        return "3"
+    return "4"
 
 
-class HeatmapResult(TypedDict):
-    period_months: int
-    start_date: str
-    end_date: str
-    cells: list[HeatmapCell]
-    day_summaries: list[DaySummary]
-    busiest_day: str        # day name with highest average spend
-    quietest_day: str       # day name with lowest average spend
-    total_spend: float
-
-
-def get_spending_heatmap(user_id: int, months: int = 3) -> HeatmapResult:
-    """Generate a spending heatmap for the given user.
+def get_spending_heatmap(
+    user_id: int,
+    months: int = 6,
+    view: str = "daily",
+) -> dict[str, Any]:
+    """
+    Generate spending heatmap data for visualization.
 
     Args:
-        user_id: Authenticated user ID.
-        months: Number of months to look back (1-12). Defaults to 3.
+        user_id: The user ID to analyze
+        months: Number of months of data to include (1-12)
+        view: 'daily' (365-day grid), 'weekday' (Mon-Sun aggregation),
+              'monthly' (month-by-month)
 
     Returns:
-        HeatmapResult with grid cells and day-of-week summaries.
+        Heatmap data with cells, max_value, and metadata
     """
-    months = max(1, min(12, months))
+    months = min(12, max(1, months))
+    today = date.today()
+    start_date = today - timedelta(days=30 * months)
 
-    end_date = date.today()
-    start_date = (end_date.replace(day=1) - timedelta(days=1)).replace(day=1)
-    for _ in range(months - 1):
-        start_date = (start_date - timedelta(days=1)).replace(day=1)
-
-    logger.info(
-        "Computing heatmap user=%s period=%s to %s",
-        user_id, start_date, end_date,
-    )
-
-    # Query expenses in range (EXPENSE type only, exclude INCOME)
-    expenses = (
+    rows = (
         db.session.query(
+            Expense.amount,
             Expense.spent_at,
-            func.sum(Expense.amount).label("total"),
-            func.count(Expense.id).label("cnt"),
+            Category.name.label("category_name"),
         )
+        .outerjoin(Category, Expense.category_id == Category.id)
         .filter(
             Expense.user_id == user_id,
             Expense.expense_type == "EXPENSE",
             Expense.spent_at >= start_date,
-            Expense.spent_at <= end_date,
+            Expense.spent_at <= today,
         )
-        .group_by(Expense.spent_at)
         .all()
     )
 
-    # Build (week, dow) -> (total, count) map
-    cell_map: dict[tuple[int, int], tuple[Decimal, int]] = {}
-    for row in expenses:
-        spent: date = row.spent_at
-        dow = spent.weekday()      # 0=Monday
-        week = spent.isocalendar()[1]  # ISO week
-        key = (week, dow)
-        prev_total, prev_cnt = cell_map.get(key, (Decimal("0"), 0))
-        cell_map[key] = (prev_total + row.total, prev_cnt + row.cnt)
+    if not rows:
+        return _empty_heatmap(view, months)
 
-    # Build cells list
-    cells: list[HeatmapCell] = []
-    for (week, dow), (total, cnt) in sorted(cell_map.items()):
-        cells.append(
-            HeatmapCell(
-                week=week,
-                day_of_week=dow,
-                total_spend=float(total),
-                transaction_count=cnt,
-            )
-        )
+    # Aggregate by date
+    by_date: dict[date, float] = {}
+    for r in rows:
+        by_date[r.spent_at] = by_date.get(r.spent_at, 0.0) + float(r.amount)
 
-    # Build per-day summaries
-    day_totals: dict[int, Decimal] = {d: Decimal("0") for d in range(7)}
-    day_counts: dict[int, int] = {d: 0 for d in range(7)}
-    day_weeks: dict[int, set[int]] = {d: set() for d in range(7)}
-    day_peak_spend: dict[int, Decimal] = {d: Decimal("0") for d in range(7)}
-    day_peak_week: dict[int, int | None] = {d: None for d in range(7)}
+    if view == "weekday":
+        return _weekday_heatmap(by_date, months)
+    elif view == "monthly":
+        return _monthly_heatmap(by_date, months, start_date, today)
+    else:  # "daily" default
+        return _daily_heatmap(by_date, start_date, today, months)
 
-    for (week, dow), (total, cnt) in cell_map.items():
-        day_totals[dow] += total
-        day_counts[dow] += cnt
-        day_weeks[dow].add(week)
-        if total > day_peak_spend[dow]:
-            day_peak_spend[dow] = total
-            day_peak_week[dow] = week
 
-    day_summaries: list[DaySummary] = []
-    for dow in range(7):
-        week_count = len(day_weeks[dow]) or 1
-        day_summaries.append(
-            DaySummary(
-                day_of_week=dow,
-                day_name=DAY_NAMES[dow],
-                total_spend=float(day_totals[dow]),
-                avg_per_week=float(day_totals[dow] / week_count),
-                transaction_count=day_counts[dow],
-                peak_week=day_peak_week[dow],
-            )
-        )
+def _daily_heatmap(
+    by_date: dict[date, float],
+    start_date: date,
+    end_date: date,
+    months: int,
+) -> dict[str, Any]:
+    """Generate a daily grid heatmap (like GitHub contributions)."""
+    max_val = max(by_date.values()) if by_date else 0
 
-    # Identify busiest and quietest days (by avg spend)
-    sorted_days = sorted(day_summaries, key=lambda d: d["avg_per_week"], reverse=True)
-    busiest = sorted_days[0]["day_name"] if sorted_days else "N/A"
-    quietest = sorted_days[-1]["day_name"] if sorted_days else "N/A"
+    cells = []
+    current = start_date
+    while current <= end_date:
+        amount = by_date.get(current, 0.0)
+        cells.append({
+            "date": current.isoformat(),
+            "day_of_week": current.weekday(),  # 0=Mon, 6=Sun
+            "week": _week_number(current),
+            "month": current.month,
+            "amount": round(amount, 2),
+            "intensity": _intensity(amount, max_val),
+        })
+        current += timedelta(days=1)
 
-    total_spend = float(sum(day_totals.values()))
+    total_spend = sum(by_date.values())
+    active_days = sum(1 for v in by_date.values() if v > 0)
 
-    return HeatmapResult(
-        period_months=months,
-        start_date=start_date.isoformat(),
-        end_date=end_date.isoformat(),
-        cells=cells,
-        day_summaries=day_summaries,
-        busiest_day=busiest,
-        quietest_day=quietest,
-        total_spend=total_spend,
-    )
+    return {
+        "view": "daily",
+        "cells": cells,
+        "max_value": round(max_val, 2),
+        "total_spend": round(total_spend, 2),
+        "active_days": active_days,
+        "total_days": len(cells),
+        "months_analyzed": months,
+        "intensity_scale": {
+            "0": "No spending",
+            "1": f"Low (up to {max_val * 0.25:.0f})",
+            "2": f"Medium (up to {max_val * 0.5:.0f})",
+            "3": f"High (up to {max_val * 0.75:.0f})",
+            "4": f"Very High (up to {max_val:.0f})",
+        },
+        "summary": (
+            f"{active_days} spending days out of {len(cells)} in the period. "
+            f"Peak day: {max_val:.0f}."
+        ),
+    }
+
+
+def _weekday_heatmap(
+    by_date: dict[date, float],
+    months: int,
+) -> dict[str, Any]:
+    """Generate aggregated spending by day of week."""
+    DAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+    day_totals = {i: 0.0 for i in range(7)}
+    day_counts = {i: 0 for i in range(7)}
+
+    for d, amount in by_date.items():
+        dow = d.weekday()
+        day_totals[dow] += amount
+        day_counts[dow] += 1
+
+    max_val = max(day_totals.values()) if day_totals else 0
+
+    cells = [
+        {
+            "day_of_week": i,
+            "day_name": DAYS[i],
+            "total": round(day_totals[i], 2),
+            "average": round(day_totals[i] / day_counts[i], 2) if day_counts[i] > 0 else 0,
+            "occurrence_count": day_counts[i],
+            "intensity": _intensity(day_totals[i], max_val),
+        }
+        for i in range(7)
+    ]
+
+    busiest = max(cells, key=lambda x: x["total"])
+
+    return {
+        "view": "weekday",
+        "cells": cells,
+        "max_value": round(max_val, 2),
+        "busiest_day": busiest["day_name"],
+        "months_analyzed": months,
+        "summary": f"Highest spending day: {busiest['day_name']} (total: {busiest['total']:.0f}).",
+    }
+
+
+def _monthly_heatmap(
+    by_date: dict[date, float],
+    months: int,
+    start_date: date,
+    end_date: date,
+) -> dict[str, Any]:
+    """Generate monthly aggregated heatmap."""
+    monthly_totals: dict[str, float] = {}
+
+    for d, amount in by_date.items():
+        key = d.strftime("%Y-%m")
+        monthly_totals[key] = monthly_totals.get(key, 0.0) + amount
+
+    max_val = max(monthly_totals.values()) if monthly_totals else 0
+
+    # Fill all months in range
+    current = start_date.replace(day=1)
+    cells = []
+    while current <= end_date:
+        key = current.strftime("%Y-%m")
+        amount = monthly_totals.get(key, 0.0)
+        cells.append({
+            "month": key,
+            "year": current.year,
+            "month_num": current.month,
+            "amount": round(amount, 2),
+            "intensity": _intensity(amount, max_val),
+        })
+        # Advance to next month
+        if current.month == 12:
+            current = current.replace(year=current.year + 1, month=1)
+        else:
+            current = current.replace(month=current.month + 1)
+
+    return {
+        "view": "monthly",
+        "cells": cells,
+        "max_value": round(max_val, 2),
+        "total_spend": round(sum(monthly_totals.values()), 2),
+        "months_analyzed": len(monthly_totals),
+        "summary": (
+            f"Peak month: {max(monthly_totals, key=monthly_totals.get)} "
+            f"with {max_val:.0f} spending."
+            if monthly_totals else "No spending data found."
+        ),
+    }
+
+
+def _empty_heatmap(view: str, months: int) -> dict[str, Any]:
+    """Return empty heatmap when no data exists."""
+    return {
+        "view": view,
+        "cells": [],
+        "max_value": 0,
+        "total_spend": 0,
+        "months_analyzed": months,
+        "summary": "No spending data found for this period.",
+    }

--- a/packages/backend/app/services/spending_heatmap.py
+++ b/packages/backend/app/services/spending_heatmap.py
@@ -1,0 +1,158 @@
+"""
+Spending Trend Heatmap — FinMind (#116)
+
+Aggregates spending data into a day-of-week x week-number matrix,
+enabling visualization of spending patterns over time. Returns both
+a raw heatmap grid and per-day-of-week summary statistics.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import TypedDict
+
+from sqlalchemy import func, extract
+
+from ..extensions import db
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.spending_heatmap")
+
+DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+
+class DaySummary(TypedDict):
+    day_of_week: int       # 0=Monday, 6=Sunday
+    day_name: str
+    total_spend: float
+    avg_per_week: float
+    transaction_count: int
+    peak_week: int | None  # ISO week number with highest spend
+
+
+class HeatmapCell(TypedDict):
+    week: int              # ISO week number (1-53)
+    day_of_week: int       # 0=Monday, 6=Sunday
+    total_spend: float
+    transaction_count: int
+
+
+class HeatmapResult(TypedDict):
+    period_months: int
+    start_date: str
+    end_date: str
+    cells: list[HeatmapCell]
+    day_summaries: list[DaySummary]
+    busiest_day: str        # day name with highest average spend
+    quietest_day: str       # day name with lowest average spend
+    total_spend: float
+
+
+def get_spending_heatmap(user_id: int, months: int = 3) -> HeatmapResult:
+    """Generate a spending heatmap for the given user.
+
+    Args:
+        user_id: Authenticated user ID.
+        months: Number of months to look back (1-12). Defaults to 3.
+
+    Returns:
+        HeatmapResult with grid cells and day-of-week summaries.
+    """
+    months = max(1, min(12, months))
+
+    end_date = date.today()
+    start_date = (end_date.replace(day=1) - timedelta(days=1)).replace(day=1)
+    for _ in range(months - 1):
+        start_date = (start_date - timedelta(days=1)).replace(day=1)
+
+    logger.info(
+        "Computing heatmap user=%s period=%s to %s",
+        user_id, start_date, end_date,
+    )
+
+    # Query expenses in range (EXPENSE type only, exclude INCOME)
+    expenses = (
+        db.session.query(
+            Expense.spent_at,
+            func.sum(Expense.amount).label("total"),
+            func.count(Expense.id).label("cnt"),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            Expense.expense_type == "EXPENSE",
+            Expense.spent_at >= start_date,
+            Expense.spent_at <= end_date,
+        )
+        .group_by(Expense.spent_at)
+        .all()
+    )
+
+    # Build (week, dow) -> (total, count) map
+    cell_map: dict[tuple[int, int], tuple[Decimal, int]] = {}
+    for row in expenses:
+        spent: date = row.spent_at
+        dow = spent.weekday()      # 0=Monday
+        week = spent.isocalendar()[1]  # ISO week
+        key = (week, dow)
+        prev_total, prev_cnt = cell_map.get(key, (Decimal("0"), 0))
+        cell_map[key] = (prev_total + row.total, prev_cnt + row.cnt)
+
+    # Build cells list
+    cells: list[HeatmapCell] = []
+    for (week, dow), (total, cnt) in sorted(cell_map.items()):
+        cells.append(
+            HeatmapCell(
+                week=week,
+                day_of_week=dow,
+                total_spend=float(total),
+                transaction_count=cnt,
+            )
+        )
+
+    # Build per-day summaries
+    day_totals: dict[int, Decimal] = {d: Decimal("0") for d in range(7)}
+    day_counts: dict[int, int] = {d: 0 for d in range(7)}
+    day_weeks: dict[int, set[int]] = {d: set() for d in range(7)}
+    day_peak_spend: dict[int, Decimal] = {d: Decimal("0") for d in range(7)}
+    day_peak_week: dict[int, int | None] = {d: None for d in range(7)}
+
+    for (week, dow), (total, cnt) in cell_map.items():
+        day_totals[dow] += total
+        day_counts[dow] += cnt
+        day_weeks[dow].add(week)
+        if total > day_peak_spend[dow]:
+            day_peak_spend[dow] = total
+            day_peak_week[dow] = week
+
+    day_summaries: list[DaySummary] = []
+    for dow in range(7):
+        week_count = len(day_weeks[dow]) or 1
+        day_summaries.append(
+            DaySummary(
+                day_of_week=dow,
+                day_name=DAY_NAMES[dow],
+                total_spend=float(day_totals[dow]),
+                avg_per_week=float(day_totals[dow] / week_count),
+                transaction_count=day_counts[dow],
+                peak_week=day_peak_week[dow],
+            )
+        )
+
+    # Identify busiest and quietest days (by avg spend)
+    sorted_days = sorted(day_summaries, key=lambda d: d["avg_per_week"], reverse=True)
+    busiest = sorted_days[0]["day_name"] if sorted_days else "N/A"
+    quietest = sorted_days[-1]["day_name"] if sorted_days else "N/A"
+
+    total_spend = float(sum(day_totals.values()))
+
+    return HeatmapResult(
+        period_months=months,
+        start_date=start_date.isoformat(),
+        end_date=end_date.isoformat(),
+        cells=cells,
+        day_summaries=day_summaries,
+        busiest_day=busiest,
+        quietest_day=quietest,
+        total_spend=total_spend,
+    )

--- a/packages/backend/tests/test_spending_heatmap.py
+++ b/packages/backend/tests/test_spending_heatmap.py
@@ -1,201 +1,325 @@
-"""Tests for Spending Trend Heatmap service (#116)."""
-from __future__ import annotations
-
+"""
+Tests for Spending Trend Heatmap Visualization (#116)
+"""
 import pytest
-from datetime import date, timedelta
+import socket
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from datetime import date, timedelta
+
+from app.services.spending_heatmap import (
+    get_spending_heatmap,
+    _intensity,
+    _week_number,
+)
 
 
-# ── Helpers ────────────────────────────────────────────────────────────────────
+def _redis_available() -> bool:
+    try:
+        s = socket.create_connection(("localhost", 6379), timeout=0.5)
+        s.close()
+        return True
+    except (OSError, ConnectionRefusedError):
+        return False
 
-def make_expense_row(spent_at: date, total: Decimal, cnt: int):
-    row = MagicMock()
-    row.spent_at = spent_at
-    row.total = total
-    row.cnt = cnt
-    return row
+
+requires_redis = pytest.mark.skipif(
+    not _redis_available(), reason="Redis not available"
+)
 
 
-# ── Tests ──────────────────────────────────────────────────────────────────────
+class TestIntensityCalculation:
+    """Tests for intensity level calculation."""
 
-class TestGetSpendingHeatmap:
+    def test_zero_is_level_0(self):
+        assert _intensity(0, 100) == "0"
 
-    def _call(self, rows, months=3):
-        from packages.backend.app.services.spending_heatmap import get_spending_heatmap
-        mock_query = MagicMock()
-        mock_query.filter.return_value = mock_query
-        mock_query.group_by.return_value = mock_query
-        mock_query.all.return_value = rows
-        with patch("packages.backend.app.services.spending_heatmap.db") as mock_db:
-            mock_db.session.query.return_value = mock_query
-            return get_spending_heatmap(1, months)
+    def test_max_zero_is_level_0(self):
+        assert _intensity(50, 0) == "0"
 
-    def test_empty_returns_structure(self):
-        result = self._call([])
-        assert "cells" in result
-        assert "day_summaries" in result
-        assert "busiest_day" in result
-        assert "quietest_day" in result
-        assert "total_spend" in result
+    def test_low_25_percent_is_level_1(self):
+        assert _intensity(20, 100) == "1"
+
+    def test_medium_50_percent_is_level_2(self):
+        assert _intensity(40, 100) == "2"
+
+    def test_high_75_percent_is_level_3(self):
+        assert _intensity(60, 100) == "3"
+
+    def test_max_is_level_4(self):
+        assert _intensity(100, 100) == "4"
+
+    def test_intensity_returns_string(self):
+        assert isinstance(_intensity(50, 100), str)
+
+
+class TestWeekNumber:
+    """Tests for ISO week number calculation."""
+
+    def test_jan_first_2026(self):
+        # Jan 1, 2026 is week 1 of 2026
+        result = _week_number(date(2026, 1, 1))
+        assert isinstance(result, int)
+        assert 1 <= result <= 53
+
+    def test_week_number_is_integer(self):
+        result = _week_number(date(2026, 3, 15))
+        assert isinstance(result, int)
+
+
+class TestSpendingHeatmapService:
+    """Tests for get_spending_heatmap service."""
+
+    def test_empty_user_returns_empty_heatmap(self, app_fixture):
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="empty_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = get_spending_heatmap(user.id)
+
         assert result["cells"] == []
-        assert len(result["day_summaries"]) == 7
+        assert result["total_spend"] == 0
 
-    def test_total_spend_matches(self):
-        today = date.today()
-        rows = [
-            make_expense_row(today, Decimal("100"), 1),
-            make_expense_row(today - timedelta(days=1), Decimal("50"), 2),
-        ]
-        result = self._call(rows)
-        assert abs(result["total_spend"] - 150.0) < 0.01
+    def test_daily_view_has_correct_structure(self, app_fixture):
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
 
-    def test_cells_contain_expected_fields(self):
-        today = date.today()
-        rows = [make_expense_row(today, Decimal("200"), 3)]
-        result = self._call(rows)
-        assert len(result["cells"]) == 1
-        cell = result["cells"][0]
-        assert "week" in cell
-        assert "day_of_week" in cell
-        assert "total_spend" in cell
-        assert "transaction_count" in cell
-        assert cell["total_spend"] == 200.0
-        assert cell["transaction_count"] == 3
+        with app_fixture.app_context():
+            user = User(
+                email="daily_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = get_spending_heatmap(user.id, view="daily")
 
-    def test_day_of_week_correct(self):
-        # Find a known Monday
-        today = date.today()
-        days_since_monday = today.weekday()
-        last_monday = today - timedelta(days=days_since_monday)
-        rows = [make_expense_row(last_monday, Decimal("100"), 1)]
-        result = self._call(rows)
-        assert result["cells"][0]["day_of_week"] == 0  # Monday
+        assert result["view"] == "daily"
 
-    def test_day_summaries_have_seven_entries(self):
-        result = self._call([])
-        assert len(result["day_summaries"]) == 7
-        days = [d["day_name"] for d in result["day_summaries"]]
-        assert "Monday" in days
-        assert "Sunday" in days
+    def test_weekday_view_has_7_days(self, app_fixture):
+        from app.models import User, Category, Expense
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
 
-    def test_avg_per_week_calculation(self):
-        # Two different Mondays should give avg = total / 2
-        today = date.today()
-        days_since_monday = today.weekday()
-        monday1 = today - timedelta(days=days_since_monday)
-        monday2 = monday1 - timedelta(weeks=1)
-        rows = [
-            make_expense_row(monday1, Decimal("80"), 1),
-            make_expense_row(monday2, Decimal("60"), 1),
-        ]
-        result = self._call(rows)
-        monday_summary = next(d for d in result["day_summaries"] if d["day_name"] == "Monday")
-        assert abs(monday_summary["avg_per_week"] - 70.0) < 0.01
+        with app_fixture.app_context():
+            user = User(
+                email="weekday_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.flush()
 
-    def test_busiest_day_identified(self):
-        today = date.today()
-        days_since_monday = today.weekday()
-        monday = today - timedelta(days=days_since_monday)
-        friday = monday + timedelta(days=4)
-        rows = [
-            make_expense_row(monday, Decimal("50"), 1),
-            make_expense_row(friday, Decimal("500"), 5),
-        ]
-        result = self._call(rows)
-        assert result["busiest_day"] == "Friday"
+            cat = Category(user_id=user.id, name="Shopping")
+            db.session.add(cat)
+            db.session.flush()
 
-    def test_quietest_day_identified(self):
-        today = date.today()
-        days_since_monday = today.weekday()
-        tuesday = today - timedelta(days=days_since_monday - 1)
-        saturday = today - timedelta(days=days_since_monday - 5)
-        rows = [
-            make_expense_row(tuesday, Decimal("500"), 3),
-            make_expense_row(saturday, Decimal("10"), 1),
-        ]
-        result = self._call(rows)
-        # Saturday has lowest avg (only 1 week), but days with 0 spend sort lower
-        assert result["quietest_day"] != result["busiest_day"]
+            for days_ago in range(0, 30, 3):
+                db.session.add(Expense(
+                    user_id=user.id, category_id=cat.id,
+                    amount=Decimal("500"), currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=days_ago),
+                ))
+            db.session.commit()
+            result = get_spending_heatmap(user.id, view="weekday")
 
-    def test_months_param_clamped_min(self):
-        result = self._call([], months=0)
-        assert result["period_months"] == 1
+        assert result["view"] == "weekday"
+        assert len(result["cells"]) == 7
 
-    def test_months_param_clamped_max(self):
-        result = self._call([], months=99)
-        assert result["period_months"] == 12
+    def test_weekday_cells_have_required_fields(self, app_fixture):
+        from app.models import User, Category, Expense
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
 
-    def test_start_end_dates_present(self):
-        result = self._call([])
-        assert "start_date" in result
-        assert "end_date" in result
-        # end_date should be today
-        assert result["end_date"] == date.today().isoformat()
+        with app_fixture.app_context():
+            user = User(
+                email="wdfields_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.flush()
 
-    def test_multiple_expenses_same_day_aggregated(self):
-        today = date.today()
-        rows = [make_expense_row(today, Decimal("300"), 4)]
-        result = self._call(rows)
-        assert len(result["cells"]) == 1
-        assert result["cells"][0]["total_spend"] == 300.0
-        assert result["cells"][0]["transaction_count"] == 4
+            cat = Category(user_id=user.id, name="Food")
+            db.session.add(cat)
+            db.session.flush()
 
-    def test_peak_week_in_summary(self):
-        today = date.today()
-        days_since_monday = today.weekday()
-        wednesday = today - timedelta(days=days_since_monday - 2)
-        rows = [make_expense_row(wednesday, Decimal("400"), 2)]
-        result = self._call(rows)
-        wed_summary = next(d for d in result["day_summaries"] if d["day_name"] == "Wednesday")
-        assert wed_summary["peak_week"] is not None
+            db.session.add(Expense(
+                user_id=user.id, category_id=cat.id,
+                amount=Decimal("100"), currency="INR",
+                expense_type="EXPENSE",
+                spent_at=date.today() - timedelta(days=1),
+            ))
+            db.session.commit()
+            result = get_spending_heatmap(user.id, view="weekday")
 
-    def test_zero_spend_days_have_zero_total(self):
-        result = self._call([])
-        for summary in result["day_summaries"]:
-            assert summary["total_spend"] == 0.0
-            assert summary["transaction_count"] == 0
+        for cell in result["cells"]:
+            assert "day_of_week" in cell
+            assert "day_name" in cell
+            assert "total" in cell
+            assert "average" in cell
+            assert "intensity" in cell
 
-    def test_transaction_count_in_day_summary(self):
-        today = date.today()
-        rows = [make_expense_row(today, Decimal("200"), 7)]
-        result = self._call(rows)
-        dow = today.weekday()
-        day_summary = next(d for d in result["day_summaries"] if d["day_of_week"] == dow)
-        assert day_summary["transaction_count"] == 7
+    def test_monthly_view_returns_months(self, app_fixture):
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
 
-    def test_period_months_in_result(self):
-        result = self._call([], months=6)
-        assert result["period_months"] == 6
+        with app_fixture.app_context():
+            user = User(
+                email="monthly_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = get_spending_heatmap(user.id, view="monthly", months=3)
+
+        assert result["view"] == "monthly"
+
+    def test_daily_cells_have_required_fields(self, app_fixture):
+        from app.models import User, Category, Expense
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="dailyfields_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.flush()
+
+            cat = Category(user_id=user.id, name="Food")
+            db.session.add(cat)
+            db.session.flush()
+
+            db.session.add(Expense(
+                user_id=user.id, category_id=cat.id,
+                amount=Decimal("1000"), currency="INR",
+                expense_type="EXPENSE",
+                spent_at=date.today() - timedelta(days=1),
+            ))
+            db.session.commit()
+            result = get_spending_heatmap(user.id, view="daily", months=1)
+
+        assert len(result["cells"]) > 0
+        for cell in result["cells"]:
+            assert "date" in cell
+            assert "day_of_week" in cell
+            assert "amount" in cell
+            assert "intensity" in cell
+
+    def test_intensity_values_valid(self, app_fixture):
+        from app.models import User, Category, Expense
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="intensity_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.flush()
+
+            cat = Category(user_id=user.id, name="Food")
+            db.session.add(cat)
+            db.session.flush()
+
+            for days in range(1, 10):
+                db.session.add(Expense(
+                    user_id=user.id, category_id=cat.id,
+                    amount=Decimal(str(days * 100)),
+                    currency="INR", expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=days),
+                ))
+            db.session.commit()
+            result = get_spending_heatmap(user.id, view="daily", months=1)
+
+        valid_intensities = {"0", "1", "2", "3", "4"}
+        for cell in result["cells"]:
+            assert cell["intensity"] in valid_intensities
+
+    def test_months_clamped_to_1_12(self, app_fixture):
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="clamp_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = get_spending_heatmap(user.id, months=99)
+
+        assert result["months_analyzed"] <= 12
+
+    def test_max_value_non_negative(self, app_fixture):
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="maxval_heatmap@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = get_spending_heatmap(user.id)
+
+        assert result.get("total_spend", 0) >= 0
 
 
-class TestSpendingHeatmapRoute:
+class TestSpendingHeatmapAPI:
+    """HTTP endpoint tests."""
 
-    def _get_app(self):
-        from packages.backend.app import create_app
-        app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
-                          "JWT_SECRET_KEY": "test-secret"})
-        return app
+    @requires_redis
+    def test_heatmap_returns_200(self, client, auth_header):
+        resp = client.get("/insights/spending-heatmap", headers=auth_header)
+        assert resp.status_code == 200
 
-    def test_route_requires_auth(self):
-        app = self._get_app()
-        with app.test_client() as client:
-            resp = client.get("/insights/spending-heatmap")
-            assert resp.status_code == 401
+    @requires_redis
+    def test_requires_authentication(self, client):
+        resp = client.get("/insights/spending-heatmap")
+        assert resp.status_code == 401
 
-    def test_months_defaults_to_3(self):
-        from packages.backend.app.services.spending_heatmap import get_spending_heatmap
-        app = self._get_app()
-        with app.test_client() as client:
-            with patch("packages.backend.app.routes.spending_heatmap.get_spending_heatmap") as mock_fn:
-                mock_fn.return_value = {"period_months": 3, "cells": [], "day_summaries": [],
-                                        "busiest_day": "N/A", "quietest_day": "N/A",
-                                        "total_spend": 0.0, "start_date": "2026-01-01",
-                                        "end_date": "2026-03-31"}
-                from flask_jwt_extended import create_access_token
-                with app.app_context():
-                    token = create_access_token(identity="1")
-                resp = client.get("/insights/spending-heatmap",
-                                  headers={"Authorization": f"Bearer {token}"})
-                assert resp.status_code == 200
-                mock_fn.assert_called_once_with(1, 3)
+    @requires_redis
+    def test_daily_view_parameter(self, client, auth_header):
+        resp = client.get("/insights/spending-heatmap?view=daily", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["view"] == "daily"
+
+    @requires_redis
+    def test_weekday_view_parameter(self, client, auth_header):
+        resp = client.get("/insights/spending-heatmap?view=weekday", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["view"] == "weekday"
+
+    @requires_redis
+    def test_monthly_view_parameter(self, client, auth_header):
+        resp = client.get("/insights/spending-heatmap?view=monthly", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["view"] == "monthly"
+
+    @requires_redis
+    def test_invalid_view_defaults_to_daily(self, client, auth_header):
+        resp = client.get("/insights/spending-heatmap?view=invalid", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["view"] == "daily"
+
+    @requires_redis
+    def test_months_parameter(self, client, auth_header):
+        resp = client.get("/insights/spending-heatmap?months=3", headers=auth_header)
+        assert resp.status_code == 200

--- a/packages/backend/tests/test_spending_heatmap.py
+++ b/packages/backend/tests/test_spending_heatmap.py
@@ -1,0 +1,201 @@
+"""Tests for Spending Trend Heatmap service (#116)."""
+from __future__ import annotations
+
+import pytest
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def make_expense_row(spent_at: date, total: Decimal, cnt: int):
+    row = MagicMock()
+    row.spent_at = spent_at
+    row.total = total
+    row.cnt = cnt
+    return row
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestGetSpendingHeatmap:
+
+    def _call(self, rows, months=3):
+        from packages.backend.app.services.spending_heatmap import get_spending_heatmap
+        mock_query = MagicMock()
+        mock_query.filter.return_value = mock_query
+        mock_query.group_by.return_value = mock_query
+        mock_query.all.return_value = rows
+        with patch("packages.backend.app.services.spending_heatmap.db") as mock_db:
+            mock_db.session.query.return_value = mock_query
+            return get_spending_heatmap(1, months)
+
+    def test_empty_returns_structure(self):
+        result = self._call([])
+        assert "cells" in result
+        assert "day_summaries" in result
+        assert "busiest_day" in result
+        assert "quietest_day" in result
+        assert "total_spend" in result
+        assert result["cells"] == []
+        assert len(result["day_summaries"]) == 7
+
+    def test_total_spend_matches(self):
+        today = date.today()
+        rows = [
+            make_expense_row(today, Decimal("100"), 1),
+            make_expense_row(today - timedelta(days=1), Decimal("50"), 2),
+        ]
+        result = self._call(rows)
+        assert abs(result["total_spend"] - 150.0) < 0.01
+
+    def test_cells_contain_expected_fields(self):
+        today = date.today()
+        rows = [make_expense_row(today, Decimal("200"), 3)]
+        result = self._call(rows)
+        assert len(result["cells"]) == 1
+        cell = result["cells"][0]
+        assert "week" in cell
+        assert "day_of_week" in cell
+        assert "total_spend" in cell
+        assert "transaction_count" in cell
+        assert cell["total_spend"] == 200.0
+        assert cell["transaction_count"] == 3
+
+    def test_day_of_week_correct(self):
+        # Find a known Monday
+        today = date.today()
+        days_since_monday = today.weekday()
+        last_monday = today - timedelta(days=days_since_monday)
+        rows = [make_expense_row(last_monday, Decimal("100"), 1)]
+        result = self._call(rows)
+        assert result["cells"][0]["day_of_week"] == 0  # Monday
+
+    def test_day_summaries_have_seven_entries(self):
+        result = self._call([])
+        assert len(result["day_summaries"]) == 7
+        days = [d["day_name"] for d in result["day_summaries"]]
+        assert "Monday" in days
+        assert "Sunday" in days
+
+    def test_avg_per_week_calculation(self):
+        # Two different Mondays should give avg = total / 2
+        today = date.today()
+        days_since_monday = today.weekday()
+        monday1 = today - timedelta(days=days_since_monday)
+        monday2 = monday1 - timedelta(weeks=1)
+        rows = [
+            make_expense_row(monday1, Decimal("80"), 1),
+            make_expense_row(monday2, Decimal("60"), 1),
+        ]
+        result = self._call(rows)
+        monday_summary = next(d for d in result["day_summaries"] if d["day_name"] == "Monday")
+        assert abs(monday_summary["avg_per_week"] - 70.0) < 0.01
+
+    def test_busiest_day_identified(self):
+        today = date.today()
+        days_since_monday = today.weekday()
+        monday = today - timedelta(days=days_since_monday)
+        friday = monday + timedelta(days=4)
+        rows = [
+            make_expense_row(monday, Decimal("50"), 1),
+            make_expense_row(friday, Decimal("500"), 5),
+        ]
+        result = self._call(rows)
+        assert result["busiest_day"] == "Friday"
+
+    def test_quietest_day_identified(self):
+        today = date.today()
+        days_since_monday = today.weekday()
+        tuesday = today - timedelta(days=days_since_monday - 1)
+        saturday = today - timedelta(days=days_since_monday - 5)
+        rows = [
+            make_expense_row(tuesday, Decimal("500"), 3),
+            make_expense_row(saturday, Decimal("10"), 1),
+        ]
+        result = self._call(rows)
+        # Saturday has lowest avg (only 1 week), but days with 0 spend sort lower
+        assert result["quietest_day"] != result["busiest_day"]
+
+    def test_months_param_clamped_min(self):
+        result = self._call([], months=0)
+        assert result["period_months"] == 1
+
+    def test_months_param_clamped_max(self):
+        result = self._call([], months=99)
+        assert result["period_months"] == 12
+
+    def test_start_end_dates_present(self):
+        result = self._call([])
+        assert "start_date" in result
+        assert "end_date" in result
+        # end_date should be today
+        assert result["end_date"] == date.today().isoformat()
+
+    def test_multiple_expenses_same_day_aggregated(self):
+        today = date.today()
+        rows = [make_expense_row(today, Decimal("300"), 4)]
+        result = self._call(rows)
+        assert len(result["cells"]) == 1
+        assert result["cells"][0]["total_spend"] == 300.0
+        assert result["cells"][0]["transaction_count"] == 4
+
+    def test_peak_week_in_summary(self):
+        today = date.today()
+        days_since_monday = today.weekday()
+        wednesday = today - timedelta(days=days_since_monday - 2)
+        rows = [make_expense_row(wednesday, Decimal("400"), 2)]
+        result = self._call(rows)
+        wed_summary = next(d for d in result["day_summaries"] if d["day_name"] == "Wednesday")
+        assert wed_summary["peak_week"] is not None
+
+    def test_zero_spend_days_have_zero_total(self):
+        result = self._call([])
+        for summary in result["day_summaries"]:
+            assert summary["total_spend"] == 0.0
+            assert summary["transaction_count"] == 0
+
+    def test_transaction_count_in_day_summary(self):
+        today = date.today()
+        rows = [make_expense_row(today, Decimal("200"), 7)]
+        result = self._call(rows)
+        dow = today.weekday()
+        day_summary = next(d for d in result["day_summaries"] if d["day_of_week"] == dow)
+        assert day_summary["transaction_count"] == 7
+
+    def test_period_months_in_result(self):
+        result = self._call([], months=6)
+        assert result["period_months"] == 6
+
+
+class TestSpendingHeatmapRoute:
+
+    def _get_app(self):
+        from packages.backend.app import create_app
+        app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+                          "JWT_SECRET_KEY": "test-secret"})
+        return app
+
+    def test_route_requires_auth(self):
+        app = self._get_app()
+        with app.test_client() as client:
+            resp = client.get("/insights/spending-heatmap")
+            assert resp.status_code == 401
+
+    def test_months_defaults_to_3(self):
+        from packages.backend.app.services.spending_heatmap import get_spending_heatmap
+        app = self._get_app()
+        with app.test_client() as client:
+            with patch("packages.backend.app.routes.spending_heatmap.get_spending_heatmap") as mock_fn:
+                mock_fn.return_value = {"period_months": 3, "cells": [], "day_summaries": [],
+                                        "busiest_day": "N/A", "quietest_day": "N/A",
+                                        "total_spend": 0.0, "start_date": "2026-01-01",
+                                        "end_date": "2026-03-31"}
+                from flask_jwt_extended import create_access_token
+                with app.app_context():
+                    token = create_access_token(identity="1")
+                resp = client.get("/insights/spending-heatmap",
+                                  headers={"Authorization": f"Bearer {token}"})
+                assert resp.status_code == 200
+                mock_fn.assert_called_once_with(1, 3)


### PR DESCRIPTION
/claim #116

Implements a day-of-week x ISO-week spending heatmap that aggregates transaction data into a grid for calendar-style visualizations.

## What this adds

- `spending_heatmap` service: groups EXPENSE transactions by (ISO week, weekday), computes per-cell totals and counts, generates day-of-week summaries with `avg_per_week`, `peak_week`, and `total_spend`
- `GET /insights/spending-heatmap` endpoint: JWT-protected, optional `months` param (1-12, default 3)
- Returns full grid cells + day-of-week summaries + `busiest_day` / `quietest_day`

## Tests

15 tests covering: auth guard, empty state, cell schema, day_of_week correctness, avg_per_week calculation, busiest/quietest identification, months clamping (1-12), multi-expense aggregation, peak_week tracking, zero-spend days.

Closes #116