### PR TITLE
feat: API response compression & payload optimization

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -8,6 +8,7 @@ from .observability import (
     finalize_request,
     init_request_context,
 )
+from .compression import init_compression, optimize_json_response
 from flask_cors import CORS
 import click
 import os
@@ -48,6 +49,9 @@ def create_app(settings: Settings | None = None) -> Flask:
     # CORS for local dev frontend
     CORS(app, resources={r"*": {"origins": "*"}}, supports_credentials=True)
 
+    # Response compression (gzip / brotli)
+    init_compression(app)
+
     # Redis (already global)
     # Blueprint routes
     register_routes(app)
@@ -62,6 +66,7 @@ def create_app(settings: Settings | None = None) -> Flask:
 
     @app.after_request
     def _after_request(response):
+        response = optimize_json_response(response)
         return finalize_request(response)
 
     @app.get("/health")

--- a/packages/backend/app/compression.py
+++ b/packages/backend/app/compression.py
@@ -1,0 +1,154 @@
+"""API response compression, payload optimization, and ETag support.
+
+Provides:
+- gzip/brotli compression via flask-compress
+- Automatic null-field stripping from JSON responses
+- ETag generation for conditional GET (304 Not Modified)
+- Response-size observability headers (X-Original-Size / X-Compressed-Size)
+- A generic ``paginate_query`` helper for list endpoints
+"""
+
+import hashlib
+import json
+import logging
+from typing import Any
+
+from flask import Flask, Response, request
+
+logger = logging.getLogger("finmind.compression")
+
+
+# ---------------------------------------------------------------------------
+# flask-compress configuration
+# ---------------------------------------------------------------------------
+
+def init_compression(app: Flask) -> None:
+    """Initialise flask-compress with sensible defaults for an API backend."""
+    from flask_compress import Compress
+
+    app.config.setdefault("COMPRESS_ALGORITHM", ["br", "gzip", "deflate"])
+    app.config.setdefault("COMPRESS_MIN_SIZE", 256)  # bytes
+    # Compress JSON and plain-text responses
+    app.config.setdefault(
+        "COMPRESS_MIMETYPES",
+        [
+            "application/json",
+            "text/plain",
+            "text/html",
+            "text/css",
+            "application/javascript",
+        ],
+    )
+    Compress(app)
+    logger.info("Response compression enabled (br + gzip)")
+
+
+# ---------------------------------------------------------------------------
+# JSON payload optimisation – strip null / None values
+# ---------------------------------------------------------------------------
+
+def _strip_nulls(obj: Any) -> Any:
+    """Recursively remove keys whose value is ``None`` from dicts."""
+    if isinstance(obj, dict):
+        return {k: _strip_nulls(v) for k, v in obj.items() if v is not None}
+    if isinstance(obj, list):
+        return [_strip_nulls(item) for item in obj]
+    return obj
+
+
+def optimize_json_response(response: Response) -> Response:
+    """Strip null fields from JSON responses and inject size / ETag headers.
+
+    This is designed to be called from an ``after_request`` hook.
+    """
+    if response.content_type and "application/json" not in response.content_type:
+        return response
+
+    # Only process successful responses with a body
+    if response.status_code < 200 or response.status_code >= 300:
+        return response
+
+    raw = response.get_data(as_text=True)
+    if not raw:
+        return response
+
+    original_size = len(raw.encode("utf-8"))
+
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return response
+
+    optimized = _strip_nulls(data)
+    compact = json.dumps(optimized, separators=(",", ":"), sort_keys=True)
+    optimized_size = len(compact.encode("utf-8"))
+
+    # ETag based on content hash – enables 304 responses
+    etag = '"' + hashlib.md5(compact.encode("utf-8")).hexdigest() + '"'
+
+    # Check If-None-Match for conditional GET
+    if request.method == "GET":
+        if_none_match = request.headers.get("If-None-Match", "").strip()
+        if if_none_match == etag:
+            not_modified = Response(status=304)
+            not_modified.headers["ETag"] = etag
+            return not_modified
+
+    response.set_data(compact)
+    response.headers["ETag"] = etag
+    response.headers["X-Original-Size"] = str(original_size)
+    response.headers["X-Compressed-Size"] = str(optimized_size)
+    response.headers["Content-Length"] = str(optimized_size)
+
+    savings_pct = (
+        round((1 - optimized_size / original_size) * 100, 1)
+        if original_size > 0
+        else 0
+    )
+    if savings_pct > 0:
+        logger.debug(
+            "JSON optimised %s %s: %d -> %d bytes (%.1f%% savings)",
+            request.method,
+            request.path,
+            original_size,
+            optimized_size,
+            savings_pct,
+        )
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Generic pagination helper
+# ---------------------------------------------------------------------------
+
+def paginate_query(query, *, page: int = 1, page_size: int = 50, max_page_size: int = 200):
+    """Apply LIMIT/OFFSET pagination to an SQLAlchemy query.
+
+    Returns ``(items, meta)`` where *meta* is a dict with pagination info.
+    """
+    page = max(1, page)
+    page_size = max(1, min(page_size, max_page_size))
+
+    total = query.count()
+    items = query.offset((page - 1) * page_size).limit(page_size).all()
+
+    return items, {
+        "page": page,
+        "page_size": page_size,
+        "total": total,
+        "total_pages": max(1, -(-total // page_size)),  # ceil division
+    }
+
+
+def parse_pagination_args() -> tuple[int, int]:
+    """Extract ``page`` and ``page_size`` from the current request query string."""
+    try:
+        page = max(1, int(request.args.get("page", "1")))
+    except (ValueError, TypeError):
+        page = 1
+    try:
+        page_size = max(1, min(200, int(request.args.get("page_size", "50"))))
+    except (ValueError, TypeError):
+        page_size = 50
+    return page, page_size

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, BillCadence, User
 from ..services.cache import cache_delete_patterns
+from ..compression import paginate_query, parse_pagination_args
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -14,15 +15,16 @@ logger = logging.getLogger("finmind.bills")
 @jwt_required()
 def list_bills():
     uid = int(get_jwt_identity())
-    items = (
+    page, page_size = parse_pagination_args()
+    q = (
         db.session.query(Bill)
         .filter_by(user_id=uid, active=True)
         .order_by(Bill.next_due_date)
-        .all()
     )
+    items, meta = paginate_query(q, page=page, page_size=page_size)
     logger.info("List bills user=%s count=%s", uid, len(items))
     return jsonify(
-        [
+        data=[
             {
                 "id": b.id,
                 "name": b.name,
@@ -35,7 +37,8 @@ def list_bills():
                 "channel_email": b.channel_email,
             }
             for b in items
-        ]
+        ],
+        pagination=meta,
     )
 
 

--- a/packages/backend/app/routes/categories.py
+++ b/packages/backend/app/routes/categories.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Category
+from ..compression import paginate_query, parse_pagination_args
 
 bp = Blueprint("categories", __name__)
 logger = logging.getLogger("finmind.categories")
@@ -12,11 +13,11 @@ logger = logging.getLogger("finmind.categories")
 @jwt_required()
 def list_categories():
     uid = int(get_jwt_identity())
-    items = (
-        db.session.query(Category).filter_by(user_id=uid).order_by(Category.name).all()
-    )
+    page, page_size = parse_pagination_args()
+    q = db.session.query(Category).filter_by(user_id=uid).order_by(Category.name)
+    items, meta = paginate_query(q, page=page, page_size=page_size)
     logger.info("List categories for user=%s count=%s", uid, len(items))
-    return jsonify([{"id": c.id, "name": c.name} for c in items])
+    return jsonify(data=[{"id": c.id, "name": c.name} for c in items], pagination=meta)
 
 
 @bp.post("")

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -25,7 +25,7 @@ def list_expenses():
     category_id = request.args.get("category_id")
     try:
         page = max(1, int(request.args.get("page", "1")))
-        page_size = min(200, max(1, int(request.args.get("page_size", "200"))))
+        page_size = min(200, max(1, int(request.args.get("page_size", "50"))))
     except ValueError:
         return jsonify(error="invalid pagination"), 400
 
@@ -41,15 +41,19 @@ def list_expenses():
     if search:
         q = q.filter(Expense.notes.ilike(f"%{search}%"))
 
-    items = (
-        q.order_by(Expense.spent_at.desc())
-        .offset((page - 1) * page_size)
-        .limit(page_size)
-        .all()
-    )
+    ordered = q.order_by(Expense.spent_at.desc())
+    total = ordered.count()
+    items = ordered.offset((page - 1) * page_size).limit(page_size).all()
     logger.info("List expenses user=%s count=%s", uid, len(items))
-    data = [_expense_to_dict(e) for e in items]
-    return jsonify(data)
+    return jsonify(
+        data=[_expense_to_dict(e) for e in items],
+        pagination={
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "total_pages": max(1, -(-total // page_size)),
+        },
+    )
 
 
 @bp.post("")

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -5,6 +5,7 @@ from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
+from ..compression import paginate_query, parse_pagination_args
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -15,15 +16,16 @@ logger = logging.getLogger("finmind.reminders")
 @jwt_required()
 def list_reminders():
     uid = int(get_jwt_identity())
-    items = (
+    page, page_size = parse_pagination_args()
+    q = (
         db.session.query(Reminder)
         .filter_by(user_id=uid)
         .order_by(Reminder.send_at)
-        .all()
     )
+    items, meta = paginate_query(q, page=page, page_size=page_size)
     logger.info("List reminders user=%s count=%s", uid, len(items))
     return jsonify(
-        [
+        data=[
             {
                 "id": r.id,
                 "message": r.message,
@@ -32,7 +34,8 @@ def list_reminders():
                 "channel": r.channel,
             }
             for r in items
-        ]
+        ],
+        pagination=meta,
     )
 
 

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -1,4 +1,5 @@
 flask==3.0.3
+flask-compress==1.15
 gunicorn==22.0.0
 flask-cors==4.0.1
 flask-sqlalchemy==3.1.1

--- a/packages/backend/tests/test_bills.py
+++ b/packages/backend/tests/test_bills.py
@@ -5,7 +5,7 @@ def test_bills_crud_and_mark_paid(client, auth_header):
     # Initially empty
     r = client.get("/bills", headers=auth_header)
     assert r.status_code == 200
-    assert r.get_json() == []
+    assert r.get_json()["data"] == []
 
     # Create bill
     payload = {
@@ -24,7 +24,7 @@ def test_bills_crud_and_mark_paid(client, auth_header):
     # List has 1
     r = client.get("/bills", headers=auth_header)
     assert r.status_code == 200
-    items = r.get_json()
+    items = r.get_json()["data"]
     assert any(b["id"] == bill_id for b in items)
 
     # Mark paid
@@ -51,6 +51,6 @@ def test_bill_create_defaults_to_user_preferred_currency(client, auth_header):
 
     r = client.get("/bills", headers=auth_header)
     assert r.status_code == 200
-    created = next((item for item in r.get_json() if item["id"] == bill_id), None)
+    created = next((item for item in r.get_json()["data"] if item["id"] == bill_id), None)
     assert created is not None
     assert created["currency"] == "INR"

--- a/packages/backend/tests/test_categories.py
+++ b/packages/backend/tests/test_categories.py
@@ -2,7 +2,7 @@ def test_categories_crud_flow(client, auth_header):
     # Initially empty
     r = client.get("/categories", headers=auth_header)
     assert r.status_code == 200
-    assert r.get_json() == []
+    assert r.get_json()["data"] == []
 
     # Create
     r = client.post("/categories", json={"name": "Food"}, headers=auth_header)
@@ -17,7 +17,7 @@ def test_categories_crud_flow(client, auth_header):
     # List should have 1
     r = client.get("/categories", headers=auth_header)
     assert r.status_code == 200
-    items = r.get_json()
+    items = r.get_json()["data"]
     assert len(items) == 1
 
     # Update
@@ -35,4 +35,4 @@ def test_categories_crud_flow(client, auth_header):
     # List should be empty again
     r = client.get("/categories", headers=auth_header)
     assert r.status_code == 200
-    assert r.get_json() == []
+    assert r.get_json()["data"] == []

--- a/packages/backend/tests/test_compression.py
+++ b/packages/backend/tests/test_compression.py
@@ -1,0 +1,148 @@
+"""Tests for API response compression, null stripping, ETags, and pagination."""
+
+import gzip
+import json
+
+
+def test_health_response_has_etag(client):
+    """Health endpoint should include an ETag header on JSON responses."""
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.headers.get("ETag") is not None
+
+
+def test_etag_returns_304_on_conditional_get(client):
+    """A second GET with If-None-Match matching the ETag should return 304."""
+    r1 = client.get("/health")
+    assert r1.status_code == 200
+    etag = r1.headers["ETag"]
+
+    r2 = client.get("/health", headers={"If-None-Match": etag})
+    assert r2.status_code == 304
+
+
+def test_etag_mismatch_returns_200(client):
+    """If-None-Match with a wrong ETag should still return 200."""
+    r = client.get("/health", headers={"If-None-Match": '"wrong-etag"'})
+    assert r.status_code == 200
+
+
+def test_null_fields_stripped_from_json(app_fixture):
+    """None/null values should be stripped from JSON responses."""
+
+    @app_fixture.get("/test-nulls")
+    def _test_nulls():
+        from flask import jsonify
+
+        return jsonify(name="Alice", nickname=None, age=30, extra=None)
+
+    with app_fixture.test_client() as c:
+        r = c.get("/test-nulls")
+        assert r.status_code == 200
+        data = json.loads(r.get_data(as_text=True))
+        assert "name" in data
+        assert "age" in data
+        assert "nickname" not in data
+        assert "extra" not in data
+
+
+def test_response_size_headers_present(client):
+    """JSON responses should include X-Original-Size and X-Compressed-Size."""
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert "X-Original-Size" in r.headers
+    assert "X-Compressed-Size" in r.headers
+    # Both should be parseable integers
+    assert int(r.headers["X-Original-Size"]) > 0
+    assert int(r.headers["X-Compressed-Size"]) > 0
+
+
+def test_gzip_accepted_and_compressed(client):
+    """When Accept-Encoding: gzip is sent, response should be compressed."""
+    r = client.get("/health", headers={"Accept-Encoding": "gzip"})
+    assert r.status_code == 200
+    # flask-compress may or may not compress very small payloads depending
+    # on the COMPRESS_MIN_SIZE setting, so we just check the response is valid
+    raw = r.get_data()
+    # If it was gzip-compressed, the first two bytes are the gzip magic number
+    if raw[:2] == b"\x1f\x8b":
+        decompressed = gzip.decompress(raw)
+        data = json.loads(decompressed)
+    else:
+        data = json.loads(raw)
+    assert data["status"] == "ok"
+
+
+def test_expenses_list_returns_pagination_metadata(client, auth_header):
+    """GET /expenses should return pagination metadata alongside data."""
+    r = client.get("/expenses", headers=auth_header)
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "data" in body
+    assert "pagination" in body
+    meta = body["pagination"]
+    assert meta["page"] == 1
+    assert meta["total"] == 0
+    assert meta["total_pages"] == 1
+
+
+def test_bills_list_returns_pagination_metadata(client, auth_header):
+    """GET /bills should return pagination metadata alongside data."""
+    r = client.get("/bills", headers=auth_header)
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "data" in body
+    assert "pagination" in body
+    assert body["pagination"]["page"] == 1
+
+
+def test_categories_list_returns_pagination_metadata(client, auth_header):
+    """GET /categories should return pagination metadata alongside data."""
+    r = client.get("/categories", headers=auth_header)
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "data" in body
+    assert "pagination" in body
+    assert body["pagination"]["page"] == 1
+
+
+def test_reminders_list_returns_pagination_metadata(client, auth_header):
+    """GET /reminders should return pagination metadata alongside data."""
+    r = client.get("/reminders", headers=auth_header)
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "data" in body
+    assert "pagination" in body
+    assert body["pagination"]["page"] == 1
+
+
+def test_pagination_page_and_page_size_params(client, auth_header):
+    """Custom page/page_size query params should be reflected in metadata."""
+    # Create a few expenses
+    for i in range(5):
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": 10 + i,
+                "description": f"Item {i}",
+                "date": "2026-02-01",
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get("/expenses?page=1&page_size=2", headers=auth_header)
+    assert r.status_code == 200
+    body = r.get_json()
+    assert len(body["data"]) == 2
+    assert body["pagination"]["page"] == 1
+    assert body["pagination"]["page_size"] == 2
+    assert body["pagination"]["total"] == 5
+    assert body["pagination"]["total_pages"] == 3
+
+    # Page 3 should have 1 item
+    r = client.get("/expenses?page=3&page_size=2", headers=auth_header)
+    assert r.status_code == 200
+    body = r.get_json()
+    assert len(body["data"]) == 1
+    assert body["pagination"]["page"] == 3

--- a/packages/backend/tests/test_expenses.py
+++ b/packages/backend/tests/test_expenses.py
@@ -6,7 +6,7 @@ def _create_category(client, auth_header, name="General"):
     assert r.status_code in (201, 409)
     r = client.get("/categories", headers=auth_header)
     assert r.status_code == 200
-    return r.get_json()[0]["id"]
+    return r.get_json()["data"][0]["id"]
 
 
 def test_expenses_crud_filters_and_canonical_fields(client, auth_header):
@@ -14,7 +14,7 @@ def test_expenses_crud_filters_and_canonical_fields(client, auth_header):
 
     r = client.get("/expenses", headers=auth_header)
     assert r.status_code == 200
-    assert r.get_json() == []
+    assert r.get_json()["data"] == []
 
     payload = {
         "amount": 12.5,
@@ -43,20 +43,20 @@ def test_expenses_crud_filters_and_canonical_fields(client, auth_header):
 
     r = client.get("/expenses?search=milk", headers=auth_header)
     assert r.status_code == 200
-    items = r.get_json()
+    items = r.get_json()["data"]
     assert len(items) == 1
     assert items[0]["id"] == exp_id
 
     r = client.get("/expenses?from=2026-02-01&to=2026-02-28", headers=auth_header)
     assert r.status_code == 200
-    assert len(r.get_json()) == 1
+    assert len(r.get_json()["data"]) == 1
 
     r = client.delete(f"/expenses/{exp_id}", headers=auth_header)
     assert r.status_code == 200
 
     r = client.get("/expenses", headers=auth_header)
     assert r.status_code == 200
-    assert r.get_json() == []
+    assert r.get_json()["data"] == []
 
 
 def test_expense_create_defaults_to_user_preferred_currency(client, auth_header):
@@ -231,7 +231,7 @@ def test_recurring_expense_create_list_and_generate(client, auth_header):
 
     r = client.get("/expenses?search=House%20Rent", headers=auth_header)
     assert r.status_code == 200
-    generated = r.get_json()
+    generated = r.get_json()["data"]
     assert len(generated) == 3
 
 
@@ -258,5 +258,5 @@ def test_recurring_expense_generate_respects_end_date(client, auth_header):
 
     r = client.get("/expenses?search=Gym%20Membership", headers=auth_header)
     assert r.status_code == 200
-    generated = r.get_json()
+    generated = r.get_json()["data"]
     assert len(generated) == 3

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -60,7 +60,7 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
 
     r = client.get("/reminders", headers=auth_header)
     assert r.status_code == 200
-    reminders = r.get_json()
+    reminders = r.get_json()["data"]
     autopay_pre = [x for x in reminders if "Autopay check" in x["message"]]
     assert len(autopay_pre) == 2
     assert sorted([x["channel"] for x in autopay_pre]) == ["email", "whatsapp"]
@@ -76,7 +76,7 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
 
     r = client.get("/reminders", headers=auth_header)
     assert r.status_code == 200
-    reminders = r.get_json()
+    reminders = r.get_json()["data"]
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]


### PR DESCRIPTION
## Summary
- Adds **gzip/brotli compression** via `flask-compress` middleware for all API responses
- **Strips null fields** from JSON payloads to reduce response size
- Adds **ETag headers** with `If-None-Match` support, returning `304 Not Modified` when content hasn't changed
- Adds **`X-Original-Size` / `X-Compressed-Size`** response headers for measuring size reduction
- Adds **pagination metadata** (`data` + `pagination` envelope) to all list endpoints: `/expenses`, `/bills`, `/categories`, `/reminders`
- Includes a reusable `paginate_query()` helper and `parse_pagination_args()` utility

Closes #129

## Changes
| File | What |
|------|------|
| `app/compression.py` | New module: compression init, null stripping, ETag, pagination helpers |
| `app/__init__.py` | Wire in `flask-compress` and `optimize_json_response` after_request hook |
| `app/routes/expenses.py` | Paginated response envelope for `GET /expenses` |
| `app/routes/bills.py` | Paginated response envelope for `GET /bills` |
| `app/routes/categories.py` | Paginated response envelope for `GET /categories` |
| `app/routes/reminders.py` | Paginated response envelope for `GET /reminders` |
| `requirements.txt` | Add `flask-compress==1.15` |
| `tests/test_compression.py` | 11 new tests for ETags, null stripping, gzip, pagination |
| Existing test files | Updated to use `response["data"]` instead of bare list |

## Test plan
- [x] ETags present on JSON responses
- [x] Conditional GET returns 304 when ETag matches
- [x] Null fields stripped from JSON output
- [x] `X-Original-Size` / `X-Compressed-Size` headers present
- [x] gzip-compressed responses decode correctly
- [x] All list endpoints return `{data: [...], pagination: {...}}` envelope
- [x] Custom `page` / `page_size` params respected
- [x] Existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)