### PR TITLE
feat: resilient background job retry with exponential backoff and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,68 @@ OpenAPI: `backend/app/openapi.yaml`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Jobs (monitoring): `/jobs/status`, `/jobs/reminders/stats`, `/jobs/reminders/run`
+
+## Background Jobs & Retry Logic
+
+Reminders are dispatched by a background job running every minute via APScheduler.
+The `dispatch_reminders()` function in `app/services/jobs.py` can also be triggered
+on-demand via the `/jobs/reminders/run` endpoint.
+
+### Retry Schedule (Exponential Backoff)
+
+| Attempt | Delay before next retry |
+|---------|------------------------|
+| 1st failure | 5 minutes |
+| 2nd failure | 15 minutes |
+| 3rd failure | 45 minutes |
+| 4th failure | Permanently failed (`failed=True`) |
+
+### Reminder Retry State Columns
+
+The `reminders` table includes these retry tracking columns:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `retry_count` | integer | Number of failed send attempts |
+| `last_error` | varchar | Error message from the last failure |
+| `next_retry_at` | timestamp | When the next retry attempt should run |
+| `failed` | boolean | True after all retries are exhausted |
+| `retry_status` | varchar | `pending` / `retrying` / `sent` / `failed` |
+
+### Monitoring Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/jobs/status` | None | APScheduler state and job list |
+| `GET` | `/jobs/reminders/stats` | JWT | Aggregate counts by retry_status |
+| `POST` | `/jobs/reminders/run` | JWT | Trigger dispatch_reminders immediately |
+
+Example `/jobs/reminders/stats` response:
+```json
+{
+  "total": 120,
+  "pending": 45,
+  "sent": 68,
+  "retrying": 4,
+  "failed": 3
+}
+```
+
+Example `/jobs/status` response:
+```json
+{
+  "scheduler": "running",
+  "jobs": [
+    {
+      "id": "dispatch_reminders",
+      "name": "dispatch_reminders",
+      "next_run_time": "2026-03-20T12:01:00+00:00",
+      "trigger": "interval[0:01:00]"
+    }
+  ]
+}
+```
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ The `reminders` table includes these retry tracking columns:
 | `failed` | boolean | True after all retries are exhausted |
 | `retry_status` | varchar | `pending` / `retrying` / `sent` / `failed` |
 
+### Configuration
+
+The retry behavior can be tuned via environment variables:
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `JOB_MAX_RETRIES` | integer | `3` | Maximum retry attempts before marking a reminder as permanently failed |
+| `JOB_RETRY_DELAYS` | comma-separated minutes | `5,15,45` | Backoff intervals (in minutes) between successive retry attempts |
+
+Example `.env` entries:
+```
+JOB_MAX_RETRIES=3
+JOB_RETRY_DELAYS=5,15,45
+```
+
 ### Monitoring Endpoints
 
 | Method | Path | Auth | Description |

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -14,6 +14,13 @@ import os
 import logging
 from datetime import timedelta
 
+try:
+    from apscheduler.schedulers.background import BackgroundScheduler
+
+    _apscheduler_available = True
+except ImportError:  # pragma: no cover
+    _apscheduler_available = False
+
 
 def create_app(settings: Settings | None = None) -> Flask:
     app = Flask(__name__)
@@ -51,6 +58,13 @@ def create_app(settings: Settings | None = None) -> Flask:
     # Redis (already global)
     # Blueprint routes
     register_routes(app)
+
+    # Background scheduler (skip in testing to avoid thread/timing issues).
+    # Check FLASK_ENV because app.config["TESTING"] may be set after create_app returns.
+    _is_testing = app.config.get("TESTING") or os.environ.get("FLASK_ENV", "").lower() == "testing"
+    if not _is_testing and _apscheduler_available:
+        scheduler = _start_scheduler(app)
+        app.extensions["scheduler"] = scheduler
 
     # Backward-compatible schema patch for existing databases.
     with app.app_context():
@@ -110,11 +124,37 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        # Retry state columns on reminders
+        for stmt in [
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS retry_count INTEGER NOT NULL DEFAULT 0",
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS last_error VARCHAR(500)",
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP",
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS failed BOOLEAN NOT NULL DEFAULT FALSE",
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS retry_status VARCHAR(20) NOT NULL DEFAULT 'pending'",
+        ]:
+            cur.execute(stmt)
         conn.commit()
     except Exception:
-        app.logger.exception(
-            "Schema compatibility patch failed for users.preferred_currency"
-        )
+        app.logger.exception("Schema compatibility patch failed")
         conn.rollback()
     finally:
         conn.close()
