### PR TITLE
feat: reminder reliability tracking & delivery metrics (#123)

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,16 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+class ReminderDeliveryLog(db.Model):
+    """Tracks every reminder delivery attempt for reliability metrics."""
+    __tablename__ = "reminder_delivery_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    reminder_id = db.Column(db.Integer, db.ForeignKey("reminders.id"), nullable=False)
+    channel = db.Column(db.String(20), nullable=False)  # email, sms, push, webhook
+    status = db.Column(db.String(20), nullable=False)   # delivered, failed, pending
+    latency_ms = db.Column(db.Float, nullable=True)
+    error_code = db.Column(db.String(50), nullable=True)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    attempted_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .reminder_reliability import bp as reminder_reliability_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(reminder_reliability_bp, url_prefix="/reminders")

--- a/packages/backend/app/routes/reminder_reliability.py
+++ b/packages/backend/app/routes/reminder_reliability.py
@@ -1,0 +1,61 @@
+"""
+Routes for Reminder Reliability Tracking & Delivery Metrics (Issue #123)
+"""
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.reminder_reliability import ReminderReliabilityService
+
+bp = Blueprint("reminder_reliability", __name__)
+_svc = ReminderReliabilityService()
+
+
+@bp.get("/metrics")
+@jwt_required()
+def get_delivery_metrics():
+    """GET /reminders/metrics?days=30&channel=email"""
+    uid = int(get_jwt_identity())
+    days = min(int(request.args.get("days", 30)), 365)
+    channel = request.args.get("channel")
+    return jsonify(_svc.get_delivery_metrics(uid, days=days, channel=channel))
+
+
+@bp.get("/metrics/<int:reminder_id>")
+@jwt_required()
+def get_reminder_metrics(reminder_id: int):
+    """GET /reminders/metrics/<id> - per-reminder reliability"""
+    uid = int(get_jwt_identity())
+    result = _svc.get_reminder_metrics(uid, reminder_id)
+    if result.get("error") == "not_found":
+        return jsonify(error="Reminder not found"), 404
+    return jsonify(result)
+
+
+@bp.get("/failed")
+@jwt_required()
+def get_failed_reminders():
+    """GET /reminders/failed - list reminders with delivery failures"""
+    uid = int(get_jwt_identity())
+    limit = min(int(request.args.get("limit", 50)), 200)
+    return jsonify(_svc.get_failed_reminders(uid, limit=limit))
+
+
+@bp.post("/<int:reminder_id>/delivery-log")
+@jwt_required()
+def record_delivery(reminder_id: int):
+    """POST /reminders/<id>/delivery-log - record a delivery attempt"""
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    status = data.get("status", "delivered")
+    if status not in ("delivered", "failed", "pending"):
+        return jsonify(error="status must be delivered|failed|pending"), 400
+    log = _svc.record_delivery_attempt(
+        user_id=uid,
+        reminder_id=reminder_id,
+        channel=data.get("channel", "email"),
+        status=status,
+        latency_ms=data.get("latency_ms"),
+        error_code=data.get("error_code"),
+        retry_count=data.get("retry_count", 0),
+    )
+    return jsonify(id=log.id, status=log.status), 201

--- a/packages/backend/app/services/reminder_reliability.py
+++ b/packages/backend/app/services/reminder_reliability.py
@@ -1,0 +1,194 @@
+"""
+Reminder Reliability Tracking & Delivery Metrics Service (#123)
+
+Tracks delivery success rates, latency, and failure analysis for reminders.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+from collections import defaultdict
+
+from sqlalchemy import func, and_
+
+from ..extensions import db
+from ..models import ReminderDeliveryLog, Reminder
+
+
+class ReminderReliabilityService:
+    """Tracks and analyzes reminder delivery reliability metrics."""
+
+    CHANNEL_WEIGHTS = {"email": 1.0, "sms": 0.9, "push": 0.85, "webhook": 0.95}
+
+    def get_delivery_metrics(
+        self,
+        user_id: int,
+        days: int = 30,
+        channel: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Compute overall delivery metrics for a user over the given window."""
+        since = datetime.utcnow() - timedelta(days=days)
+        query = db.session.query(ReminderDeliveryLog).filter(
+            ReminderDeliveryLog.user_id == user_id,
+            ReminderDeliveryLog.attempted_at >= since,
+        )
+        if channel:
+            query = query.filter(ReminderDeliveryLog.channel == channel)
+
+        logs: List[ReminderDeliveryLog] = query.all()
+        if not logs:
+            return {
+                "total_attempts": 0,
+                "success_rate": 1.0,
+                "failure_rate": 0.0,
+                "avg_latency_ms": None,
+                "p95_latency_ms": None,
+                "channels": {},
+                "error_breakdown": {},
+                "period_days": days,
+            }
+
+        total = len(logs)
+        successes = [l for l in logs if l.status == "delivered"]
+        failures = [l for l in logs if l.status == "failed"]
+        success_rate = len(successes) / total if total else 1.0
+
+        latencies = [
+            l.latency_ms for l in logs if l.latency_ms is not None
+        ]
+        avg_latency = sum(latencies) / len(latencies) if latencies else None
+        p95_latency = None
+        if latencies:
+            sorted_lat = sorted(latencies)
+            idx = int(0.95 * len(sorted_lat))
+            p95_latency = sorted_lat[min(idx, len(sorted_lat) - 1)]
+
+        # Per-channel breakdown
+        channel_stats: Dict[str, Dict] = defaultdict(
+            lambda: {"attempts": 0, "delivered": 0, "failed": 0}
+        )
+        for l in logs:
+            channel_stats[l.channel]["attempts"] += 1
+            if l.status == "delivered":
+                channel_stats[l.channel]["delivered"] += 1
+            elif l.status == "failed":
+                channel_stats[l.channel]["failed"] += 1
+
+        for ch, stats in channel_stats.items():
+            stats["success_rate"] = (
+                stats["delivered"] / stats["attempts"]
+                if stats["attempts"]
+                else 1.0
+            )
+
+        # Error breakdown
+        error_breakdown: Dict[str, int] = defaultdict(int)
+        for l in failures:
+            error_code = l.error_code or "unknown"
+            error_breakdown[error_code] += 1
+
+        return {
+            "total_attempts": total,
+            "success_rate": round(success_rate, 4),
+            "failure_rate": round(1 - success_rate, 4),
+            "avg_latency_ms": round(avg_latency, 2) if avg_latency else None,
+            "p95_latency_ms": round(p95_latency, 2) if p95_latency else None,
+            "channels": dict(channel_stats),
+            "error_breakdown": dict(error_breakdown),
+            "period_days": days,
+        }
+
+    def get_reminder_metrics(
+        self, user_id: int, reminder_id: int
+    ) -> Dict[str, Any]:
+        """Per-reminder delivery history and reliability score."""
+        reminder = db.session.get(Reminder, reminder_id)
+        if not reminder or reminder.user_id != user_id:
+            return {"error": "not_found"}
+
+        logs: List[ReminderDeliveryLog] = (
+            db.session.query(ReminderDeliveryLog)
+            .filter_by(user_id=user_id, reminder_id=reminder_id)
+            .order_by(ReminderDeliveryLog.attempted_at.desc())
+            .all()
+        )
+
+        total = len(logs)
+        delivered = sum(1 for l in logs if l.status == "delivered")
+        reliability_score = delivered / total if total else 1.0
+        last_attempt = logs[0].attempted_at.isoformat() if logs else None
+        last_status = logs[0].status if logs else None
+
+        return {
+            "reminder_id": reminder_id,
+            "message": reminder.message,
+            "channel": reminder.channel,
+            "total_attempts": total,
+            "delivered_count": delivered,
+            "failed_count": total - delivered,
+            "reliability_score": round(reliability_score, 4),
+            "last_attempt": last_attempt,
+            "last_status": last_status,
+            "delivery_history": [
+                {
+                    "attempted_at": l.attempted_at.isoformat(),
+                    "status": l.status,
+                    "latency_ms": l.latency_ms,
+                    "error_code": l.error_code,
+                    "retry_count": l.retry_count,
+                }
+                for l in logs[:20]
+            ],
+        }
+
+    def get_failed_reminders(
+        self, user_id: int, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """List reminders with recent failures for retry."""
+        logs = (
+            db.session.query(ReminderDeliveryLog)
+            .filter_by(user_id=user_id, status="failed")
+            .order_by(ReminderDeliveryLog.attempted_at.desc())
+            .limit(limit)
+            .all()
+        )
+        seen: set = set()
+        result = []
+        for l in logs:
+            if l.reminder_id not in seen:
+                seen.add(l.reminder_id)
+                result.append(
+                    {
+                        "reminder_id": l.reminder_id,
+                        "channel": l.channel,
+                        "error_code": l.error_code,
+                        "last_failed_at": l.attempted_at.isoformat(),
+                        "retry_count": l.retry_count,
+                    }
+                )
+        return result
+
+    def record_delivery_attempt(
+        self,
+        user_id: int,
+        reminder_id: int,
+        channel: str,
+        status: str,
+        latency_ms: Optional[float] = None,
+        error_code: Optional[str] = None,
+        retry_count: int = 0,
+    ) -> ReminderDeliveryLog:
+        """Record a delivery attempt and persist to DB."""
+        log = ReminderDeliveryLog(
+            user_id=user_id,
+            reminder_id=reminder_id,
+            channel=channel,
+            status=status,
+            latency_ms=latency_ms,
+            error_code=error_code,
+            retry_count=retry_count,
+            attempted_at=datetime.utcnow(),
+        )
+        db.session.add(log)
+        db.session.commit()
+        return log

--- a/packages/backend/tests/test_reminder_reliability.py
+++ b/packages/backend/tests/test_reminder_reliability.py
@@ -1,0 +1,176 @@
+"""
+Tests for Reminder Reliability Tracking & Delivery Metrics (Issue #123)
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta
+
+from app.services.reminder_reliability import ReminderReliabilityService
+from app.models import ReminderDeliveryLog, Reminder
+
+
+@pytest.fixture
+def svc():
+    return ReminderReliabilityService()
+
+
+@pytest.fixture
+def mock_db(monkeypatch):
+    """Patch db.session for unit tests."""
+    session = MagicMock()
+    monkeypatch.setattr("app.services.reminder_reliability.db.session", session)
+    monkeypatch.setattr("app.services.reminder_reliability.db.session", session)
+    return session
+
+
+def make_log(status="delivered", channel="email", latency_ms=120.0, error_code=None, retry_count=0):
+    log = MagicMock(spec=ReminderDeliveryLog)
+    log.status = status
+    log.channel = channel
+    log.latency_ms = latency_ms
+    log.error_code = error_code
+    log.retry_count = retry_count
+    log.attempted_at = datetime.utcnow()
+    log.reminder_id = 1
+    log.user_id = 1
+    return log
+
+
+class TestGetDeliveryMetrics:
+    def test_empty_returns_defaults(self, svc, mock_db):
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+        result = svc.get_delivery_metrics(user_id=1)
+        assert result["total_attempts"] == 0
+        assert result["success_rate"] == 1.0
+        assert result["failure_rate"] == 0.0
+
+    def test_all_delivered(self, svc, mock_db):
+        logs = [make_log(status="delivered", latency_ms=100.0) for _ in range(10)]
+        mock_db.query.return_value.filter.return_value.all.return_value = logs
+        result = svc.get_delivery_metrics(user_id=1)
+        assert result["total_attempts"] == 10
+        assert result["success_rate"] == 1.0
+        assert result["failure_rate"] == 0.0
+
+    def test_mixed_success_failure(self, svc, mock_db):
+        logs = (
+            [make_log(status="delivered", latency_ms=100.0) for _ in range(7)]
+            + [make_log(status="failed", error_code="SMTP_TIMEOUT") for _ in range(3)]
+        )
+        mock_db.query.return_value.filter.return_value.all.return_value = logs
+        result = svc.get_delivery_metrics(user_id=1)
+        assert result["success_rate"] == pytest.approx(0.7, abs=0.01)
+        assert result["failure_rate"] == pytest.approx(0.3, abs=0.01)
+        assert result["error_breakdown"]["SMTP_TIMEOUT"] == 3
+
+    def test_latency_calculation(self, svc, mock_db):
+        latencies = [100.0, 200.0, 150.0, 300.0, 50.0]
+        logs = [make_log(latency_ms=l) for l in latencies]
+        mock_db.query.return_value.filter.return_value.all.return_value = logs
+        result = svc.get_delivery_metrics(user_id=1)
+        assert result["avg_latency_ms"] == pytest.approx(160.0, abs=1.0)
+        assert result["p95_latency_ms"] is not None
+
+    def test_channel_filter(self, svc, mock_db):
+        logs = [make_log(channel="email") for _ in range(5)]
+        query_mock = mock_db.query.return_value.filter.return_value
+        query_mock.filter.return_value.all.return_value = logs
+        result = svc.get_delivery_metrics(user_id=1, channel="email")
+        assert "email" in result["channels"]
+
+    def test_per_channel_breakdown(self, svc, mock_db):
+        logs = (
+            [make_log(channel="email", status="delivered") for _ in range(8)]
+            + [make_log(channel="sms", status="failed", error_code="NO_CREDIT") for _ in range(2)]
+        )
+        mock_db.query.return_value.filter.return_value.all.return_value = logs
+        result = svc.get_delivery_metrics(user_id=1)
+        assert result["channels"]["email"]["delivered"] == 8
+        assert result["channels"]["sms"]["failed"] == 2
+
+    def test_period_days_in_result(self, svc, mock_db):
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+        result = svc.get_delivery_metrics(user_id=1, days=90)
+        assert result["period_days"] == 90
+
+
+class TestGetReminderMetrics:
+    def test_not_found(self, svc, mock_db):
+        mock_db.get.return_value = None
+        result = svc.get_reminder_metrics(user_id=1, reminder_id=999)
+        assert result["error"] == "not_found"
+
+    def test_wrong_user(self, svc, mock_db):
+        reminder = MagicMock(spec=Reminder)
+        reminder.user_id = 2  # different user
+        mock_db.get.return_value = reminder
+        result = svc.get_reminder_metrics(user_id=1, reminder_id=1)
+        assert result["error"] == "not_found"
+
+    def test_success(self, svc, mock_db):
+        reminder = MagicMock(spec=Reminder)
+        reminder.user_id = 1
+        reminder.message = "Pay rent"
+        reminder.channel = "email"
+        mock_db.get.return_value = reminder
+        logs = [
+            make_log(status="delivered"),
+            make_log(status="delivered"),
+            make_log(status="failed", error_code="TIMEOUT"),
+        ]
+        mock_db.query.return_value.filter_by.return_value.order_by.return_value.all.return_value = logs
+        result = svc.get_reminder_metrics(user_id=1, reminder_id=1)
+        assert result["total_attempts"] == 3
+        assert result["delivered_count"] == 2
+        assert result["failed_count"] == 1
+        assert result["reliability_score"] == pytest.approx(2/3, abs=0.01)
+
+    def test_empty_history(self, svc, mock_db):
+        reminder = MagicMock(spec=Reminder)
+        reminder.user_id = 1
+        reminder.message = "Test"
+        reminder.channel = "push"
+        mock_db.get.return_value = reminder
+        mock_db.query.return_value.filter_by.return_value.order_by.return_value.all.return_value = []
+        result = svc.get_reminder_metrics(user_id=1, reminder_id=1)
+        assert result["total_attempts"] == 0
+        assert result["reliability_score"] == 1.0
+
+
+class TestRecordDeliveryAttempt:
+    def test_records_delivered(self, svc, mock_db):
+        mock_db.add = MagicMock()
+        mock_db.commit = MagicMock()
+        log = svc.record_delivery_attempt(
+            user_id=1, reminder_id=1, channel="email",
+            status="delivered", latency_ms=95.0
+        )
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    def test_records_failure(self, svc, mock_db):
+        mock_db.add = MagicMock()
+        mock_db.commit = MagicMock()
+        log = svc.record_delivery_attempt(
+            user_id=1, reminder_id=1, channel="sms",
+            status="failed", error_code="CARRIER_ERROR", retry_count=2
+        )
+        mock_db.add.assert_called_once()
+
+
+class TestGetFailedReminders:
+    def test_returns_unique_reminders(self, svc, mock_db):
+        logs = [
+            make_log(status="failed", error_code="TIMEOUT"),
+            make_log(status="failed", error_code="TIMEOUT"),
+        ]
+        logs[0].reminder_id = 1
+        logs[1].reminder_id = 1  # same reminder, duplicate
+        mock_db.query.return_value.filter_by.return_value.order_by.return_value.limit.return_value.all.return_value = logs
+        result = svc.get_failed_reminders(user_id=1)
+        assert len(result) == 1  # deduplicated
+
+    def test_empty(self, svc, mock_db):
+        mock_db.query.return_value.filter_by.return_value.order_by.return_value.limit.return_value.all.return_value = []
+        result = svc.get_failed_reminders(user_id=1)
+        assert result == []


### PR DESCRIPTION
## Summary

Implements Reminder Reliability Tracking & Delivery Metrics (Issue #123).

## Changes

### New Model: ReminderDeliveryLog
- Tracks every reminder delivery attempt with: status, channel, latency_ms, error_code, retry_count, attempted_at
- Linked to existing Reminder model via foreign key

### New Service: ReminderReliabilityService
- get_delivery_metrics(user_id, days, channel): Overall success rate, failure rate, avg latency, p95 latency, per-channel breakdown, error code breakdown
- get_reminder_metrics(user_id, reminder_id): Per-reminder reliability score + full delivery history
- get_failed_reminders(user_id): List reminders with recent failures for retry workflows
- record_delivery_attempt(): Record a new delivery attempt with all metadata

### New Routes (under /reminders prefix)
- GET /reminders/metrics?days=30&channel=email
- GET /reminders/metrics/{reminder_id}
- GET /reminders/failed?limit=50
- POST /reminders/{id}/delivery-log

## Tests
15 unit tests covering:
- Empty state defaults
- All delivered / mixed success+failure
- Latency percentile calculation (p95)
- Per-channel filtering and breakdown
- Error code aggregation
- Per-reminder reliability score
- Delivery log recording (success + failure)
- Deduplication in failed reminders list

Closes #123
