### PR TITLE
feat: add smart weekly financial digest with trends & email

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import WeeklyDigest from "./pages/WeeklyDigest";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="weekly-digest"
+              element={
+                <ProtectedRoute>
+                  <WeeklyDigest />
                 </ProtectedRoute>
               }
             />

--- a/app/src/__tests__/WeeklyDigest.integration.test.tsx
+++ b/app/src/__tests__/WeeklyDigest.integration.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import WeeklyDigest from '@/pages/WeeklyDigest';
+
+const toastMock = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.PropsWithChildren & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+jest.mock('@/components/ui/badge', () => ({
+  Badge: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLDivElement>) => (
+    <span {...props}>{children}</span>
+  ),
+}));
+jest.mock('@/components/ui/progress', () => ({
+  Progress: ({ value, ...props }: { value: number } & React.HTMLAttributes<HTMLDivElement>) => (
+    <div role="progressbar" aria-valuenow={value} {...props} />
+  ),
+}));
+jest.mock('@/components/ui/financial-card', () => ({
+  FinancialCard: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+  FinancialCardHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardTitle: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLHeadingElement>) => (
+    <h3 {...props}>{children}</h3>
+  ),
+  FinancialCardDescription: ({ children }: React.PropsWithChildren) => <p>{children}</p>,
+  FinancialCardContent: ({ children, ...props }: React.PropsWithChildren & React.HTMLAttributes<HTMLDivElement>) => (
+    <div {...props}>{children}</div>
+  ),
+}));
+jest.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+const digestMock = jest.fn();
+const sendEmailMock = jest.fn();
+
+jest.mock('@/api/insights', () => ({
+  getWeeklyDigest: (...args: unknown[]) => digestMock(...args),
+  sendWeeklyDigestEmail: (...args: unknown[]) => sendEmailMock(...args),
+}));
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+const mockDigest = {
+  period: {
+    week_start: '2026-03-15',
+    week_end: '2026-03-21',
+    prev_week_start: '2026-03-08',
+    prev_week_end: '2026-03-14',
+  },
+  summary: {
+    total_expenses: 350,
+    total_income: 500,
+    net_flow: 150,
+    prev_week_expenses: 400,
+    prev_week_income: 500,
+    wow_change_pct: -12.5,
+    trend: 'down' as const,
+    transaction_count: 8,
+  },
+  category_breakdown: [
+    { category_id: 1, category_name: 'Food', amount: 200, count: 5, share_pct: 57.1 },
+    { category_id: 2, category_name: 'Transport', amount: 150, count: 3, share_pct: 42.9 },
+  ],
+  top_categories: [
+    { category_id: 1, category_name: 'Food', amount: 200, count: 5, share_pct: 57.1 },
+    { category_id: 2, category_name: 'Transport', amount: 150, count: 3, share_pct: 42.9 },
+  ],
+  daily_spending: [
+    { date: '2026-03-15', amount: 50 },
+    { date: '2026-03-16', amount: 75 },
+    { date: '2026-03-17', amount: 0 },
+    { date: '2026-03-18', amount: 100 },
+    { date: '2026-03-19', amount: 25 },
+    { date: '2026-03-20', amount: 50 },
+    { date: '2026-03-21', amount: 50 },
+  ],
+  upcoming_bills: [],
+  insights: ['Great job! You reduced spending by 12.5% compared to last week.'],
+};
+
+describe('WeeklyDigest page', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders digest with summary data', async () => {
+    digestMock.mockResolvedValue(mockDigest);
+    renderWithProviders(<WeeklyDigest />);
+
+    await waitFor(() => {
+      expect(screen.getByText('$350.00')).toBeInTheDocument();
+    });
+    expect(screen.getByText('$500.00')).toBeInTheDocument();
+    expect(screen.getByText('$150.00')).toBeInTheDocument();
+    expect(screen.getByText('-12.5%')).toBeInTheDocument();
+    expect(screen.getByText('Spending Down')).toBeInTheDocument();
+  });
+
+  it('renders top categories', async () => {
+    digestMock.mockResolvedValue(mockDigest);
+    renderWithProviders(<WeeklyDigest />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Food')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Transport')).toBeInTheDocument();
+  });
+
+  it('renders insights', async () => {
+    digestMock.mockResolvedValue(mockDigest);
+    renderWithProviders(<WeeklyDigest />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/reduced spending by 12.5%/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows email digest button', async () => {
+    digestMock.mockResolvedValue(mockDigest);
+    renderWithProviders(<WeeklyDigest />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/email digest/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows week navigation', async () => {
+    digestMock.mockResolvedValue(mockDigest);
+    renderWithProviders(<WeeklyDigest />);
+
+    await waitFor(() => {
+      expect(screen.getByText('2026-03-15 — 2026-03-21')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,59 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type CategoryBreakdown = {
+  category_id: number | null;
+  category_name: string;
+  amount: number;
+  count: number;
+  share_pct: number;
+};
+
+export type DailySpending = {
+  date: string;
+  amount: number;
+};
+
+export type WeeklyDigest = {
+  period: {
+    week_start: string;
+    week_end: string;
+    prev_week_start: string;
+    prev_week_end: string;
+  };
+  summary: {
+    total_expenses: number;
+    total_income: number;
+    net_flow: number;
+    prev_week_expenses: number;
+    prev_week_income: number;
+    wow_change_pct: number;
+    trend: 'up' | 'down' | 'stable';
+    transaction_count: number;
+  };
+  category_breakdown: CategoryBreakdown[];
+  top_categories: CategoryBreakdown[];
+  daily_spending: DailySpending[];
+  upcoming_bills: {
+    id: number;
+    name: string;
+    amount: number;
+    currency: string;
+    next_due_date: string;
+  }[];
+  insights: string[];
+};
+
+export async function getWeeklyDigest(refDate?: string): Promise<WeeklyDigest> {
+  const qs = refDate ? `?date=${refDate}` : '';
+  return api<WeeklyDigest>(`/insights/weekly-digest${qs}`);
+}
+
+export async function sendWeeklyDigestEmail(refDate?: string): Promise<{ sent: boolean }> {
+  const qs = refDate ? `?date=${refDate}` : '';
+  return api<{ sent: boolean }>(`/insights/weekly-digest/send${qs}`, { method: 'POST' });
+}
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Digest', href: '/weekly-digest' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/WeeklyDigest.tsx
+++ b/app/src/pages/WeeklyDigest.tsx
@@ -1,0 +1,248 @@
+import { useState } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+  FinancialCardDescription,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Mail,
+  Calendar,
+  DollarSign,
+  BarChart3,
+  Lightbulb,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
+import { getWeeklyDigest, sendWeeklyDigestEmail, type WeeklyDigest } from '@/api/insights';
+
+export default function WeeklyDigestPage() {
+  const { toast } = useToast();
+  const [refDate, setRefDate] = useState<string | undefined>();
+
+  const { data: digest, isLoading } = useQuery<WeeklyDigest>({
+    queryKey: ['weekly-digest', refDate],
+    queryFn: () => getWeeklyDigest(refDate),
+  });
+
+  const sendEmailMutation = useMutation({
+    mutationFn: () => sendWeeklyDigestEmail(refDate),
+    onSuccess: (data) => {
+      toast({
+        title: data.sent ? 'Email sent' : 'Email not sent',
+        description: data.sent
+          ? 'Weekly digest has been sent to your email.'
+          : 'Could not send email. Check SMTP settings.',
+      });
+    },
+    onError: (err: Error) => {
+      toast({ title: 'Error', description: err.message, variant: 'destructive' });
+    },
+  });
+
+  const navigateWeek = (direction: 'prev' | 'next') => {
+    const current = refDate ? new Date(refDate) : new Date();
+    const offset = direction === 'prev' ? -7 : 7;
+    current.setDate(current.getDate() + offset);
+    setRefDate(current.toISOString().split('T')[0]);
+  };
+
+  const trendIcon = {
+    up: <TrendingUp className="h-5 w-5 text-destructive" />,
+    down: <TrendingDown className="h-5 w-5 text-green-600" />,
+    stable: <Minus className="h-5 w-5 text-muted-foreground" />,
+  };
+
+  const trendBadge = {
+    up: <Badge variant="destructive">Spending Up</Badge>,
+    down: <Badge className="bg-green-100 text-green-800">Spending Down</Badge>,
+    stable: <Badge variant="secondary">Stable</Badge>,
+  };
+
+  return (
+    <div className="container-financial py-8 space-y-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <BarChart3 className="h-6 w-6 text-primary" />
+            Weekly Digest
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Your weekly financial summary and insights
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          onClick={() => sendEmailMutation.mutate()}
+          disabled={sendEmailMutation.isPending}
+        >
+          <Mail className="h-4 w-4 mr-2" />
+          {sendEmailMutation.isPending ? 'Sending...' : 'Email Digest'}
+        </Button>
+      </div>
+
+      {/* Week Navigation */}
+      <div className="flex items-center justify-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => navigateWeek('prev')}>
+          <ChevronLeft className="h-5 w-5" />
+        </Button>
+        <span className="text-sm font-medium">
+          {digest ? `${digest.period.week_start} — ${digest.period.week_end}` : 'Loading...'}
+        </span>
+        <Button variant="ghost" size="icon" onClick={() => navigateWeek('next')}>
+          <ChevronRight className="h-5 w-5" />
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground text-center py-12">Loading digest...</p>
+      ) : !digest ? (
+        <p className="text-muted-foreground text-center py-12">No data available</p>
+      ) : (
+        <>
+          {/* Summary Cards */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <FinancialCard variant="premium">
+              <FinancialCardHeader>
+                <FinancialCardDescription>Total Expenses</FinancialCardDescription>
+                <FinancialCardTitle className="text-2xl">
+                  ${digest.summary.total_expenses.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+            </FinancialCard>
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardDescription>Total Income</FinancialCardDescription>
+                <FinancialCardTitle className="text-2xl text-green-600">
+                  ${digest.summary.total_income.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+            </FinancialCard>
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardDescription>Net Flow</FinancialCardDescription>
+                <FinancialCardTitle className={`text-2xl ${digest.summary.net_flow >= 0 ? 'text-green-600' : 'text-destructive'}`}>
+                  ${digest.summary.net_flow.toLocaleString('en-US', { minimumFractionDigits: 2 })}
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+            </FinancialCard>
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardDescription>Week-over-Week</FinancialCardDescription>
+                <div className="flex items-center gap-2 mt-1">
+                  {trendIcon[digest.summary.trend]}
+                  <FinancialCardTitle className="text-xl">
+                    {digest.summary.wow_change_pct > 0 ? '+' : ''}{digest.summary.wow_change_pct}%
+                  </FinancialCardTitle>
+                </div>
+                <div className="mt-1">{trendBadge[digest.summary.trend]}</div>
+              </FinancialCardHeader>
+            </FinancialCard>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {/* Daily Spending */}
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle className="flex items-center gap-2">
+                  <Calendar className="h-4 w-4" />
+                  Daily Spending
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="space-y-3">
+                  {digest.daily_spending.map((day) => {
+                    const maxAmount = Math.max(...digest.daily_spending.map((d) => d.amount), 1);
+                    const pct = (day.amount / maxAmount) * 100;
+                    return (
+                      <div key={day.date} className="space-y-1">
+                        <div className="flex justify-between text-sm">
+                          <span className="text-muted-foreground">
+                            {new Date(day.date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+                          </span>
+                          <span className="font-medium">${day.amount.toFixed(2)}</span>
+                        </div>
+                        <Progress value={pct} className="h-2" />
+                      </div>
+                    );
+                  })}
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            {/* Top Categories */}
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle className="flex items-center gap-2">
+                  <DollarSign className="h-4 w-4" />
+                  Top Categories
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                {digest.top_categories.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No expenses this week</p>
+                ) : (
+                  <div className="space-y-3">
+                    {digest.top_categories.map((cat) => (
+                      <div key={cat.category_name} className="space-y-1">
+                        <div className="flex justify-between text-sm">
+                          <span className="font-medium">{cat.category_name}</span>
+                          <span>
+                            ${cat.amount.toFixed(2)}{' '}
+                            <span className="text-muted-foreground">({cat.share_pct}%)</span>
+                          </span>
+                        </div>
+                        <Progress value={cat.share_pct} className="h-2" />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </FinancialCardContent>
+            </FinancialCard>
+          </div>
+
+          {/* Insights */}
+          {digest.insights.length > 0 && (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle className="flex items-center gap-2">
+                  <Lightbulb className="h-4 w-4 text-yellow-500" />
+                  Insights
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="space-y-2">
+                  {digest.insights.map((insight, i) => (
+                    <p key={i} className="text-sm text-muted-foreground">
+                      {insight}
+                    </p>
+                  ))}
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+
+          {/* Previous Week Comparison */}
+          <FinancialCard variant="financial" size="sm">
+            <FinancialCardContent>
+              <p className="text-sm text-muted-foreground">
+                Previous week ({digest.period.prev_week_start} to {digest.period.prev_week_end}):
+                expenses ${digest.summary.prev_week_expenses.toFixed(2)}, income ${digest.summary.prev_week_income.toFixed(2)}
+              </p>
+            </FinancialCardContent>
+          </FinancialCard>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,9 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.weekly_digest import generate_weekly_digest, send_weekly_digest_email
+from ..models import User
+from ..extensions import db
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +26,27 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-digest")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    ref = request.args.get("date")
+    ref_date = date.fromisoformat(ref) if ref else None
+    digest = generate_weekly_digest(uid, ref_date)
+    logger.info("Weekly digest served user=%s", uid)
+    return jsonify(digest)
+
+
+@bp.post("/weekly-digest/send")
+@jwt_required()
+def send_digest_email():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="user not found"), 404
+    ref = request.args.get("date")
+    ref_date = date.fromisoformat(ref) if ref else None
+    sent = send_weekly_digest_email(uid, user.email, ref_date)
+    return jsonify(sent=sent)

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -28,14 +28,27 @@ def budget_suggestion():
     return jsonify(suggestion)
 
 
+def _parse_ref_date() -> date | None:
+    """Parse optional ``date`` query-param, returning *None* when absent."""
+    raw = request.args.get("date")
+    if not raw:
+        return None
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
 @bp.get("/weekly-digest")
 @jwt_required()
 def weekly_digest():
     uid = int(get_jwt_identity())
-    ref = request.args.get("date")
-    ref_date = date.fromisoformat(ref) if ref else None
+    ref_date = _parse_ref_date()
+    # Guard against clearly invalid / future dates
+    if ref_date and ref_date > date.today():
+        return jsonify(error="date cannot be in the future"), 400
     digest = generate_weekly_digest(uid, ref_date)
-    logger.info("Weekly digest served user=%s", uid)
+    logger.info("Weekly digest served user=%s date=%s", uid, ref_date)
     return jsonify(digest)
 
 
@@ -46,7 +59,9 @@ def send_digest_email():
     user = db.session.get(User, uid)
     if not user:
         return jsonify(error="user not found"), 404
-    ref = request.args.get("date")
-    ref_date = date.fromisoformat(ref) if ref else None
+    ref_date = _parse_ref_date()
+    if ref_date and ref_date > date.today():
+        return jsonify(error="date cannot be in the future"), 400
     sent = send_weekly_digest_email(uid, user.email, ref_date)
+    logger.info("Digest email sent=%s user=%s", sent, uid)
     return jsonify(sent=sent)

--- a/packages/backend/app/services/weekly_digest.py
+++ b/packages/backend/app/services/weekly_digest.py
@@ -1,0 +1,273 @@
+from datetime import date, timedelta
+from sqlalchemy import func, extract
+from ..extensions import db
+from ..models import Expense, Category, Bill
+from ..services.cache import cache_get, cache_set
+from ..services.reminders import send_email
+import logging
+
+logger = logging.getLogger("finmind.weekly_digest")
+
+DIGEST_CACHE_TTL = 1800  # 30 minutes
+
+
+def generate_weekly_digest(user_id: int, ref_date: date | None = None) -> dict:
+    today = ref_date or date.today()
+    week_end = today
+    week_start = today - timedelta(days=6)
+    prev_week_end = week_start - timedelta(days=1)
+    prev_week_start = prev_week_end - timedelta(days=6)
+
+    cache_key = f"user:{user_id}:weekly_digest:{week_start.isoformat()}"
+    cached = cache_get(cache_key)
+    if cached:
+        return cached
+
+    # Current week expenses
+    current_expenses = _get_expenses_in_range(user_id, week_start, week_end)
+    current_total = sum(float(e.amount) for e in current_expenses if e.expense_type != "INCOME")
+    current_income = sum(float(e.amount) for e in current_expenses if e.expense_type == "INCOME")
+
+    # Previous week expenses
+    prev_expenses = _get_expenses_in_range(user_id, prev_week_start, prev_week_end)
+    prev_total = sum(float(e.amount) for e in prev_expenses if e.expense_type != "INCOME")
+    prev_income = sum(float(e.amount) for e in prev_expenses if e.expense_type == "INCOME")
+
+    # Week-over-week change
+    if prev_total > 0:
+        wow_change_pct = round(((current_total - prev_total) / prev_total) * 100, 1)
+    else:
+        wow_change_pct = 0.0 if current_total == 0 else 100.0
+
+    # Category breakdown for current week
+    category_breakdown = _get_category_breakdown(user_id, week_start, week_end)
+
+    # Top categories
+    top_categories = sorted(category_breakdown, key=lambda c: c["amount"], reverse=True)[:5]
+
+    # Daily spending for current week
+    daily_spending = _get_daily_spending(user_id, week_start, week_end)
+
+    # Spending trend (up/down/stable)
+    if wow_change_pct > 5:
+        trend = "up"
+    elif wow_change_pct < -5:
+        trend = "down"
+    else:
+        trend = "stable"
+
+    # Upcoming bills in next 7 days
+    upcoming_bills = _get_upcoming_bills(user_id, today, today + timedelta(days=7))
+
+    # Insights
+    insights = _generate_insights(
+        current_total, prev_total, wow_change_pct, trend, top_categories, current_income
+    )
+
+    digest = {
+        "period": {
+            "week_start": week_start.isoformat(),
+            "week_end": week_end.isoformat(),
+            "prev_week_start": prev_week_start.isoformat(),
+            "prev_week_end": prev_week_end.isoformat(),
+        },
+        "summary": {
+            "total_expenses": round(current_total, 2),
+            "total_income": round(current_income, 2),
+            "net_flow": round(current_income - current_total, 2),
+            "prev_week_expenses": round(prev_total, 2),
+            "prev_week_income": round(prev_income, 2),
+            "wow_change_pct": wow_change_pct,
+            "trend": trend,
+            "transaction_count": len(current_expenses),
+        },
+        "category_breakdown": category_breakdown,
+        "top_categories": top_categories,
+        "daily_spending": daily_spending,
+        "upcoming_bills": upcoming_bills,
+        "insights": insights,
+    }
+
+    cache_set(cache_key, digest, ttl_seconds=DIGEST_CACHE_TTL)
+    return digest
+
+
+def send_weekly_digest_email(user_id: int, to_email: str, ref_date: date | None = None) -> bool:
+    digest = generate_weekly_digest(user_id, ref_date)
+    summary = digest["summary"]
+    period = digest["period"]
+
+    subject = f"FinMind Weekly Digest: {period['week_start']} to {period['week_end']}"
+
+    body_lines = [
+        f"Your Weekly Financial Summary ({period['week_start']} to {period['week_end']})",
+        "",
+        f"Total Expenses: ${summary['total_expenses']:.2f}",
+        f"Total Income: ${summary['total_income']:.2f}",
+        f"Net Flow: ${summary['net_flow']:.2f}",
+        f"Week-over-Week Change: {summary['wow_change_pct']:+.1f}%",
+        f"Trend: {summary['trend'].capitalize()}",
+        f"Transactions: {summary['transaction_count']}",
+        "",
+        "Top Categories:",
+    ]
+
+    for cat in digest["top_categories"]:
+        body_lines.append(f"  - {cat['category_name']}: ${cat['amount']:.2f} ({cat['share_pct']:.1f}%)")
+
+    if digest["upcoming_bills"]:
+        body_lines.append("")
+        body_lines.append("Upcoming Bills (next 7 days):")
+        for bill in digest["upcoming_bills"]:
+            body_lines.append(f"  - {bill['name']}: ${bill['amount']:.2f} (due {bill['next_due_date']})")
+
+    if digest["insights"]:
+        body_lines.append("")
+        body_lines.append("Insights:")
+        for insight in digest["insights"]:
+            body_lines.append(f"  - {insight}")
+
+    body = "\n".join(body_lines)
+    result = send_email(to_email, subject, body)
+    logger.info("Weekly digest email sent=%s user=%s", result, user_id)
+    return result
+
+
+def _get_expenses_in_range(user_id: int, start: date, end: date) -> list:
+    return (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .all()
+    )
+
+
+def _get_category_breakdown(user_id: int, start: date, end: date) -> list[dict]:
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(Category.name, "Uncategorized").label("category_name"),
+            func.coalesce(func.sum(Expense.amount), 0).label("total_amount"),
+            func.count(Expense.id).label("count"),
+        )
+        .outerjoin(
+            Category,
+            (Category.id == Expense.category_id) & (Category.user_id == user_id),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id, Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .all()
+    )
+    total = sum(float(r.total_amount or 0) for r in rows)
+    return [
+        {
+            "category_id": r.category_id,
+            "category_name": r.category_name,
+            "amount": round(float(r.total_amount or 0), 2),
+            "count": r.count,
+            "share_pct": round((float(r.total_amount or 0) / total) * 100, 1) if total > 0 else 0,
+        }
+        for r in rows
+    ]
+
+
+def _get_daily_spending(user_id: int, start: date, end: date) -> list[dict]:
+    rows = (
+        db.session.query(
+            Expense.spent_at,
+            func.coalesce(func.sum(Expense.amount), 0).label("total"),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.spent_at)
+        .order_by(Expense.spent_at)
+        .all()
+    )
+    spent_map = {r.spent_at: float(r.total) for r in rows}
+    result = []
+    current = start
+    while current <= end:
+        result.append({
+            "date": current.isoformat(),
+            "amount": round(spent_map.get(current, 0), 2),
+        })
+        current += timedelta(days=1)
+    return result
+
+
+def _get_upcoming_bills(user_id: int, start: date, end: date) -> list[dict]:
+    bills = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == user_id,
+            Bill.active.is_(True),
+            Bill.next_due_date >= start,
+            Bill.next_due_date <= end,
+        )
+        .order_by(Bill.next_due_date)
+        .all()
+    )
+    return [
+        {
+            "id": b.id,
+            "name": b.name,
+            "amount": float(b.amount),
+            "currency": b.currency,
+            "next_due_date": b.next_due_date.isoformat(),
+        }
+        for b in bills
+    ]
+
+
+def _generate_insights(
+    current_total: float,
+    prev_total: float,
+    wow_pct: float,
+    trend: str,
+    top_categories: list[dict],
+    current_income: float,
+) -> list[str]:
+    insights = []
+
+    if trend == "up" and abs(wow_pct) > 10:
+        insights.append(
+            f"Your spending increased by {wow_pct:.1f}% compared to last week. "
+            "Consider reviewing your expenses."
+        )
+    elif trend == "down":
+        insights.append(
+            f"Great job! You reduced spending by {abs(wow_pct):.1f}% compared to last week."
+        )
+    elif trend == "stable":
+        insights.append("Your spending is consistent with last week.")
+
+    if current_income > 0 and current_total > current_income:
+        insights.append(
+            f"You spent ${current_total - current_income:.2f} more than you earned this week."
+        )
+    elif current_income > 0 and current_total < current_income:
+        savings = current_income - current_total
+        insights.append(f"You saved ${savings:.2f} this week. Keep it up!")
+
+    if top_categories:
+        top = top_categories[0]
+        if top["share_pct"] > 50:
+            insights.append(
+                f"{top['category_name']} accounts for {top['share_pct']:.0f}% of your spending. "
+                "Consider diversifying or reducing this category."
+            )
+
+    return insights

--- a/packages/backend/app/services/weekly_digest.py
+++ b/packages/backend/app/services/weekly_digest.py
@@ -1,5 +1,5 @@
 from datetime import date, timedelta
-from sqlalchemy import func, extract
+from sqlalchemy import func
 from ..extensions import db
 from ..models import Expense, Category, Bill
 from ..services.cache import cache_get, cache_set
@@ -61,7 +61,8 @@ def generate_weekly_digest(user_id: int, ref_date: date | None = None) -> dict:
 
     # Insights
     insights = _generate_insights(
-        current_total, prev_total, wow_change_pct, trend, top_categories, current_income
+        current_total, prev_total, wow_change_pct, trend, top_categories, current_income,
+        daily_spending,
     )
 
     digest = {
@@ -239,9 +240,11 @@ def _generate_insights(
     trend: str,
     top_categories: list[dict],
     current_income: float,
+    daily_spending: list[dict] | None = None,
 ) -> list[str]:
     insights = []
 
+    # Trend insight
     if trend == "up" and abs(wow_pct) > 10:
         insights.append(
             f"Your spending increased by {wow_pct:.1f}% compared to last week. "
@@ -254,20 +257,37 @@ def _generate_insights(
     elif trend == "stable":
         insights.append("Your spending is consistent with last week.")
 
+    # Income vs. expenses
     if current_income > 0 and current_total > current_income:
         insights.append(
             f"You spent ${current_total - current_income:.2f} more than you earned this week."
         )
     elif current_income > 0 and current_total < current_income:
         savings = current_income - current_total
-        insights.append(f"You saved ${savings:.2f} this week. Keep it up!")
+        savings_rate = round((savings / current_income) * 100, 1)
+        insights.append(
+            f"You saved ${savings:.2f} this week ({savings_rate}% savings rate). Keep it up!"
+        )
 
+    # Dominant category warning
     if top_categories:
         top = top_categories[0]
         if top["share_pct"] > 50:
             insights.append(
                 f"{top['category_name']} accounts for {top['share_pct']:.0f}% of your spending. "
                 "Consider diversifying or reducing this category."
+            )
+
+    # Average daily spend & peak day
+    if daily_spending:
+        amounts = [d["amount"] for d in daily_spending]
+        nonzero = [a for a in amounts if a > 0]
+        if nonzero:
+            avg_daily = sum(nonzero) / len(nonzero)
+            peak = max(daily_spending, key=lambda d: d["amount"])
+            insights.append(
+                f"Your average daily spend was ${avg_daily:.2f}. "
+                f"Peak spending day: {peak['date']} (${peak['amount']:.2f})."
             )
 
     return insights

--- a/packages/backend/tests/test_weekly_digest.py
+++ b/packages/backend/tests/test_weekly_digest.py
@@ -1,0 +1,131 @@
+from datetime import date, timedelta
+
+
+def _create_expenses(client, auth_header, days_ago_amounts):
+    for days_ago, amount, exp_type in days_ago_amounts:
+        d = (date.today() - timedelta(days=days_ago)).isoformat()
+        client.post(
+            "/expenses",
+            json={
+                "amount": amount,
+                "description": f"Expense {amount}",
+                "date": d,
+                "expense_type": exp_type,
+            },
+            headers=auth_header,
+        )
+
+
+def test_weekly_digest_empty(client, auth_header):
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "period" in data
+    assert "summary" in data
+    assert "category_breakdown" in data
+    assert "daily_spending" in data
+    assert "insights" in data
+    assert data["summary"]["total_expenses"] == 0
+    assert data["summary"]["transaction_count"] == 0
+    assert len(data["daily_spending"]) == 7
+
+
+def test_weekly_digest_with_expenses(client, auth_header):
+    _create_expenses(client, auth_header, [
+        (0, 50, "EXPENSE"),
+        (1, 30, "EXPENSE"),
+        (2, 100, "INCOME"),
+        (3, 20, "EXPENSE"),
+    ])
+
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["summary"]["total_expenses"] == 100.0
+    assert data["summary"]["total_income"] == 100.0
+    assert data["summary"]["net_flow"] == 0.0
+    assert data["summary"]["transaction_count"] == 4
+
+
+def test_weekly_digest_wow_comparison(client, auth_header):
+    # Previous week: spend 200
+    _create_expenses(client, auth_header, [
+        (10, 100, "EXPENSE"),
+        (11, 100, "EXPENSE"),
+    ])
+    # Current week: spend 100
+    _create_expenses(client, auth_header, [
+        (0, 50, "EXPENSE"),
+        (1, 50, "EXPENSE"),
+    ])
+
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    # Current week: 100, prev week: 200 -> -50%
+    assert data["summary"]["wow_change_pct"] == -50.0
+    assert data["summary"]["trend"] == "down"
+
+
+def test_weekly_digest_with_ref_date(client, auth_header):
+    ref = (date.today() - timedelta(days=14)).isoformat()
+    r = client.get(f"/insights/weekly-digest?date={ref}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["period"]["week_end"] == ref
+
+
+def test_weekly_digest_insights_generated(client, auth_header):
+    # Create expenses to trigger insights
+    _create_expenses(client, auth_header, [
+        (0, 500, "EXPENSE"),
+        (0, 200, "INCOME"),
+    ])
+
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    # Should have at least one insight
+    assert len(data["insights"]) >= 1
+
+
+def test_weekly_digest_category_breakdown(client, auth_header):
+    # Create a category
+    r = client.post(
+        "/categories", json={"name": "Food"}, headers=auth_header
+    )
+    assert r.status_code == 201
+    cat_id = r.get_json()["id"]
+
+    # Create expense with category
+    client.post(
+        "/expenses",
+        json={
+            "amount": 75,
+            "description": "Groceries",
+            "date": date.today().isoformat(),
+            "category_id": cat_id,
+        },
+        headers=auth_header,
+    )
+
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["category_breakdown"]) >= 1
+    assert data["category_breakdown"][0]["category_name"] == "Food"
+    assert data["category_breakdown"][0]["share_pct"] == 100.0
+
+
+def test_weekly_digest_daily_spending_all_days(client, auth_header):
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["daily_spending"]) == 7
+
+
+def test_send_digest_email_endpoint(client, auth_header):
+    r = client.post("/insights/weekly-digest/send", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "sent" in data

--- a/packages/backend/tests/test_weekly_digest.py
+++ b/packages/backend/tests/test_weekly_digest.py
@@ -129,3 +129,71 @@ def test_send_digest_email_endpoint(client, auth_header):
     assert r.status_code == 200
     data = r.get_json()
     assert "sent" in data
+
+
+def test_weekly_digest_future_date_rejected(client, auth_header):
+    future = (date.today() + timedelta(days=7)).isoformat()
+    r = client.get(f"/insights/weekly-digest?date={future}", headers=auth_header)
+    assert r.status_code == 400
+    assert "future" in r.get_json()["error"]
+
+
+def test_send_digest_email_future_date_rejected(client, auth_header):
+    future = (date.today() + timedelta(days=7)).isoformat()
+    r = client.post(f"/insights/weekly-digest/send?date={future}", headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_weekly_digest_invalid_date_ignored(client, auth_header):
+    r = client.get("/insights/weekly-digest?date=not-a-date", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["period"]["week_end"] == date.today().isoformat()
+
+
+def test_weekly_digest_savings_rate_insight(client, auth_header):
+    _create_expenses(client, auth_header, [
+        (0, 200, "EXPENSE"),
+        (0, 1000, "INCOME"),
+    ])
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    # Should mention savings rate
+    assert any("savings rate" in i.lower() for i in data["insights"])
+
+
+def test_weekly_digest_daily_avg_insight(client, auth_header):
+    _create_expenses(client, auth_header, [
+        (0, 100, "EXPENSE"),
+        (1, 50, "EXPENSE"),
+        (2, 75, "EXPENSE"),
+    ])
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert any("average daily" in i.lower() for i in data["insights"])
+
+
+def test_weekly_digest_upcoming_bills(client, auth_header):
+    # Create a bill due within 7 days
+    client.post(
+        "/bills",
+        json={
+            "name": "Rent",
+            "amount": 1200,
+            "next_due_date": (date.today() + timedelta(days=3)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    r = client.get("/insights/weekly-digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["upcoming_bills"]) >= 1
+    assert data["upcoming_bills"][0]["name"] == "Rent"
+
+
+def test_weekly_digest_requires_auth(client):
+    r = client.get("/insights/weekly-digest")
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary
- Weekly digest service: expense aggregation, week-over-week comparison, category breakdown, daily spending, trend detection (up/down/stable), auto-generated insights
- API endpoints: `GET /insights/weekly-digest` (with date navigation), `POST /insights/weekly-digest/send` (email via SMTP)
- Frontend: WeeklyDigest page with summary cards (expenses, income, net flow, WoW %), daily spending bars, top categories with progress bars, insights panel, week navigation arrows, email digest button
- Added "Digest" link to navigation bar
- 30-minute cache TTL on digest data

## Test plan
- [x] Backend: 9 pytest tests (empty state, with expenses, WoW comparison, ref date navigation, insights generation, category breakdown, daily spending completeness, email endpoint)
- [x] Frontend: 5 jest integration tests (summary rendering, categories, insights, email button, week navigation)

/claim #121

https://claude.ai/code/session_01K5UYcnS3skK6SKhFz3dcZs