### PR TITLE
feat: add goal-based savings tracking & milestones

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import SavingsGoals from "./pages/SavingsGoals";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="savings-goals"
+              element={
+                <ProtectedRoute>
+                  <SavingsGoals />
                 </ProtectedRoute>
               }
             />

--- a/app/src/__tests__/SavingsGoals.integration.test.tsx
+++ b/app/src/__tests__/SavingsGoals.integration.test.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SavingsGoals from '@/pages/SavingsGoals';
+
+const toastMock = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.PropsWithChildren & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+jest.mock('@/components/ui/input', () => ({
+  Input: ({ ...props }: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+jest.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: React.PropsWithChildren & React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: React.PropsWithChildren) => <h3>{children}</h3>,
+  DialogTrigger: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+jest.mock('@/components/ui/financial-card', () => ({
+  FinancialCard: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  FinancialCardHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardTitle: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h3 {...props}>{children}</h3>
+  ),
+  FinancialCardDescription: ({ children }: React.PropsWithChildren) => <p>{children}</p>,
+  FinancialCardContent: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+jest.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLDivElement>) => (
+    <span {...props}>{children}</span>
+  ),
+}));
+jest.mock('@/components/ui/progress', () => ({
+  Progress: ({ value, ...props }: { value: number } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div role="progressbar" aria-valuenow={value} {...props} />
+  ),
+}));
+jest.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+const listGoalsMock = jest.fn();
+const createGoalMock = jest.fn();
+const depositMock = jest.fn();
+const deleteGoalMock = jest.fn();
+const updateGoalMock = jest.fn();
+
+jest.mock('@/api/savingsGoals', () => ({
+  listSavingsGoals: (...args: unknown[]) => listGoalsMock(...args),
+  createSavingsGoal: (...args: unknown[]) => createGoalMock(...args),
+  depositToGoal: (...args: unknown[]) => depositMock(...args),
+  deleteSavingsGoal: (...args: unknown[]) => deleteGoalMock(...args),
+  updateSavingsGoal: (...args: unknown[]) => updateGoalMock(...args),
+}));
+
+// Suppress console.error from React Query
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('SavingsGoals page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders empty state when no goals exist', async () => {
+    listGoalsMock.mockResolvedValue([]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/no savings goals yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders goals list with progress and milestones', async () => {
+    listGoalsMock.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Emergency Fund',
+        target_amount: 5000,
+        current_amount: 2500,
+        currency: 'USD',
+        deadline: '2026-12-31',
+        status: 'ACTIVE',
+        progress: 50,
+        milestones: [
+          { percentage: 25, reached: true },
+          { percentage: 50, reached: true },
+          { percentage: 75, reached: false },
+          { percentage: 100, reached: false },
+        ],
+      },
+    ]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Emergency Fund')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/50%/)).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('renders summary cards with totals', async () => {
+    listGoalsMock.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Goal A',
+        target_amount: 1000,
+        current_amount: 400,
+        currency: 'USD',
+        deadline: null,
+        status: 'ACTIVE',
+        progress: 40,
+        milestones: [
+          { percentage: 25, reached: true },
+          { percentage: 50, reached: false },
+          { percentage: 75, reached: false },
+          { percentage: 100, reached: false },
+        ],
+      },
+    ]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$400.00')).toBeInTheDocument();
+      expect(screen.getByText('$1,000.00')).toBeInTheDocument();
+    });
+  });
+
+  it('shows New Goal button', async () => {
+    listGoalsMock.mockResolvedValue([]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/new goal/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/__tests__/SavingsGoals.integration.test.tsx
+++ b/app/src/__tests__/SavingsGoals.integration.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import SavingsGoals from '@/pages/SavingsGoals';
 
 const toastMock = jest.fn();
-jest.mock('@/hooks/use-toast', () => ({
+jest.mock('@/components/ui/use-toast', () => ({
   useToast: () => ({ toast: toastMock }),
 }));
 
@@ -22,7 +22,9 @@ jest.mock('@/components/ui/label', () => ({
   ),
 }));
 jest.mock('@/components/ui/dialog', () => ({
-  Dialog: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  Dialog: ({ children, open }: React.PropsWithChildren & { open?: boolean }) => (
+    <div data-open={open}>{children}</div>
+  ),
   DialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
   DialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
   DialogTitle: ({ children }: React.PropsWithChildren) => <h3>{children}</h3>,
@@ -51,13 +53,11 @@ jest.mock('@/components/ui/progress', () => ({
     <div role="progressbar" aria-valuenow={value} {...props} />
   ),
 }));
-jest.mock('@/components/ui/use-toast', () => ({
-  useToast: () => ({ toast: toastMock }),
-}));
 
 const listGoalsMock = jest.fn();
 const createGoalMock = jest.fn();
 const depositMock = jest.fn();
+const withdrawMock = jest.fn();
 const deleteGoalMock = jest.fn();
 const updateGoalMock = jest.fn();
 
@@ -65,6 +65,7 @@ jest.mock('@/api/savingsGoals', () => ({
   listSavingsGoals: (...args: unknown[]) => listGoalsMock(...args),
   createSavingsGoal: (...args: unknown[]) => createGoalMock(...args),
   depositToGoal: (...args: unknown[]) => depositMock(...args),
+  withdrawFromGoal: (...args: unknown[]) => withdrawMock(...args),
   deleteSavingsGoal: (...args: unknown[]) => deleteGoalMock(...args),
   updateSavingsGoal: (...args: unknown[]) => updateGoalMock(...args),
 }));
@@ -85,6 +86,24 @@ function renderWithProviders(ui: React.ReactElement) {
   );
 }
 
+const sampleGoal = {
+  id: 1,
+  name: 'Emergency Fund',
+  target_amount: 5000,
+  current_amount: 2500,
+  currency: 'USD',
+  deadline: '2026-12-31',
+  status: 'ACTIVE' as const,
+  progress: 50,
+  milestones: [
+    { percentage: 25, reached: true },
+    { percentage: 50, reached: true },
+    { percentage: 75, reached: false },
+    { percentage: 100, reached: false },
+  ],
+  created_at: '2026-01-01T00:00:00',
+};
+
 describe('SavingsGoals page', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -100,24 +119,7 @@ describe('SavingsGoals page', () => {
   });
 
   it('renders goals list with progress and milestones', async () => {
-    listGoalsMock.mockResolvedValue([
-      {
-        id: 1,
-        name: 'Emergency Fund',
-        target_amount: 5000,
-        current_amount: 2500,
-        currency: 'USD',
-        deadline: '2026-12-31',
-        status: 'ACTIVE',
-        progress: 50,
-        milestones: [
-          { percentage: 25, reached: true },
-          { percentage: 50, reached: true },
-          { percentage: 75, reached: false },
-          { percentage: 100, reached: false },
-        ],
-      },
-    ]);
+    listGoalsMock.mockResolvedValue([sampleGoal]);
     renderWithProviders(<SavingsGoals />);
 
     await waitFor(() => {
@@ -127,30 +129,14 @@ describe('SavingsGoals page', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
 
-  it('renders summary cards with totals', async () => {
-    listGoalsMock.mockResolvedValue([
-      {
-        id: 1,
-        name: 'Goal A',
-        target_amount: 1000,
-        current_amount: 400,
-        currency: 'USD',
-        deadline: null,
-        status: 'ACTIVE',
-        progress: 40,
-        milestones: [
-          { percentage: 25, reached: true },
-          { percentage: 50, reached: false },
-          { percentage: 75, reached: false },
-          { percentage: 100, reached: false },
-        ],
-      },
-    ]);
+  it('renders summary cards with formatted amounts using goal currency', async () => {
+    listGoalsMock.mockResolvedValue([sampleGoal]);
     renderWithProviders(<SavingsGoals />);
 
     await waitFor(() => {
-      expect(screen.getByText('$400.00')).toBeInTheDocument();
-      expect(screen.getByText('$1,000.00')).toBeInTheDocument();
+      // Should use USD formatting, not hardcoded $
+      expect(screen.getByText('$2,500.00')).toBeInTheDocument();
+      expect(screen.getByText('$5,000.00')).toBeInTheDocument();
     });
   });
 
@@ -160,6 +146,87 @@ describe('SavingsGoals page', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/new goal/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders status filter buttons', async () => {
+    listGoalsMock.mockResolvedValue([]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('All')).toBeInTheDocument();
+      expect(screen.getByText('ACTIVE')).toBeInTheDocument();
+      expect(screen.getByText('COMPLETED')).toBeInTheDocument();
+      expect(screen.getByText('CANCELLED')).toBeInTheDocument();
+    });
+  });
+
+  it('shows deposit and withdraw buttons for active goals with balance', async () => {
+    listGoalsMock.mockResolvedValue([sampleGoal]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Deposit')).toBeInTheDocument();
+      expect(screen.getByText('Withdraw')).toBeInTheDocument();
+    });
+  });
+
+  it('shows completed badge for completed goals', async () => {
+    const completedGoal = {
+      ...sampleGoal,
+      id: 2,
+      status: 'COMPLETED' as const,
+      current_amount: 5000,
+      progress: 100,
+      milestones: sampleGoal.milestones.map((m) => ({ ...m, reached: true })),
+    };
+    listGoalsMock.mockResolvedValue([completedGoal]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Completed')).toBeInTheDocument();
+    });
+  });
+
+  it('shows overdue indicator for past-deadline active goals', async () => {
+    const overdueGoal = {
+      ...sampleGoal,
+      deadline: '2020-01-01', // past date
+    };
+    listGoalsMock.mockResolvedValue([overdueGoal]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/overdue/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows goals progress count in summary', async () => {
+    const completedGoal = {
+      ...sampleGoal,
+      id: 2,
+      name: 'Done Goal',
+      status: 'COMPLETED' as const,
+      current_amount: 5000,
+      progress: 100,
+      milestones: sampleGoal.milestones.map((m) => ({ ...m, reached: true })),
+    };
+    listGoalsMock.mockResolvedValue([sampleGoal, completedGoal]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      expect(screen.getByText('1 / 2 completed')).toBeInTheDocument();
+    });
+  });
+
+  it('renders delete confirmation dialog text', async () => {
+    listGoalsMock.mockResolvedValue([sampleGoal]);
+    renderWithProviders(<SavingsGoals />);
+
+    await waitFor(() => {
+      // The delete confirmation dialog is always in DOM (but may be hidden)
+      expect(screen.getByText('Delete Goal')).toBeInTheDocument();
+      expect(screen.getByText(/permanently delete/i)).toBeInTheDocument();
     });
   });
 });

--- a/app/src/api/savingsGoals.ts
+++ b/app/src/api/savingsGoals.ts
@@ -1,0 +1,64 @@
+import { api } from './client';
+
+export type Milestone = {
+  percentage: number;
+  reached: boolean;
+};
+
+export type SavingsGoal = {
+  id: number;
+  name: string;
+  target_amount: number;
+  current_amount: number;
+  currency: string;
+  deadline: string | null;
+  status: 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+  progress: number;
+  milestones: Milestone[];
+};
+
+export type SavingsGoalCreate = {
+  name: string;
+  target_amount: number;
+  current_amount?: number;
+  currency?: string;
+  deadline?: string | null;
+};
+
+export type SavingsGoalUpdate = Partial<SavingsGoalCreate> & {
+  status?: 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+};
+
+export async function listSavingsGoals(status?: string): Promise<SavingsGoal[]> {
+  const qs = status ? `?status=${status}` : '';
+  return api<SavingsGoal[]>(`/savings-goals${qs}`);
+}
+
+export async function getSavingsGoal(id: number): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings-goals/${id}`);
+}
+
+export async function createSavingsGoal(payload: SavingsGoalCreate): Promise<SavingsGoal> {
+  return api<SavingsGoal>('/savings-goals', { method: 'POST', body: payload });
+}
+
+export async function updateSavingsGoal(
+  id: number,
+  payload: SavingsGoalUpdate,
+): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings-goals/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function depositToGoal(
+  id: number,
+  amount: number,
+): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings-goals/${id}/deposit`, {
+    method: 'POST',
+    body: { amount },
+  });
+}
+
+export async function deleteSavingsGoal(id: number): Promise<{ message: string }> {
+  return api<{ message: string }>(`/savings-goals/${id}`, { method: 'DELETE' });
+}

--- a/app/src/api/savingsGoals.ts
+++ b/app/src/api/savingsGoals.ts
@@ -15,6 +15,7 @@ export type SavingsGoal = {
   status: 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
   progress: number;
   milestones: Milestone[];
+  created_at: string | null;
 };
 
 export type SavingsGoalCreate = {
@@ -30,7 +31,7 @@ export type SavingsGoalUpdate = Partial<SavingsGoalCreate> & {
 };
 
 export async function listSavingsGoals(status?: string): Promise<SavingsGoal[]> {
-  const qs = status ? `?status=${status}` : '';
+  const qs = status ? `?status=${encodeURIComponent(status)}` : '';
   return api<SavingsGoal[]>(`/savings-goals${qs}`);
 }
 
@@ -54,6 +55,16 @@ export async function depositToGoal(
   amount: number,
 ): Promise<SavingsGoal> {
   return api<SavingsGoal>(`/savings-goals/${id}/deposit`, {
+    method: 'POST',
+    body: { amount },
+  });
+}
+
+export async function withdrawFromGoal(
+  id: number,
+  amount: number,
+): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings-goals/${id}/withdraw`, {
     method: 'POST',
     body: { amount },
   });

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Savings', href: '/savings-goals' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/SavingsGoals.tsx
+++ b/app/src/pages/SavingsGoals.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   FinancialCard,
@@ -20,34 +20,42 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { Target, Plus, Trash2, PiggyBank, Trophy, Calendar } from 'lucide-react';
+import { Target, Plus, Trash2, PiggyBank, Trophy, Calendar, ArrowDownLeft } from 'lucide-react';
 import {
   listSavingsGoals,
   createSavingsGoal,
   updateSavingsGoal,
   depositToGoal,
+  withdrawFromGoal,
   deleteSavingsGoal,
   type SavingsGoal,
   type SavingsGoalCreate,
 } from '@/api/savingsGoals';
+
+type TransactionType = 'deposit' | 'withdraw';
 
 export default function SavingsGoals() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [statusFilter, setStatusFilter] = useState<string>('');
   const [createOpen, setCreateOpen] = useState(false);
-  const [depositOpen, setDepositOpen] = useState<number | null>(null);
-  const [depositAmount, setDepositAmount] = useState('');
+  const [transactionGoal, setTransactionGoal] = useState<{ id: number; type: TransactionType } | null>(null);
+  const [transactionAmount, setTransactionAmount] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
 
   const { data: goals = [], isLoading } = useQuery({
     queryKey: ['savings-goals', statusFilter],
     queryFn: () => listSavingsGoals(statusFilter || undefined),
   });
 
+  const invalidateGoals = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+  }, [queryClient]);
+
   const createMutation = useMutation({
     mutationFn: (payload: SavingsGoalCreate) => createSavingsGoal(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+      invalidateGoals();
       setCreateOpen(false);
       toast({ title: 'Goal created', description: 'Your savings goal has been created.' });
     },
@@ -58,30 +66,53 @@ export default function SavingsGoals() {
 
   const depositMutation = useMutation({
     mutationFn: ({ id, amount }: { id: number; amount: number }) => depositToGoal(id, amount),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
-      setDepositOpen(null);
-      setDepositAmount('');
-      toast({ title: 'Deposit added', description: 'Amount has been added to your goal.' });
+    onSuccess: (data) => {
+      invalidateGoals();
+      setTransactionGoal(null);
+      setTransactionAmount('');
+      const msg = data.status === 'COMPLETED'
+        ? 'Congratulations! You have reached your savings goal!'
+        : 'Amount has been added to your goal.';
+      toast({ title: 'Deposit added', description: msg });
     },
     onError: (err: Error) => {
-      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+      toast({ title: 'Deposit failed', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const withdrawMutation = useMutation({
+    mutationFn: ({ id, amount }: { id: number; amount: number }) => withdrawFromGoal(id, amount),
+    onSuccess: () => {
+      invalidateGoals();
+      setTransactionGoal(null);
+      setTransactionAmount('');
+      toast({ title: 'Withdrawal complete', description: 'Amount has been withdrawn from your goal.' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Withdrawal failed', description: err.message, variant: 'destructive' });
     },
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: number) => deleteSavingsGoal(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+      invalidateGoals();
+      setConfirmDelete(null);
       toast({ title: 'Goal deleted' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Delete failed', description: err.message, variant: 'destructive' });
     },
   });
 
   const cancelMutation = useMutation({
     mutationFn: (id: number) => updateSavingsGoal(id, { status: 'CANCELLED' }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+      invalidateGoals();
       toast({ title: 'Goal cancelled' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Error', description: err.message, variant: 'destructive' });
     },
   });
 
@@ -89,25 +120,55 @@ export default function SavingsGoals() {
     e.preventDefault();
     const form = new FormData(e.currentTarget);
     const payload: SavingsGoalCreate = {
-      name: form.get('name') as string,
+      name: (form.get('name') as string).trim(),
       target_amount: Number(form.get('target_amount')),
       current_amount: Number(form.get('current_amount') || 0),
       currency: (form.get('currency') as string) || undefined,
       deadline: (form.get('deadline') as string) || undefined,
     };
+    if (!payload.name) return;
+    if (!payload.target_amount || payload.target_amount <= 0) return;
     createMutation.mutate(payload);
   };
 
-  const handleDeposit = (goalId: number) => {
-    const amount = parseFloat(depositAmount);
+  const handleTransaction = () => {
+    if (!transactionGoal) return;
+    const amount = parseFloat(transactionAmount);
     if (!amount || amount <= 0) return;
-    depositMutation.mutate({ id: goalId, amount });
+    if (transactionGoal.type === 'deposit') {
+      depositMutation.mutate({ id: transactionGoal.id, amount });
+    } else {
+      withdrawMutation.mutate({ id: transactionGoal.id, amount });
+    }
   };
+
+  const isTransacting = depositMutation.isPending || withdrawMutation.isPending;
 
   const activeGoals = goals.filter((g) => g.status === 'ACTIVE');
   const completedGoals = goals.filter((g) => g.status === 'COMPLETED');
   const totalSaved = goals.reduce((sum, g) => sum + g.current_amount, 0);
   const totalTarget = goals.reduce((sum, g) => sum + g.target_amount, 0);
+
+  // Use the most common currency among goals, or a generic label
+  const primaryCurrency = goals.length > 0 ? goals[0].currency : '';
+
+  const formatAmount = (amount: number, currency?: string) => {
+    const cur = currency || primaryCurrency;
+    try {
+      return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: cur || 'USD',
+        minimumFractionDigits: 2,
+      }).format(amount);
+    } catch {
+      // Fallback if Intl doesn't recognize the currency
+      return `${cur} ${amount.toLocaleString('en-US', { minimumFractionDigits: 2 })}`;
+    }
+  };
+
+  // Check if all goals share the same currency (only show summary totals if so)
+  const currencies = new Set(goals.map((g) => g.currency));
+  const isMixedCurrency = currencies.size > 1;
 
   return (
     <div className="container-financial py-8 space-y-8">
@@ -136,7 +197,13 @@ export default function SavingsGoals() {
             <form onSubmit={handleCreate} className="space-y-4">
               <div>
                 <Label htmlFor="name">Goal Name</Label>
-                <Input id="name" name="name" placeholder="e.g. Emergency Fund" required />
+                <Input
+                  id="name"
+                  name="name"
+                  placeholder="e.g. Emergency Fund"
+                  maxLength={200}
+                  required
+                />
               </div>
               <div className="grid grid-cols-2 gap-4">
                 <div>
@@ -166,7 +233,7 @@ export default function SavingsGoals() {
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label htmlFor="currency">Currency</Label>
-                  <Input id="currency" name="currency" placeholder="USD" />
+                  <Input id="currency" name="currency" placeholder="USD" maxLength={10} />
                 </div>
                 <div>
                   <Label htmlFor="deadline">Deadline</Label>
@@ -187,7 +254,9 @@ export default function SavingsGoals() {
           <FinancialCardHeader>
             <FinancialCardDescription>Total Saved</FinancialCardDescription>
             <FinancialCardTitle className="text-2xl">
-              ${totalSaved.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+              {isMixedCurrency
+                ? `${totalSaved.toLocaleString('en-US', { minimumFractionDigits: 2 })} (mixed)`
+                : formatAmount(totalSaved)}
             </FinancialCardTitle>
           </FinancialCardHeader>
         </FinancialCard>
@@ -195,7 +264,9 @@ export default function SavingsGoals() {
           <FinancialCardHeader>
             <FinancialCardDescription>Total Target</FinancialCardDescription>
             <FinancialCardTitle className="text-2xl">
-              ${totalTarget.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+              {isMixedCurrency
+                ? `${totalTarget.toLocaleString('en-US', { minimumFractionDigits: 2 })} (mixed)`
+                : formatAmount(totalTarget)}
             </FinancialCardTitle>
           </FinancialCardHeader>
         </FinancialCard>
@@ -231,7 +302,9 @@ export default function SavingsGoals() {
           <FinancialCardContent>
             <PiggyBank className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
             <p className="text-muted-foreground">
-              No savings goals yet. Create your first goal to start tracking!
+              {statusFilter
+                ? `No ${statusFilter.toLowerCase()} goals found.`
+                : 'No savings goals yet. Create your first goal to start tracking!'}
             </p>
           </FinancialCardContent>
         </FinancialCard>
@@ -241,39 +314,87 @@ export default function SavingsGoals() {
             <GoalCard
               key={goal.id}
               goal={goal}
-              onDeposit={() => setDepositOpen(goal.id)}
-              onCancel={() => cancelMutation.mutate(goal.id)}
-              onDelete={() => deleteMutation.mutate(goal.id)}
+              formatAmount={formatAmount}
+              onDeposit={() => setTransactionGoal({ id: goal.id, type: 'deposit' })}
+              onWithdraw={() => setTransactionGoal({ id: goal.id, type: 'withdraw' })}
+              onCancel={() => {
+                if (window.confirm(`Cancel the goal "${goal.name}"? You can still view it later.`)) {
+                  cancelMutation.mutate(goal.id);
+                }
+              }}
+              onDelete={() => setConfirmDelete(goal.id)}
+              isCancelling={cancelMutation.isPending}
             />
           ))}
         </div>
       )}
 
-      {/* Deposit Dialog */}
-      <Dialog open={depositOpen !== null} onOpenChange={() => { setDepositOpen(null); setDepositAmount(''); }}>
+      {/* Deposit / Withdraw Dialog */}
+      <Dialog
+        open={transactionGoal !== null}
+        onOpenChange={() => {
+          setTransactionGoal(null);
+          setTransactionAmount('');
+        }}
+      >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Add Deposit</DialogTitle>
+            <DialogTitle>
+              {transactionGoal?.type === 'deposit' ? 'Add Deposit' : 'Withdraw Funds'}
+            </DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
             <div>
-              <Label htmlFor="deposit_amount">Amount</Label>
+              <Label htmlFor="transaction_amount">Amount</Label>
               <Input
-                id="deposit_amount"
+                id="transaction_amount"
                 type="number"
                 step="0.01"
                 min="0.01"
-                value={depositAmount}
-                onChange={(e) => setDepositAmount(e.target.value)}
+                value={transactionAmount}
+                onChange={(e) => setTransactionAmount(e.target.value)}
                 placeholder="100.00"
+                autoFocus
               />
             </div>
             <Button
               className="w-full"
-              onClick={() => depositOpen && handleDeposit(depositOpen)}
-              disabled={depositMutation.isPending}
+              onClick={handleTransaction}
+              disabled={isTransacting || !transactionAmount || parseFloat(transactionAmount) <= 0}
             >
-              {depositMutation.isPending ? 'Adding...' : 'Add Deposit'}
+              {isTransacting
+                ? 'Processing...'
+                : transactionGoal?.type === 'deposit'
+                  ? 'Add Deposit'
+                  : 'Withdraw'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={confirmDelete !== null} onOpenChange={() => setConfirmDelete(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Goal</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to permanently delete this savings goal? This action cannot be undone.
+          </p>
+          <div className="flex gap-2 justify-end pt-4">
+            <Button variant="outline" onClick={() => setConfirmDelete(null)}>
+              Keep
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (confirmDelete !== null) {
+                  deleteMutation.mutate(confirmDelete);
+                }
+              }}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete'}
             </Button>
           </div>
         </DialogContent>
@@ -284,20 +405,31 @@ export default function SavingsGoals() {
 
 function GoalCard({
   goal,
+  formatAmount,
   onDeposit,
+  onWithdraw,
   onCancel,
   onDelete,
+  isCancelling,
 }: {
   goal: SavingsGoal;
+  formatAmount: (amount: number, currency?: string) => string;
   onDeposit: () => void;
+  onWithdraw: () => void;
   onCancel: () => void;
   onDelete: () => void;
+  isCancelling: boolean;
 }) {
   const statusBadge = {
     ACTIVE: <Badge variant="default">Active</Badge>,
     COMPLETED: <Badge className="bg-green-100 text-green-800">Completed</Badge>,
     CANCELLED: <Badge variant="secondary">Cancelled</Badge>,
   };
+
+  const isOverdue =
+    goal.deadline &&
+    goal.status === 'ACTIVE' &&
+    new Date(goal.deadline) < new Date();
 
   return (
     <FinancialCard variant="financial">
@@ -306,8 +438,8 @@ function GoalCard({
           <div>
             <FinancialCardTitle className="text-lg">{goal.name}</FinancialCardTitle>
             <FinancialCardDescription className="mt-1">
-              {goal.currency} {goal.current_amount.toLocaleString('en-US', { minimumFractionDigits: 2 })}{' '}
-              / {goal.target_amount.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+              {formatAmount(goal.current_amount, goal.currency)}{' '}
+              / {formatAmount(goal.target_amount, goal.currency)}
             </FinancialCardDescription>
           </div>
           {statusBadge[goal.status]}
@@ -339,9 +471,10 @@ function GoalCard({
 
         {/* Deadline */}
         {goal.deadline && (
-          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+          <div className={`flex items-center gap-1 text-sm ${isOverdue ? 'text-destructive font-medium' : 'text-muted-foreground'}`}>
             <Calendar className="h-3.5 w-3.5" />
-            Deadline: {new Date(goal.deadline).toLocaleDateString()}
+            {isOverdue ? 'Overdue: ' : 'Deadline: '}
+            {new Date(goal.deadline).toLocaleDateString()}
           </div>
         )}
 
@@ -353,10 +486,22 @@ function GoalCard({
                 <PiggyBank className="h-3.5 w-3.5 mr-1" />
                 Deposit
               </Button>
-              <Button size="sm" variant="outline" onClick={onCancel}>
+              {goal.current_amount > 0 && (
+                <Button size="sm" variant="outline" onClick={onWithdraw}>
+                  <ArrowDownLeft className="h-3.5 w-3.5 mr-1" />
+                  Withdraw
+                </Button>
+              )}
+              <Button size="sm" variant="outline" onClick={onCancel} disabled={isCancelling}>
                 Cancel
               </Button>
             </>
+          )}
+          {goal.status === 'COMPLETED' && goal.current_amount > 0 && (
+            <Button size="sm" variant="outline" onClick={onWithdraw}>
+              <ArrowDownLeft className="h-3.5 w-3.5 mr-1" />
+              Withdraw
+            </Button>
           )}
           <Button size="sm" variant="ghost" className="text-destructive ml-auto" onClick={onDelete}>
             <Trash2 className="h-3.5 w-3.5" />

--- a/app/src/pages/SavingsGoals.tsx
+++ b/app/src/pages/SavingsGoals.tsx
@@ -1,0 +1,368 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+  FinancialCardDescription,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Target, Plus, Trash2, PiggyBank, Trophy, Calendar } from 'lucide-react';
+import {
+  listSavingsGoals,
+  createSavingsGoal,
+  updateSavingsGoal,
+  depositToGoal,
+  deleteSavingsGoal,
+  type SavingsGoal,
+  type SavingsGoalCreate,
+} from '@/api/savingsGoals';
+
+export default function SavingsGoals() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<string>('');
+  const [createOpen, setCreateOpen] = useState(false);
+  const [depositOpen, setDepositOpen] = useState<number | null>(null);
+  const [depositAmount, setDepositAmount] = useState('');
+
+  const { data: goals = [], isLoading } = useQuery({
+    queryKey: ['savings-goals', statusFilter],
+    queryFn: () => listSavingsGoals(statusFilter || undefined),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: SavingsGoalCreate) => createSavingsGoal(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+      setCreateOpen(false);
+      toast({ title: 'Goal created', description: 'Your savings goal has been created.' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const depositMutation = useMutation({
+    mutationFn: ({ id, amount }: { id: number; amount: number }) => depositToGoal(id, amount),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+      setDepositOpen(null);
+      setDepositAmount('');
+      toast({ title: 'Deposit added', description: 'Amount has been added to your goal.' });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteSavingsGoal(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+      toast({ title: 'Goal deleted' });
+    },
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (id: number) => updateSavingsGoal(id, { status: 'CANCELLED' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['savings-goals'] });
+      toast({ title: 'Goal cancelled' });
+    },
+  });
+
+  const handleCreate = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = new FormData(e.currentTarget);
+    const payload: SavingsGoalCreate = {
+      name: form.get('name') as string,
+      target_amount: Number(form.get('target_amount')),
+      current_amount: Number(form.get('current_amount') || 0),
+      currency: (form.get('currency') as string) || undefined,
+      deadline: (form.get('deadline') as string) || undefined,
+    };
+    createMutation.mutate(payload);
+  };
+
+  const handleDeposit = (goalId: number) => {
+    const amount = parseFloat(depositAmount);
+    if (!amount || amount <= 0) return;
+    depositMutation.mutate({ id: goalId, amount });
+  };
+
+  const activeGoals = goals.filter((g) => g.status === 'ACTIVE');
+  const completedGoals = goals.filter((g) => g.status === 'COMPLETED');
+  const totalSaved = goals.reduce((sum, g) => sum + g.current_amount, 0);
+  const totalTarget = goals.reduce((sum, g) => sum + g.target_amount, 0);
+
+  return (
+    <div className="container-financial py-8 space-y-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <Target className="h-6 w-6 text-primary" />
+            Savings Goals
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Track your financial goals and milestones
+          </p>
+        </div>
+        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+          <DialogTrigger asChild>
+            <Button variant="hero">
+              <Plus className="h-4 w-4 mr-2" />
+              New Goal
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create Savings Goal</DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleCreate} className="space-y-4">
+              <div>
+                <Label htmlFor="name">Goal Name</Label>
+                <Input id="name" name="name" placeholder="e.g. Emergency Fund" required />
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="target_amount">Target Amount</Label>
+                  <Input
+                    id="target_amount"
+                    name="target_amount"
+                    type="number"
+                    step="0.01"
+                    min="0.01"
+                    placeholder="5000"
+                    required
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="current_amount">Starting Amount</Label>
+                  <Input
+                    id="current_amount"
+                    name="current_amount"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    placeholder="0"
+                  />
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label htmlFor="currency">Currency</Label>
+                  <Input id="currency" name="currency" placeholder="USD" />
+                </div>
+                <div>
+                  <Label htmlFor="deadline">Deadline</Label>
+                  <Input id="deadline" name="deadline" type="date" />
+                </div>
+              </div>
+              <Button type="submit" className="w-full" disabled={createMutation.isPending}>
+                {createMutation.isPending ? 'Creating...' : 'Create Goal'}
+              </Button>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <FinancialCard variant="financial">
+          <FinancialCardHeader>
+            <FinancialCardDescription>Total Saved</FinancialCardDescription>
+            <FinancialCardTitle className="text-2xl">
+              ${totalSaved.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+        </FinancialCard>
+        <FinancialCard variant="financial">
+          <FinancialCardHeader>
+            <FinancialCardDescription>Total Target</FinancialCardDescription>
+            <FinancialCardTitle className="text-2xl">
+              ${totalTarget.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+        </FinancialCard>
+        <FinancialCard variant="financial">
+          <FinancialCardHeader>
+            <FinancialCardDescription>Goals Progress</FinancialCardDescription>
+            <FinancialCardTitle className="text-2xl">
+              {completedGoals.length} / {goals.length} completed
+            </FinancialCardTitle>
+          </FinancialCardHeader>
+        </FinancialCard>
+      </div>
+
+      {/* Filter */}
+      <div className="flex gap-2">
+        {['', 'ACTIVE', 'COMPLETED', 'CANCELLED'].map((s) => (
+          <Button
+            key={s}
+            variant={statusFilter === s ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setStatusFilter(s)}
+          >
+            {s || 'All'}
+          </Button>
+        ))}
+      </div>
+
+      {/* Goals List */}
+      {isLoading ? (
+        <p className="text-muted-foreground text-center py-12">Loading goals...</p>
+      ) : goals.length === 0 ? (
+        <FinancialCard variant="financial" className="text-center py-12">
+          <FinancialCardContent>
+            <PiggyBank className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+            <p className="text-muted-foreground">
+              No savings goals yet. Create your first goal to start tracking!
+            </p>
+          </FinancialCardContent>
+        </FinancialCard>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {goals.map((goal) => (
+            <GoalCard
+              key={goal.id}
+              goal={goal}
+              onDeposit={() => setDepositOpen(goal.id)}
+              onCancel={() => cancelMutation.mutate(goal.id)}
+              onDelete={() => deleteMutation.mutate(goal.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Deposit Dialog */}
+      <Dialog open={depositOpen !== null} onOpenChange={() => { setDepositOpen(null); setDepositAmount(''); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Deposit</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="deposit_amount">Amount</Label>
+              <Input
+                id="deposit_amount"
+                type="number"
+                step="0.01"
+                min="0.01"
+                value={depositAmount}
+                onChange={(e) => setDepositAmount(e.target.value)}
+                placeholder="100.00"
+              />
+            </div>
+            <Button
+              className="w-full"
+              onClick={() => depositOpen && handleDeposit(depositOpen)}
+              disabled={depositMutation.isPending}
+            >
+              {depositMutation.isPending ? 'Adding...' : 'Add Deposit'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function GoalCard({
+  goal,
+  onDeposit,
+  onCancel,
+  onDelete,
+}: {
+  goal: SavingsGoal;
+  onDeposit: () => void;
+  onCancel: () => void;
+  onDelete: () => void;
+}) {
+  const statusBadge = {
+    ACTIVE: <Badge variant="default">Active</Badge>,
+    COMPLETED: <Badge className="bg-green-100 text-green-800">Completed</Badge>,
+    CANCELLED: <Badge variant="secondary">Cancelled</Badge>,
+  };
+
+  return (
+    <FinancialCard variant="financial">
+      <FinancialCardHeader>
+        <div className="flex items-start justify-between">
+          <div>
+            <FinancialCardTitle className="text-lg">{goal.name}</FinancialCardTitle>
+            <FinancialCardDescription className="mt-1">
+              {goal.currency} {goal.current_amount.toLocaleString('en-US', { minimumFractionDigits: 2 })}{' '}
+              / {goal.target_amount.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+            </FinancialCardDescription>
+          </div>
+          {statusBadge[goal.status]}
+        </div>
+      </FinancialCardHeader>
+      <FinancialCardContent className="space-y-4">
+        {/* Progress Bar */}
+        <div>
+          <div className="flex justify-between text-sm mb-1">
+            <span className="text-muted-foreground">Progress</span>
+            <span className="font-medium">{goal.progress}%</span>
+          </div>
+          <Progress value={Math.min(goal.progress, 100)} className="h-3" />
+        </div>
+
+        {/* Milestones */}
+        <div className="flex justify-between">
+          {goal.milestones.map((m) => (
+            <div key={m.percentage} className="flex flex-col items-center gap-1">
+              <Trophy
+                className={`h-4 w-4 ${m.reached ? 'text-yellow-500' : 'text-muted-foreground/30'}`}
+              />
+              <span className={`text-xs ${m.reached ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}>
+                {m.percentage}%
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Deadline */}
+        {goal.deadline && (
+          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+            <Calendar className="h-3.5 w-3.5" />
+            Deadline: {new Date(goal.deadline).toLocaleDateString()}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-2">
+          {goal.status === 'ACTIVE' && (
+            <>
+              <Button size="sm" onClick={onDeposit}>
+                <PiggyBank className="h-3.5 w-3.5 mr-1" />
+                Deposit
+              </Button>
+              <Button size="sm" variant="outline" onClick={onCancel}>
+                Cancel
+              </Button>
+            </>
+          )}
+          <Button size="sm" variant="ghost" className="text-destructive ml-auto" onClick={onDelete}>
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </FinancialCardContent>
+    </FinancialCard>
+  );
+}

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -117,6 +117,19 @@ CREATE TABLE IF NOT EXISTS user_subscriptions (
   started_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS savings_goals (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  target_amount NUMERIC(12,2) NOT NULL,
+  current_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  deadline DATE,
+  status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_goals_user ON savings_goals(user_id, status);
+
 CREATE TABLE IF NOT EXISTS audit_logs (
   id SERIAL PRIMARY KEY,
   user_id INT REFERENCES users(id) ON DELETE SET NULL,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,27 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class GoalStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
+
+
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    target_amount = db.Column(db.Numeric(12, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    deadline = db.Column(db.Date, nullable=True)
+    status = db.Column(
+        db.String(20), default=GoalStatus.ACTIVE.value, nullable=False
+    )
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings_goals import bp as savings_goals_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_goals_bp, url_prefix="/savings-goals")

--- a/packages/backend/app/routes/savings_goals.py
+++ b/packages/backend/app/routes/savings_goals.py
@@ -1,0 +1,175 @@
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import GoalStatus, SavingsGoal, User
+import logging
+
+bp = Blueprint("savings_goals", __name__)
+logger = logging.getLogger("finmind.savings_goals")
+
+
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    status = request.args.get("status")
+    q = db.session.query(SavingsGoal).filter_by(user_id=uid)
+    if status:
+        q = q.filter(SavingsGoal.status == status.upper())
+    items = q.order_by(SavingsGoal.created_at.desc()).all()
+    logger.info("List savings goals user=%s count=%s", uid, len(items))
+    return jsonify([_goal_to_dict(g) for g in items])
+
+
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    target = _parse_amount(data.get("target_amount"))
+    if target is None or target <= 0:
+        return jsonify(error="invalid target_amount"), 400
+    current = _parse_amount(data.get("current_amount") or 0) or Decimal("0")
+    deadline = None
+    if data.get("deadline"):
+        try:
+            deadline = date.fromisoformat(data["deadline"])
+        except ValueError:
+            return jsonify(error="invalid deadline"), 400
+    goal = SavingsGoal(
+        user_id=uid,
+        name=name,
+        target_amount=target,
+        current_amount=current,
+        currency=data.get("currency") or (user.preferred_currency if user else "INR"),
+        deadline=deadline,
+    )
+    db.session.add(goal)
+    db.session.commit()
+    logger.info("Created savings goal id=%s user=%s", goal.id, uid)
+    return jsonify(_goal_to_dict(goal)), 201
+
+
+@bp.get("/<int:goal_id>")
+@jwt_required()
+def get_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.patch("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = (data["name"] or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        goal.name = name
+    if "target_amount" in data:
+        target = _parse_amount(data["target_amount"])
+        if target is None or target <= 0:
+            return jsonify(error="invalid target_amount"), 400
+        goal.target_amount = target
+    if "current_amount" in data:
+        current = _parse_amount(data["current_amount"])
+        if current is None or current < 0:
+            return jsonify(error="invalid current_amount"), 400
+        goal.current_amount = current
+    if "currency" in data:
+        goal.currency = str(data["currency"] or "INR")[:10]
+    if "deadline" in data:
+        if data["deadline"]:
+            try:
+                goal.deadline = date.fromisoformat(data["deadline"])
+            except ValueError:
+                return jsonify(error="invalid deadline"), 400
+        else:
+            goal.deadline = None
+    if "status" in data:
+        status_val = str(data["status"] or "").upper()
+        if status_val not in {s.value for s in GoalStatus}:
+            return jsonify(error="invalid status"), 400
+        goal.status = status_val
+    # Auto-complete when current >= target
+    if float(goal.current_amount) >= float(goal.target_amount):
+        goal.status = GoalStatus.COMPLETED.value
+    db.session.commit()
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.post("/<int:goal_id>/deposit")
+@jwt_required()
+def deposit(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    if goal.status != GoalStatus.ACTIVE.value:
+        return jsonify(error="goal is not active"), 400
+    data = request.get_json() or {}
+    amount = _parse_amount(data.get("amount"))
+    if amount is None or amount <= 0:
+        return jsonify(error="invalid amount"), 400
+    goal.current_amount = Decimal(str(goal.current_amount)) + amount
+    if goal.current_amount >= goal.target_amount:
+        goal.status = GoalStatus.COMPLETED.value
+    db.session.commit()
+    logger.info("Deposit to goal id=%s amount=%s", goal.id, amount)
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(goal)
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+def _goal_to_dict(g: SavingsGoal) -> dict:
+    target = float(g.target_amount)
+    current = float(g.current_amount)
+    progress = round((current / target) * 100, 1) if target > 0 else 0
+    milestones = []
+    for pct in [25, 50, 75, 100]:
+        milestones.append({
+            "percentage": pct,
+            "reached": progress >= pct,
+        })
+    return {
+        "id": g.id,
+        "name": g.name,
+        "target_amount": target,
+        "current_amount": current,
+        "currency": g.currency,
+        "deadline": g.deadline.isoformat() if g.deadline else None,
+        "status": g.status,
+        "progress": progress,
+        "milestones": milestones,
+    }
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None

--- a/packages/backend/app/routes/savings_goals.py
+++ b/packages/backend/app/routes/savings_goals.py
@@ -10,6 +10,13 @@ import logging
 bp = Blueprint("savings_goals", __name__)
 logger = logging.getLogger("finmind.savings_goals")
 
+_MAX_NAME_LENGTH = 200
+_MAX_AMOUNT = Decimal("9999999999.99")  # fits NUMERIC(12,2)
+_VALID_CURRENCIES = {
+    "INR", "USD", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SGD",
+    "HKD", "NZD", "SEK", "NOK", "DKK", "KRW", "ZAR", "BRL", "MXN", "PLN",
+}
+
 
 @bp.get("")
 @jwt_required()
@@ -18,7 +25,10 @@ def list_goals():
     status = request.args.get("status")
     q = db.session.query(SavingsGoal).filter_by(user_id=uid)
     if status:
-        q = q.filter(SavingsGoal.status == status.upper())
+        status_upper = status.upper()
+        if status_upper not in {s.value for s in GoalStatus}:
+            return jsonify(error="invalid status filter"), 400
+        q = q.filter(SavingsGoal.status == status_upper)
     items = q.order_by(SavingsGoal.created_at.desc()).all()
     logger.info("List savings goals user=%s count=%s", uid, len(items))
     return jsonify([_goal_to_dict(g) for g in items])
@@ -30,26 +40,57 @@ def create_goal():
     uid = int(get_jwt_identity())
     user = db.session.get(User, uid)
     data = request.get_json() or {}
+
+    # Validate name
     name = (data.get("name") or "").strip()
     if not name:
         return jsonify(error="name required"), 400
+    if len(name) > _MAX_NAME_LENGTH:
+        return jsonify(error=f"name must be {_MAX_NAME_LENGTH} characters or fewer"), 400
+
+    # Validate target_amount
     target = _parse_amount(data.get("target_amount"))
     if target is None or target <= 0:
         return jsonify(error="invalid target_amount"), 400
+    if target > _MAX_AMOUNT:
+        return jsonify(error="target_amount exceeds maximum"), 400
+
+    # Validate current_amount
     current = _parse_amount(data.get("current_amount") or 0) or Decimal("0")
+    if current < 0:
+        return jsonify(error="current_amount cannot be negative"), 400
+    if current > _MAX_AMOUNT:
+        return jsonify(error="current_amount exceeds maximum"), 400
+
+    # Validate currency
+    currency = _validate_currency(
+        data.get("currency"),
+        fallback=user.preferred_currency if user else "INR",
+    )
+    if currency is None:
+        return jsonify(error="unsupported currency"), 400
+
+    # Validate deadline
     deadline = None
     if data.get("deadline"):
         try:
             deadline = date.fromisoformat(data["deadline"])
         except ValueError:
             return jsonify(error="invalid deadline"), 400
+
+    # Determine initial status (auto-complete if already at target)
+    status = GoalStatus.ACTIVE.value
+    if current >= target:
+        status = GoalStatus.COMPLETED.value
+
     goal = SavingsGoal(
         user_id=uid,
         name=name,
         target_amount=target,
         current_amount=current,
-        currency=data.get("currency") or (user.preferred_currency if user else "INR"),
+        currency=currency,
         deadline=deadline,
+        status=status,
     )
     db.session.add(goal)
     db.session.commit()
@@ -75,23 +116,37 @@ def update_goal(goal_id: int):
     if not goal or goal.user_id != uid:
         return jsonify(error="not found"), 404
     data = request.get_json() or {}
+
     if "name" in data:
         name = (data["name"] or "").strip()
         if not name:
             return jsonify(error="name required"), 400
+        if len(name) > _MAX_NAME_LENGTH:
+            return jsonify(error=f"name must be {_MAX_NAME_LENGTH} characters or fewer"), 400
         goal.name = name
+
     if "target_amount" in data:
         target = _parse_amount(data["target_amount"])
         if target is None or target <= 0:
             return jsonify(error="invalid target_amount"), 400
+        if target > _MAX_AMOUNT:
+            return jsonify(error="target_amount exceeds maximum"), 400
         goal.target_amount = target
+
     if "current_amount" in data:
         current = _parse_amount(data["current_amount"])
         if current is None or current < 0:
             return jsonify(error="invalid current_amount"), 400
+        if current > _MAX_AMOUNT:
+            return jsonify(error="current_amount exceeds maximum"), 400
         goal.current_amount = current
+
     if "currency" in data:
-        goal.currency = str(data["currency"] or "INR")[:10]
+        currency = _validate_currency(data["currency"])
+        if currency is None:
+            return jsonify(error="unsupported currency"), 400
+        goal.currency = currency
+
     if "deadline" in data:
         if data["deadline"]:
             try:
@@ -100,14 +155,17 @@ def update_goal(goal_id: int):
                 return jsonify(error="invalid deadline"), 400
         else:
             goal.deadline = None
+
     if "status" in data:
         status_val = str(data["status"] or "").upper()
         if status_val not in {s.value for s in GoalStatus}:
             return jsonify(error="invalid status"), 400
         goal.status = status_val
+
     # Auto-complete when current >= target
     if float(goal.current_amount) >= float(goal.target_amount):
         goal.status = GoalStatus.COMPLETED.value
+
     db.session.commit()
     return jsonify(_goal_to_dict(goal))
 
@@ -125,11 +183,45 @@ def deposit(goal_id: int):
     amount = _parse_amount(data.get("amount"))
     if amount is None or amount <= 0:
         return jsonify(error="invalid amount"), 400
-    goal.current_amount = Decimal(str(goal.current_amount)) + amount
+    if amount > _MAX_AMOUNT:
+        return jsonify(error="amount exceeds maximum"), 400
+    new_amount = Decimal(str(goal.current_amount)) + amount
+    if new_amount > _MAX_AMOUNT:
+        return jsonify(error="deposit would exceed maximum balance"), 400
+    goal.current_amount = new_amount
     if goal.current_amount >= goal.target_amount:
         goal.status = GoalStatus.COMPLETED.value
     db.session.commit()
     logger.info("Deposit to goal id=%s amount=%s", goal.id, amount)
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.post("/<int:goal_id>/withdraw")
+@jwt_required()
+def withdraw(goal_id: int):
+    """Withdraw funds from a savings goal."""
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    if goal.status not in (GoalStatus.ACTIVE.value, GoalStatus.COMPLETED.value):
+        return jsonify(error="cannot withdraw from cancelled goal"), 400
+    data = request.get_json() or {}
+    amount = _parse_amount(data.get("amount"))
+    if amount is None or amount <= 0:
+        return jsonify(error="invalid amount"), 400
+    current = Decimal(str(goal.current_amount))
+    if amount > current:
+        return jsonify(error="insufficient balance"), 400
+    goal.current_amount = current - amount
+    # If was completed but now below target, revert to active
+    if (
+        goal.status == GoalStatus.COMPLETED.value
+        and float(goal.current_amount) < float(goal.target_amount)
+    ):
+        goal.status = GoalStatus.ACTIVE.value
+    db.session.commit()
+    logger.info("Withdraw from goal id=%s amount=%s", goal.id, amount)
     return jsonify(_goal_to_dict(goal))
 
 
@@ -142,6 +234,7 @@ def delete_goal(goal_id: int):
         return jsonify(error="not found"), 404
     db.session.delete(goal)
     db.session.commit()
+    logger.info("Deleted savings goal id=%s user=%s", goal.id, uid)
     return jsonify(message="deleted")
 
 
@@ -165,11 +258,25 @@ def _goal_to_dict(g: SavingsGoal) -> dict:
         "status": g.status,
         "progress": progress,
         "milestones": milestones,
+        "created_at": g.created_at.isoformat() if g.created_at else None,
     }
 
 
 def _parse_amount(raw) -> Decimal | None:
     try:
-        return Decimal(str(raw)).quantize(Decimal("0.01"))
+        val = Decimal(str(raw)).quantize(Decimal("0.01"))
+        return val
     except (InvalidOperation, ValueError, TypeError):
         return None
+
+
+def _validate_currency(raw, fallback: str | None = None) -> str | None:
+    """Validate and normalize a currency code. Returns None if invalid."""
+    if not raw and fallback:
+        return fallback.upper()[:10]
+    if not raw:
+        return None
+    code = str(raw).strip().upper()[:10]
+    if code in _VALID_CURRENCIES:
+        return code
+    return None

--- a/packages/backend/tests/test_savings_goals.py
+++ b/packages/backend/tests/test_savings_goals.py
@@ -1,0 +1,181 @@
+from datetime import date, timedelta
+
+
+def test_savings_goals_crud(client, auth_header):
+    # Initially empty
+    r = client.get("/savings-goals", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+    # Create goal
+    payload = {
+        "name": "Emergency Fund",
+        "target_amount": 5000,
+        "current_amount": 500,
+        "currency": "USD",
+        "deadline": (date.today() + timedelta(days=180)).isoformat(),
+    }
+    r = client.post("/savings-goals", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    goal = r.get_json()
+    goal_id = goal["id"]
+    assert goal["name"] == "Emergency Fund"
+    assert goal["target_amount"] == 5000.0
+    assert goal["current_amount"] == 500.0
+    assert goal["progress"] == 10.0
+    assert goal["status"] == "ACTIVE"
+    assert len(goal["milestones"]) == 4
+    assert goal["milestones"][0]["percentage"] == 25
+    assert goal["milestones"][0]["reached"] is False
+
+    # Get single goal
+    r = client.get(f"/savings-goals/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["id"] == goal_id
+
+    # List has 1
+    r = client.get("/savings-goals", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 1
+
+    # Update goal
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"name": "Rainy Day Fund", "current_amount": 1500},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    updated = r.get_json()
+    assert updated["name"] == "Rainy Day Fund"
+    assert updated["current_amount"] == 1500.0
+    assert updated["progress"] == 30.0
+    assert updated["milestones"][0]["reached"] is True  # 25% reached
+
+    # Delete goal
+    r = client.delete(f"/savings-goals/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+
+    # List is empty again
+    r = client.get("/savings-goals", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_savings_goal_deposit(client, auth_header):
+    # Create goal
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Vacation", "target_amount": 1000, "currency": "USD"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    goal_id = r.get_json()["id"]
+
+    # Deposit
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 300},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["current_amount"] == 300.0
+    assert r.get_json()["progress"] == 30.0
+
+    # Deposit to complete
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 800},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["current_amount"] == 1100.0
+    assert data["status"] == "COMPLETED"
+    assert all(m["reached"] for m in data["milestones"])
+
+    # Cannot deposit to completed goal
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 50},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_savings_goal_filter_by_status(client, auth_header):
+    # Create two goals
+    client.post(
+        "/savings-goals",
+        json={"name": "Goal A", "target_amount": 100},
+        headers=auth_header,
+    )
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Goal B", "target_amount": 50, "current_amount": 50},
+        headers=auth_header,
+    )
+    # Goal B should auto-complete (current >= target)
+    # but auto-complete only happens on update, so let's trigger it
+    goal_b_id = r.get_json()["id"]
+    client.patch(
+        f"/savings-goals/{goal_b_id}",
+        json={"current_amount": 50},
+        headers=auth_header,
+    )
+
+    # Filter active
+    r = client.get("/savings-goals?status=ACTIVE", headers=auth_header)
+    assert r.status_code == 200
+    names = [g["name"] for g in r.get_json()]
+    assert "Goal A" in names
+
+    # Filter completed
+    r = client.get("/savings-goals?status=COMPLETED", headers=auth_header)
+    assert r.status_code == 200
+    names = [g["name"] for g in r.get_json()]
+    assert "Goal B" in names
+
+
+def test_savings_goal_validation(client, auth_header):
+    # Missing name
+    r = client.post(
+        "/savings-goals",
+        json={"target_amount": 100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Invalid target_amount
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Test", "target_amount": -100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Not found
+    r = client.get("/savings-goals/99999", headers=auth_header)
+    assert r.status_code == 404
+
+    # Invalid deadline
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Test", "target_amount": 100, "deadline": "not-a-date"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_savings_goal_defaults_to_user_currency(client, auth_header):
+    r = client.patch(
+        "/auth/me", json={"preferred_currency": "EUR"}, headers=auth_header
+    )
+    assert r.status_code == 200
+
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Euro Goal", "target_amount": 500},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    assert r.get_json()["currency"] == "EUR"

--- a/packages/backend/tests/test_savings_goals.py
+++ b/packages/backend/tests/test_savings_goals.py
@@ -1,6 +1,10 @@
 from datetime import date, timedelta
 
 
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
 def test_savings_goals_crud(client, auth_header):
     # Initially empty
     r = client.get("/savings-goals", headers=auth_header)
@@ -27,6 +31,7 @@ def test_savings_goals_crud(client, auth_header):
     assert len(goal["milestones"]) == 4
     assert goal["milestones"][0]["percentage"] == 25
     assert goal["milestones"][0]["reached"] is False
+    assert goal["created_at"] is not None  # created_at should be in response
 
     # Get single goal
     r = client.get(f"/savings-goals/{goal_id}", headers=auth_header)
@@ -60,6 +65,10 @@ def test_savings_goals_crud(client, auth_header):
     assert r.status_code == 200
     assert r.get_json() == []
 
+
+# ---------------------------------------------------------------------------
+# Deposit
+# ---------------------------------------------------------------------------
 
 def test_savings_goal_deposit(client, auth_header):
     # Create goal
@@ -100,41 +109,187 @@ def test_savings_goal_deposit(client, auth_header):
         headers=auth_header,
     )
     assert r.status_code == 400
+    assert "not active" in r.get_json()["error"]
 
+
+def test_deposit_invalid_amounts(client, auth_header):
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Test", "target_amount": 1000, "currency": "USD"},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    # Zero amount
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 0},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Negative amount
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": -50},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Non-numeric amount
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": "abc"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Missing amount
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Deposit to non-existent goal
+    r = client.post(
+        "/savings-goals/99999/deposit",
+        json={"amount": 50},
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Withdraw
+# ---------------------------------------------------------------------------
+
+def test_savings_goal_withdraw(client, auth_header):
+    # Create goal with initial amount
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Travel", "target_amount": 2000, "current_amount": 500, "currency": "USD"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    goal_id = r.get_json()["id"]
+
+    # Withdraw some
+    r = client.post(
+        f"/savings-goals/{goal_id}/withdraw",
+        json={"amount": 200},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["current_amount"] == 300.0
+
+    # Cannot withdraw more than balance
+    r = client.post(
+        f"/savings-goals/{goal_id}/withdraw",
+        json={"amount": 500},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "insufficient" in r.get_json()["error"]
+
+
+def test_withdraw_reverts_completed_to_active(client, auth_header):
+    # Create and complete a goal
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Done", "target_amount": 100, "current_amount": 100, "currency": "USD"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    goal_id = r.get_json()["id"]
+    assert r.get_json()["status"] == "COMPLETED"
+
+    # Withdraw to go below target
+    r = client.post(
+        f"/savings-goals/{goal_id}/withdraw",
+        json={"amount": 50},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["status"] == "ACTIVE"
+    assert r.get_json()["current_amount"] == 50.0
+
+
+def test_withdraw_from_cancelled_goal_fails(client, auth_header):
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Cancel Me", "target_amount": 100, "current_amount": 50, "currency": "USD"},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    # Cancel it
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"status": "CANCELLED"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+
+    # Cannot withdraw
+    r = client.post(
+        f"/savings-goals/{goal_id}/withdraw",
+        json={"amount": 10},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "cancelled" in r.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Filter by status
+# ---------------------------------------------------------------------------
 
 def test_savings_goal_filter_by_status(client, auth_header):
     # Create two goals
     client.post(
         "/savings-goals",
-        json={"name": "Goal A", "target_amount": 100},
+        json={"name": "Goal A", "target_amount": 100, "currency": "USD"},
         headers=auth_header,
     )
     r = client.post(
         "/savings-goals",
-        json={"name": "Goal B", "target_amount": 50, "current_amount": 50},
+        json={"name": "Goal B", "target_amount": 50, "current_amount": 50, "currency": "USD"},
         headers=auth_header,
     )
-    # Goal B should auto-complete (current >= target)
-    # but auto-complete only happens on update, so let's trigger it
-    goal_b_id = r.get_json()["id"]
-    client.patch(
-        f"/savings-goals/{goal_b_id}",
-        json={"current_amount": 50},
-        headers=auth_header,
-    )
+    # Goal B should auto-complete on create since current >= target
+    assert r.get_json()["status"] == "COMPLETED"
 
     # Filter active
     r = client.get("/savings-goals?status=ACTIVE", headers=auth_header)
     assert r.status_code == 200
     names = [g["name"] for g in r.get_json()]
     assert "Goal A" in names
+    assert "Goal B" not in names
 
     # Filter completed
     r = client.get("/savings-goals?status=COMPLETED", headers=auth_header)
     assert r.status_code == 200
     names = [g["name"] for g in r.get_json()]
     assert "Goal B" in names
+    assert "Goal A" not in names
 
+    # All
+    r = client.get("/savings-goals", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 2
+
+
+def test_savings_goal_filter_invalid_status(client, auth_header):
+    r = client.get("/savings-goals?status=INVALID", headers=auth_header)
+    assert r.status_code == 400
+    assert "invalid status" in r.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
 
 def test_savings_goal_validation(client, auth_header):
     # Missing name
@@ -144,11 +299,53 @@ def test_savings_goal_validation(client, auth_header):
         headers=auth_header,
     )
     assert r.status_code == 400
+    assert "name" in r.get_json()["error"]
 
-    # Invalid target_amount
+    # Empty name (whitespace only)
+    r = client.post(
+        "/savings-goals",
+        json={"name": "   ", "target_amount": 100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Name too long
+    r = client.post(
+        "/savings-goals",
+        json={"name": "x" * 201, "target_amount": 100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "200" in r.get_json()["error"]
+
+    # Invalid target_amount (negative)
     r = client.post(
         "/savings-goals",
         json={"name": "Test", "target_amount": -100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Invalid target_amount (zero)
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Test", "target_amount": 0},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Invalid target_amount (non-numeric)
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Test", "target_amount": "abc"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Negative current_amount
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Test", "target_amount": 100, "current_amount": -10},
         headers=auth_header,
     )
     assert r.status_code == 400
@@ -165,6 +362,132 @@ def test_savings_goal_validation(client, auth_header):
     )
     assert r.status_code == 400
 
+    # Invalid currency
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Test", "target_amount": 100, "currency": "FAKE"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "currency" in r.get_json()["error"]
+
+
+def test_update_validation(client, auth_header):
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Valid", "target_amount": 100, "currency": "USD"},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    # Update with empty name
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"name": ""},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Update with invalid target
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"target_amount": -1},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Update with negative current
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"current_amount": -1},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Update with invalid status
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"status": "INVALID"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Update with invalid currency
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"currency": "FAKE"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Update with invalid deadline
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"deadline": "not-a-date"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Clear deadline (null) should work
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"deadline": None},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["deadline"] is None
+
+    # Update non-existent goal
+    r = client.patch(
+        "/savings-goals/99999",
+        json={"name": "Nope"},
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+    # Delete non-existent goal
+    r = client.delete("/savings-goals/99999", headers=auth_header)
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Auto-complete on create
+# ---------------------------------------------------------------------------
+
+def test_auto_complete_on_create(client, auth_header):
+    """When current_amount >= target_amount at creation, goal is auto-completed."""
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Already Done", "target_amount": 100, "current_amount": 150, "currency": "USD"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    assert r.get_json()["status"] == "COMPLETED"
+    assert r.get_json()["progress"] == 150.0  # 150% progress
+
+
+def test_auto_complete_on_update(client, auth_header):
+    """When updating current_amount to >= target_amount, goal is auto-completed."""
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Growing", "target_amount": 100, "currency": "USD"},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+    assert r.get_json()["status"] == "ACTIVE"
+
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"current_amount": 100},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["status"] == "COMPLETED"
+
+
+# ---------------------------------------------------------------------------
+# Defaults to user currency
+# ---------------------------------------------------------------------------
 
 def test_savings_goal_defaults_to_user_currency(client, auth_header):
     r = client.patch(
@@ -179,3 +502,176 @@ def test_savings_goal_defaults_to_user_currency(client, auth_header):
     )
     assert r.status_code == 201
     assert r.get_json()["currency"] == "EUR"
+
+
+# ---------------------------------------------------------------------------
+# Authorization (user isolation)
+# ---------------------------------------------------------------------------
+
+def test_user_cannot_access_other_users_goals(client, auth_header):
+    """Goals belong to the authenticated user; another user cannot see/modify them."""
+    # Create goal as user 1
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Private Goal", "target_amount": 1000, "currency": "USD"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    goal_id = r.get_json()["id"]
+
+    # Register and login as user 2
+    email2 = "user2@example.com"
+    password2 = "password456"
+    r = client.post("/auth/register", json={"email": email2, "password": password2})
+    assert r.status_code in (200, 201)
+    r = client.post("/auth/login", json={"email": email2, "password": password2})
+    assert r.status_code == 200
+    header2 = {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+    # User 2 should not see user 1's goals
+    r = client.get("/savings-goals", headers=header2)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 0
+
+    # User 2 cannot get user 1's goal
+    r = client.get(f"/savings-goals/{goal_id}", headers=header2)
+    assert r.status_code == 404
+
+    # User 2 cannot update user 1's goal
+    r = client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"name": "Hacked"},
+        headers=header2,
+    )
+    assert r.status_code == 404
+
+    # User 2 cannot deposit to user 1's goal
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 100},
+        headers=header2,
+    )
+    assert r.status_code == 404
+
+    # User 2 cannot withdraw from user 1's goal
+    r = client.post(
+        f"/savings-goals/{goal_id}/withdraw",
+        json={"amount": 10},
+        headers=header2,
+    )
+    assert r.status_code == 404
+
+    # User 2 cannot delete user 1's goal
+    r = client.delete(f"/savings-goals/{goal_id}", headers=header2)
+    assert r.status_code == 404
+
+    # Verify user 1's goal is still intact
+    r = client.get(f"/savings-goals/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["name"] == "Private Goal"
+
+
+# ---------------------------------------------------------------------------
+# Milestones correctness
+# ---------------------------------------------------------------------------
+
+def test_milestone_progression(client, auth_header):
+    """Verify milestones update correctly as deposits accumulate."""
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Milestone Test", "target_amount": 400, "currency": "USD"},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    # 0% - no milestones reached
+    data = r.get_json()
+    assert all(not m["reached"] for m in data["milestones"])
+
+    # Deposit 100 => 25%
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 100},
+        headers=auth_header,
+    )
+    data = r.get_json()
+    assert data["milestones"][0]["reached"] is True   # 25%
+    assert data["milestones"][1]["reached"] is False   # 50%
+
+    # Deposit 100 => 50%
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 100},
+        headers=auth_header,
+    )
+    data = r.get_json()
+    assert data["milestones"][0]["reached"] is True   # 25%
+    assert data["milestones"][1]["reached"] is True    # 50%
+    assert data["milestones"][2]["reached"] is False   # 75%
+
+    # Deposit 200 => 100%
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 200},
+        headers=auth_header,
+    )
+    data = r.get_json()
+    assert all(m["reached"] for m in data["milestones"])
+    assert data["status"] == "COMPLETED"
+
+
+# ---------------------------------------------------------------------------
+# Deposit to cancelled goal
+# ---------------------------------------------------------------------------
+
+def test_deposit_to_cancelled_goal_fails(client, auth_header):
+    r = client.post(
+        "/savings-goals",
+        json={"name": "Will Cancel", "target_amount": 100, "currency": "USD"},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    # Cancel it
+    client.patch(
+        f"/savings-goals/{goal_id}",
+        json={"status": "CANCELLED"},
+        headers=auth_header,
+    )
+
+    # Cannot deposit
+    r = client.post(
+        f"/savings-goals/{goal_id}/deposit",
+        json={"amount": 10},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "not active" in r.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# No auth
+# ---------------------------------------------------------------------------
+
+def test_savings_goals_require_auth(client):
+    """All endpoints require authentication."""
+    r = client.get("/savings-goals")
+    assert r.status_code == 401
+
+    r = client.post("/savings-goals", json={"name": "X", "target_amount": 100})
+    assert r.status_code == 401
+
+    r = client.get("/savings-goals/1")
+    assert r.status_code == 401
+
+    r = client.patch("/savings-goals/1", json={"name": "Y"})
+    assert r.status_code == 401
+
+    r = client.post("/savings-goals/1/deposit", json={"amount": 10})
+    assert r.status_code == 401
+
+    r = client.post("/savings-goals/1/withdraw", json={"amount": 10})
+    assert r.status_code == 401
+
+    r = client.delete("/savings-goals/1")
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- Added `SavingsGoal` model with CRUD API endpoints (`/savings-goals`)
- Deposit endpoint with auto-completion when target is reached
- Frontend Savings Goals page with progress bars, milestone badges (25%/50%/75%/100%), summary cards
- Status filtering (Active/Completed/Cancelled)
- Added "Savings" link to navigation bar
- Database schema updated with `savings_goals` table
- Comprehensive backend (pytest) and frontend (jest) tests

## Test plan
- [x] Backend: pytest tests for CRUD, deposit, validation, status filter, currency defaults
- [x] Frontend: integration tests for empty state, goals list rendering, summary cards
- [x] Navigation updated with Savings link

/claim #133

https://claude.ai/code/session_01K5UYcnS3skK6SKhFz3dcZs