### PR TITLE
feat: Transaction Deduplication Intelligence (issue #113)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .transaction_dedup import bp as transaction_dedup_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(transaction_dedup_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/transaction_dedup.py
+++ b/packages/backend/app/routes/transaction_dedup.py
@@ -1,0 +1,61 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from app.services.transaction_dedup import detect_duplicates
+
+bp = Blueprint("transaction_dedup", __name__)
+
+
+@bp.route("/deduplication", methods=["GET"])
+@jwt_required()
+def deduplication():
+    """
+    GET /insights/deduplication?months=3&days_window=2&min_confidence=0.7
+
+    Detects potential duplicate transactions using multiple strategies:
+    - Exact duplicates: same amount, date, category, type
+    - Near-date duplicates: same amount within N days (configurable window)
+
+    Returns duplicate groups with confidence scores, suggested keep/remove IDs.
+    """
+    user_id = get_jwt_identity()
+
+    try:
+        months = int(request.args.get("months", 3))
+    except (ValueError, TypeError):
+        months = 3
+    try:
+        days_window = int(request.args.get("days_window", 2))
+    except (ValueError, TypeError):
+        days_window = 2
+    try:
+        min_confidence = float(request.args.get("min_confidence", 0.7))
+    except (ValueError, TypeError):
+        min_confidence = 0.7
+
+    result = detect_duplicates(
+        user_id=int(user_id),
+        months=months,
+        days_window=days_window,
+        min_confidence=min_confidence,
+    )
+
+    return jsonify(
+        {
+            "total_duplicates_found": result.total_duplicates_found,
+            "estimated_duplicate_amount": result.estimated_duplicate_amount,
+            "summary": result.summary,
+            "duplicate_groups": [
+                {
+                    "transaction_ids": g.transaction_ids,
+                    "confidence": g.confidence,
+                    "reason": g.reason,
+                    "suggested_keep_id": g.suggested_keep_id,
+                    "amounts": g.amounts,
+                    "dates": g.dates,
+                    "descriptions": g.descriptions,
+                }
+                for g in result.duplicate_groups
+            ],
+        }
+    )

--- a/packages/backend/app/services/transaction_dedup.py
+++ b/packages/backend/app/services/transaction_dedup.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import date, timedelta
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy import func, and_, or_
+
+from app.models import Transaction
+from app import db
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DuplicateGroup:
+    transaction_ids: list[int]
+    confidence: float            # 0.0 - 1.0
+    reason: str                  # why these are considered duplicates
+    suggested_keep_id: int       # which one to keep (oldest)
+    amounts: list[float]
+    dates: list[str]
+    descriptions: list[str]
+
+
+@dataclass
+class DeduplicationResult:
+    duplicate_groups: list[DuplicateGroup]
+    total_duplicates_found: int
+    estimated_duplicate_amount: float  # total amount of duplicate transactions
+    summary: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_description(desc: Optional[str]) -> str:
+    """Normalize a transaction description for comparison."""
+    if not desc:
+        return ""
+    # Lowercase, strip numbers that vary (reference IDs, etc.)
+    import re
+    normalized = desc.lower().strip()
+    normalized = re.sub(r'\d+', 'N', normalized)  # replace all numbers
+    normalized = re.sub(r'\s+', ' ', normalized)   # collapse whitespace
+    return normalized
+
+
+def _date_str(tx_date) -> str:
+    if isinstance(tx_date, date):
+        return tx_date.isoformat()
+    return str(tx_date)
+
+
+# ---------------------------------------------------------------------------
+# Detection strategies
+# ---------------------------------------------------------------------------
+
+def _find_exact_duplicates(transactions: list) -> list[DuplicateGroup]:
+    """Find transactions with identical amount + date + category."""
+    groups: dict[str, list] = {}
+    for tx in transactions:
+        key = f"{tx.amount}_{_date_str(tx.date)}_{tx.category or ''}_{tx.type}"
+        if key not in groups:
+            groups[key] = []
+        groups[key].append(tx)
+
+    result = []
+    for key, txs in groups.items():
+        if len(txs) >= 2:
+            sorted_txs = sorted(txs, key=lambda t: t.id)
+            result.append(
+                DuplicateGroup(
+                    transaction_ids=[t.id for t in sorted_txs],
+                    confidence=0.99,
+                    reason="Exact match: same amount, date, category, and type.",
+                    suggested_keep_id=sorted_txs[0].id,
+                    amounts=[float(t.amount) for t in sorted_txs],
+                    dates=[_date_str(t.date) for t in sorted_txs],
+                    descriptions=[t.description or "" for t in sorted_txs],
+                )
+            )
+    return result
+
+
+def _find_near_date_duplicates(transactions: list, days_window: int = 2) -> list[DuplicateGroup]:
+    """Find transactions with same amount within N days of each other."""
+    # Group by amount + type + category
+    by_key: dict[str, list] = {}
+    for tx in transactions:
+        key = f"{float(tx.amount):.2f}_{tx.type}_{tx.category or ''}"
+        if key not in by_key:
+            by_key[key] = []
+        by_key[key].append(tx)
+
+    result = []
+    seen_pairs: set = set()
+
+    for key, txs in by_key.items():
+        if len(txs) < 2:
+            continue
+        # Sort by date
+        try:
+            sorted_txs = sorted(txs, key=lambda t: (str(t.date), t.id))
+        except Exception:
+            sorted_txs = txs
+
+        for i in range(len(sorted_txs)):
+            for j in range(i + 1, len(sorted_txs)):
+                tx_a = sorted_txs[i]
+                tx_b = sorted_txs[j]
+
+                pair_key = tuple(sorted([tx_a.id, tx_b.id]))
+                if pair_key in seen_pairs:
+                    continue
+
+                # Date proximity check
+                try:
+                    date_a = date.fromisoformat(str(tx_a.date)) if not isinstance(tx_a.date, date) else tx_a.date
+                    date_b = date.fromisoformat(str(tx_b.date)) if not isinstance(tx_b.date, date) else tx_b.date
+                    delta = abs((date_a - date_b).days)
+                except (ValueError, AttributeError):
+                    delta = 999
+
+                if delta <= days_window and delta > 0:  # > 0 excludes exact date (caught above)
+                    seen_pairs.add(pair_key)
+                    pair_sorted = sorted([tx_a, tx_b], key=lambda t: t.id)
+                    result.append(
+                        DuplicateGroup(
+                            transaction_ids=[t.id for t in pair_sorted],
+                            confidence=0.75,
+                            reason=f"Same amount ${float(tx_a.amount):.2f} within {delta} day(s). Possible import duplicate.",
+                            suggested_keep_id=pair_sorted[0].id,
+                            amounts=[float(t.amount) for t in pair_sorted],
+                            dates=[_date_str(t.date) for t in pair_sorted],
+                            descriptions=[t.description or "" for t in pair_sorted],
+                        )
+                    )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Main service
+# ---------------------------------------------------------------------------
+
+def detect_duplicates(
+    user_id: int,
+    months: int = 3,
+    days_window: int = 2,
+    min_confidence: float = 0.7,
+) -> DeduplicationResult:
+    """
+    Detect duplicate transactions using multiple strategies.
+
+    Args:
+        user_id: JWT user id
+        months: how many months back to scan (1-12)
+        days_window: near-date window in days (0-7)
+        min_confidence: minimum confidence threshold for results
+    """
+    months = max(1, min(12, months))
+    days_window = max(0, min(7, days_window))
+
+    cutoff = date.today() - timedelta(days=months * 31)
+
+    transactions = (
+        db.session.query(Transaction)
+        .filter(
+            Transaction.user_id == user_id,
+            Transaction.date >= cutoff,
+        )
+        .all()
+    )
+
+    if not transactions:
+        return DeduplicationResult(
+            duplicate_groups=[],
+            total_duplicates_found=0,
+            estimated_duplicate_amount=0.0,
+            summary="No transactions found in the selected period.",
+        )
+
+    all_groups: list[DuplicateGroup] = []
+
+    # Strategy 1: Exact duplicates (highest confidence)
+    exact = _find_exact_duplicates(transactions)
+    all_groups.extend(exact)
+
+    # Strategy 2: Near-date duplicates (only if window > 0)
+    if days_window > 0:
+        # Exclude transaction IDs already in exact groups
+        exact_ids = {tid for g in exact for tid in g.transaction_ids}
+        non_exact = [t for t in transactions if t.id not in exact_ids]
+        near = _find_near_date_duplicates(non_exact, days_window=days_window)
+        all_groups.extend(near)
+
+    # Filter by min_confidence
+    all_groups = [g for g in all_groups if g.confidence >= min_confidence]
+
+    # Sort by confidence desc
+    all_groups.sort(key=lambda g: -g.confidence)
+
+    total_duplicates = sum(len(g.transaction_ids) - 1 for g in all_groups)  # extras to remove
+    estimated_amount = sum(
+        g.amounts[0] * (len(g.transaction_ids) - 1)  # duplicate amounts
+        for g in all_groups
+    )
+    estimated_amount = round(estimated_amount, 2)
+
+    if not all_groups:
+        summary = "No duplicate transactions detected in the selected period."
+    else:
+        summary = (
+            f"Found {len(all_groups)} duplicate group(s) with {total_duplicates} "
+            f"extra transaction(s) totaling ${estimated_amount:.2f}."
+        )
+
+    return DeduplicationResult(
+        duplicate_groups=all_groups,
+        total_duplicates_found=total_duplicates,
+        estimated_duplicate_amount=estimated_amount,
+        summary=summary,
+    )

--- a/packages/backend/tests/test_transaction_dedup.py
+++ b/packages/backend/tests/test_transaction_dedup.py
@@ -1,0 +1,157 @@
+"""Tests for Transaction Deduplication Intelligence (issue #113)."""
+import pytest
+from unittest.mock import MagicMock
+from datetime import date
+
+from app.services.transaction_dedup import (
+    detect_duplicates,
+    DeduplicationResult,
+    DuplicateGroup,
+    _normalize_description,
+)
+
+
+def _make_tx(tx_id, amount, tx_date, category="Food", tx_type="expense", description=""):
+    tx = MagicMock()
+    tx.id = tx_id
+    tx.amount = amount
+    tx.date = tx_date
+    tx.category = category
+    tx.type = tx_type
+    tx.description = description
+    return tx
+
+
+def _mock_query(rows):
+    q = MagicMock()
+    q.filter.return_value = q
+    q.all.return_value = rows
+    return q
+
+
+def test_empty_returns_no_duplicates(mocker):
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query([]))
+    result = detect_duplicates(user_id=1)
+    assert result.duplicate_groups == []
+    assert result.total_duplicates_found == 0
+
+
+def test_required_fields_present(mocker):
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query([]))
+    result = detect_duplicates(user_id=1)
+    assert hasattr(result, "duplicate_groups")
+    assert hasattr(result, "total_duplicates_found")
+    assert hasattr(result, "estimated_duplicate_amount")
+    assert hasattr(result, "summary")
+
+
+def test_exact_duplicate_detected(mocker):
+    txs = [
+        _make_tx(1, 100.0, date(2026, 1, 15)),
+        _make_tx(2, 100.0, date(2026, 1, 15)),  # exact duplicate
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1)
+    assert len(result.duplicate_groups) >= 1
+    assert result.total_duplicates_found >= 1
+
+
+def test_exact_duplicate_high_confidence(mocker):
+    txs = [
+        _make_tx(1, 150.0, date(2026, 1, 10)),
+        _make_tx(2, 150.0, date(2026, 1, 10)),
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1)
+    if result.duplicate_groups:
+        assert result.duplicate_groups[0].confidence >= 0.9
+
+
+def test_duplicate_group_fields_present(mocker):
+    txs = [
+        _make_tx(1, 200.0, date(2026, 1, 5)),
+        _make_tx(2, 200.0, date(2026, 1, 5)),
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1)
+    if result.duplicate_groups:
+        g = result.duplicate_groups[0]
+        assert hasattr(g, "transaction_ids")
+        assert hasattr(g, "confidence")
+        assert hasattr(g, "reason")
+        assert hasattr(g, "suggested_keep_id")
+        assert hasattr(g, "amounts")
+        assert hasattr(g, "dates")
+
+
+def test_suggested_keep_is_oldest(mocker):
+    txs = [
+        _make_tx(5, 100.0, date(2026, 1, 15)),
+        _make_tx(3, 100.0, date(2026, 1, 15)),  # lower id = earlier
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1)
+    if result.duplicate_groups:
+        assert result.duplicate_groups[0].suggested_keep_id == 3
+
+
+def test_near_date_duplicate_detected(mocker):
+    txs = [
+        _make_tx(1, 100.0, date(2026, 1, 15)),
+        _make_tx(2, 100.0, date(2026, 1, 17)),  # 2 days later, same amount
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1, days_window=2)
+    assert len(result.duplicate_groups) >= 1
+
+
+def test_near_date_outside_window_not_flagged(mocker):
+    txs = [
+        _make_tx(1, 100.0, date(2026, 1, 15)),
+        _make_tx(2, 100.0, date(2026, 1, 20)),  # 5 days later, outside window=2
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1, days_window=2)
+    assert len(result.duplicate_groups) == 0
+
+
+def test_different_amounts_not_duplicates(mocker):
+    txs = [
+        _make_tx(1, 100.0, date(2026, 1, 15)),
+        _make_tx(2, 200.0, date(2026, 1, 15)),  # different amount
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1)
+    assert len(result.duplicate_groups) == 0
+
+
+def test_estimated_amount_correct(mocker):
+    txs = [
+        _make_tx(1, 100.0, date(2026, 1, 15)),
+        _make_tx(2, 100.0, date(2026, 1, 15)),  # duplicate
+    ]
+    mocker.patch("app.services.transaction_dedup.db.session.query",
+                 return_value=_mock_query(txs))
+    result = detect_duplicates(user_id=1)
+    # 1 duplicate of $100 = estimated_amount = $100
+    assert abs(result.estimated_duplicate_amount - 100.0) < 0.01
+
+
+def test_normalize_description_removes_numbers():
+    normalized = _normalize_description("Payment ref 12345")
+    assert "12345" not in normalized
+    assert "N" in normalized
+
+
+def test_route_requires_auth(client):
+    resp = client.get("/insights/deduplication")
+    assert resp.status_code == 401


### PR DESCRIPTION
feat: Transaction Deduplication Intelligence (issue #113)

Implements GET /insights/deduplication to improve duplicate detection across imports and syncs.

Two detection strategies:

Strategy 1 - Exact Duplicates (confidence=0.99):
Finds transactions with identical amount + date + category + type. Catches the classic "imported the same CSV twice" scenario.

Strategy 2 - Near-Date Duplicates (confidence=0.75):
Finds transactions with the same amount within N days of each other (configurable, default 2 days). Catches re-imports with slightly different timestamps due to timezone or processing delays.

Features:
- Multi-strategy pipeline with configurable minimum confidence threshold (default 0.7)
- suggested_keep_id always points to the lowest transaction ID (earliest created = most likely original)
- estimated_duplicate_amount shows total financial impact of removing duplicates
- Strategies are exclusive: near-date detection skips IDs already flagged by exact detection
- Results sorted by confidence descending
- Configurable: months (1-12), days_window (0-7), min_confidence (0.0-1.0)
- JWT-protected endpoint
- 12 unit tests covering both detection strategies, windows, field validation, amount calculation, auth

/claim #113
