### PR TITLE
feat: Lifestyle Inflation Detection Insights (issue #118)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .lifestyle_inflation import bp as lifestyle_inflation_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(lifestyle_inflation_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/lifestyle_inflation.py
+++ b/packages/backend/app/routes/lifestyle_inflation.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.services.lifestyle_inflation import get_lifestyle_inflation
+
+bp = Blueprint("lifestyle_inflation", __name__)
+
+
+@bp.route("/lifestyle-inflation", methods=["GET"])
+@jwt_required()
+def lifestyle_inflation():
+    """
+    GET /insights/lifestyle-inflation?months=6&threshold=5
+
+    Detects rising lifestyle expenses by comparing the older half of the period
+    to the recent half. Returns inflation signals per category with severity.
+    """
+    user_id = get_jwt_identity()
+    try:
+        months = int(request.args.get("months", 6))
+    except (ValueError, TypeError):
+        months = 6
+    try:
+        threshold = float(request.args.get("threshold", 5.0))
+    except (ValueError, TypeError):
+        threshold = 5.0
+
+    result = get_lifestyle_inflation(
+        user_id=int(user_id), months=months, threshold_pct=threshold
+    )
+
+    return jsonify(
+        {
+            "analysis_months": result.analysis_months,
+            "total_lifestyle_old": result.total_lifestyle_old,
+            "total_lifestyle_new": result.total_lifestyle_new,
+            "lifestyle_inflation_pct": result.lifestyle_inflation_pct,
+            "top_inflated_category": result.top_inflated_category,
+            "is_inflating": result.is_inflating,
+            "summary": result.summary,
+            "inflation_signals": [
+                {
+                    "category": s.category,
+                    "is_lifestyle": s.is_lifestyle,
+                    "monthly_avg_old": s.monthly_avg_old,
+                    "monthly_avg_new": s.monthly_avg_new,
+                    "inflation_pct": s.inflation_pct,
+                    "severity": s.severity,
+                    "trend_note": s.trend_note,
+                }
+                for s in result.inflation_signals
+            ],
+        }
+    )

--- a/packages/backend/app/services/lifestyle_inflation.py
+++ b/packages/backend/app/services/lifestyle_inflation.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import statistics
+from datetime import date, timedelta
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy import func
+
+from app.models import Transaction
+from app import db
+
+
+# ---------------------------------------------------------------------------
+# Keywords that indicate lifestyle (non-essential) spending
+# ---------------------------------------------------------------------------
+
+LIFESTYLE_KEYWORDS = {
+    "dining", "restaurant", "coffee", "cafe", "bar", "pub", "takeaway",
+    "gym", "fitness", "yoga", "spa", "beauty", "salon", "barber",
+    "entertainment", "cinema", "theater", "concert", "streaming", "netflix",
+    "spotify", "subscription", "clothing", "fashion", "shopping", "amazon",
+    "travel", "hotel", "airbnb", "vacation", "holiday", "trip",
+    "gaming", "apps", "accessories", "gadgets", "electronics",
+}
+
+
+def _is_lifestyle(category: str) -> bool:
+    cat_lower = (category or "").lower()
+    return any(kw in cat_lower for kw in LIFESTYLE_KEYWORDS)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class InflationSignal:
+    category: str
+    is_lifestyle: bool
+    monthly_avg_old: float    # avg of earlier half of the period
+    monthly_avg_new: float    # avg of recent half
+    inflation_pct: float      # % increase
+    severity: str             # "mild" (5-20%), "moderate" (20-50%), "high" (>50%)
+    trend_note: str
+
+
+@dataclass
+class LifestyleInflationResult:
+    analysis_months: int
+    total_lifestyle_old: float
+    total_lifestyle_new: float
+    lifestyle_inflation_pct: float
+    inflation_signals: list[InflationSignal]
+    top_inflated_category: Optional[str]
+    summary: str
+    is_inflating: bool
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+def get_lifestyle_inflation(
+    user_id: int,
+    months: int = 6,
+    threshold_pct: float = 5.0,
+) -> LifestyleInflationResult:
+    """
+    Detect rising lifestyle expenses over time by comparing the older half
+    of the analysis period to the recent half.
+
+    Args:
+        user_id: JWT user id
+        months: total months to analyze (2-24, must be even for fair comparison)
+        threshold_pct: minimum % increase to flag as inflation (default 5%)
+    """
+    months = max(2, min(24, months))
+    if months % 2 != 0:
+        months += 1  # ensure even split
+
+    cutoff = date.today() - timedelta(days=months * 31)
+
+    rows = (
+        db.session.query(
+            func.strftime("%Y-%m", Transaction.date).label("month"),
+            Transaction.category,
+            func.sum(Transaction.amount).label("total"),
+        )
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.date >= cutoff,
+            Transaction.type == "expense",
+        )
+        .group_by("month", Transaction.category)
+        .all()
+    )
+
+    if not rows:
+        return LifestyleInflationResult(
+            analysis_months=months,
+            total_lifestyle_old=0.0,
+            total_lifestyle_new=0.0,
+            lifestyle_inflation_pct=0.0,
+            inflation_signals=[],
+            top_inflated_category=None,
+            summary="No spending data available for lifestyle inflation analysis.",
+            is_inflating=False,
+        )
+
+    # Build {month -> {category -> amount}} map
+    all_months_set: set[str] = set()
+    data: dict[str, dict[str, float]] = {}
+    for row in rows:
+        m = row.month
+        cat = row.category or "Uncategorized"
+        all_months_set.add(m)
+        if cat not in data:
+            data[cat] = {}
+        data[cat][m] = float(row.total or 0)
+
+    sorted_months = sorted(all_months_set)
+    half = len(sorted_months) // 2
+    old_months = sorted_months[:half]
+    new_months = sorted_months[half:]
+
+    if not old_months or not new_months:
+        return LifestyleInflationResult(
+            analysis_months=months,
+            total_lifestyle_old=0.0,
+            total_lifestyle_new=0.0,
+            lifestyle_inflation_pct=0.0,
+            inflation_signals=[],
+            top_inflated_category=None,
+            summary="Insufficient data to compare periods.",
+            is_inflating=False,
+        )
+
+    signals: list[InflationSignal] = []
+    total_ls_old = 0.0
+    total_ls_new = 0.0
+
+    for cat, month_map in data.items():
+        old_vals = [month_map.get(m, 0.0) for m in old_months]
+        new_vals = [month_map.get(m, 0.0) for m in new_months]
+
+        avg_old = statistics.mean(old_vals)
+        avg_new = statistics.mean(new_vals)
+
+        is_ls = _is_lifestyle(cat)
+        if is_ls:
+            total_ls_old += avg_old
+            total_ls_new += avg_new
+
+        if avg_old <= 0:
+            continue
+
+        inflation_pct = round((avg_new - avg_old) / avg_old * 100, 1)
+
+        if inflation_pct < threshold_pct:
+            continue  # not inflating enough to flag
+
+        # Severity
+        if inflation_pct >= 50:
+            severity = "high"
+        elif inflation_pct >= 20:
+            severity = "moderate"
+        else:
+            severity = "mild"
+
+        ls_label = "lifestyle" if is_ls else "general"
+        note = (
+            f"{cat} ({ls_label}) avg {inflation_pct:+.1f}% over period "
+            f"(${avg_old:.2f} -> ${avg_new:.2f}/month)."
+        )
+        signals.append(
+            InflationSignal(
+                category=cat,
+                is_lifestyle=is_ls,
+                monthly_avg_old=round(avg_old, 2),
+                monthly_avg_new=round(avg_new, 2),
+                inflation_pct=inflation_pct,
+                severity=severity,
+                trend_note=note,
+            )
+        )
+
+    # Sort by inflation % descending
+    signals.sort(key=lambda s: -s.inflation_pct)
+
+    total_ls_old = round(total_ls_old, 2)
+    total_ls_new = round(total_ls_new, 2)
+
+    if total_ls_old > 0:
+        lifestyle_inflation_pct = round((total_ls_new - total_ls_old) / total_ls_old * 100, 1)
+    else:
+        lifestyle_inflation_pct = 0.0
+
+    is_inflating = lifestyle_inflation_pct >= threshold_pct
+    top_inflated = signals[0].category if signals else None
+
+    if not signals:
+        summary = "No significant lifestyle inflation detected. Spending patterns look stable."
+    elif is_inflating:
+        summary = (
+            f"Lifestyle inflation detected: +{lifestyle_inflation_pct:.1f}% over the analysis period. "
+            f"Top driver: {top_inflated}."
+        )
+    else:
+        summary = (
+            f"Some category increases found ({len(signals)}) but overall lifestyle spending "
+            f"is relatively stable ({lifestyle_inflation_pct:+.1f}%)."
+        )
+
+    return LifestyleInflationResult(
+        analysis_months=months,
+        total_lifestyle_old=total_ls_old,
+        total_lifestyle_new=total_ls_new,
+        lifestyle_inflation_pct=lifestyle_inflation_pct,
+        inflation_signals=signals,
+        top_inflated_category=top_inflated,
+        summary=summary,
+        is_inflating=is_inflating,
+    )

