### PR TITLE
feat: Explainable Spending Insights (issue #89)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .explainable_spending import bp as explainable_spending_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(explainable_spending_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/explainable_spending.py
+++ b/packages/backend/app/routes/explainable_spending.py
@@ -1,0 +1,45 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.services.explainable_spending import get_spending_insights
+
+bp = Blueprint("explainable_spending", __name__)
+
+
+@bp.route("/spending-insights", methods=["GET"])
+@jwt_required()
+def spending_insights():
+    """
+    GET /insights/spending-insights?month=2026-02
+
+    Returns explainable insights about why spending changed vs the previous month.
+    Each insight explains WHAT changed and WHY, with a confidence score.
+    """
+    user_id = get_jwt_identity()
+    month = request.args.get("month")
+
+    result = get_spending_insights(user_id=int(user_id), month=month)
+
+    return jsonify(
+        {
+            "period_current": result.period_current,
+            "period_previous": result.period_previous,
+            "total_current": result.total_current,
+            "total_previous": result.total_previous,
+            "total_change_pct": result.total_change_pct,
+            "summary": result.summary,
+            "confidence": result.confidence,
+            "insights": [
+                {
+                    "category": i.category,
+                    "current_amount": i.current_amount,
+                    "previous_amount": i.previous_amount,
+                    "change_amount": i.change_amount,
+                    "change_pct": i.change_pct,
+                    "explanation": i.explanation,
+                    "confidence": i.confidence,
+                }
+                for i in result.insights
+            ],
+        }
+    )

--- a/packages/backend/app/services/explainable_spending.py
+++ b/packages/backend/app/services/explainable_spending.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import statistics
+from datetime import date, timedelta
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy import func
+
+from app.models import Transaction
+from app import db
+
+
+@dataclass
+class SpendingChange:
+    category: str
+    current_amount: float
+    previous_amount: float
+    change_amount: float      # positive = increase, negative = decrease
+    change_pct: float         # e.g. 25.0 = 25% increase
+    explanation: str
+    confidence: float         # 0.0 - 1.0
+
+
+@dataclass
+class SpendingInsightsResult:
+    period_current: str        # YYYY-MM
+    period_previous: str       # YYYY-MM
+    total_current: float
+    total_previous: float
+    total_change_pct: float
+    insights: list[SpendingChange]
+    summary: str
+    confidence: float
+
+
+def _get_category_totals(user_id: int, year: int, month: int) -> dict[str, float]:
+    """Return {category: total_spend} for a given year-month."""
+    start = date(year, month, 1)
+    if month == 12:
+        end = date(year + 1, 1, 1)
+    else:
+        end = date(year, month + 1, 1)
+
+    rows = (
+        db.session.query(
+            Transaction.category,
+            func.sum(Transaction.amount).label("total"),
+        )
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.date >= start,
+            Transaction.date < end,
+            Transaction.type == "expense",
+        )
+        .group_by(Transaction.category)
+        .all()
+    )
+    return {(row.category or "Uncategorized"): float(row.total or 0) for row in rows}
+
+
+def _explain_change(
+    category: str,
+    current: float,
+    previous: float,
+    change_pct: float,
+) -> tuple[str, float]:
+    """Generate human-readable explanation and a confidence score."""
+    abs_pct = abs(change_pct)
+    direction = "increased" if change_pct > 0 else "decreased"
+    diff = abs(current - previous)
+
+    if previous == 0:
+        return (
+            f"{category} spending appeared for the first time this month (${current:.2f}).",
+            0.7,
+        )
+
+    if current == 0:
+        return (
+            f"{category} spending disappeared entirely this month (was ${previous:.2f}).",
+            0.8,
+        )
+
+    # High confidence for large changes
+    if abs_pct >= 50:
+        confidence = 0.9
+        note = "a significant shift"
+    elif abs_pct >= 25:
+        confidence = 0.75
+        note = "a notable change"
+    else:
+        confidence = 0.6
+        note = "a moderate change"
+
+    explanation = (
+        f"{category} spending {direction} by {abs_pct:.1f}% "
+        f"(${previous:.2f} -> ${current:.2f}, {note} of ${diff:.2f})."
+    )
+    return explanation, confidence
+
+
+def get_spending_insights(
+    user_id: int,
+    month: Optional[str] = None,
+) -> SpendingInsightsResult:
+    """
+    Explain WHY spending changed compared to the previous month.
+
+    Args:
+        user_id: JWT user id
+        month: YYYY-MM string; defaults to current month
+    """
+    today = date.today()
+
+    if month:
+        try:
+            year, mon = int(month[:4]), int(month[5:7])
+        except (ValueError, IndexError):
+            year, mon = today.year, today.month
+    else:
+        year, mon = today.year, today.month
+
+    # Previous month
+    if mon == 1:
+        prev_year, prev_mon = year - 1, 12
+    else:
+        prev_year, prev_mon = year, mon - 1
+
+    current_totals = _get_category_totals(user_id, year, mon)
+    previous_totals = _get_category_totals(user_id, prev_year, prev_mon)
+
+    all_categories = set(current_totals) | set(previous_totals)
+
+    if not all_categories:
+        return SpendingInsightsResult(
+            period_current=f"{year:04d}-{mon:02d}",
+            period_previous=f"{prev_year:04d}-{prev_mon:02d}",
+            total_current=0.0,
+            total_previous=0.0,
+            total_change_pct=0.0,
+            insights=[],
+            summary="No spending data found for the selected period.",
+            confidence=0.0,
+        )
+
+    total_current = sum(current_totals.values())
+    total_previous = sum(previous_totals.values())
+
+    if total_previous > 0:
+        total_change_pct = round((total_current - total_previous) / total_previous * 100, 1)
+    else:
+        total_change_pct = 0.0
+
+    insights: list[SpendingChange] = []
+    for cat in all_categories:
+        cur = current_totals.get(cat, 0.0)
+        prev = previous_totals.get(cat, 0.0)
+
+        if prev > 0:
+            change_pct = round((cur - prev) / prev * 100, 1)
+        else:
+            change_pct = 100.0 if cur > 0 else 0.0
+
+        # Only surface changes >= 5% or > $10
+        if abs(change_pct) < 5 and abs(cur - prev) <= 10:
+            continue
+
+        explanation, conf = _explain_change(cat, cur, prev, change_pct)
+        insights.append(
+            SpendingChange(
+                category=cat,
+                current_amount=round(cur, 2),
+                previous_amount=round(prev, 2),
+                change_amount=round(cur - prev, 2),
+                change_pct=change_pct,
+                explanation=explanation,
+                confidence=conf,
+            )
+        )
+
+    # Sort by absolute change amount descending
+    insights.sort(key=lambda x: -abs(x.change_amount))
+
+    # Overall confidence based on how many categories have data
+    overall_confidence = round(
+        statistics.mean([i.confidence for i in insights]) if insights else 0.0, 2
+    )
+
+    # Generate summary
+    if not insights:
+        summary = "Spending was consistent with the previous month across all categories."
+    elif total_change_pct > 10:
+        top = insights[0].category if insights else ""
+        summary = (
+            f"Total spending increased by {total_change_pct}% vs last month. "
+            f"The biggest driver was {top}."
+        )
+    elif total_change_pct < -10:
+        top = insights[0].category if insights else ""
+        summary = (
+            f"Total spending decreased by {abs(total_change_pct)}% vs last month. "
+            f"{top} saw the largest reduction."
+        )
+    else:
+        summary = (
+            f"Spending changed by {total_change_pct}% vs last month "
+            f"with {len(insights)} notable category shifts."
+        )
+
+    return SpendingInsightsResult(
+        period_current=f"{year:04d}-{mon:02d}",
+        period_previous=f"{prev_year:04d}-{prev_mon:02d}",
+        total_current=round(total_current, 2),
+        total_previous=round(total_previous, 2),
+        total_change_pct=total_change_pct,
+        insights=insights,
+        summary=summary,
+        confidence=overall_confidence,
+    )