+
+
+def _start_scheduler(app: Flask) -> "BackgroundScheduler":
+    """Start APScheduler with a 1-minute dispatch_reminders job."""
+    from .services.jobs import dispatch_reminders
+
+    scheduler = BackgroundScheduler()
+
+    def _job():
+        with app.app_context():
+            try:
+                dispatch_reminders()
+            except Exception:
+                app.logger.exception("dispatch_reminders job raised an exception")
+
+    scheduler.add_job(_job, "interval", minutes=1, id="dispatch_reminders", name="dispatch_reminders")
+    scheduler.start()
+    app.logger.info("APScheduler started with dispatch_reminders job")
+    return scheduler

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,12 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    # Retry state
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    last_error = db.Column(db.String(500), nullable=True)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    failed = db.Column(db.Boolean, default=False, nullable=False)
+    retry_status = db.Column(db.String(20), default="pending", nullable=False)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .jobs import bp as jobs_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(jobs_bp, url_prefix="/jobs")

--- a/packages/backend/app/routes/jobs.py
+++ b/packages/backend/app/routes/jobs.py
@@ -1,0 +1,43 @@
+"""Monitoring and control endpoints for background jobs."""
+from flask import Blueprint, current_app, jsonify
+from flask_jwt_extended import jwt_required
+
+from ..services.jobs import dispatch_reminders, reminder_stats
+
+bp = Blueprint("jobs", __name__)
+
+
+@bp.get("/status")
+def job_status():
+    """Return APScheduler job list and scheduler state (no auth required)."""
+    scheduler = current_app.extensions.get("scheduler")
+    if scheduler is None:
+        return jsonify({"scheduler": "not_configured", "jobs": []})
+
+    running = scheduler.running
+    jobs = []
+    for job in scheduler.get_jobs():
+        jobs.append(
+            {
+                "id": job.id,
+                "name": job.name,
+                "next_run_time": job.next_run_time.isoformat() if job.next_run_time else None,
+                "trigger": str(job.trigger),
+            }
+        )
+    return jsonify({"scheduler": "running" if running else "stopped", "jobs": jobs})
+
+
+@bp.get("/reminders/stats")
+@jwt_required()
+def reminders_stats():
+    """Return aggregate reminder counts by state."""
+    return jsonify(reminder_stats())
+
+
+@bp.post("/reminders/run")
+@jwt_required()
+def run_reminders():
+    """Trigger dispatch_reminders immediately and return result counts."""
+    counts = dispatch_reminders()
+    return jsonify(counts), 200

--- a/packages/backend/app/routes/jobs.py
+++ b/packages/backend/app/routes/jobs.py
@@ -2,7 +2,7 @@
 from flask import Blueprint, current_app, jsonify
 from flask_jwt_extended import jwt_required
 
-from ..services.jobs import dispatch_reminders, reminder_stats
+from ..services.jobs import run_dispatch_cycle, reminder_stats
 
 bp = Blueprint("jobs", __name__)
 
@@ -38,6 +38,6 @@ def reminders_stats():
 @bp.post("/reminders/run")
 @jwt_required()
 def run_reminders():
-    """Trigger dispatch_reminders immediately and return result counts."""
-    counts = dispatch_reminders()
+    """Trigger run_dispatch_cycle immediately and return result counts."""
+    counts = run_dispatch_cycle()
     return jsonify(counts), 200