--- a/packages/backend/tests/test_lifestyle_inflation.py
+++ b/packages/backend/tests/test_lifestyle_inflation.py
@@ -1,0 +1,163 @@
+"""Tests for Lifestyle Inflation Detection Insights (issue #118)."""
+import pytest
+from unittest.mock import MagicMock
+
+from app.services.lifestyle_inflation import (
+    get_lifestyle_inflation,
+    LifestyleInflationResult,
+    InflationSignal,
+    _is_lifestyle,
+)
+
+
+def _make_row(month, category, total):
+    row = MagicMock()
+    row.month = month
+    row.category = category
+    row.total = total
+    return row
+
+
+def _mock_query(rows):
+    q = MagicMock()
+    q.filter.return_value = q
+    q.group_by.return_value = q
+    q.all.return_value = rows
+    return q
+
+
+def test_empty_returns_no_signals(mocker):
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query([]))
+    result = get_lifestyle_inflation(user_id=1)
+    assert result.inflation_signals == []
+    assert result.is_inflating is False
+
+
+def test_required_fields_present(mocker):
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query([]))
+    result = get_lifestyle_inflation(user_id=1)
+    assert hasattr(result, "analysis_months")
+    assert hasattr(result, "lifestyle_inflation_pct")
+    assert hasattr(result, "inflation_signals")
+    assert hasattr(result, "is_inflating")
+    assert hasattr(result, "summary")
+    assert hasattr(result, "top_inflated_category")
+
+
+def test_lifestyle_keyword_detected():
+    assert _is_lifestyle("Dining") is True
+    assert _is_lifestyle("Gym") is True
+    assert _is_lifestyle("Streaming") is True
+    assert _is_lifestyle("Coffee") is True
+
+
+def test_non_lifestyle_not_flagged():
+    assert _is_lifestyle("Rent") is False
+    assert _is_lifestyle("Utilities") is False
+    assert _is_lifestyle("Mortgage") is False
+
+
+def test_inflation_signal_detected(mocker):
+    # Dining goes from 200 (old) to 300 (new) = 50% increase
+    rows = [
+        _make_row("2025-07", "Dining", 200),
+        _make_row("2025-08", "Dining", 200),
+        _make_row("2025-09", "Dining", 200),
+        _make_row("2025-10", "Dining", 300),
+        _make_row("2025-11", "Dining", 300),
+        _make_row("2025-12", "Dining", 300),
+    ]
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query(rows))
+    result = get_lifestyle_inflation(user_id=1, months=6)
+    dining = next((s for s in result.inflation_signals if s.category == "Dining"), None)
+    assert dining is not None
+    assert dining.inflation_pct > 0
+    assert dining.severity in ("moderate", "high")
+
+
+def test_no_inflation_below_threshold(mocker):
+    # Dining changes by 2% - below 5% threshold
+    rows = [
+        _make_row("2025-07", "Dining", 100),
+        _make_row("2025-08", "Dining", 100),
+        _make_row("2025-09", "Dining", 100),
+        _make_row("2025-10", "Dining", 102),
+        _make_row("2025-11", "Dining", 102),
+        _make_row("2025-12", "Dining", 102),
+    ]
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query(rows))
+    result = get_lifestyle_inflation(user_id=1, months=6, threshold_pct=5.0)
+    assert len(result.inflation_signals) == 0
+
+
+def test_severity_high_for_50pct_plus(mocker):
+    rows = [
+        _make_row("2025-07", "Entertainment", 100),
+        _make_row("2025-08", "Entertainment", 100),
+        _make_row("2025-09", "Entertainment", 100),
+        _make_row("2025-10", "Entertainment", 200),
+        _make_row("2025-11", "Entertainment", 200),
+        _make_row("2025-12", "Entertainment", 200),
+    ]
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query(rows))
+    result = get_lifestyle_inflation(user_id=1, months=6)
+    sig = next((s for s in result.inflation_signals if s.category == "Entertainment"), None)
+    if sig:
+        assert sig.severity == "high"
+
+
+def test_signals_sorted_by_inflation_pct(mocker):
+    rows = [
+        # Cat A: 10% increase
+        _make_row("2025-07", "Coffee", 100),
+        _make_row("2025-08", "Coffee", 100),
+        _make_row("2025-09", "Coffee", 100),
+        _make_row("2025-10", "Coffee", 110),
+        _make_row("2025-11", "Coffee", 110),
+        _make_row("2025-12", "Coffee", 110),
+        # Cat B: 50% increase
+        _make_row("2025-07", "Dining", 100),
+        _make_row("2025-08", "Dining", 100),
+        _make_row("2025-09", "Dining", 100),
+        _make_row("2025-10", "Dining", 150),
+        _make_row("2025-11", "Dining", 150),
+        _make_row("2025-12", "Dining", 150),
+    ]
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query(rows))
+    result = get_lifestyle_inflation(user_id=1, months=6)
+    if len(result.inflation_signals) >= 2:
+        pcts = [s.inflation_pct for s in result.inflation_signals]
+        assert pcts == sorted(pcts, reverse=True)
+
+
+def test_is_inflating_flag_set(mocker):
+    rows = [
+        _make_row("2025-07", "Dining", 100),
+        _make_row("2025-08", "Dining", 100),
+        _make_row("2025-09", "Dining", 100),
+        _make_row("2025-10", "Dining", 200),
+        _make_row("2025-11", "Dining", 200),
+        _make_row("2025-12", "Dining", 200),
+    ]
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query(rows))
+    result = get_lifestyle_inflation(user_id=1, months=6)
+    assert result.is_inflating is True
+
+
+def test_months_must_be_even(mocker):
+    mocker.patch("app.services.lifestyle_inflation.db.session.query",
+                 return_value=_mock_query([]))
+    result = get_lifestyle_inflation(user_id=1, months=5)
+    assert result.analysis_months % 2 == 0
+
+
+def test_route_requires_auth(client):
+    resp = client.get("/insights/lifestyle-inflation")
+    assert resp.status_code == 401


### PR DESCRIPTION
feat: Lifestyle Inflation Detection Insights (issue #118)

Implements GET /insights/lifestyle-inflation that detects rising lifestyle expenses over time.

How it works:
- Splits the analysis period in half: "old" (earlier months) vs "recent" (later months)
- Compares average monthly spend per category between the two halves
- Lifestyle categories identified via keyword matching (dining, gym, coffee, streaming, shopping, travel, etc.)
- Only flags categories with >= threshold_pct increase (default 5%, configurable)

Features:
- Three severity tiers: "mild" (5-20%), "moderate" (20-50%), "high" (>50%)
- Overall lifestyle_inflation_pct comparing aggregate lifestyle spend old vs new
- is_inflating boolean flag for easy UI integration
- top_inflated_category for quick summary display
- Signals sorted by inflation percentage descending
- Optional months param (2-24), always rounded to even for equal period comparison
- Optional threshold param to customize sensitivity
- JWT-protected endpoint
- 11 unit tests: empty state, keyword detection, inflation math, severity, sort order, threshold, months-even rule, auth

/claim #118
