### PR TITLE
Add locale-aware date, currency & number formatting

### DIFF
--- a/app/src/__tests__/formatting.test.ts
+++ b/app/src/__tests__/formatting.test.ts
@@ -1,0 +1,116 @@
+import {
+  formatMoney,
+  formatNumber,
+  formatDate,
+  formatDateTime,
+  formatPercent,
+} from '@/lib/formatting';
+
+// Mock the auth module so we control locale/currency
+jest.mock('@/lib/auth', () => ({
+  getLocale: jest.fn(() => 'en-US'),
+  getCurrency: jest.fn(() => 'USD'),
+}));
+
+import { getLocale, getCurrency } from '@/lib/auth';
+
+describe('formatting utilities', () => {
+  beforeEach(() => {
+    (getLocale as jest.Mock).mockReturnValue('en-US');
+    (getCurrency as jest.Mock).mockReturnValue('USD');
+  });
+
+  describe('formatMoney', () => {
+    it('formats currency with user locale', () => {
+      const result = formatMoney(1234.56);
+      expect(result).toContain('1,234.56');
+      expect(result).toContain('$');
+    });
+
+    it('respects explicit currency code', () => {
+      const result = formatMoney(1000, 'EUR');
+      expect(result).toContain('1,000.00');
+    });
+
+    it('respects explicit locale', () => {
+      const result = formatMoney(1234.56, 'EUR', 'de-DE');
+      // German format uses . for thousands and , for decimals
+      expect(result).toContain('1.234,56');
+    });
+
+    it('handles zero', () => {
+      const result = formatMoney(0);
+      expect(result).toContain('0.00');
+    });
+
+    it('falls back on invalid currency code', () => {
+      const result = formatMoney(100, 'INVALID');
+      expect(result).toContain('INVALID');
+      expect(result).toContain('100.00');
+    });
+  });
+
+  describe('formatNumber', () => {
+    it('formats with thousand separators for en-US', () => {
+      expect(formatNumber(1234567)).toBe('1,234,567');
+    });
+
+    it('respects explicit locale', () => {
+      const result = formatNumber(1234567, 'de-DE');
+      expect(result).toBe('1.234.567');
+    });
+
+    it('handles zero', () => {
+      expect(formatNumber(0)).toBe('0');
+    });
+  });
+
+  describe('formatDate', () => {
+    it('formats a date string', () => {
+      const result = formatDate('2024-03-15');
+      // en-US short month format
+      expect(result).toMatch(/Mar\s+15,?\s+2024/);
+    });
+
+    it('formats a Date object', () => {
+      const result = formatDate(new Date(2024, 0, 1));
+      expect(result).toMatch(/Jan\s+1,?\s+2024/);
+    });
+
+    it('returns original string for invalid date', () => {
+      expect(formatDate('not-a-date')).toBe('not-a-date');
+    });
+
+    it('respects explicit locale', () => {
+      const result = formatDate('2024-03-15', 'de-DE');
+      // German format: "15. Mrz 2024" or "15. Mär. 2024" or "15. März 2024"
+      expect(result).toMatch(/15\.\s*(Mrz|Mär|März)\.?\s*2024/);
+    });
+  });
+
+  describe('formatDateTime', () => {
+    it('includes time in the output', () => {
+      const result = formatDateTime('2024-03-15T14:30:00');
+      expect(result).toMatch(/Mar/);
+      // Should contain some time representation
+      expect(result).toMatch(/\d{1,2}:\d{2}/);
+    });
+  });
+
+  describe('formatPercent', () => {
+    it('formats a percentage value', () => {
+      expect(formatPercent(75)).toBe('75%');
+    });
+
+    it('respects fraction digits', () => {
+      const result = formatPercent(33.33, undefined, 1);
+      expect(result).toBe('33.3%');
+    });
+
+    it('respects explicit locale', () => {
+      const result = formatPercent(50, 'fr-FR');
+      // French uses non-breaking space before %
+      expect(result).toMatch(/50\s*%/);
+    });
+  });
+});