--- a/packages/backend/app/services/jobs.py
+++ b/packages/backend/app/services/jobs.py
@@ -1,0 +1,115 @@
+"""Background job dispatch logic with exponential backoff retry."""
+from datetime import datetime, timedelta
+import logging
+
+from ..extensions import db
+from ..models import Reminder
+from .reminders import send_reminder
+
+logger = logging.getLogger("finmind.jobs")
+
+RETRY_DELAYS_MINUTES = [5, 15, 45]  # delay before each retry attempt
+MAX_RETRIES = 3
+
+
+def _due_reminders():
+    """Return reminders that are due for initial send or a scheduled retry."""
+    now = datetime.utcnow()
+    return (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
+            db.or_(
+                db.and_(Reminder.retry_count == 0, Reminder.send_at <= now),
+                db.and_(Reminder.retry_count > 0, Reminder.next_retry_at <= now),
+            ),
+        )
+        .all()
+    )
+
+
+def dispatch_reminders() -> dict:
+    """Process all due reminders; apply exponential backoff on failure.
+
+    Must be called within an active Flask application context.
+
+    Returns a dict with counts: processed, sent, retrying, failed.
+    """
+    now = datetime.utcnow()
+    reminders = _due_reminders()
+
+    counts = {"processed": 0, "sent": 0, "retrying": 0, "failed": 0}
+
+    for r in reminders:
+        counts["processed"] += 1
+        try:
+            success = send_reminder(r)
+        except Exception as exc:
+            success = False
+            r.last_error = str(exc)[:500]
+
+        if success:
+            r.sent = True
+            r.retry_status = "sent"
+            counts["sent"] += 1
+            logger.info("Reminder sent id=%s channel=%s", r.id, r.channel)
+        else:
+            new_count = r.retry_count + 1
+            r.retry_count = new_count
+            if not r.last_error:
+                r.last_error = "send_reminder returned False"
+
+            if new_count > MAX_RETRIES:
+                r.failed = True
+                r.retry_status = "failed"
+                counts["failed"] += 1
+                logger.warning(
+                    "Reminder permanently failed id=%s retries=%s error=%s",
+                    r.id,
+                    new_count,
+                    r.last_error,
+                )
+            else:
+                delay = RETRY_DELAYS_MINUTES[new_count - 1]
+                r.next_retry_at = now + timedelta(minutes=delay)
+                r.retry_status = "retrying"
+                counts["retrying"] += 1
+                logger.info(
+                    "Reminder retry scheduled id=%s attempt=%s next_in=%dmin",
+                    r.id,
+                    new_count,
+                    delay,
+                )
+
+    db.session.commit()
+    logger.info("dispatch_reminders complete counts=%s", counts)
+    return counts
+
+
+def reminder_stats() -> dict:
+    """Return aggregate counts for the reminders table."""
+    total = db.session.query(Reminder).count()
+    pending = (
+        db.session.query(Reminder)
+        .filter(Reminder.sent.is_(False), Reminder.failed.is_(False), Reminder.retry_count == 0)
+        .count()
+    )
+    sent = db.session.query(Reminder).filter(Reminder.sent.is_(True)).count()
+    failed = db.session.query(Reminder).filter(Reminder.failed.is_(True)).count()
+    retrying = (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
+            Reminder.retry_count > 0,
+        )
+        .count()
+    )
+    return {
+        "total": total,
+        "pending": pending,
+        "sent": sent,
+        "retrying": retrying,
+        "failed": failed,
+    }

--- a/packages/backend/app/services/jobs.py
+++ b/packages/backend/app/services/jobs.py
@@ -1,6 +1,7 @@
 """Background job dispatch logic with exponential backoff retry."""
 from datetime import datetime, timedelta
 import logging
+import os
 
 from ..extensions import db
 from ..models import Reminder
@@ -8,8 +9,10 @@ from .reminders import send_reminder
 
 logger = logging.getLogger("finmind.jobs")
 
-RETRY_DELAYS_MINUTES = [5, 15, 45]  # delay before each retry attempt
-MAX_RETRIES = 3
+MAX_RETRIES = int(os.environ.get("JOB_MAX_RETRIES", 3))
+RETRY_DELAYS_MINUTES = [
+    int(x) for x in os.environ.get("JOB_RETRY_DELAYS", "5,15,45").split(",")
+]
 
 
 def _due_reminders():

--- a/packages/backend/app/services/jobs.py
+++ b/packages/backend/app/services/jobs.py
@@ -32,22 +32,22 @@ def _due_reminders():
     )
 
 
-def dispatch_reminders() -> dict:
-    """Process all due reminders; apply exponential backoff on failure.
+def dispatch_reminders(candidates, sender_func, now) -> dict:
+    """Pure retry/backoff logic — no DB access.
 
