### PR TITLE
feat: device trust management & recognition

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Devices from "./pages/Devices";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="devices"
+              element={
+                <ProtectedRoute>
+                  <Devices />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/devices.ts
+++ b/app/src/api/devices.ts
@@ -1,0 +1,28 @@
+import { api } from './client';
+
+export interface Device {
+  id: number;
+  device_name: string;
+  device_hash: string;
+  ip_address: string | null;
+  last_seen: string | null;
+  trusted: boolean;
+  created_at: string | null;
+}
+
+export async function listDevices(): Promise<Device[]> {
+  return api<Device[]>('/auth/devices');
+}
+
+export async function trustDevice(deviceId: number): Promise<{ message: string }> {
+  return api<{ message: string }>('/auth/devices/trust', {
+    method: 'POST',
+    body: { device_id: deviceId },
+  });
+}
+
+export async function removeDevice(deviceId: number): Promise<{ message: string }> {
+  return api<{ message: string }>(`/auth/devices/${deviceId}`, {
+    method: 'DELETE',
+  });
+}

--- a/app/src/pages/Devices.tsx
+++ b/app/src/pages/Devices.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { listDevices, trustDevice, removeDevice, type Device } from '@/api/devices';
+
+export default function Devices() {
+  const { toast } = useToast();
+  const [devices, setDevices] = useState<Device[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadDevices = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await listDevices();
+      setDevices(data);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to load devices';
+      toast({ title: 'Error', description: message });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void loadDevices();
+  }, [loadDevices]);
+
+  const handleTrust = async (deviceId: number) => {
+    try {
+      await trustDevice(deviceId);
+      toast({ title: 'Device trusted', description: 'Device has been marked as trusted.' });
+      await loadDevices();
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to trust device';
+      toast({ title: 'Error', description: message });
+    }
+  };
+
+  const handleRemove = async (deviceId: number) => {
+    try {
+      await removeDevice(deviceId);
+      toast({ title: 'Device removed', description: 'Device has been removed.' });
+      await loadDevices();
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to remove device';
+      toast({ title: 'Error', description: message });
+    }
+  };
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header">
+        <div className="relative">
+          <h1 className="page-title">Trusted Devices</h1>
+          <p className="page-subtitle">
+            Manage devices that have accessed your account. Trust devices you
+            recognize and remove any you do not.
+          </p>
+        </div>
+      </div>
+
+      <div className="card card-interactive space-y-4 fade-in-up">
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading devices...</div>
+        ) : devices.length === 0 ? (
+          <div className="text-sm text-muted-foreground">No devices recorded yet.</div>
+        ) : (
+          <div className="space-y-3">
+            {devices.map((device) => (
+              <div
+                key={device.id}
+                className="flex items-center justify-between rounded-lg border p-4"
+              >
+                <div className="space-y-1">
+                  <div className="font-medium text-sm">{device.device_name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    IP: {device.ip_address || 'Unknown'} &middot; Last seen:{' '}
+                    {device.last_seen
+                      ? new Date(device.last_seen).toLocaleString()
+                      : 'N/A'}
+                  </div>
+                  <div className="text-xs">
+                    {device.trusted ? (
+                      <span className="text-green-600 font-medium">Trusted</span>
+                    ) : (
+                      <span className="text-yellow-600 font-medium">Untrusted</span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  {!device.trusted && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleTrust(device.id)}
+                    >
+                      Trust
+                    </Button>
+                  )}
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => handleRemove(device.id)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,18 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class DeviceFingerprint(db.Model):
+    __tablename__ = "device_fingerprints"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    device_hash = db.Column(db.String(64), nullable=False)
+    device_name = db.Column(db.String(255), nullable=False)
+    ip_address = db.Column(db.String(45), nullable=True)
+    last_seen = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    trusted = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .devices import bp as devices_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(devices_bp, url_prefix="/auth/devices")

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -10,6 +10,7 @@ from flask_jwt_extended import (
 )
 from ..extensions import db, redis_client
 from ..models import User
+from .devices import record_device_on_login
 import logging
 import time
 
@@ -62,6 +63,10 @@ def login():
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
+    try:
+        record_device_on_login(user.id)
+    except Exception:
+        logger.exception("Failed to record device for user_id=%s", user.id)
     logger.info("Login success user_id=%s", user.id)
     return jsonify(access_token=access, refresh_token=refresh)
 

--- a/packages/backend/app/routes/devices.py
+++ b/packages/backend/app/routes/devices.py
@@ -1,0 +1,131 @@
+"""Device trust management & recognition (Issue #125)."""
+
+import hashlib
+import logging
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import DeviceFingerprint
+
+bp = Blueprint("devices", __name__)
+logger = logging.getLogger("finmind.devices")
+
+
+def _compute_device_hash(user_agent: str, ip_address: str) -> str:
+    """Generate a deterministic fingerprint hash from user-agent + IP."""
+    raw = f"{user_agent}|{ip_address}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _device_name_from_ua(user_agent: str) -> str:
+    """Extract a human-friendly device name from the User-Agent string."""
+    ua = user_agent or "Unknown Device"
+    # Simple heuristic: take the first segment before '('
+    if "(" in ua:
+        platform = ua.split("(")[1].split(")")[0] if "(" in ua else ""
+        # Try to find browser name
+        browser = ""
+        for token in ("Chrome", "Firefox", "Safari", "Edge", "Opera"):
+            if token in ua:
+                browser = token
+                break
+        if browser and platform:
+            return f"{browser} on {platform}"
+        if platform:
+            return platform
+    if len(ua) > 80:
+        return ua[:80]
+    return ua
+
+
+def record_device_on_login(user_id: int) -> None:
+    """Called during login to record/update the device fingerprint."""
+    user_agent = request.headers.get("User-Agent", "")
+    ip_address = request.remote_addr or "unknown"
+    device_hash = _compute_device_hash(user_agent, ip_address)
+
+    existing = (
+        db.session.query(DeviceFingerprint)
+        .filter_by(user_id=user_id, device_hash=device_hash)
+        .first()
+    )
+    if existing:
+        existing.last_seen = datetime.utcnow()
+        db.session.commit()
+        return
+
+    device = DeviceFingerprint(
+        user_id=user_id,
+        device_hash=device_hash,
+        device_name=_device_name_from_ua(user_agent),
+        ip_address=ip_address,
+        trusted=False,
+    )
+    db.session.add(device)
+    db.session.commit()
+    logger.info("New device recorded user=%s hash=%s", user_id, device_hash[:12])
+
+
+@bp.get("")
+@jwt_required()
+def list_devices():
+    """List all devices for the authenticated user."""
+    uid = int(get_jwt_identity())
+    devices = (
+        db.session.query(DeviceFingerprint)
+        .filter_by(user_id=uid)
+        .order_by(DeviceFingerprint.last_seen.desc())
+        .all()
+    )
+    return jsonify(
+        [
+            {
+                "id": d.id,
+                "device_name": d.device_name,
+                "device_hash": d.device_hash[:12] + "...",
+                "ip_address": d.ip_address,
+                "last_seen": d.last_seen.isoformat() if d.last_seen else None,
+                "trusted": d.trusted,
+                "created_at": d.created_at.isoformat() if d.created_at else None,
+            }
+            for d in devices
+        ]
+    )
+
+
+@bp.post("/trust")
+@jwt_required()
+def trust_device():
+    """Mark a device as trusted."""
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    device_id = data.get("device_id")
+    if not device_id:
+        return jsonify(error="device_id required"), 400
+
+    device = db.session.get(DeviceFingerprint, int(device_id))
+    if not device or device.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    device.trusted = True
+    db.session.commit()
+    logger.info("Device trusted user=%s device_id=%s", uid, device_id)
+    return jsonify(message="device trusted")
+
+
+@bp.delete("/<int:device_id>")
+@jwt_required()
+def remove_device(device_id: int):
+    """Remove a device fingerprint."""
+    uid = int(get_jwt_identity())
+    device = db.session.get(DeviceFingerprint, device_id)
+    if not device or device.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    db.session.delete(device)
+    db.session.commit()
+    logger.info("Device removed user=%s device_id=%s", uid, device_id)
+    return jsonify(message="device removed")

--- a/packages/backend/tests/test_devices.py
+++ b/packages/backend/tests/test_devices.py
@@ -1,0 +1,131 @@
+"""Tests for device trust management (Issue #125)."""
+
+
+def _login(client, email="test@example.com", password="password123", user_agent=None, ip=None):
+    """Helper to register + login and return (auth_header, response_json)."""
+    client.post("/auth/register", json={"email": email, "password": password})
+    headers = {}
+    if user_agent:
+        headers["User-Agent"] = user_agent
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    token = r.get_json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_login_records_device(client):
+    auth = _login(client, user_agent="Mozilla/5.0 (Macintosh) Chrome/120")
+    r = client.get("/auth/devices", headers=auth)
+    assert r.status_code == 200
+    devices = r.get_json()
+    assert len(devices) >= 1
+    assert "Chrome" in devices[0]["device_name"]
+    assert devices[0]["trusted"] is False
+
+
+def test_list_devices_empty_before_login(client, auth_header):
+    # auth_header fixture uses register+login, which records a device
+    r = client.get("/auth/devices", headers=auth_header)
+    assert r.status_code == 200
+    devices = r.get_json()
+    # At least one device from the login in auth_header fixture
+    assert isinstance(devices, list)
+    assert len(devices) >= 1
+
+
+def test_trust_device(client):
+    auth = _login(client, user_agent="TestBrowser/1.0")
+    r = client.get("/auth/devices", headers=auth)
+    devices = r.get_json()
+    device_id = devices[0]["id"]
+
+    r = client.post(
+        "/auth/devices/trust",
+        json={"device_id": device_id},
+        headers=auth,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "device trusted"
+
+    # Verify it's now trusted
+    r = client.get("/auth/devices", headers=auth)
+    updated = [d for d in r.get_json() if d["id"] == device_id]
+    assert updated[0]["trusted"] is True
+
+
+def test_trust_device_not_found(client, auth_header):
+    r = client.post(
+        "/auth/devices/trust",
+        json={"device_id": 99999},
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+def test_trust_device_missing_id(client, auth_header):
+    r = client.post(
+        "/auth/devices/trust",
+        json={},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_remove_device(client):
+    auth = _login(client, user_agent="RemovableDevice/1.0")
+    r = client.get("/auth/devices", headers=auth)
+    devices = r.get_json()
+    device_id = devices[0]["id"]
+
+    r = client.delete(f"/auth/devices/{device_id}", headers=auth)
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "device removed"
+
+    # Verify it's gone
+    r = client.get("/auth/devices", headers=auth)
+    remaining = [d for d in r.get_json() if d["id"] == device_id]
+    assert len(remaining) == 0
+
+
+def test_remove_device_not_found(client, auth_header):
+    r = client.delete("/auth/devices/99999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_same_device_updates_last_seen(client):
+    """Logging in twice from the same device should update last_seen, not create duplicate."""
+    ua = "SameDevice/1.0"
+    email = "repeat@example.com"
+    client.post("/auth/register", json={"email": email, "password": "password123"})
+
+    # Login twice with same UA
+    r1 = client.post(
+        "/auth/login",
+        json={"email": email, "password": "password123"},
+        headers={"User-Agent": ua},
+    )
+    auth = {"Authorization": f"Bearer {r1.get_json()['access_token']}"}
+
+    r = client.get("/auth/devices", headers=auth)
+    count_before = len(r.get_json())
+
+    r2 = client.post(
+        "/auth/login",
+        json={"email": email, "password": "password123"},
+        headers={"User-Agent": ua},
+    )
+    auth2 = {"Authorization": f"Bearer {r2.get_json()['access_token']}"}
+
+    r = client.get("/auth/devices", headers=auth2)
+    count_after = len(r.get_json())
+
+    assert count_after == count_before
+
+
+def test_devices_requires_auth(client):
+    r = client.get("/auth/devices")
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- Add `DeviceFingerprint` model (user_id, device_hash, device_name, ip_address, last_seen, trusted)
- Generate SHA-256 device hash from user-agent + IP on each login
- Add endpoints: GET `/auth/devices`, POST `/auth/devices/trust`, DELETE `/auth/devices/:id`
- Record device automatically on login (non-blocking, exception-safe)
- Add frontend Devices page with trust/remove buttons per device
- Comprehensive backend tests covering login recording, trust, remove, deduplication

Closes #125

## Test plan
- [ ] Login creates a device fingerprint entry
- [ ] GET `/auth/devices` returns list of devices for authenticated user
- [ ] POST `/auth/devices/trust` marks a device as trusted
- [ ] DELETE `/auth/devices/:id` removes a device
- [ ] Repeated logins from same device update `last_seen` without creating duplicates
- [ ] Endpoints reject unauthenticated requests with 401
- [ ] Frontend page displays devices with trust/remove buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)