### PR TITLE
feat: smart caching strategy for dashboard & analytics

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -9,6 +9,7 @@ from .observability import (
     init_request_context,
 )
 from flask_cors import CORS
+from flask import g
 import click
 import os
 import logging
@@ -48,6 +49,10 @@ def create_app(settings: Settings | None = None) -> Flask:
     # CORS for local dev frontend
     CORS(app, resources={r"*": {"origins": "*"}}, supports_credentials=True)
 
+    # In-memory cache (SimpleCache)
+    from .services.memory_cache import init_memory_cache
+    init_memory_cache(app)
+
     # Redis (already global)
     # Blueprint routes
     register_routes(app)
@@ -62,6 +67,10 @@ def create_app(settings: Settings | None = None) -> Flask:
 
     @app.after_request
     def _after_request(response):
+        # Add X-Cache-Hit header for debugging
+        cache_hit = getattr(g, "cache_hit", None)
+        if cache_hit is not None:
+            response.headers["X-Cache-Hit"] = "true" if cache_hit else "false"
         return finalize_request(response)
 
     @app.get("/health")

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, BillCadence, User
 from ..services.cache import cache_delete_patterns
+from ..services.memory_cache import invalidate_user_cache
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -62,6 +63,7 @@ def create_bill():
     cache_delete_patterns(
         [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
     )
+    invalidate_user_cache(uid)
     return jsonify(id=b.id), 201
 
 
@@ -85,6 +87,7 @@ def mark_paid(bill_id: int):
     cache_delete_patterns(
         [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
     )
+    invalidate_user_cache(uid)
     logger.info(
         "Marked bill paid id=%s user=%s next_due_date=%s", b.id, uid, b.next_due_date
     )

--- a/packages/backend/app/routes/categories.py
+++ b/packages/backend/app/routes/categories.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Category
+from ..services.memory_cache import invalidate_user_cache
 
 bp = Blueprint("categories", __name__)
 logger = logging.getLogger("finmind.categories")
@@ -36,6 +37,7 @@ def create_category():
     db.session.add(c)
     db.session.commit()
     logger.info("Created category id=%s user=%s", c.id, uid)
+    invalidate_user_cache(uid)
     return jsonify(id=c.id, name=c.name), 201
 
 
@@ -53,6 +55,7 @@ def update_category(category_id: int):
     c.name = name
     db.session.commit()
     logger.info("Updated category id=%s user=%s", c.id, uid)
+    invalidate_user_cache(uid)
     return jsonify(id=c.id, name=c.name)
 
 
@@ -66,4 +69,5 @@ def delete_category(category_id: int):
     db.session.delete(c)
     db.session.commit()
     logger.info("Deleted category id=%s user=%s", c.id, uid)
+    invalidate_user_cache(uid)
     return jsonify(message="deleted")

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -1,11 +1,12 @@
 from datetime import date
 from sqlalchemy import extract, func
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, g
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..extensions import db
 from ..models import Bill, Expense, Category
 from ..services.cache import cache_get, cache_set, dashboard_summary_key
+from ..services.memory_cache import memory_cache, DASHBOARD_TTL, _build_cache_key
 
 bp = Blueprint("dashboard", __name__)
 
@@ -17,9 +18,20 @@ def dashboard_summary():
     ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
     if not _is_valid_month(ym):
         return jsonify(error="invalid month, expected YYYY-MM"), 400
+
+    # Check in-memory cache first
+    mem_key = _build_cache_key("dashboard", uid)
+    mem_cached = memory_cache.get(mem_key)
+    if mem_cached is not None:
+        g.cache_hit = True
+        return mem_cached
+
+    g.cache_hit = False
     key = dashboard_summary_key(uid, ym)
     cached = cache_get(key)
     if cached:
+        resp = jsonify(cached)
+        memory_cache.set(mem_key, resp, timeout=DASHBOARD_TTL)
         return jsonify(cached)
 
     payload = {
@@ -165,6 +177,8 @@ def dashboard_summary():
         payload["errors"].append("category_breakdown_unavailable")
 
     cache_set(key, payload, ttl_seconds=300)
+    resp = jsonify(payload)
+    memory_cache.set(mem_key, resp, timeout=DASHBOARD_TTL)
     return jsonify(payload)
 
 

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -7,6 +7,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
+from ..services.memory_cache import invalidate_user_cache
 from ..services import expense_import
 import logging
 
@@ -393,3 +394,4 @@ def _invalidate_expense_cache(uid: int, at: str):
             f"user:{uid}:dashboard_summary:*",
         ]
     )
+    invalidate_user_cache(uid)

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,7 +1,8 @@
 from datetime import date
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, g
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.memory_cache import memory_cache, ANALYTICS_TTL, _build_cache_key
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -13,6 +14,15 @@ logger = logging.getLogger("finmind.insights")
 def budget_suggestion():
     uid = int(get_jwt_identity())
     ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
+
+    # Check in-memory cache (15 min TTL for analytics)
+    mem_key = _build_cache_key("insights", uid)
+    mem_cached = memory_cache.get(mem_key)
+    if mem_cached is not None:
+        g.cache_hit = True
+        return mem_cached
+
+    g.cache_hit = False
     user_gemini_key = (request.headers.get("X-Gemini-Api-Key") or "").strip() or None
     persona = (request.headers.get("X-Insight-Persona") or "").strip() or None
     suggestion = monthly_budget_suggestion(
@@ -22,4 +32,6 @@ def budget_suggestion():
         persona=persona,
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
+    resp = jsonify(suggestion)
+    memory_cache.set(mem_key, resp, timeout=ANALYTICS_TTL)
     return jsonify(suggestion)

--- a/packages/backend/app/services/memory_cache.py
+++ b/packages/backend/app/services/memory_cache.py
@@ -1,0 +1,76 @@
+"""In-memory caching layer using Flask-Caching SimpleCache (Issue #127).
+
+Provides smart caching for dashboard and analytics queries with:
+- TTL of 5 minutes for dashboard queries
+- TTL of 15 minutes for analytics queries
+- Cache key based on user_id + query params
+- Invalidation on expense/bill/category CRUD operations
+"""
+
+import hashlib
+import logging
+from functools import wraps
+from typing import Callable
+
+from flask import request, g
+from flask_caching import Cache
+
+logger = logging.getLogger("finmind.memory_cache")
+
+# The Cache instance; initialized during app creation via init_memory_cache()
+memory_cache = Cache()
+
+DASHBOARD_TTL = 300   # 5 minutes
+ANALYTICS_TTL = 900   # 15 minutes
+
+
+def init_memory_cache(app):
+    """Initialize the in-memory cache on the Flask app."""
+    app.config.setdefault("CACHE_TYPE", "SimpleCache")
+    app.config.setdefault("CACHE_DEFAULT_TIMEOUT", DASHBOARD_TTL)
+    memory_cache.init_app(app)
+    logger.info("In-memory cache initialized (SimpleCache)")
+
+
+def _build_cache_key(prefix: str, user_id: int) -> str:
+    """Build a deterministic cache key from prefix, user_id and query params."""
+    params = sorted(request.args.items())
+    raw = f"{prefix}:{user_id}:{params}"
+    h = hashlib.md5(raw.encode()).hexdigest()[:16]
+    return f"{prefix}:{user_id}:{h}"
+
+
+def cached_endpoint(prefix: str, ttl: int) -> Callable:
+    """Decorator for caching JWT-protected endpoint responses.
+
+    Sets g.cache_hit so the after_request hook can add the X-Cache-Hit header.
+    """
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            from flask_jwt_extended import get_jwt_identity
+            uid = int(get_jwt_identity())
+            key = _build_cache_key(prefix, uid)
+            cached = memory_cache.get(key)
+            if cached is not None:
+                g.cache_hit = True
+                logger.debug("Cache HIT key=%s", key)
+                return cached
+            g.cache_hit = False
+            result = fn(*args, **kwargs)
+            memory_cache.set(key, result, timeout=ttl)
+            logger.debug("Cache MISS key=%s ttl=%s", key, ttl)
+            return result
+        return wrapper
+    return decorator
+
+
+def invalidate_user_cache(user_id: int) -> None:
+    """Invalidate all in-memory cached entries for a user.
+
+    Since SimpleCache doesn't support pattern-based deletion, we clear
+    the entire cache. For production at scale, a tagged cache backend
+    (e.g. Redis) would be more appropriate.
+    """
+    memory_cache.clear()
+    logger.info("In-memory cache cleared for user=%s (full clear)", user_id)

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -18,4 +18,5 @@ pytest==8.2.2
 black==24.8.0
 flake8==7.0.0
 bandit==1.7.9
+flask-caching==2.3.0
 

--- a/packages/backend/tests/test_caching.py
+++ b/packages/backend/tests/test_caching.py
@@ -1,0 +1,162 @@
+"""Tests for smart in-memory caching strategy (Issue #127)."""
+
+from datetime import date, timedelta
+
+
+def test_dashboard_returns_x_cache_hit_header(client, auth_header):
+    """First call should be a miss, second call should be a hit."""
+    # Seed some data so the response is non-trivial
+    client.post(
+        "/expenses",
+        json={"amount": 100, "description": "Test", "date": date.today().isoformat()},
+        headers=auth_header,
+    )
+
+    # First call - cache miss
+    r1 = client.get("/dashboard/summary", headers=auth_header)
+    assert r1.status_code == 200
+    assert r1.headers.get("X-Cache-Hit") == "false"
+
+    # Second call - cache hit
+    r2 = client.get("/dashboard/summary", headers=auth_header)
+    assert r2.status_code == 200
+    assert r2.headers.get("X-Cache-Hit") == "true"
+
+
+def test_dashboard_cache_invalidated_on_expense_create(client, auth_header):
+    """Creating an expense should invalidate the dashboard cache."""
+    # Warm the cache
+    client.get("/dashboard/summary", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # Create expense - should invalidate
+    client.post(
+        "/expenses",
+        json={"amount": 50, "description": "Invalidator", "date": date.today().isoformat()},
+        headers=auth_header,
+    )
+
+    # Next call should be a miss
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"
+
+
+def test_dashboard_cache_invalidated_on_expense_update(client, auth_header):
+    """Updating an expense should invalidate the cache."""
+    r = client.post(
+        "/expenses",
+        json={"amount": 75, "description": "Updatable", "date": date.today().isoformat()},
+        headers=auth_header,
+    )
+    expense_id = r.get_json()["id"]
+
+    # Warm cache
+    client.get("/dashboard/summary", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # Update expense
+    client.patch(
+        f"/expenses/{expense_id}",
+        json={"amount": 150},
+        headers=auth_header,
+    )
+
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"
+
+
+def test_dashboard_cache_invalidated_on_expense_delete(client, auth_header):
+    """Deleting an expense should invalidate the cache."""
+    r = client.post(
+        "/expenses",
+        json={"amount": 25, "description": "Deletable", "date": date.today().isoformat()},
+        headers=auth_header,
+    )
+    expense_id = r.get_json()["id"]
+
+    # Warm cache
+    client.get("/dashboard/summary", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # Delete expense
+    client.delete(f"/expenses/{expense_id}", headers=auth_header)
+
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"
+
+
+def test_dashboard_cache_invalidated_on_bill_create(client, auth_header):
+    """Creating a bill should invalidate the cache."""
+    # Warm cache
+    client.get("/dashboard/summary", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # Create bill
+    client.post(
+        "/bills",
+        json={
+            "name": "Phone",
+            "amount": 30,
+            "next_due_date": (date.today() + timedelta(days=5)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"
+
+
+def test_dashboard_cache_invalidated_on_category_crud(client, auth_header):
+    """Category CRUD should invalidate the cache."""
+    # Warm cache
+    client.get("/dashboard/summary", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # Create category
+    r = client.post("/categories", json={"name": "TestCat"}, headers=auth_header)
+    assert r.status_code == 201
+    cat_id = r.get_json()["id"]
+
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"
+
+    # Warm cache again
+    client.get("/dashboard/summary", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # Update category
+    client.patch(f"/categories/{cat_id}", json={"name": "UpdatedCat"}, headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"
+
+    # Warm cache again
+    client.get("/dashboard/summary", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # Delete category
+    client.delete(f"/categories/{cat_id}", headers=auth_header)
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"
+
+
+def test_different_month_params_cached_separately(client, auth_header):
+    """Different month query params should produce separate cache entries."""
+    month_a = date.today().strftime("%Y-%m")
+    month_b = (date.today().replace(day=1) - timedelta(days=1)).strftime("%Y-%m")
+
+    # Warm cache for month_a
+    client.get(f"/dashboard/summary?month={month_a}", headers=auth_header)
+    r = client.get(f"/dashboard/summary?month={month_a}", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "true"
+
+    # month_b should still be a miss
+    r = client.get(f"/dashboard/summary?month={month_b}", headers=auth_header)
+    assert r.headers.get("X-Cache-Hit") == "false"


### PR DESCRIPTION
## Summary
- Add in-memory caching layer using Flask-Caching with SimpleCache backend
- Dashboard queries cached with 5-minute TTL, analytics with 15-minute TTL
- Cache key based on user_id + query parameters (MD5 hash)
- Cache invalidation triggered on expense, bill, and category CRUD operations
- Add `X-Cache-Hit` response header (`true`/`false`) for debugging
- Add `flask-caching==2.3.0` dependency

Closes #127

## Test plan
- [ ] First dashboard request returns `X-Cache-Hit: false`
- [ ] Second identical request returns `X-Cache-Hit: true`
- [ ] Creating/updating/deleting an expense invalidates dashboard cache
- [ ] Creating a bill invalidates dashboard cache
- [ ] Category CRUD (create, update, delete) each invalidate dashboard cache
- [ ] Different month query params produce separate cache entries
- [ ] Analytics (insights) endpoint uses 15-minute TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)