-    Must be called within an active Flask application context.
+    Args:
+        candidates: list of reminder objects to process.
+        sender_func: callable(reminder) -> bool that attempts delivery.
+        now: datetime representing the current time (used for scheduling retries).
 
     Returns a dict with counts: processed, sent, retrying, failed.
     """
-    now = datetime.utcnow()
-    reminders = _due_reminders()
-
     counts = {"processed": 0, "sent": 0, "retrying": 0, "failed": 0}
 
-    for r in reminders:
+    for r in candidates:
         counts["processed"] += 1
         try:
-            success = send_reminder(r)
+            success = sender_func(r)
         except Exception as exc:
             success = False
             r.last_error = str(exc)[:500]
@@ -85,8 +85,19 @@ def dispatch_reminders() -> dict:
                     delay,
                 )
 
-    db.session.commit()
     logger.info("dispatch_reminders complete counts=%s", counts)
+    return counts
+
+
+def run_dispatch_cycle() -> dict:
+    """Fetch due reminders from DB, dispatch them, and commit.
+
+    Must be called within an active Flask application context.
+    """
+    now = datetime.utcnow()
+    candidates = _due_reminders()
+    counts = dispatch_reminders(candidates, send_reminder, now)
+    db.session.commit()
     return counts
 
 

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,64 @@
 import os
 import pytest
+from unittest.mock import MagicMock
 from app import create_app
 from app.config import Settings
 from app.extensions import db
 from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class _FakeRedis:
+    """Minimal in-memory Redis stand-in for unit tests."""
+
+    def __init__(self):
+        self._store: dict = {}
+
+    def get(self, key):
+        return self._store.get(key)
+
+    def set(self, key, value):
+        self._store[key] = value
+        return True
+
+    def setex(self, key, ttl, value):
+        self._store[key] = value
+        return True
+
+    def delete(self, *keys):
+        for k in keys:
+            self._store.pop(k, None)
+        return len(keys)
+
+    def scan(self, cursor=0, match=None, count=100):
+        import fnmatch
+        if match:
+            matched = [k for k in self._store if fnmatch.fnmatch(k, match)]
+        else:
+            matched = list(self._store.keys())
+        return (0, matched)
+
+    def flushdb(self):
+        self._store.clear()
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _mock_redis(monkeypatch):
+    """Replace the Redis client with a no-op in-memory stub so tests don't
+    need a live server. The module-level redis_client in extensions.py connects
+    to the Docker service name 'redis' which is not available in local test runs.
+    """
+    fake = _FakeRedis()
+
+    import app.extensions as ext_mod
+    import app.routes.auth as auth_mod
+    import app.services.cache as cache_mod
+
+    monkeypatch.setattr(ext_mod, "redis_client", fake)
+    monkeypatch.setattr(auth_mod, "redis_client", fake)
+    monkeypatch.setattr(cache_mod, "redis_client", fake)
+    return fake
 
 
 class TestSettings(Settings):

--- a/packages/backend/tests/test_jobs.py
+++ b/packages/backend/tests/test_jobs.py
@@ -1,0 +1,401 @@
+"""Tests for resilient background job dispatch and monitoring endpoints."""
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app.extensions import db
+from app.models import Reminder
+from app.services.jobs import (
+    MAX_RETRIES,
+    RETRY_DELAYS_MINUTES,
+    dispatch_reminders,
+    reminder_stats,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_reminder(app_fixture, *, send_at=None, channel="email", retry_count=0,
+                   next_retry_at=None, failed=False, sent=False, retry_status="pending"):
+    """Create a Reminder row inside an app context and return its id."""
+    with app_fixture.app_context():
+        r = Reminder(
+            user_id=1,
+            message="Test reminder",
+            send_at=send_at or datetime.utcnow() - timedelta(minutes=1),
+            channel=channel,
+            retry_count=retry_count,
+            next_retry_at=next_retry_at,
+            failed=failed,
+            sent=sent,
+            retry_status=retry_status,
+        )
+        db.session.add(r)
+        db.session.commit()
+        return r.id
+
+
+def _get_reminder(app_fixture, rid):
+    with app_fixture.app_context():
+        db.session.expire_all()
+        return db.session.get(Reminder, rid)
+
+
+def _register_user(app_fixture):
+    """Ensure user id=1 exists in the test database."""
+    from app.models import User
+    import bcrypt
+
+    with app_fixture.app_context():
+        if not db.session.get(User, 1):
+            u = User(
+                email="jobs-test@example.com",
+                password_hash=bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode(),
+            )
+            db.session.add(u)
+            db.session.commit()
+
+
+# ---------------------------------------------------------------------------
+# dispatch_reminders — success path
+# ---------------------------------------------------------------------------
+
+def test_dispatch_sends_due_reminder(app_fixture):
+    _register_user(app_fixture)
+    rid = _make_reminder(app_fixture)
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["sent"] == 1
+    assert result["processed"] == 1
+    assert result["retrying"] == 0
+    assert result["failed"] == 0
+
+    r = _get_reminder(app_fixture, rid)
+    assert r.sent is True
+    assert r.retry_status == "sent"
+
+
+def test_dispatch_skips_future_reminder(app_fixture):
+    _register_user(app_fixture)
+    _make_reminder(app_fixture, send_at=datetime.utcnow() + timedelta(hours=1))
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["processed"] == 0
+
+
+def test_dispatch_skips_already_sent(app_fixture):
+    _register_user(app_fixture)
+    _make_reminder(app_fixture, sent=True, retry_status="sent")
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["processed"] == 0
+
+
+def test_dispatch_skips_permanently_failed(app_fixture):
+    _register_user(app_fixture)
+    _make_reminder(app_fixture, failed=True, retry_status="failed")
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["processed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# dispatch_reminders — failure / backoff path
+# ---------------------------------------------------------------------------
+
+def test_dispatch_schedules_first_retry_on_failure(app_fixture):
+    _register_user(app_fixture)
+    rid = _make_reminder(app_fixture)
+
+    before = datetime.utcnow()
+    with patch("app.services.jobs.send_reminder", return_value=False):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["retrying"] == 1
+    assert result["sent"] == 0
+    assert result["failed"] == 0
+
+    r = _get_reminder(app_fixture, rid)
+    assert r.retry_count == 1
+    assert r.retry_status == "retrying"
+    assert r.sent is False
+    assert r.failed is False
+    expected_delay = RETRY_DELAYS_MINUTES[0]
+    assert r.next_retry_at >= before + timedelta(minutes=expected_delay - 1)
+    assert r.last_error is not None
+
+
+def test_dispatch_second_retry_uses_15min_backoff(app_fixture):
+    _register_user(app_fixture)
+    # Simulate first retry already scheduled and now due
+    rid = _make_reminder(
+        app_fixture,
+        retry_count=1,
+        next_retry_at=datetime.utcnow() - timedelta(seconds=1),
+        retry_status="retrying",
+    )
+
+    before = datetime.utcnow()
+    with patch("app.services.jobs.send_reminder", return_value=False):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["retrying"] == 1
+    r = _get_reminder(app_fixture, rid)
+    assert r.retry_count == 2
+    expected_delay = RETRY_DELAYS_MINUTES[1]
+    assert r.next_retry_at >= before + timedelta(minutes=expected_delay - 1)
+
+
+def test_dispatch_third_retry_uses_45min_backoff(app_fixture):
+    _register_user(app_fixture)
+    rid = _make_reminder(
+        app_fixture,
+        retry_count=2,
+        next_retry_at=datetime.utcnow() - timedelta(seconds=1),
+        retry_status="retrying",
+    )
+
+    before = datetime.utcnow()
+    with patch("app.services.jobs.send_reminder", return_value=False):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["retrying"] == 1
+    r = _get_reminder(app_fixture, rid)
+    assert r.retry_count == 3
+    expected_delay = RETRY_DELAYS_MINUTES[2]
+    assert r.next_retry_at >= before + timedelta(minutes=expected_delay - 1)
+
+
+def test_dispatch_marks_failed_after_max_retries(app_fixture):
+    _register_user(app_fixture)
+    rid = _make_reminder(
+        app_fixture,
+        retry_count=MAX_RETRIES,
+        next_retry_at=datetime.utcnow() - timedelta(seconds=1),
+        retry_status="retrying",
+    )
+
+    with patch("app.services.jobs.send_reminder", return_value=False):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["failed"] == 1
+    assert result["retrying"] == 0
+
+    r = _get_reminder(app_fixture, rid)
+    assert r.failed is True
+    assert r.retry_status == "failed"
+    assert r.sent is False
+
+
+def test_dispatch_retry_due_is_processed(app_fixture):
+    """A retrying reminder whose next_retry_at is in the past must be picked up."""
+    _register_user(app_fixture)
+    rid = _make_reminder(
+        app_fixture,
+        retry_count=1,
+        next_retry_at=datetime.utcnow() - timedelta(minutes=10),
+        retry_status="retrying",
+    )
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["sent"] == 1
+    r = _get_reminder(app_fixture, rid)
+    assert r.sent is True
+    assert r.retry_status == "sent"
+
+
+def test_dispatch_retry_not_yet_due_is_skipped(app_fixture):
+    """A retrying reminder whose next_retry_at is in the future must NOT be picked up."""
+    _register_user(app_fixture)
+    _make_reminder(
+        app_fixture,
+        retry_count=1,
+        next_retry_at=datetime.utcnow() + timedelta(minutes=4),
+        retry_status="retrying",
+    )
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["processed"] == 0
+
+
+def test_dispatch_captures_exception_as_error(app_fixture):
+    """send_reminder raising an exception is treated as a failure."""
+    _register_user(app_fixture)
+    rid = _make_reminder(app_fixture)
+
+    with patch("app.services.jobs.send_reminder", side_effect=RuntimeError("SMTP timeout")):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["retrying"] == 1
+    r = _get_reminder(app_fixture, rid)
+    assert "SMTP timeout" in r.last_error
+
+
+def test_dispatch_processes_multiple_reminders(app_fixture):
+    _register_user(app_fixture)
+    for _ in range(3):
+        _make_reminder(app_fixture)
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        with app_fixture.app_context():
+            result = dispatch_reminders()
+
+    assert result["sent"] == 3
+    assert result["processed"] == 3
+
+
+# ---------------------------------------------------------------------------
+# reminder_stats
+# ---------------------------------------------------------------------------
+
+def test_reminder_stats_counts(app_fixture):
+    _register_user(app_fixture)
+    # pending
+    _make_reminder(app_fixture)
+    # sent
+    _make_reminder(app_fixture, sent=True, retry_status="sent")
+    # retrying
+    _make_reminder(
+        app_fixture,
+        retry_count=1,
+        next_retry_at=datetime.utcnow() + timedelta(minutes=5),
+        retry_status="retrying",
+    )
+    # failed
+    _make_reminder(app_fixture, failed=True, retry_status="failed")
+
+    with app_fixture.app_context():
+        stats = reminder_stats()
+
+    assert stats["total"] == 4
+    assert stats["pending"] == 1
+    assert stats["sent"] == 1
+    assert stats["retrying"] == 1
+    assert stats["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /jobs/status endpoint
+# ---------------------------------------------------------------------------
+
+def test_jobs_status_no_scheduler(client):
+    r = client.get("/jobs/status")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["scheduler"] == "not_configured"
+    assert data["jobs"] == []
+
+
+def test_jobs_status_with_mock_scheduler(client, app_fixture):
+    class _MockJob:
+        id = "dispatch_reminders"
+        name = "dispatch_reminders"
+        next_run_time = datetime(2026, 3, 20, 12, 0, 0)
+        trigger = "interval[0:01:00]"
+
+    class _MockScheduler:
+        running = True
+
+        def get_jobs(self):
+            return [_MockJob()]
+
+    with app_fixture.app_context():
+        app_fixture.extensions["scheduler"] = _MockScheduler()
+
+    r = client.get("/jobs/status")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["scheduler"] == "running"
+    assert len(data["jobs"]) == 1
+    assert data["jobs"][0]["id"] == "dispatch_reminders"
+
+    # Clean up
+    with app_fixture.app_context():
+        app_fixture.extensions.pop("scheduler", None)
+
+
+# ---------------------------------------------------------------------------
+# /jobs/reminders/stats endpoint
+# ---------------------------------------------------------------------------
+
+def test_jobs_reminders_stats_requires_auth(client):
+    r = client.get("/jobs/reminders/stats")
+    assert r.status_code == 401
+
+
+def test_jobs_reminders_stats_returns_counts(client, auth_header, app_fixture):
+    _register_user(app_fixture)
+    r = client.get("/jobs/reminders/stats", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    for key in ("total", "pending", "sent", "retrying", "failed"):
+        assert key in data
+
+
+# ---------------------------------------------------------------------------
+# /jobs/reminders/run endpoint
+# ---------------------------------------------------------------------------
+
+def test_jobs_reminders_run_requires_auth(client):
+    r = client.post("/jobs/reminders/run")
+    assert r.status_code == 401
+
+
+def test_jobs_reminders_run_dispatches(client, auth_header, app_fixture):
+    _register_user(app_fixture)
+    _make_reminder(app_fixture)
+
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        r = client.post("/jobs/reminders/run", headers=auth_header)
+
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["sent"] == 1
+    assert data["processed"] == 1
+
+
+def test_jobs_reminders_run_returns_zero_when_nothing_due(client, auth_header):
+    with patch("app.services.jobs.send_reminder", return_value=True):
+        r = client.post("/jobs/reminders/run", headers=auth_header)
+
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["processed"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Backoff delay constants
+# ---------------------------------------------------------------------------
+
+def test_retry_delay_constants():
+    assert len(RETRY_DELAYS_MINUTES) == MAX_RETRIES
+    assert RETRY_DELAYS_MINUTES == [5, 15, 45]
+    # Each delay is larger than the previous (exponential growth)
+    for i in range(1, len(RETRY_DELAYS_MINUTES)):
+        assert RETRY_DELAYS_MINUTES[i] > RETRY_DELAYS_MINUTES[i - 1]

--- a/packages/backend/tests/test_jobs.py
+++ b/packages/backend/tests/test_jobs.py
@@ -1,5 +1,6 @@
 """Tests for resilient background job dispatch and monitoring endpoints."""
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,7 @@ from app.services.jobs import (
     MAX_RETRIES,
     RETRY_DELAYS_MINUTES,
     dispatch_reminders,
+    run_dispatch_cycle,
     reminder_stats,
 )
 
@@ -59,24 +61,35 @@ def _register_user(app_fixture):
             db.session.commit()
 
 
+def _mock_reminder(**kwargs):
+    """Create a SimpleNamespace reminder suitable for pure-function tests."""
+    defaults = dict(
+        id=1,
+        channel="email",
+        sent=False,
+        failed=False,
+        retry_count=0,
+        last_error=None,
+        retry_status="pending",
+        next_retry_at=None,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
 # ---------------------------------------------------------------------------
-# dispatch_reminders — success path
+# dispatch_reminders — success path (pure function, no DB needed)
 # ---------------------------------------------------------------------------
 
-def test_dispatch_sends_due_reminder(app_fixture):
-    _register_user(app_fixture)
-    rid = _make_reminder(app_fixture)
-
-    with patch("app.services.jobs.send_reminder", return_value=True):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+def test_dispatch_sends_due_reminder():
+    r = _mock_reminder()
+    now = datetime.utcnow()
+    result = dispatch_reminders([r], lambda _: True, now)
 
     assert result["sent"] == 1
     assert result["processed"] == 1
     assert result["retrying"] == 0
     assert result["failed"] == 0
-
-    r = _get_reminder(app_fixture, rid)
     assert r.sent is True
     assert r.retry_status == "sent"
 
@@ -87,7 +100,7 @@ def test_dispatch_skips_future_reminder(app_fixture):
 
     with patch("app.services.jobs.send_reminder", return_value=True):
         with app_fixture.app_context():
-            result = dispatch_reminders()
+            result = run_dispatch_cycle()
 
     assert result["processed"] == 0
 
@@ -98,7 +111,7 @@ def test_dispatch_skips_already_sent(app_fixture):
 
     with patch("app.services.jobs.send_reminder", return_value=True):
         with app_fixture.app_context():
-            result = dispatch_reminders()
+            result = run_dispatch_cycle()
 
     assert result["processed"] == 0
 
@@ -109,29 +122,23 @@ def test_dispatch_skips_permanently_failed(app_fixture):
 
     with patch("app.services.jobs.send_reminder", return_value=True):
         with app_fixture.app_context():
-            result = dispatch_reminders()
+            result = run_dispatch_cycle()
 
     assert result["processed"] == 0
 
 
 # ---------------------------------------------------------------------------
-# dispatch_reminders — failure / backoff path
+# dispatch_reminders — failure / backoff path (pure function, no DB needed)
 # ---------------------------------------------------------------------------
 
-def test_dispatch_schedules_first_retry_on_failure(app_fixture):
-    _register_user(app_fixture)
-    rid = _make_reminder(app_fixture)
-
+def test_dispatch_schedules_first_retry_on_failure():
+    r = _mock_reminder()
     before = datetime.utcnow()
-    with patch("app.services.jobs.send_reminder", return_value=False):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+    result = dispatch_reminders([r], lambda _: False, before)
 
     assert result["retrying"] == 1
     assert result["sent"] == 0
     assert result["failed"] == 0
-
-    r = _get_reminder(app_fixture, rid)
     assert r.retry_count == 1
     assert r.retry_status == "retrying"
     assert r.sent is False
@@ -141,87 +148,47 @@ def test_dispatch_schedules_first_retry_on_failure(app_fixture):
     assert r.last_error is not None
 
 
-def test_dispatch_second_retry_uses_15min_backoff(app_fixture):
-    _register_user(app_fixture)
-    # Simulate first retry already scheduled and now due
-    rid = _make_reminder(
-        app_fixture,
-        retry_count=1,
-        next_retry_at=datetime.utcnow() - timedelta(seconds=1),
-        retry_status="retrying",
-    )
-
+def test_dispatch_second_retry_uses_15min_backoff():
+    r = _mock_reminder(retry_count=1, retry_status="retrying")
     before = datetime.utcnow()
-    with patch("app.services.jobs.send_reminder", return_value=False):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+    result = dispatch_reminders([r], lambda _: False, before)
 
     assert result["retrying"] == 1
-    r = _get_reminder(app_fixture, rid)
     assert r.retry_count == 2
     expected_delay = RETRY_DELAYS_MINUTES[1]
     assert r.next_retry_at >= before + timedelta(minutes=expected_delay - 1)
 
 
-def test_dispatch_third_retry_uses_45min_backoff(app_fixture):
-    _register_user(app_fixture)
-    rid = _make_reminder(
-        app_fixture,
-        retry_count=2,
-        next_retry_at=datetime.utcnow() - timedelta(seconds=1),
-        retry_status="retrying",
-    )
-
+def test_dispatch_third_retry_uses_45min_backoff():
+    r = _mock_reminder(retry_count=2, retry_status="retrying")
     before = datetime.utcnow()
-    with patch("app.services.jobs.send_reminder", return_value=False):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+    result = dispatch_reminders([r], lambda _: False, before)
 
     assert result["retrying"] == 1
-    r = _get_reminder(app_fixture, rid)
     assert r.retry_count == 3
     expected_delay = RETRY_DELAYS_MINUTES[2]
     assert r.next_retry_at >= before + timedelta(minutes=expected_delay - 1)
 
 
-def test_dispatch_marks_failed_after_max_retries(app_fixture):
-    _register_user(app_fixture)
-    rid = _make_reminder(
-        app_fixture,
-        retry_count=MAX_RETRIES,
-        next_retry_at=datetime.utcnow() - timedelta(seconds=1),
-        retry_status="retrying",
-    )
-
-    with patch("app.services.jobs.send_reminder", return_value=False):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+def test_dispatch_marks_failed_after_max_retries():
+    r = _mock_reminder(retry_count=MAX_RETRIES, retry_status="retrying")
+    now = datetime.utcnow()
+    result = dispatch_reminders([r], lambda _: False, now)
 
     assert result["failed"] == 1
     assert result["retrying"] == 0
-
-    r = _get_reminder(app_fixture, rid)
     assert r.failed is True
     assert r.retry_status == "failed"
     assert r.sent is False
 
 
-def test_dispatch_retry_due_is_processed(app_fixture):
+def test_dispatch_retry_due_is_processed():
     """A retrying reminder whose next_retry_at is in the past must be picked up."""
-    _register_user(app_fixture)
-    rid = _make_reminder(
-        app_fixture,
-        retry_count=1,
-        next_retry_at=datetime.utcnow() - timedelta(minutes=10),
-        retry_status="retrying",
-    )
-
-    with patch("app.services.jobs.send_reminder", return_value=True):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+    r = _mock_reminder(retry_count=1, retry_status="retrying")
+    now = datetime.utcnow()
+    result = dispatch_reminders([r], lambda _: True, now)
 
     assert result["sent"] == 1
-    r = _get_reminder(app_fixture, rid)
     assert r.sent is True
     assert r.retry_status == "sent"
 
@@ -238,33 +205,29 @@ def test_dispatch_retry_not_yet_due_is_skipped(app_fixture):
 
     with patch("app.services.jobs.send_reminder", return_value=True):
         with app_fixture.app_context():
-            result = dispatch_reminders()
+            result = run_dispatch_cycle()
 
     assert result["processed"] == 0
 
 
-def test_dispatch_captures_exception_as_error(app_fixture):
+def test_dispatch_captures_exception_as_error():
     """send_reminder raising an exception is treated as a failure."""
-    _register_user(app_fixture)
-    rid = _make_reminder(app_fixture)
+    r = _mock_reminder()
+    now = datetime.utcnow()
 
-    with patch("app.services.jobs.send_reminder", side_effect=RuntimeError("SMTP timeout")):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+    def boom(_):
+        raise RuntimeError("SMTP timeout")
+
+    result = dispatch_reminders([r], boom, now)
 
     assert result["retrying"] == 1
-    r = _get_reminder(app_fixture, rid)
     assert "SMTP timeout" in r.last_error
 
 
-def test_dispatch_processes_multiple_reminders(app_fixture):
-    _register_user(app_fixture)
-    for _ in range(3):
-        _make_reminder(app_fixture)
-
-    with patch("app.services.jobs.send_reminder", return_value=True):
-        with app_fixture.app_context():
-            result = dispatch_reminders()
+def test_dispatch_processes_multiple_reminders():
+    reminders = [_mock_reminder(id=i) for i in range(3)]
+    now = datetime.utcnow()
+    result = dispatch_reminders(reminders, lambda _: True, now)
 
     assert result["sent"] == 3
     assert result["processed"] == 3


### PR DESCRIPTION
## Summary

Implements resilient background job retry & monitoring for async job execution.

/claim #130

## Changes

### Retry Mechanism (Exponential Backoff)
- Configurable via `JOB_MAX_RETRIES` (default 3) and `JOB_RETRY_DELAYS` (default "5,15,45" minutes)
- Backoff: 5min → 15min → 45min, permanently failed after max retries

### Job State Tracking
- Added `retry_count`, `last_error`, `next_retry_at`, `failed`, `retry_status` to Reminder model
- Backward-compatible migration with `ADD COLUMN IF NOT EXISTS`

### Pure Dispatch Function
- `dispatch_reminders(candidates, sender_func, now)` — zero DB coupling, fully testable
- Separate `run_dispatch_cycle()` wrapper for DB operations

### Monitoring Endpoints
- `GET /jobs/status` — scheduler health (no auth)
- `GET /jobs/reminders/stats` — counts by status (JWT)
- `POST /jobs/reminders/run` — manual trigger (JWT)

### Tests
- 21 new tests (43 total), all passing
- Covers: backoff logic, dispatch success/failure/max-retries, endpoints, auth

### Documentation
- README updated with retry system docs, endpoint reference, env var configuration

Fixes #130