### PR TITLE
Add notification priority & grouping system (#122)

### DIFF
--- a/app/src/api/notifications.ts
+++ b/app/src/api/notifications.ts
@@ -1,0 +1,32 @@
+import { api } from './client';
+
+export type NotificationPriority = 'critical' | 'high' | 'medium' | 'low';
+
+export type NotificationItem = {
+  id: number;
+  type: string;
+  priority: NotificationPriority;
+  group: string;
+  message: string;
+  read: boolean;
+  created_at: string;
+};
+
+export type NotificationsResponse = {
+  notifications: Record<string, NotificationItem[]>;
+  unread_count: number;
+};
+
+export async function listNotifications(): Promise<NotificationsResponse> {
+  return api<NotificationsResponse>('/notifications');
+}
+
+export async function markNotificationRead(id: number): Promise<{ message: string }> {
+  return api<{ message: string }>(`/notifications/${id}/read`, { method: 'PATCH' });
+}
+
+export async function markAllNotificationsRead(): Promise<{ message: string; count: number }> {
+  return api<{ message: string; count: number }>('/notifications/mark-all-read', {
+    method: 'POST',
+  });
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -5,6 +5,7 @@ import { Menu, X, TrendingUp, ShieldCheck } from 'lucide-react';
 import { getToken, getRefreshToken, clearToken, clearRefreshToken } from '@/lib/auth';
 import { useToast } from '@/components/ui/use-toast';
 import { logout as logoutApi } from '@/api/auth';
+import { NotificationCenter } from './NotificationCenter';
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard' },
@@ -86,6 +87,7 @@ export function Navbar() {
             </div>
             {isAuthed ? (
               <>
+                <NotificationCenter />
                 <Button variant="outline" size="sm" asChild>
                   <Link to="/account">Account</Link>
                 </Button>

--- a/app/src/components/layout/NotificationCenter.tsx
+++ b/app/src/components/layout/NotificationCenter.tsx
@@ -1,0 +1,185 @@
+import { useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Bell, Check, CheckCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  listNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+  type NotificationItem,
+  type NotificationPriority,
+} from '@/api/notifications';
+import { getToken } from '@/lib/auth';
+
+const PRIORITY_STYLES: Record<NotificationPriority, string> = {
+  critical: 'bg-red-100 text-red-800 border-red-200',
+  high: 'bg-orange-100 text-orange-800 border-orange-200',
+  medium: 'bg-blue-100 text-blue-800 border-blue-200',
+  low: 'bg-gray-100 text-gray-600 border-gray-200',
+};
+
+const GROUP_LABELS: Record<string, string> = {
+  bills: 'Bills & Payments',
+  budgets: 'Budget Alerts',
+  savings: 'Savings Opportunities',
+  summary: 'Weekly Summary',
+};
+
+// Sort groups by priority: budgets (critical) first, then bills, savings, summary
+const GROUP_ORDER = ['budgets', 'bills', 'savings', 'summary'];
+
+function PriorityBadge({ priority }: { priority: NotificationPriority }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-semibold ${PRIORITY_STYLES[priority]}`}
+    >
+      {priority}
+    </span>
+  );
+}
+
+function NotificationRow({
+  notification,
+  onMarkRead,
+}: {
+  notification: NotificationItem;
+  onMarkRead: (id: number) => void;
+}) {
+  return (
+    <div
+      className={`flex items-start gap-2 rounded-lg px-3 py-2 text-sm transition ${
+        notification.read ? 'opacity-60' : 'bg-muted/40'
+      }`}
+    >
+      <div className="flex-1 space-y-1">
+        <div className="flex items-center gap-2">
+          <PriorityBadge priority={notification.priority} />
+          <span className="text-[11px] text-muted-foreground">
+            {new Date(notification.created_at).toLocaleDateString()}
+          </span>
+        </div>
+        <p className="text-xs leading-relaxed text-foreground">{notification.message}</p>
+      </div>
+      {!notification.read && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 shrink-0"
+          onClick={() => onMarkRead(notification.id)}
+          title="Mark as read"
+        >
+          <Check className="h-3.5 w-3.5" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function NotificationCenter() {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const isAuthed = !!getToken();
+
+  const { data } = useQuery({
+    queryKey: ['notifications'],
+    queryFn: listNotifications,
+    enabled: isAuthed && open,
+    refetchInterval: open ? 30_000 : false,
+  });
+
+  // Also poll unread count when popover is closed
+  const { data: countData } = useQuery({
+    queryKey: ['notifications-count'],
+    queryFn: listNotifications,
+    enabled: isAuthed,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  const unreadCount = data?.unread_count ?? countData?.unread_count ?? 0;
+  const groups = data?.notifications ?? {};
+
+  const markReadMutation = useMutation({
+    mutationFn: markNotificationRead,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] });
+      void queryClient.invalidateQueries({ queryKey: ['notifications-count'] });
+    },
+  });
+
+  const markAllMutation = useMutation({
+    mutationFn: markAllNotificationsRead,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] });
+      void queryClient.invalidateQueries({ queryKey: ['notifications-count'] });
+    },
+  });
+
+  const handleMarkRead = useCallback(
+    (id: number) => {
+      markReadMutation.mutate(id);
+    },
+    [markReadMutation],
+  );
+
+  if (!isAuthed) return null;
+
+  const sortedGroups = GROUP_ORDER.filter((g) => groups[g]?.length);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative h-9 w-9">
+          <Bell className="h-4 w-4" />
+          {unreadCount > 0 && (
+            <Badge
+              variant="destructive"
+              className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center p-0 text-[10px]"
+            >
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[360px] p-0">
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <h3 className="text-sm font-semibold">Notifications</h3>
+          {unreadCount > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 text-xs"
+              onClick={() => markAllMutation.mutate()}
+            >
+              <CheckCheck className="h-3.5 w-3.5" />
+              Mark all read
+            </Button>
+          )}
+        </div>
+        <ScrollArea className="max-h-[400px]">
+          {sortedGroups.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+              No notifications
+            </div>
+          ) : (
+            <div className="space-y-1 p-2">
+              {sortedGroups.map((groupKey) => (
+                <div key={groupKey}>
+                  <div className="px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                    {GROUP_LABELS[groupKey] ?? groupKey}
+                  </div>
+                  {groups[groupKey].map((n) => (
+                    <NotificationRow key={n.id} notification={n} onMarkRead={handleMarkRead} />
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -117,6 +117,18 @@ CREATE TABLE IF NOT EXISTS user_subscriptions (
   started_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS notifications (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type VARCHAR(50) NOT NULL,
+  priority VARCHAR(20) NOT NULL DEFAULT 'medium',
+  "group" VARCHAR(50) NOT NULL,
+  message VARCHAR(500) NOT NULL,
+  read BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_read ON notifications(user_id, read, created_at DESC);
+
 CREATE TABLE IF NOT EXISTS audit_logs (
   id SERIAL PRIMARY KEY,
   user_id INT REFERENCES users(id) ON DELETE SET NULL,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,34 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class NotificationType(str, Enum):
+    BILL_DUE = "BILL_DUE"
+    BUDGET_EXCEEDED = "BUDGET_EXCEEDED"
+    SAVINGS_OPPORTUNITY = "SAVINGS_OPPORTUNITY"
+    WEEKLY_SUMMARY = "WEEKLY_SUMMARY"
+
+
+class NotificationPriority(str, Enum):
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class Notification(db.Model):
+    __tablename__ = "notifications"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    type = db.Column(db.String(50), nullable=False)
+    priority = db.Column(
+        db.String(20), nullable=False, default=NotificationPriority.MEDIUM.value
+    )
+    group = db.Column(db.String(50), nullable=False)
+    message = db.Column(db.String(500), nullable=False)
+    read = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .notifications import bp as notifications_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(notifications_bp, url_prefix="/notifications")

--- a/packages/backend/app/routes/notifications.py
+++ b/packages/backend/app/routes/notifications.py
@@ -1,0 +1,66 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import Notification
+import logging
+
+bp = Blueprint("notifications", __name__)
+logger = logging.getLogger("finmind.notifications")
+
+
+@bp.get("")
+@jwt_required()
+def list_notifications():
+    uid = int(get_jwt_identity())
+    items = (
+        db.session.query(Notification)
+        .filter_by(user_id=uid)
+        .order_by(Notification.created_at.desc())
+        .all()
+    )
+    logger.info("List notifications user=%s count=%s", uid, len(items))
+
+    # Group by type
+    grouped: dict[str, list[dict]] = {}
+    for n in items:
+        entry = {
+            "id": n.id,
+            "type": n.type,
+            "priority": n.priority,
+            "group": n.group,
+            "message": n.message,
+            "read": n.read,
+            "created_at": n.created_at.isoformat(),
+        }
+        grouped.setdefault(n.group, []).append(entry)
+
+    unread_count = sum(1 for n in items if not n.read)
+
+    return jsonify({"notifications": grouped, "unread_count": unread_count})
+
+
+@bp.patch("/<int:notification_id>/read")
+@jwt_required()
+def mark_read(notification_id: int):
+    uid = int(get_jwt_identity())
+    n = db.session.get(Notification, notification_id)
+    if not n or n.user_id != uid:
+        return jsonify(error="not found"), 404
+    n.read = True
+    db.session.commit()
+    logger.info("Marked notification read id=%s user=%s", n.id, uid)
+    return jsonify(message="marked as read")
+
+
+@bp.post("/mark-all-read")
+@jwt_required()
+def mark_all_read():
+    uid = int(get_jwt_identity())
+    count = (
+        db.session.query(Notification)
+        .filter_by(user_id=uid, read=False)
+        .update({"read": True})
+    )
+    db.session.commit()
+    logger.info("Marked all notifications read user=%s count=%s", uid, count)
+    return jsonify(message="all marked as read", count=count)

--- a/packages/backend/app/services/notifications.py
+++ b/packages/backend/app/services/notifications.py
@@ -1,0 +1,122 @@
+"""Auto-generate notifications from financial events."""
+
+from datetime import date, timedelta
+from decimal import Decimal
+from ..extensions import db
+from ..models import (
+    Bill,
+    Notification,
+    NotificationType,
+    NotificationPriority,
+)
+import logging
+
+logger = logging.getLogger("finmind.notifications.service")
+
+# Priority mapping for each notification type
+_TYPE_PRIORITY = {
+    NotificationType.BILL_DUE: NotificationPriority.HIGH,
+    NotificationType.BUDGET_EXCEEDED: NotificationPriority.CRITICAL,
+    NotificationType.SAVINGS_OPPORTUNITY: NotificationPriority.MEDIUM,
+    NotificationType.WEEKLY_SUMMARY: NotificationPriority.LOW,
+}
+
+# Group mapping for each notification type
+_TYPE_GROUP = {
+    NotificationType.BILL_DUE: "bills",
+    NotificationType.BUDGET_EXCEEDED: "budgets",
+    NotificationType.SAVINGS_OPPORTUNITY: "savings",
+    NotificationType.WEEKLY_SUMMARY: "summary",
+}
+
+
+def generate_bill_due_notifications(user_id: int, days_ahead: int = 3) -> int:
+    """Create notifications for bills due within `days_ahead` days."""
+    threshold = date.today() + timedelta(days=days_ahead)
+    bills = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == user_id,
+            Bill.active == True,  # noqa: E712
+            Bill.next_due_date <= threshold,
+            Bill.next_due_date >= date.today(),
+        )
+        .all()
+    )
+    created = 0
+    for bill in bills:
+        # Avoid duplicates: check if notification already exists for this bill
+        existing = (
+            db.session.query(Notification)
+            .filter(
+                Notification.user_id == user_id,
+                Notification.type == NotificationType.BILL_DUE.value,
+                Notification.message.contains(bill.name),
+                Notification.read == False,  # noqa: E712
+            )
+            .first()
+        )
+        if existing:
+            continue
+        n = Notification(
+            user_id=user_id,
+            type=NotificationType.BILL_DUE.value,
+            priority=_TYPE_PRIORITY[NotificationType.BILL_DUE].value,
+            group=_TYPE_GROUP[NotificationType.BILL_DUE],
+            message=f"Bill '{bill.name}' ({bill.currency} {float(bill.amount):.2f}) is due on {bill.next_due_date.isoformat()}",
+        )
+        db.session.add(n)
+        created += 1
+    if created:
+        db.session.commit()
+    logger.info("Generated %s bill-due notifications for user=%s", created, user_id)
+    return created
+
+
+def generate_budget_exceeded_notification(
+    user_id: int, category_name: str, spent: Decimal, budget: Decimal
+) -> Notification:
+    """Create a critical notification when spending exceeds budget."""
+    n = Notification(
+        user_id=user_id,
+        type=NotificationType.BUDGET_EXCEEDED.value,
+        priority=_TYPE_PRIORITY[NotificationType.BUDGET_EXCEEDED].value,
+        group=_TYPE_GROUP[NotificationType.BUDGET_EXCEEDED],
+        message=f"Budget exceeded for '{category_name}': spent {float(spent):.2f} of {float(budget):.2f}",
+    )
+    db.session.add(n)
+    db.session.commit()
+    logger.info("Generated budget-exceeded notification for user=%s category=%s", user_id, category_name)
+    return n
+
+
+def generate_savings_opportunity(user_id: int, message: str) -> Notification:
+    """Create a medium-priority savings opportunity notification."""
+    n = Notification(
+        user_id=user_id,
+        type=NotificationType.SAVINGS_OPPORTUNITY.value,
+        priority=_TYPE_PRIORITY[NotificationType.SAVINGS_OPPORTUNITY].value,
+        group=_TYPE_GROUP[NotificationType.SAVINGS_OPPORTUNITY],
+        message=message,
+    )
+    db.session.add(n)
+    db.session.commit()
+    logger.info("Generated savings-opportunity notification for user=%s", user_id)
+    return n
+
+
+def generate_weekly_summary(
+    user_id: int, total_spent: Decimal, transaction_count: int
+) -> Notification:
+    """Create a low-priority weekly summary notification."""
+    n = Notification(
+        user_id=user_id,
+        type=NotificationType.WEEKLY_SUMMARY.value,
+        priority=_TYPE_PRIORITY[NotificationType.WEEKLY_SUMMARY].value,
+        group=_TYPE_GROUP[NotificationType.WEEKLY_SUMMARY],
+        message=f"Weekly summary: {transaction_count} transactions totalling {float(total_spent):.2f}",
+    )
+    db.session.add(n)
+    db.session.commit()
+    logger.info("Generated weekly-summary notification for user=%s", user_id)
+    return n

--- a/packages/backend/tests/test_notifications.py
+++ b/packages/backend/tests/test_notifications.py
@@ -1,0 +1,157 @@
+from datetime import date, timedelta
+from app.models import Notification, NotificationType, NotificationPriority, Bill, BillCadence
+from app.extensions import db
+from app.services.notifications import (
+    generate_bill_due_notifications,
+    generate_budget_exceeded_notification,
+    generate_weekly_summary,
+)
+from decimal import Decimal
+
+
+def _create_notification(app, uid, **kwargs):
+    defaults = {
+        "user_id": uid,
+        "type": NotificationType.BILL_DUE.value,
+        "priority": NotificationPriority.HIGH.value,
+        "group": "bills",
+        "message": "Test notification",
+        "read": False,
+    }
+    defaults.update(kwargs)
+    with app.app_context():
+        n = Notification(**defaults)
+        db.session.add(n)
+        db.session.commit()
+        return n.id
+
+
+def test_list_notifications_empty(client, auth_header):
+    r = client.get("/notifications", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["unread_count"] == 0
+    assert data["notifications"] == {}
+
+
+def test_list_notifications_grouped(client, auth_header, app_fixture):
+    from flask_jwt_extended import decode_token
+
+    with app_fixture.app_context():
+        token = auth_header["Authorization"].split(" ")[1]
+        uid = int(decode_token(token)["sub"])
+
+    _create_notification(
+        app_fixture,
+        uid,
+        type=NotificationType.BILL_DUE.value,
+        group="bills",
+        message="Bill A due",
+    )
+    _create_notification(
+        app_fixture,
+        uid,
+        type=NotificationType.BUDGET_EXCEEDED.value,
+        group="budgets",
+        message="Budget exceeded",
+    )
+
+    r = client.get("/notifications", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["unread_count"] == 2
+    assert "bills" in data["notifications"]
+    assert "budgets" in data["notifications"]
+    assert len(data["notifications"]["bills"]) == 1
+    assert len(data["notifications"]["budgets"]) == 1
+
+
+def test_mark_notification_read(client, auth_header, app_fixture):
+    from flask_jwt_extended import decode_token
+
+    with app_fixture.app_context():
+        token = auth_header["Authorization"].split(" ")[1]
+        uid = int(decode_token(token)["sub"])
+
+    nid = _create_notification(app_fixture, uid)
+
+    r = client.patch(f"/notifications/{nid}/read", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "marked as read"
+
+    r = client.get("/notifications", headers=auth_header)
+    assert r.get_json()["unread_count"] == 0
+
+
+def test_mark_notification_read_not_found(client, auth_header):
+    r = client.patch("/notifications/99999/read", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_mark_all_read(client, auth_header, app_fixture):
+    from flask_jwt_extended import decode_token
+
+    with app_fixture.app_context():
+        token = auth_header["Authorization"].split(" ")[1]
+        uid = int(decode_token(token)["sub"])
+
+    _create_notification(app_fixture, uid, message="A")
+    _create_notification(app_fixture, uid, message="B")
+
+    r = client.post("/notifications/mark-all-read", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["count"] == 2
+
+    r = client.get("/notifications", headers=auth_header)
+    assert r.get_json()["unread_count"] == 0
+
+
+def test_generate_bill_due_notifications(app_fixture, auth_header):
+    from flask_jwt_extended import decode_token
+
+    with app_fixture.app_context():
+        token = auth_header["Authorization"].split(" ")[1]
+        uid = int(decode_token(token)["sub"])
+
+        bill = Bill(
+            user_id=uid,
+            name="Internet",
+            amount=49.99,
+            currency="USD",
+            next_due_date=date.today() + timedelta(days=1),
+            cadence=BillCadence.MONTHLY,
+        )
+        db.session.add(bill)
+        db.session.commit()
+
+        count = generate_bill_due_notifications(uid)
+        assert count == 1
+
+        # Running again should not duplicate
+        count2 = generate_bill_due_notifications(uid)
+        assert count2 == 0
+
+
+def test_generate_budget_exceeded_notification(app_fixture, auth_header):
+    from flask_jwt_extended import decode_token
+
+    with app_fixture.app_context():
+        token = auth_header["Authorization"].split(" ")[1]
+        uid = int(decode_token(token)["sub"])
+
+        n = generate_budget_exceeded_notification(uid, "Food", Decimal("150.00"), Decimal("100.00"))
+        assert n.priority == NotificationPriority.CRITICAL.value
+        assert "Food" in n.message
+
+
+def test_generate_weekly_summary(app_fixture, auth_header):
+    from flask_jwt_extended import decode_token
+
+    with app_fixture.app_context():
+        token = auth_header["Authorization"].split(" ")[1]
+        uid = int(decode_token(token)["sub"])
+
+        n = generate_weekly_summary(uid, Decimal("500.00"), 12)
+        assert n.priority == NotificationPriority.LOW.value
+        assert "12 transactions" in n.message


### PR DESCRIPTION
## Summary
- Add a **notification system** with four priority levels (critical, high, medium, low) and grouping by type (bills, budgets, savings, summary)
- **Backend**: Notification model, 3 API endpoints (`GET /notifications`, `PATCH /notifications/:id/read`, `POST /notifications/mark-all-read`), and a notification generation service that auto-creates alerts for bill-due, budget-exceeded, savings-opportunity, and weekly-summary events
- **Frontend**: NotificationCenter component with bell icon (unread count badge), popover with grouped/prioritized view, priority badges, and mark-read functionality integrated into the Navbar

## Test plan
- [x] 8 backend tests covering all endpoints and service functions (all passing)
- [ ] Verify bell icon appears in navbar when authenticated
- [ ] Verify notification popover opens with grouped view
- [ ] Verify mark-read and mark-all-read update unread count
- [ ] Verify priority badges display correct colors (red/orange/blue/gray)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)