### PR TITLE
feat: secure backup & encrypted export options

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Export from "./pages/Export";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="export"
+              element={
+                <ProtectedRoute>
+                  <Export />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/export.ts
+++ b/app/src/api/export.ts
@@ -1,0 +1,23 @@
+import { api } from './client';
+
+export type ExportFormat = 'json' | 'csv';
+
+export interface EncryptedExport {
+  algorithm: string;
+  kdf: string;
+  iterations: number;
+  salt: string;
+  nonce: string;
+  ciphertext: string;
+  format: ExportFormat;
+}
+
+export async function exportData(
+  password: string,
+  format: ExportFormat,
+): Promise<EncryptedExport> {
+  return api<EncryptedExport>('/export', {
+    method: 'POST',
+    body: { password, format },
+  });
+}

--- a/app/src/pages/Export.tsx
+++ b/app/src/pages/Export.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import { exportData, type ExportFormat, type EncryptedExport } from '@/api/export';
+
+export default function Export() {
+  const { toast } = useToast();
+  const [password, setPassword] = useState('');
+  const [format, setFormat] = useState<ExportFormat>('json');
+  const [loading, setLoading] = useState(false);
+
+  const handleExport = async () => {
+    if (password.length < 8) {
+      toast({ title: 'Password too short', description: 'Password must be at least 8 characters.' });
+      return;
+    }
+    setLoading(true);
+    try {
+      const result: EncryptedExport = await exportData(password, format);
+      // Download as .json file
+      const blob = new Blob([JSON.stringify(result, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `finmind-backup-${new Date().toISOString().slice(0, 10)}.encrypted.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast({ title: 'Export complete', description: 'Your encrypted backup has been downloaded.' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Export failed';
+      toast({ title: 'Export failed', description: message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header">
+        <div className="relative">
+          <h1 className="page-title">Secure Backup</h1>
+          <p className="page-subtitle">
+            Export your financial data as an encrypted file. Your data is
+            protected with AES-256-GCM encryption using a password you provide.
+          </p>
+        </div>
+      </div>
+
+      <div className="card card-interactive space-y-5 fade-in-up">
+        <div className="space-y-2">
+          <Label htmlFor="export-format">Export Format</Label>
+          <select
+            id="export-format"
+            className="input"
+            value={format}
+            onChange={(e) => setFormat(e.target.value as ExportFormat)}
+          >
+            <option value="json">JSON</option>
+            <option value="csv">CSV</option>
+          </select>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="export-password">Encryption Password</Label>
+          <p className="text-xs text-muted-foreground">
+            Minimum 8 characters. You will need this password to decrypt your backup.
+          </p>
+          <input
+            id="export-password"
+            type="password"
+            className="input"
+            placeholder="Enter a strong password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            variant="financial"
+            onClick={handleExport}
+            disabled={loading || password.length < 8}
+          >
+            {loading ? 'Encrypting...' : 'Download Encrypted Backup'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .export import bp as export_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(export_bp, url_prefix="/export")

--- a/packages/backend/app/routes/export.py
+++ b/packages/backend/app/routes/export.py
@@ -1,0 +1,170 @@
+"""Secure encrypted export of user data (Issue #126)."""
+
+import csv
+import io
+import json
+import logging
+import os
+import base64
+from datetime import date
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
+
+from flask import Blueprint, jsonify, request, Response
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import Expense, Bill, Category
+
+bp = Blueprint("export", __name__)
+logger = logging.getLogger("finmind.export")
+
+PBKDF2_ITERATIONS = 480_000
+
+
+def _derive_key(password: str, salt: bytes) -> bytes:
+    """Derive a 256-bit AES key from a password using PBKDF2-HMAC-SHA256."""
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=PBKDF2_ITERATIONS,
+    )
+    return kdf.derive(password.encode("utf-8"))
+
+
+def _encrypt_aes_gcm(plaintext: bytes, password: str) -> dict:
+    """Encrypt plaintext with AES-256-GCM using a password-derived key.
+
+    Returns a dict with base64-encoded salt, nonce, and ciphertext.
+    """
+    salt = os.urandom(16)
+    key = _derive_key(password, salt)
+    nonce = os.urandom(12)
+    aesgcm = AESGCM(key)
+    ciphertext = aesgcm.encrypt(nonce, plaintext, None)
+    return {
+        "algorithm": "AES-256-GCM",
+        "kdf": "PBKDF2-HMAC-SHA256",
+        "iterations": PBKDF2_ITERATIONS,
+        "salt": base64.b64encode(salt).decode(),
+        "nonce": base64.b64encode(nonce).decode(),
+        "ciphertext": base64.b64encode(ciphertext).decode(),
+    }
+
+
+def _collect_user_data(uid: int) -> dict:
+    """Gather all exportable user data."""
+    expenses = (
+        db.session.query(Expense)
+        .filter_by(user_id=uid)
+        .order_by(Expense.spent_at.desc())
+        .all()
+    )
+    bills = (
+        db.session.query(Bill)
+        .filter_by(user_id=uid)
+        .order_by(Bill.created_at.desc())
+        .all()
+    )
+    categories = (
+        db.session.query(Category)
+        .filter_by(user_id=uid)
+        .order_by(Category.name)
+        .all()
+    )
+
+    return {
+        "exported_at": date.today().isoformat(),
+        "expenses": [
+            {
+                "id": e.id,
+                "amount": float(e.amount),
+                "currency": e.currency,
+                "expense_type": e.expense_type,
+                "category_id": e.category_id,
+                "description": e.notes or "",
+                "date": e.spent_at.isoformat(),
+            }
+            for e in expenses
+        ],
+        "bills": [
+            {
+                "id": b.id,
+                "name": b.name,
+                "amount": float(b.amount),
+                "currency": b.currency,
+                "next_due_date": b.next_due_date.isoformat(),
+                "cadence": b.cadence.value,
+                "active": b.active,
+            }
+            for b in bills
+        ],
+        "categories": [
+            {"id": c.id, "name": c.name}
+            for c in categories
+        ],
+    }
+
+
+def _data_to_csv(data: dict) -> str:
+    """Flatten user data into a CSV string."""
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+
+    # Expenses
+    writer.writerow(["[expenses]"])
+    writer.writerow(["id", "amount", "currency", "expense_type", "category_id", "description", "date"])
+    for e in data["expenses"]:
+        writer.writerow([e["id"], e["amount"], e["currency"], e["expense_type"],
+                         e["category_id"], e["description"], e["date"]])
+
+    writer.writerow([])
+    writer.writerow(["[bills]"])
+    writer.writerow(["id", "name", "amount", "currency", "next_due_date", "cadence", "active"])
+    for b in data["bills"]:
+        writer.writerow([b["id"], b["name"], b["amount"], b["currency"],
+                         b["next_due_date"], b["cadence"], b["active"]])
+
+    writer.writerow([])
+    writer.writerow(["[categories]"])
+    writer.writerow(["id", "name"])
+    for c in data["categories"]:
+        writer.writerow([c["id"], c["name"]])
+
+    return buf.getvalue()
+
+
+@bp.post("")
+@jwt_required()
+def export_data():
+    """Export user data as encrypted JSON or CSV.
+
+    Request body:
+        password (str): encryption password (min 8 chars)
+        format (str): "json" or "csv" (default "json")
+    """
+    uid = int(get_jwt_identity())
+    body = request.get_json() or {}
+    password = (body.get("password") or "").strip()
+    fmt = (body.get("format") or "json").strip().lower()
+
+    if not password or len(password) < 8:
+        return jsonify(error="password must be at least 8 characters"), 400
+    if fmt not in ("json", "csv"):
+        return jsonify(error="format must be 'json' or 'csv'"), 400
+
+    data = _collect_user_data(uid)
+
+    if fmt == "csv":
+        plaintext = _data_to_csv(data).encode("utf-8")
+    else:
+        plaintext = json.dumps(data, indent=2).encode("utf-8")
+
+    encrypted = _encrypt_aes_gcm(plaintext, password)
+    encrypted["format"] = fmt
+
+    logger.info("Exported data user=%s format=%s", uid, fmt)
+    return jsonify(encrypted), 200

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -18,4 +18,5 @@ pytest==8.2.2
 black==24.8.0
 flake8==7.0.0
 bandit==1.7.9
+cryptography==42.0.8
 

--- a/packages/backend/tests/test_export.py
+++ b/packages/backend/tests/test_export.py
@@ -1,0 +1,119 @@
+"""Tests for the encrypted export endpoint (Issue #126)."""
+
+import base64
+import json
+from datetime import date
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
+
+
+def _decrypt(payload: dict, password: str) -> bytes:
+    salt = base64.b64decode(payload["salt"])
+    nonce = base64.b64decode(payload["nonce"])
+    ciphertext = base64.b64decode(payload["ciphertext"])
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=payload["iterations"],
+    )
+    key = kdf.derive(password.encode("utf-8"))
+    return AESGCM(key).decrypt(nonce, ciphertext, None)
+
+
+def test_export_json_encrypted(client, auth_header):
+    # Seed data
+    client.post("/categories", json={"name": "Food"}, headers=auth_header)
+    client.post(
+        "/expenses",
+        json={"amount": 100, "description": "Lunch", "date": date.today().isoformat()},
+        headers=auth_header,
+    )
+
+    password = "my-secure-password-123"
+    r = client.post(
+        "/export",
+        json={"password": password, "format": "json"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["algorithm"] == "AES-256-GCM"
+    assert body["format"] == "json"
+
+    # Decrypt and verify
+    plaintext = _decrypt(body, password)
+    data = json.loads(plaintext)
+    assert "expenses" in data
+    assert "categories" in data
+    assert "bills" in data
+    assert len(data["expenses"]) >= 1
+    assert data["expenses"][0]["description"] == "Lunch"
+
+
+def test_export_csv_encrypted(client, auth_header):
+    client.post(
+        "/expenses",
+        json={"amount": 50, "description": "Coffee", "date": date.today().isoformat()},
+        headers=auth_header,
+    )
+
+    password = "another-password-456"
+    r = client.post(
+        "/export",
+        json={"password": password, "format": "csv"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["format"] == "csv"
+
+    plaintext = _decrypt(body, password).decode("utf-8")
+    assert "[expenses]" in plaintext
+    assert "Coffee" in plaintext
+
+
+def test_export_rejects_short_password(client, auth_header):
+    r = client.post(
+        "/export",
+        json={"password": "short", "format": "json"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "password" in r.get_json()["error"].lower()
+
+
+def test_export_rejects_invalid_format(client, auth_header):
+    r = client.post(
+        "/export",
+        json={"password": "long-enough-password", "format": "xml"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "format" in r.get_json()["error"].lower()
+
+
+def test_export_requires_auth(client):
+    r = client.post("/export", json={"password": "test-password-123", "format": "json"})
+    assert r.status_code == 401
+
+
+def test_export_wrong_password_fails_decrypt(client, auth_header):
+    client.post(
+        "/expenses",
+        json={"amount": 10, "description": "Test", "date": date.today().isoformat()},
+        headers=auth_header,
+    )
+    r = client.post(
+        "/export",
+        json={"password": "correct-password-123", "format": "json"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+
+    import pytest
+    with pytest.raises(Exception):
+        _decrypt(body, "wrong-password-999")


### PR DESCRIPTION
## Summary
- Add POST `/export` endpoint for encrypted data export (expenses, bills, categories)
- Uses AES-256-GCM encryption with PBKDF2-HMAC-SHA256 key derivation from user-provided password
- Supports JSON and CSV export formats
- Add frontend Export page with format selector, password input, and download button
- Add `cryptography` dependency to requirements.txt
- Comprehensive backend tests including encryption/decryption round-trip validation

Closes #126

## Test plan
- [ ] POST `/export` with valid password and `json` format returns encrypted payload that decrypts correctly
- [ ] POST `/export` with `csv` format returns encrypted CSV data
- [ ] Passwords shorter than 8 characters are rejected with 400
- [ ] Invalid format values are rejected with 400
- [ ] Endpoint requires JWT authentication
- [ ] Wrong password fails to decrypt (authentication tag mismatch)
- [ ] Frontend page renders format selector and password field
- [ ] Download triggers a `.encrypted.json` file save

🤖 Generated with [Claude Code](https://claude.com/claude-code)