--- a/app/src/api/auth.ts
+++ b/app/src/api/auth.ts
@@ -25,13 +25,14 @@ export async function logout(refresh_token: string): Promise<{ message: string }
   });
 }
 
-export type MeResponse = { id: number; email: string; preferred_currency: string };
+export type MeResponse = { id: number; email: string; preferred_currency: string; locale: string };
 export async function me(): Promise<MeResponse> {
   return api<MeResponse>('/auth/me');
 }
 
 export async function updateMe(payload: {
-  preferred_currency: string;
+  preferred_currency?: string;
+  locale?: string;
 }): Promise<MeResponse> {
   return api<MeResponse>('/auth/me', { method: 'PATCH', body: payload });
 }

--- a/app/src/components/ui/chart.tsx
+++ b/app/src/components/ui/chart.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
 import { cn } from "@/lib/utils"
+import { formatNumber } from "@/lib/formatting"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
@@ -238,7 +239,7 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {formatNumber(item.value)}
                         </span>
                       )}
                     </div>

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -1,6 +1,7 @@
 export const TOKEN_KEY = 'fm_token';
 export const REFRESH_TOKEN_KEY = 'fm_refresh_token';
 export const CURRENCY_KEY = 'fm_currency';
+export const LOCALE_KEY = 'fm_locale';
 
 export function getToken(): string | null {
   return localStorage.getItem(TOKEN_KEY);
@@ -38,4 +39,13 @@ export function getCurrency(): string {
 export function setCurrency(currency: string) {
   localStorage.setItem(CURRENCY_KEY, currency);
   window.dispatchEvent(new Event('currency_changed'));
+}
+
+export function getLocale(): string {
+  return localStorage.getItem(LOCALE_KEY) || 'en-US';
+}
+
+export function setLocale(locale: string) {
+  localStorage.setItem(LOCALE_KEY, locale);
+  window.dispatchEvent(new Event('locale_changed'));
 }

--- a/app/src/lib/currency.ts
+++ b/app/src/lib/currency.ts
@@ -1,15 +1,3 @@
-import { getCurrency } from '@/lib/auth';
-
-export function formatMoney(amount: number, currencyCode?: string): string {
-  const currency = (currencyCode || getCurrency() || 'USD').toUpperCase();
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: 'currency',
-      currency,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(Number(amount || 0));
-  } catch {
-    return `${currency} ${Number(amount || 0).toFixed(2)}`;
-  }
-}
+// Re-export formatMoney from the locale-aware formatting module
+// for backwards compatibility with existing imports.
+export { formatMoney } from '@/lib/formatting';

--- a/app/src/lib/formatting.ts
+++ b/app/src/lib/formatting.ts
@@ -1,0 +1,101 @@
+import { getLocale } from '@/lib/auth';
+import { getCurrency } from '@/lib/auth';
+
+/**
+ * Locale-aware formatting utilities using the Intl API.
+ * All functions read the user's locale preference from localStorage
+ * unless an explicit locale is passed.
+ */
+
+export function formatMoney(
+  amount: number,
+  currencyCode?: string,
+  locale?: string,
+): string {
+  const resolvedLocale = locale || getLocale();
+  const currency = (currencyCode || getCurrency() || 'USD').toUpperCase();
+  try {
+    return new Intl.NumberFormat(resolvedLocale, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(Number(amount || 0));
+  } catch {
+    return `${currency} ${Number(amount || 0).toFixed(2)}`;
+  }
+}
+
+export function formatNumber(
+  value: number,
+  locale?: string,
+  options?: Intl.NumberFormatOptions,
+): string {
+  const resolvedLocale = locale || getLocale();
+  try {
+    return new Intl.NumberFormat(resolvedLocale, options).format(
+      Number(value || 0),
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+export function formatDate(
+  date: string | Date,
+  locale?: string,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const resolvedLocale = locale || getLocale();
+  const d = typeof date === 'string' ? new Date(date) : date;
+  if (isNaN(d.getTime())) return String(date);
+  try {
+    return new Intl.DateTimeFormat(resolvedLocale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      ...options,
+    }).format(d);
+  } catch {
+    return d.toLocaleDateString();
+  }
+}
+
+export function formatDateTime(
+  date: string | Date,
+  locale?: string,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  const resolvedLocale = locale || getLocale();
+  const d = typeof date === 'string' ? new Date(date) : date;
+  if (isNaN(d.getTime())) return String(date);
+  try {
+    return new Intl.DateTimeFormat(resolvedLocale, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      ...options,
+    }).format(d);
+  } catch {
+    return d.toLocaleString();
+  }
+}
+
+export function formatPercent(
+  value: number,
+  locale?: string,
+  fractionDigits = 0,
+): string {
+  const resolvedLocale = locale || getLocale();
+  try {
+    return new Intl.NumberFormat(resolvedLocale, {
+      style: 'percent',
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    }).format(value / 100);
+  } catch {
+    return `${value.toFixed(fractionDigits)}%`;
+  }
+}

--- a/app/src/pages/Account.tsx
+++ b/app/src/pages/Account.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { me, updateMe } from '@/api/auth';
-import { setCurrency } from '@/lib/auth';
+import { setCurrency, setLocale } from '@/lib/auth';
 
 const SUPPORTED_CURRENCIES = [
   { code: 'INR', label: 'Indian Rupee (INR)' },
@@ -17,10 +17,27 @@ const SUPPORTED_CURRENCIES = [
   { code: 'JPY', label: 'Japanese Yen (JPY)' },
 ];
 
+const SUPPORTED_LOCALES = [
+  { code: 'en-US', label: 'English (US)' },
+  { code: 'en-GB', label: 'English (UK)' },
+  { code: 'en-IN', label: 'English (India)' },
+  { code: 'en-AU', label: 'English (Australia)' },
+  { code: 'en-CA', label: 'English (Canada)' },
+  { code: 'fr-FR', label: 'French (France)' },
+  { code: 'de-DE', label: 'German (Germany)' },
+  { code: 'ja-JP', label: 'Japanese (Japan)' },
+  { code: 'hi-IN', label: 'Hindi (India)' },
+  { code: 'ar-AE', label: 'Arabic (UAE)' },
+  { code: 'zh-CN', label: 'Chinese (China)' },
+  { code: 'es-ES', label: 'Spanish (Spain)' },
+  { code: 'pt-BR', label: 'Portuguese (Brazil)' },
+];
+
 export default function Account() {
   const { toast } = useToast();
   const [email, setEmail] = useState('');
   const [currency, setCurrencyState] = useState('INR');
+  const [locale, setLocaleState] = useState('en-US');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -31,6 +48,7 @@ export default function Account() {
         const data = await me();
         setEmail(data.email);
         setCurrencyState(data.preferred_currency || 'INR');
+        setLocaleState(data.locale || 'en-US');
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.message : 'Failed to load account';
@@ -45,11 +63,12 @@ export default function Account() {
   const onSave = async () => {
     setSaving(true);
     try {
-      const updated = await updateMe({ preferred_currency: currency });
+      const updated = await updateMe({ preferred_currency: currency, locale });
       setCurrency(updated.preferred_currency);
+      setLocale(updated.locale);
       toast({
         title: 'Account updated',
-        description: `Default currency set to ${updated.preferred_currency}.`,
+        description: `Currency: ${updated.preferred_currency}, Locale: ${updated.locale}.`,
       });
     } catch (error: unknown) {
       const message =
@@ -66,8 +85,8 @@ export default function Account() {
         <div className="relative">
           <h1 className="page-title">Account Settings</h1>
           <p className="page-subtitle">
-            Manage your profile defaults. Currency stays fixed until you change
-            it again.
+            Manage your profile defaults. Currency and locale settings control
+            how dates, numbers, and amounts are displayed across the app.
           </p>
         </div>
       </div>
@@ -90,6 +109,24 @@ export default function Account() {
                 onChange={(e) => setCurrencyState(e.target.value)}
               >
                 {SUPPORTED_CURRENCIES.map((item) => (
+                  <option key={item.code} value={item.code}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="locale">Display Locale</Label>
+              <p className="text-xs text-muted-foreground">
+                Controls how dates, numbers, and currencies are formatted.
+              </p>
+              <select
+                id="locale"
+                className="input"
+                value={locale}
+                onChange={(e) => setLocaleState(e.target.value)}
+              >
+                {SUPPORTED_LOCALES.map((item) => (
                   <option key={item.code} value={item.code}>
                     {item.label}
                   </option>

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
 import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
-import { formatMoney } from '@/lib/currency';
+import { formatMoney } from '@/lib/formatting';
 
 const PERSONAS = [
   'Balanced coach',

--- a/app/src/pages/Bills.tsx
+++ b/app/src/pages/Bills.tsx
@@ -8,7 +8,7 @@ import { listBills, createBill, markBillPaid, deleteBill, type Bill } from '@/ap
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dailog';
 import { Link } from 'react-router-dom';
-import { formatMoney } from '@/lib/currency';
+import { formatMoney, formatDate, formatNumber } from '@/lib/formatting';
 
 const upcomingBills = [
   {
@@ -321,7 +321,7 @@ export function Bills() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${totalUpcoming.toLocaleString()}
+                ${formatNumber(totalUpcoming)}
               </div>
               <div className="text-sm text-muted-foreground">
                 {upcomingBills.length} bills this month
@@ -378,7 +378,7 @@ export function Bills() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${(totalUpcoming * 0.92).toLocaleString()}
+                ${formatNumber(totalUpcoming * 0.92)}
               </div>
               <div className="text-sm text-muted-foreground">
                 Last 6 months
@@ -433,7 +433,7 @@ export function Bills() {
                             {bill.name}
                           </div>
                           <div className="text-sm text-muted-foreground">
-                            {bill.provider} • Due {new Date(bill.dueDate).toLocaleDateString()}
+                            {bill.provider} • Due {formatDate(bill.dueDate)}
                           </div>
                           <div className="flex items-center space-x-2 mt-1">
                             <Badge variant="outline" className="text-xs">
@@ -522,7 +522,7 @@ export function Bills() {
                             {payment.name}
                           </div>
                           <div className="text-xs text-muted-foreground">
-                            {new Date(payment.paidDate).toLocaleDateString()} • {payment.method}
+                            {formatDate(payment.paidDate)} • {payment.method}
                           </div>
                         </div>
                       </div>

--- a/app/src/pages/Budgets.tsx
+++ b/app/src/pages/Budgets.tsx
@@ -3,6 +3,7 @@ import { FinancialCard, FinancialCardContent, FinancialCardDescription, Financia
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Calendar, DollarSign, Plus, PieChart, TrendingDown, TrendingUp, Target, AlertCircle, Settings } from 'lucide-react';
+import { formatNumber } from '@/lib/formatting';
 
 const budgetCategories = [
   {
@@ -140,7 +141,7 @@ export function Budgets() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${totalAllocated.toLocaleString()}
+                ${formatNumber(totalAllocated)}
               </div>
               <div className="text-sm text-muted-foreground">
                 This month's budget
@@ -159,7 +160,7 @@ export function Budgets() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${totalSpent.toLocaleString()}
+                ${formatNumber(totalSpent)}
               </div>
               <div className="text-sm text-muted-foreground">
                 {((totalSpent / totalAllocated) * 100).toFixed(1)}% of budget used
@@ -182,7 +183,7 @@ export function Budgets() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value mb-1">
-                ${Math.abs(totalRemaining).toLocaleString()}
+                ${formatNumber(Math.abs(totalRemaining))}
               </div>
               <div className="text-sm opacity-80">
                 {totalRemaining < 0 ? 'Overspent this month' : 'Available to spend'}
@@ -302,7 +303,7 @@ export function Budgets() {
                         <div className="space-y-2">
                           <div className="flex justify-between text-sm">
                             <span className="text-muted-foreground">
-                              ${goal.current.toLocaleString()} / ${goal.target.toLocaleString()}
+                              ${formatNumber(goal.current)} / ${formatNumber(goal.target)}
                             </span>
                             <span className="text-foreground font-medium">
                               {percentage.toFixed(0)}%

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react';
 import { getDashboardSummary, type DashboardSummary } from '@/api/dashboard';
 import { useNavigate } from 'react-router-dom';
-import { formatMoney } from '@/lib/currency';
+import { formatMoney, formatDate } from '@/lib/formatting';
 
 function currency(n: number, code?: string) {
   return formatMoney(Number(n || 0), code);
@@ -193,7 +193,7 @@ export function Dashboard() {
                           </div>
                           <div>
                             <div className="font-medium text-foreground">{transaction.description}</div>
-                            <div className="text-sm text-muted-foreground">{new Date(transaction.date).toLocaleDateString()}</div>
+                            <div className="text-sm text-muted-foreground">{formatDate(transaction.date)}</div>
                           </div>
                         </div>
                         <div className={`font-semibold ${isIncome ? 'text-success' : 'text-foreground'}`}>
@@ -231,7 +231,7 @@ export function Dashboard() {
                         </div>
                         <div>
                           <div className="font-medium text-foreground text-sm">{bill.name}</div>
-                          <div className="text-xs text-muted-foreground">Due {new Date(bill.next_due_date).toLocaleDateString()}</div>
+                          <div className="text-xs text-muted-foreground">Due {formatDate(bill.next_due_date)}</div>
                         </div>
                       </div>
                       <div className="text-sm font-semibold text-foreground">

--- a/app/src/pages/Expenses.tsx
+++ b/app/src/pages/Expenses.tsx
@@ -46,7 +46,7 @@ import {
   type RecurringExpense,
 } from '@/api/expenses';
 import { listCategories, type Category } from '@/api/categories';
-import { formatMoney } from '@/lib/currency';
+import { formatMoney } from '@/lib/formatting';
 
 export default function Expenses() {
   const { toast } = useToast();

--- a/app/src/pages/Reminders.tsx
+++ b/app/src/pages/Reminders.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { formatDateTime } from '@/lib/formatting';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dailog';
 import { useToast } from '@/hooks/use-toast';
 import {
@@ -268,7 +269,7 @@ export function Reminders() {
                 <div key={r.id} className="interactive-row flex items-center justify-between border-b py-2">
                   <div>
                     <div className="font-medium">{r.message}</div>
-                    <div className="text-xs text-muted-foreground">{new Date(r.send_at).toLocaleString()} • {r.channel} • {r.sent ? 'sent' : 'pending'}</div>
+                    <div className="text-xs text-muted-foreground">{formatDateTime(r.send_at)} • {r.channel} • {r.sent ? 'sent' : 'pending'}</div>
                   </div>
                   <AlertDialog>
                     <AlertDialogTrigger asChild>

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -27,6 +27,22 @@ SUPPORTED_CURRENCIES = {
     "JPY",
 }
 
+SUPPORTED_LOCALES = {
+    "en-US",
+    "en-GB",
+    "en-IN",
+    "en-AU",
+    "en-CA",
+    "fr-FR",
+    "de-DE",
+    "ja-JP",
+    "hi-IN",
+    "ar-AE",
+    "zh-CN",
+    "es-ES",
+    "pt-BR",
+}
+
 
 @bp.post("/register")
 def register():
@@ -77,6 +93,7 @@ def me():
         id=user.id,
         email=user.email,
         preferred_currency=user.preferred_currency or "INR",
+        locale=user.locale or "en-US",
     )
 
 
@@ -93,11 +110,17 @@ def update_me():
         if cur not in SUPPORTED_CURRENCIES:
             return jsonify(error="unsupported preferred_currency"), 400
         user.preferred_currency = cur
+    if "locale" in data:
+        loc = str(data.get("locale") or "").strip()
+        if loc not in SUPPORTED_LOCALES:
+            return jsonify(error="unsupported locale"), 400
+        user.locale = loc
     db.session.commit()
     return jsonify(
         id=user.id,
         email=user.email,
         preferred_currency=user.preferred_currency or "INR",
+        locale=user.locale or "en-US",
     )
 
 

--- a/packages/backend/tests/test_locale.py
+++ b/packages/backend/tests/test_locale.py
@@ -1,0 +1,63 @@
+"""Tests for locale preference on the User model and /auth/me endpoint."""
+
+
+def _register_and_login(client, email="locale@test.com", password="secret123"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    access = r.get_json()["access_token"]
+    return {"Authorization": f"Bearer {access}"}
+
+
+def test_me_returns_default_locale(client):
+    auth = _register_and_login(client)
+    r = client.get("/auth/me", headers=auth)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["locale"] == "en-US"
+
+
+def test_update_locale(client):
+    auth = _register_and_login(client, email="locale2@test.com")
+    r = client.patch("/auth/me", json={"locale": "fr-FR"}, headers=auth)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["locale"] == "fr-FR"
+
+    # Verify persistence
+    r = client.get("/auth/me", headers=auth)
+    assert r.get_json()["locale"] == "fr-FR"
+
+
+def test_update_locale_unsupported_returns_400(client):
+    auth = _register_and_login(client, email="locale3@test.com")
+    r = client.patch("/auth/me", json={"locale": "xx-YY"}, headers=auth)
+    assert r.status_code == 400
+    assert "unsupported locale" in r.get_json()["error"]
+
+
+def test_update_locale_and_currency_together(client):
+    auth = _register_and_login(client, email="locale4@test.com")
+    r = client.patch(
+        "/auth/me",
+        json={"preferred_currency": "EUR", "locale": "de-DE"},
+        headers=auth,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["preferred_currency"] == "EUR"
+    assert data["locale"] == "de-DE"
+
+
+def test_update_currency_alone_preserves_locale(client):
+    auth = _register_and_login(client, email="locale5@test.com")
+    # Set locale first
+    client.patch("/auth/me", json={"locale": "ja-JP"}, headers=auth)
+    # Update only currency
+    r = client.patch(
+        "/auth/me", json={"preferred_currency": "JPY"}, headers=auth
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["preferred_currency"] == "JPY"
+    assert data["locale"] == "ja-JP"


### PR DESCRIPTION
## Summary

Implements #131: Locale-aware date, currency & number formatting.

- **Backend**: Added `locale` field to the `User` model (default `en-US`, 13 supported locales). Extended `GET /auth/me` and `PATCH /auth/me` to read/update locale preference with validation.
- **Frontend formatting utility**: Created `lib/formatting.ts` with `Intl`-based helpers (`formatMoney`, `formatNumber`, `formatDate`, `formatDateTime`, `formatPercent`) that read the user's locale from localStorage.
- **App-wide adoption**: Replaced all raw `toLocaleDateString()`, `toLocaleString()`, and hardcoded number formatting across Dashboard, Expenses, Bills, Budgets, Reminders, Analytics, and chart tooltip with the new locale-aware functions.
- **Locale selector**: Added a "Display Locale" dropdown in Account Settings so users can choose their preferred locale.
- **Backwards compatibility**: `lib/currency.ts` re-exports `formatMoney` from the new module so existing imports continue to work.

## Test plan

- [x] Backend: `test_locale.py` — tests default locale on `/me`, updating locale, rejecting unsupported locales, updating both currency and locale together, and preserving locale when only currency changes
- [x] Frontend: `formatting.test.ts` — 16 tests covering `formatMoney`, `formatNumber`, `formatDate`, `formatDateTime`, `formatPercent` with default and explicit locales, edge cases (zero, invalid dates, fallbacks)
- [ ] Manual: Change locale in Account Settings, verify dates/numbers/currencies render correctly across all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)