### PR TITLE
feat: savings opportunity detection engine

### DIFF
--- a/app/src/__tests__/SavingsOpportunities.test.tsx
+++ b/app/src/__tests__/SavingsOpportunities.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SavingsOpportunities } from '@/components/ui/SavingsOpportunities';
+
+jest.mock('@/components/ui/financial-card', () => ({
+  FinancialCard: ({ children, ...props }: React.PropsWithChildren & Record<string, unknown>) => (
+    <div data-testid={props['data-testid'] as string}>{children}</div>
+  ),
+  FinancialCardHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardTitle: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardDescription: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+const getSavingsOpportunitiesMock = jest.fn();
+jest.mock('@/api/insights', () => ({
+  getSavingsOpportunities: (...args: unknown[]) => getSavingsOpportunitiesMock(...args),
+}));
+
+describe('SavingsOpportunities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    getSavingsOpportunitiesMock.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<SavingsOpportunities month="2026-03" />);
+    expect(screen.getByTestId('savings-loading')).toBeInTheDocument();
+  });
+
+  it('renders opportunity cards when data is loaded', async () => {
+    getSavingsOpportunitiesMock.mockResolvedValue({
+      month: '2026-03',
+      opportunities: [
+        {
+          type: 'month_over_month_increase',
+          title: 'Dining spending spike',
+          description: 'Your Dining spending increased 50% this month.',
+          potential_savings: 50.0,
+          category: 'Dining',
+          trend: { current_month: 150, previous_month: 100, change_pct: 50.0 },
+        },
+        {
+          type: 'high_frequency_small_purchases',
+          title: 'Small purchases add up',
+          description: 'You made 10 small purchases totalling $50.',
+          potential_savings: 25.0,
+          category: 'Coffee',
+          trend: { transaction_count: 10, total_amount: 50 },
+        },
+      ],
+    });
+
+    render(<SavingsOpportunities month="2026-03" />);
+    await waitFor(() => expect(getSavingsOpportunitiesMock).toHaveBeenCalledWith({ month: '2026-03' }));
+    await waitFor(() => expect(screen.getByTestId('savings-opportunities')).toBeInTheDocument());
+
+    const cards = screen.getAllByTestId('savings-opportunity-card');
+    expect(cards).toHaveLength(2);
+    expect(screen.getByText(/dining spending spike/i)).toBeInTheDocument();
+    expect(screen.getByText(/small purchases add up/i)).toBeInTheDocument();
+  });
+
+  it('shows empty state when no opportunities', async () => {
+    getSavingsOpportunitiesMock.mockResolvedValue({
+      month: '2026-03',
+      opportunities: [],
+    });
+
+    render(<SavingsOpportunities month="2026-03" />);
+    await waitFor(() => expect(screen.getByTestId('savings-empty')).toBeInTheDocument());
+    expect(screen.getByText(/no savings opportunities found/i)).toBeInTheDocument();
+  });
+
+  it('shows error state on failure', async () => {
+    getSavingsOpportunitiesMock.mockRejectedValue(new Error('Network error'));
+
+    render(<SavingsOpportunities month="2026-03" />);
+    await waitFor(() => expect(screen.getByTestId('savings-error')).toBeInTheDocument());
+    expect(screen.getByText(/network error/i)).toBeInTheDocument();
+  });
+
+  it('re-fetches when month prop changes', async () => {
+    getSavingsOpportunitiesMock.mockResolvedValue({
+      month: '2026-03',
+      opportunities: [],
+    });
+
+    const { rerender } = render(<SavingsOpportunities month="2026-03" />);
+    await waitFor(() => expect(getSavingsOpportunitiesMock).toHaveBeenCalledWith({ month: '2026-03' }));
+
+    getSavingsOpportunitiesMock.mockResolvedValue({
+      month: '2026-04',
+      opportunities: [],
+    });
+
+    rerender(<SavingsOpportunities month="2026-04" />);
+    await waitFor(() => expect(getSavingsOpportunitiesMock).toHaveBeenCalledWith({ month: '2026-04' }));
+    expect(getSavingsOpportunitiesMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -32,3 +32,30 @@ export async function getBudgetSuggestion(params?: {
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
 }
+
+export type SavingsOpportunityTrend = Record<string, number | string>;
+
+export type SavingsOpportunity = {
+  type: string;
+  title: string;
+  description: string;
+  potential_savings: number;
+  category: string | null;
+  trend: SavingsOpportunityTrend;
+};
+
+export type SavingsOpportunitiesResponse = {
+  month: string;
+  opportunities: SavingsOpportunity[];
+};
+
+export async function getSavingsOpportunities(
+  params?: { month?: string },
+): Promise<SavingsOpportunitiesResponse> {
+  const monthQuery = params?.month
+    ? `?month=${encodeURIComponent(params.month)}`
+    : '';
+  return api<SavingsOpportunitiesResponse>(
+    `/insights/savings-opportunities${monthQuery}`,
+  );
+}

--- a/app/src/components/ui/SavingsOpportunities.tsx
+++ b/app/src/components/ui/SavingsOpportunities.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardDescription,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { formatMoney } from '@/lib/currency';
+import {
+  getSavingsOpportunities,
+  type SavingsOpportunity,
+  type SavingsOpportunitiesResponse,
+} from '@/api/insights';
+
+const TYPE_LABELS: Record<string, string> = {
+  month_over_month_increase: 'Spending Spike',
+  high_frequency_small_purchases: 'Latte Factor',
+  subscription_duplicate: 'Possible Duplicate',
+  above_average_spending: 'Above Average',
+};
+
+const TYPE_VARIANTS: Record<string, 'warning' | 'destructive' | 'financial'> = {
+  month_over_month_increase: 'warning',
+  high_frequency_small_purchases: 'financial',
+  subscription_duplicate: 'destructive',
+  above_average_spending: 'warning',
+};
+
+function TrendBadge({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+      {label}: {value}
+    </span>
+  );
+}
+
+function OpportunityCard({ opportunity }: { opportunity: SavingsOpportunity }) {
+  const variant = TYPE_VARIANTS[opportunity.type] ?? 'financial';
+  const badge = TYPE_LABELS[opportunity.type] ?? opportunity.type;
+  const trend = opportunity.trend;
+
+  return (
+    <FinancialCard variant={variant} data-testid="savings-opportunity-card">
+      <FinancialCardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <FinancialCardTitle className="text-sm">{opportunity.title}</FinancialCardTitle>
+          <span className="rounded-full bg-background/60 px-2 py-0.5 text-xs font-medium">
+            {badge}
+          </span>
+        </div>
+        <FinancialCardDescription>{opportunity.category ?? 'General'}</FinancialCardDescription>
+      </FinancialCardHeader>
+      <FinancialCardContent>
+        <p className="text-sm mb-3">{opportunity.description}</p>
+        <div className="flex items-center justify-between">
+          <div className="font-semibold text-lg">
+            Save {formatMoney(opportunity.potential_savings)}
+          </div>
+          <div className="flex flex-wrap gap-1">
+            {trend.change_pct != null && (
+              <TrendBadge label="Change" value={`${trend.change_pct}%`} />
+            )}
+            {trend.transaction_count != null && (
+              <TrendBadge label="Txns" value={String(trend.transaction_count)} />
+            )}
+            {trend.occurrences != null && (
+              <TrendBadge label="Occurrences" value={String(trend.occurrences)} />
+            )}
+            {trend.months_in_average != null && (
+              <TrendBadge label="Avg period" value={`${trend.months_in_average}mo`} />
+            )}
+          </div>
+        </div>
+      </FinancialCardContent>
+    </FinancialCard>
+  );
+}
+
+export function SavingsOpportunities({ month }: { month?: string }) {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<SavingsOpportunitiesResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    getSavingsOpportunities({ month })
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load savings opportunities');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [month]);
+
+  if (loading) {
+    return <div className="card" data-testid="savings-loading">Analyzing spending patterns...</div>;
+  }
+
+  if (error) {
+    return <div className="card text-red-600" data-testid="savings-error">{error}</div>;
+  }
+
+  if (!data || data.opportunities.length === 0) {
+    return (
+      <FinancialCard variant="success" data-testid="savings-empty">
+        <FinancialCardHeader>
+          <FinancialCardTitle>No Savings Opportunities Found</FinancialCardTitle>
+        </FinancialCardHeader>
+        <FinancialCardContent>
+          <p className="text-sm text-muted-foreground">
+            Your spending looks healthy this month. Keep it up!
+          </p>
+        </FinancialCardContent>
+      </FinancialCard>
+    );
+  }
+
+  const totalSavings = data.opportunities.reduce((sum, o) => sum + o.potential_savings, 0);
+
+  return (
+    <div className="space-y-4" data-testid="savings-opportunities">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">
+          Savings Opportunities
+        </h2>
+        <span className="text-sm text-muted-foreground">
+          Potential total savings: {formatMoney(totalSavings)}
+        </span>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {data.opportunities.map((opp, idx) => (
+          <OpportunityCard key={`${opp.type}-${idx}`} opportunity={opp} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -12,6 +12,7 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
+import { SavingsOpportunities } from '@/components/ui/SavingsOpportunities';
 
 const PERSONAS = [
   'Balanced coach',
@@ -193,6 +194,9 @@ export function Analytics() {
           </FinancialCard>
         </div>
       ) : null}
+
+      {/* Savings Opportunity Detection */}
+      <SavingsOpportunities month={month} />
     </div>
   );
 }

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,7 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.savings import detect_savings_opportunities
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +24,16 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/savings-opportunities")
+@jwt_required()
+def savings_opportunities():
+    uid = int(get_jwt_identity())
+    ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
+    opportunities = detect_savings_opportunities(uid, ym)
+    logger.info(
+        "Savings opportunities served user=%s month=%s count=%d",
+        uid, ym, len(opportunities),
+    )
+    return jsonify({"month": ym, "opportunities": opportunities})

--- a/packages/backend/app/services/savings.py
+++ b/packages/backend/app/services/savings.py
@@ -1,0 +1,281 @@
+"""Savings opportunity detection engine.
+
+Analyses a user's spending history and returns actionable savings
+opportunities based on four detection rules:
+
+1. Month-over-month category increases
+2. High-frequency small purchases (latte factor)
+3. Subscription/recurring duplicates
+4. Above-average category spending
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter, defaultdict
+from datetime import date, timedelta
+
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Category, Expense
+
+logger = logging.getLogger("finmind.savings")
+
+# --- thresholds --------------------------------------------------------
+MOM_INCREASE_PCT = 20  # flag category if spending rose >= 20 %
+SMALL_PURCHASE_THRESHOLD = 10.0  # amounts <= this are "small"
+SMALL_PURCHASE_MIN_COUNT = 8  # need at least this many in a month
+ABOVE_AVG_FACTOR = 1.30  # flag category if > 130 % of 3-month average
+
+
+def detect_savings_opportunities(
+    user_id: int,
+    month: str | None = None,
+) -> list[dict]:
+    """Return a list of savings-opportunity dicts for *month* (YYYY-MM).
+
+    Each dict carries:
+        type        – rule identifier
+        title       – short human-readable title
+        description – actionable message
+        potential_savings – estimated dollar amount
+        category    – category name (or None)
+        trend       – contextual numbers for the frontend
+    """
+    ym = (month or date.today().strftime("%Y-%m")).strip()
+    year, mon = map(int, ym.split("-"))
+
+    opportunities: list[dict] = []
+
+    opportunities.extend(_detect_mom_increases(user_id, year, mon))
+    opportunities.extend(_detect_latte_factor(user_id, year, mon))
+    opportunities.extend(_detect_duplicate_subscriptions(user_id, year, mon))
+    opportunities.extend(_detect_above_average(user_id, year, mon))
+
+    # Sort by potential savings descending
+    opportunities.sort(key=lambda o: o["potential_savings"], reverse=True)
+    logger.info(
+        "Detected %d savings opportunities for user=%s month=%s",
+        len(opportunities),
+        user_id,
+        ym,
+    )
+    return opportunities
+
+
+# --- rule implementations -----------------------------------------------
+
+
+def _category_totals(user_id: int, year: int, month: int) -> dict[int, float]:
+    """Return {category_id: total_spend} for one month (expenses only)."""
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(func.sum(Expense.amount), 0),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+            Expense.category_id.isnot(None),
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+    return {int(cid): float(total) for cid, total in rows}
+
+
+def _prev_month(year: int, month: int) -> tuple[int, int]:
+    if month == 1:
+        return year - 1, 12
+    return year, month - 1
+
+
+def _category_name(category_id: int) -> str:
+    cat = db.session.get(Category, category_id)
+    return cat.name if cat else f"Category #{category_id}"
+
+
+def _detect_mom_increases(
+    user_id: int, year: int, month: int
+) -> list[dict]:
+    """Flag categories where spending increased >= MOM_INCREASE_PCT."""
+    current = _category_totals(user_id, year, month)
+    py, pm = _prev_month(year, month)
+    previous = _category_totals(user_id, py, pm)
+
+    results: list[dict] = []
+    for cid, cur_total in current.items():
+        prev_total = previous.get(cid, 0)
+        if prev_total <= 0:
+            continue
+        pct = ((cur_total - prev_total) / prev_total) * 100
+        if pct >= MOM_INCREASE_PCT:
+            savings = round(cur_total - prev_total, 2)
+            name = _category_name(cid)
+            results.append(
+                {
+                    "type": "month_over_month_increase",
+                    "title": f"{name} spending spike",
+                    "description": (
+                        f"Your {name} spending increased {pct:.0f}% this month. "
+                        f"Returning to last month's level could save you "
+                        f"${savings:,.2f}."
+                    ),
+                    "potential_savings": savings,
+                    "category": name,
+                    "trend": {
+                        "current_month": round(cur_total, 2),
+                        "previous_month": round(prev_total, 2),
+                        "change_pct": round(pct, 1),
+                    },
+                }
+            )
+    return results
+
+
+def _detect_latte_factor(
+    user_id: int, year: int, month: int
+) -> list[dict]:
+    """Flag high-frequency small purchases that add up."""
+    rows = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == user_id,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+            Expense.amount <= SMALL_PURCHASE_THRESHOLD,
+        )
+        .all()
+    )
+    if len(rows) < SMALL_PURCHASE_MIN_COUNT:
+        return []
+
+    total = sum(float(e.amount) for e in rows)
+    # Group by category for a richer message
+    by_cat: dict[int | None, float] = defaultdict(float)
+    for e in rows:
+        by_cat[e.category_id] += float(e.amount)
+
+    top_cat_id = max(by_cat, key=lambda k: by_cat[k])  # type: ignore[arg-type]
+    top_cat_name = _category_name(top_cat_id) if top_cat_id else "Uncategorized"
+
+    half = round(total / 2, 2)
+    return [
+        {
+            "type": "high_frequency_small_purchases",
+            "title": "Small purchases add up",
+            "description": (
+                f"You made {len(rows)} small purchases (under "
+                f"${SMALL_PURCHASE_THRESHOLD:.0f}) totalling ${total:,.2f} "
+                f"this month, mostly in {top_cat_name}. Cutting these in half "
+                f"would save ${half:,.2f}."
+            ),
+            "potential_savings": half,
+            "category": top_cat_name,
+            "trend": {
+                "transaction_count": len(rows),
+                "total_amount": round(total, 2),
+            },
+        }
+    ]
+
+
+def _detect_duplicate_subscriptions(
+    user_id: int, year: int, month: int
+) -> list[dict]:
+    """Flag notes that appear more than once with the same amount (likely duplicate subs)."""
+    rows = (
+        db.session.query(
+            Expense.notes,
+            Expense.amount,
+            func.count(Expense.id),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+            Expense.notes.isnot(None),
+            Expense.notes != "",
+        )
+        .group_by(Expense.notes, Expense.amount)
+        .having(func.count(Expense.id) > 1)
+        .all()
+    )
+
+    results: list[dict] = []
+    for notes, amount, count in rows:
+        dup_cost = round(float(amount) * (count - 1), 2)
+        results.append(
+            {
+                "type": "subscription_duplicate",
+                "title": f"Possible duplicate: {notes}",
+                "description": (
+                    f'"{notes}" (${float(amount):,.2f}) appears {count} times '
+                    f"this month. If duplicated, you could save ${dup_cost:,.2f}."
+                ),
+                "potential_savings": dup_cost,
+                "category": None,
+                "trend": {
+                    "occurrences": count,
+                    "unit_amount": round(float(amount), 2),
+                },
+            }
+        )
+    return results
+
+
+def _detect_above_average(
+    user_id: int, year: int, month: int
+) -> list[dict]:
+    """Flag categories spending > ABOVE_AVG_FACTOR of their 3-month average."""
+    current = _category_totals(user_id, year, month)
+    if not current:
+        return []
+
+    # Compute 3-month rolling average (the 3 months *before* current)
+    averages: dict[int, float] = defaultdict(float)
+    counts: Counter[int] = Counter()
+    y, m = year, month
+    for _ in range(3):
+        y, m = _prev_month(y, m)
+        totals = _category_totals(user_id, y, m)
+        for cid, val in totals.items():
+            averages[cid] += val
+            counts[cid] += 1
+
+    results: list[dict] = []
+    for cid, cur_total in current.items():
+        if counts[cid] < 2:
+            # need at least 2 months of history to be meaningful
+            continue
+        avg = averages[cid] / counts[cid]
+        if avg <= 0:
+            continue
+        if cur_total > avg * ABOVE_AVG_FACTOR:
+            savings = round(cur_total - avg, 2)
+            name = _category_name(cid)
+            results.append(
+                {
+                    "type": "above_average_spending",
+                    "title": f"{name} above your average",
+                    "description": (
+                        f"You spent ${cur_total:,.2f} on {name} this month, "
+                        f"which is {cur_total / avg:.1f}x your "
+                        f"{counts[cid]}-month average of ${avg:,.2f}. "
+                        f"Returning to average could save ${savings:,.2f}."
+                    ),
+                    "potential_savings": savings,
+                    "category": name,
+                    "trend": {
+                        "current_month": round(cur_total, 2),
+                        "rolling_average": round(avg, 2),
+                        "months_in_average": counts[cid],
+                    },
+                }
+            )
+    return results

--- a/packages/backend/tests/test_savings.py
+++ b/packages/backend/tests/test_savings.py
@@ -1,0 +1,169 @@
+"""Tests for the savings opportunity detection engine."""
+
+from datetime import date, timedelta
+
+
+def _create_category(client, auth_header, name):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+def _create_expense(client, auth_header, amount, description, spent_at, category_id=None):
+    payload = {
+        "amount": amount,
+        "description": description,
+        "date": spent_at if isinstance(spent_at, str) else spent_at.isoformat(),
+        "expense_type": "EXPENSE",
+    }
+    if category_id is not None:
+        payload["category_id"] = category_id
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+class TestSavingsOpportunitiesEndpoint:
+    def test_returns_empty_when_no_expenses(self, client, auth_header):
+        r = client.get("/insights/savings-opportunities", headers=auth_header)
+        assert r.status_code == 200
+        payload = r.get_json()
+        assert payload["opportunities"] == []
+        assert "month" in payload
+
+    def test_accepts_month_param(self, client, auth_header):
+        r = client.get(
+            "/insights/savings-opportunities?month=2025-06", headers=auth_header
+        )
+        assert r.status_code == 200
+        assert r.get_json()["month"] == "2025-06"
+
+    def test_requires_auth(self, client):
+        r = client.get("/insights/savings-opportunities")
+        assert r.status_code == 401
+
+
+class TestMonthOverMonthIncrease:
+    def test_detects_spending_spike(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Dining")
+
+        current = date.today().replace(day=10)
+        py, pm = (current.year, current.month - 1) if current.month > 1 else (current.year - 1, 12)
+        previous = date(py, pm, 10)
+
+        # Previous month: $100
+        _create_expense(client, auth_header, 100, "Dinner", previous, cat_id)
+        # Current month: $150 (50% increase, above 20% threshold)
+        _create_expense(client, auth_header, 150, "Dinner", current, cat_id)
+
+        ym = current.strftime("%Y-%m")
+        r = client.get(
+            f"/insights/savings-opportunities?month={ym}", headers=auth_header
+        )
+        assert r.status_code == 200
+        opps = r.get_json()["opportunities"]
+        mom_opps = [o for o in opps if o["type"] == "month_over_month_increase"]
+        assert len(mom_opps) >= 1
+        assert mom_opps[0]["potential_savings"] == 50.0
+        assert mom_opps[0]["category"] == "Dining"
+        assert mom_opps[0]["trend"]["change_pct"] == 50.0
+
+
+class TestHighFrequencySmallPurchases:
+    def test_detects_latte_factor(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Coffee")
+        current = date.today().replace(day=1)
+
+        # Create 10 small purchases of $5 each = $50 total
+        for i in range(10):
+            day = min(current.day + i, 28)
+            d = current.replace(day=day)
+            _create_expense(client, auth_header, 5, f"Coffee #{i}", d, cat_id)
+
+        ym = current.strftime("%Y-%m")
+        r = client.get(
+            f"/insights/savings-opportunities?month={ym}", headers=auth_header
+        )
+        assert r.status_code == 200
+        opps = r.get_json()["opportunities"]
+        latte_opps = [o for o in opps if o["type"] == "high_frequency_small_purchases"]
+        assert len(latte_opps) == 1
+        assert latte_opps[0]["potential_savings"] == 25.0  # half of $50
+        assert latte_opps[0]["trend"]["transaction_count"] == 10
+
+
+class TestDuplicateSubscriptions:
+    def test_detects_duplicate_charges(self, client, auth_header):
+        current = date.today().replace(day=5)
+
+        # Same description + amount appearing twice
+        _create_expense(client, auth_header, 9.99, "Netflix", current)
+        _create_expense(client, auth_header, 9.99, "Netflix", current.replace(day=15))
+
+        ym = current.strftime("%Y-%m")
+        r = client.get(
+            f"/insights/savings-opportunities?month={ym}", headers=auth_header
+        )
+        assert r.status_code == 200
+        opps = r.get_json()["opportunities"]
+        dup_opps = [o for o in opps if o["type"] == "subscription_duplicate"]
+        assert len(dup_opps) >= 1
+        assert dup_opps[0]["potential_savings"] == 9.99
+        assert "Netflix" in dup_opps[0]["title"]
+
+
+class TestAboveAverageSpending:
+    def test_detects_above_average_category(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Shopping")
+        current = date.today().replace(day=10)
+
+        # Build 3 months of history at $100/month
+        y, m = current.year, current.month
+        for _ in range(3):
+            if m == 1:
+                y, m = y - 1, 12
+            else:
+                m -= 1
+            d = date(y, m, 10)
+            _create_expense(client, auth_header, 100, "Shopping trip", d, cat_id)
+
+        # Current month: $200 (2x the average, above 1.3x threshold)
+        _create_expense(client, auth_header, 200, "Big shopping", current, cat_id)
+
+        ym = current.strftime("%Y-%m")
+        r = client.get(
+            f"/insights/savings-opportunities?month={ym}", headers=auth_header
+        )
+        assert r.status_code == 200
+        opps = r.get_json()["opportunities"]
+        avg_opps = [o for o in opps if o["type"] == "above_average_spending"]
+        assert len(avg_opps) >= 1
+        assert avg_opps[0]["category"] == "Shopping"
+        assert avg_opps[0]["potential_savings"] == 100.0
+
+
+class TestOpportunitiesSortedBySavings:
+    def test_sorted_descending(self, client, auth_header):
+        cat1 = _create_category(client, auth_header, "Food")
+        cat2 = _create_category(client, auth_header, "Transport")
+
+        current = date.today().replace(day=10)
+        py, pm = (current.year, current.month - 1) if current.month > 1 else (current.year - 1, 12)
+        previous = date(py, pm, 10)
+
+        # Cat1: $100 -> $200 (savings $100)
+        _create_expense(client, auth_header, 100, "Food prev", previous, cat1)
+        _create_expense(client, auth_header, 200, "Food curr", current, cat1)
+
+        # Cat2: $100 -> $150 (savings $50)
+        _create_expense(client, auth_header, 100, "Transport prev", previous, cat2)
+        _create_expense(client, auth_header, 150, "Transport curr", current, cat2)
+
+        ym = current.strftime("%Y-%m")
+        r = client.get(
+            f"/insights/savings-opportunities?month={ym}", headers=auth_header
+        )
+        assert r.status_code == 200
+        opps = r.get_json()["opportunities"]
+        savings = [o["potential_savings"] for o in opps]
+        assert savings == sorted(savings, reverse=True)


### PR DESCRIPTION
## Summary
- Add savings opportunity detection engine that analyzes spending patterns and returns actionable suggestions (closes #119)
- Backend: `GET /api/insights/savings-opportunities` endpoint with four detection rules: month-over-month category increases, high-frequency small purchases (latte factor), subscription duplicates, and above-average category spending
- Frontend: `SavingsOpportunities` component integrated into the Analytics page, showing opportunity cards with potential savings amounts and trend badges

## Detection Rules
| Rule | Trigger | Suggestion |
|------|---------|------------|
| MoM Increase | Category spending up >=20% vs previous month | Return to last month's level |
| Latte Factor | 8+ small purchases (under $10) in a month | Cut in half |
| Duplicate Subs | Same description+amount appearing multiple times | Remove duplicate |
| Above Average | Category >130% of 3-month rolling average | Return to average |

## Test plan
- [ ] Backend: `pytest tests/test_savings.py` -- 7 tests covering all detection rules, sorting, auth, and empty states
- [ ] Frontend: `npx jest SavingsOpportunities` -- 5 tests covering loading, data rendering, empty state, error state, and month re-fetch
- [ ] Manual: verify cards render on `/analytics` page with real spending data

🤖 Generated with [Claude Code](https://claude.com/claude-code)