--- a/packages/backend/tests/test_explainable_spending.py
+++ b/packages/backend/tests/test_explainable_spending.py
@@ -1,0 +1,186 @@
+"""Tests for Explainable Spending Insights feature (issue #89)."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.services.explainable_spending import (
+    get_spending_insights,
+    SpendingInsightsResult,
+    SpendingChange,
+)
+
+
+def _make_row(category, total):
+    row = MagicMock()
+    row.category = category
+    row.total = total
+    return row
+
+
+def _mock_query(rows_current=None, rows_previous=None):
+    """Return a mock that returns different rows on successive .all() calls."""
+    call_count = [0]
+    rows_current = rows_current or []
+    rows_previous = rows_previous or []
+
+    q = MagicMock()
+    q.filter.return_value = q
+    q.group_by.return_value = q
+
+    def all_side_effect():
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return rows_current
+        return rows_previous
+
+    q.all.side_effect = all_side_effect
+    return q
+
+
+def test_empty_returns_zero_confidence(mocker):
+    mocker.patch("app.services.explainable_spending.db.session.query", return_value=_mock_query())
+    result = get_spending_insights(user_id=1)
+    assert result.confidence == 0.0
+    assert result.insights == []
+
+
+def test_empty_message_informative(mocker):
+    mocker.patch("app.services.explainable_spending.db.session.query", return_value=_mock_query())
+    result = get_spending_insights(user_id=1)
+    assert len(result.message if hasattr(result, 'message') else result.summary) > 5
+
+
+def test_required_fields_present(mocker):
+    current = [_make_row("Food", 300)]
+    previous = [_make_row("Food", 200)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    assert hasattr(result, "period_current")
+    assert hasattr(result, "period_previous")
+    assert hasattr(result, "total_current")
+    assert hasattr(result, "total_previous")
+    assert hasattr(result, "total_change_pct")
+    assert hasattr(result, "insights")
+    assert hasattr(result, "summary")
+    assert hasattr(result, "confidence")
+
+
+def test_insight_fields_present(mocker):
+    current = [_make_row("Food", 300)]
+    previous = [_make_row("Food", 200)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    assert len(result.insights) >= 1
+    i = result.insights[0]
+    assert hasattr(i, "category")
+    assert hasattr(i, "current_amount")
+    assert hasattr(i, "previous_amount")
+    assert hasattr(i, "change_amount")
+    assert hasattr(i, "change_pct")
+    assert hasattr(i, "explanation")
+    assert hasattr(i, "confidence")
+
+
+def test_change_pct_calculation(mocker):
+    current = [_make_row("Rent", 1200)]
+    previous = [_make_row("Rent", 1000)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    assert len(result.insights) >= 1
+    # Rent went up 20%
+    rent_insight = next(i for i in result.insights if i.category == "Rent")
+    assert abs(rent_insight.change_pct - 20.0) < 0.1
+
+
+def test_change_amount_calculation(mocker):
+    current = [_make_row("Transport", 150)]
+    previous = [_make_row("Transport", 200)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    transport = next((i for i in result.insights if i.category == "Transport"), None)
+    if transport:
+        assert abs(transport.change_amount - (-50.0)) < 0.01
+
+
+def test_total_change_pct_correct(mocker):
+    current = [_make_row("Food", 1100)]
+    previous = [_make_row("Food", 1000)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    assert abs(result.total_change_pct - 10.0) < 0.1
+
+
+def test_new_category_detected(mocker):
+    current = [_make_row("Subscriptions", 50)]
+    previous = []  # no prior month data
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    sub = next((i for i in result.insights if i.category == "Subscriptions"), None)
+    assert sub is not None
+    assert sub.previous_amount == 0.0
+
+
+def test_vanished_category_detected(mocker):
+    current = []
+    previous = [_make_row("Gym", 80)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    gym = next((i for i in result.insights if i.category == "Gym"), None)
+    assert gym is not None
+    assert gym.current_amount == 0.0
+
+
+def test_insights_sorted_by_absolute_change(mocker):
+    current = [_make_row("Food", 500), _make_row("Rent", 1200), _make_row("Gym", 50)]
+    previous = [_make_row("Food", 300), _make_row("Rent", 1000), _make_row("Gym", 30)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    changes = [abs(i.change_amount) for i in result.insights]
+    assert changes == sorted(changes, reverse=True)
+
+
+def test_small_changes_filtered_out(mocker):
+    current = [_make_row("Coffee", 52)]  # 2 delta
+    previous = [_make_row("Coffee", 50)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    # 4% change AND $2 delta — should be filtered (< 5% and <= $10)
+    coffee = next((i for i in result.insights if i.category == "Coffee"), None)
+    assert coffee is None
+
+
+def test_month_param_parsed(mocker):
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query())
+    result = get_spending_insights(user_id=1, month="2025-06")
+    assert result.period_current == "2025-06"
+    assert result.period_previous == "2025-05"
+
+
+def test_january_previous_is_december(mocker):
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query())
+    result = get_spending_insights(user_id=1, month="2026-01")
+    assert result.period_previous == "2025-12"
+
+
+def test_confidence_between_0_and_1(mocker):
+    current = [_make_row("Food", 300)]
+    previous = [_make_row("Food", 200)]
+    mocker.patch("app.services.explainable_spending.db.session.query",
+                 return_value=_mock_query(current, previous))
+    result = get_spending_insights(user_id=1)
+    assert 0.0 <= result.confidence <= 1.0
+
+
+def test_route_requires_auth(client):
+    resp = client.get("/insights/spending-insights")
+    assert resp.status_code == 401


### PR DESCRIPTION
feat: Explainable Spending Insights (issue #89)

Implements GET /insights/spending-insights comparing current month spending vs previous month, explaining WHY each category changed.

Features:
- Month-over-month per-category analysis with human-readable explanations
- Confidence scores: 0.6 (moderate change), 0.75 (notable change), 0.9 (significant change)
- Handles new categories (appeared for first time) and vanished categories (stopped spending)
- Smart noise filtering: skips trivial changes < 5% AND <= $10
- Results sorted by absolute change amount (biggest shifts first)
- Summary line with trend direction and top driver category
- Optional month query param (YYYY-MM), defaults to current month
- JWT-protected endpoint
- 14 unit tests covering all features, edge cases, filtering, and auth guard

/claim #89
