### PR TITLE
feat: Goal-based savings tracking & milestones (#133)

### DIFF
--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,34 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Goal-based savings tracking — issue #133
+CREATE TABLE IF NOT EXISTS savings_goals (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  description VARCHAR(500),
+  target_amount NUMERIC(14, 2) NOT NULL,
+  current_amount NUMERIC(14, 2) NOT NULL DEFAULT 0.00,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  deadline DATE,
+  status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS savings_milestones (
+  id SERIAL PRIMARY KEY,
+  goal_id INT NOT NULL REFERENCES savings_goals(id) ON DELETE CASCADE,
+  label VARCHAR(200) NOT NULL,
+  target_pct NUMERIC(5, 2) NOT NULL,
+  reached BOOLEAN NOT NULL DEFAULT FALSE,
+  reached_at TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS savings_deposits (
+  id SERIAL PRIMARY KEY,
+  goal_id INT NOT NULL REFERENCES savings_goals(id) ON DELETE CASCADE,
+  amount NUMERIC(14, 2) NOT NULL,
+  note VARCHAR(300),
+  deposited_at DATE NOT NULL DEFAULT CURRENT_DATE
+);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,62 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+# ---------------------------------------------------------------------------
+# Goal-based savings tracking — issue #133
+# ---------------------------------------------------------------------------
+
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.String(500), nullable=True)
+    target_amount = db.Column(db.Numeric(14, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(14, 2), default=0, nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    deadline = db.Column(db.Date, nullable=True)
+    # ACTIVE | PAUSED | COMPLETED | CANCELLED
+    status = db.Column(db.String(20), default="ACTIVE", nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    milestones = db.relationship(
+        "SavingsMilestone",
+        backref="goal",
+        lazy="select",
+        cascade="all, delete-orphan",
+        order_by="SavingsMilestone.target_pct",
+    )
+    deposits = db.relationship(
+        "SavingsDeposit",
+        backref="goal",
+        lazy="select",
+        cascade="all, delete-orphan",
+    )
+
+
+class SavingsMilestone(db.Model):
+    __tablename__ = "savings_milestones"
+    id = db.Column(db.Integer, primary_key=True)
+    goal_id = db.Column(
+        db.Integer, db.ForeignKey("savings_goals.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    label = db.Column(db.String(200), nullable=False)
+    # Percentage of target_amount (0–100)
+    target_pct = db.Column(db.Numeric(5, 2), nullable=False)
+    reached = db.Column(db.Boolean, default=False, nullable=False)
+    reached_at = db.Column(db.DateTime, nullable=True)
+
+
+class SavingsDeposit(db.Model):
+    __tablename__ = "savings_deposits"
+    id = db.Column(db.Integer, primary_key=True)
+    goal_id = db.Column(
+        db.Integer, db.ForeignKey("savings_goals.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    amount = db.Column(db.Numeric(14, 2), nullable=False)
+    note = db.Column(db.String(300), nullable=True)
+    deposited_at = db.Column(db.Date, default=date.today, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .goals import bp as goals_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(goals_bp, url_prefix="/goals")

--- a/packages/backend/app/routes/goals.py
+++ b/packages/backend/app/routes/goals.py
@@ -1,0 +1,350 @@
+"""Goal-based savings tracking & milestones — issue #133."""
+
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import SavingsGoal, SavingsMilestone, SavingsDeposit
+import logging
+
+bp = Blueprint("goals", __name__)
+logger = logging.getLogger("finmind.goals")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _goal_to_dict(goal: SavingsGoal, include_milestones: bool = True) -> dict:
+    progress_pct = 0.0
+    if goal.target_amount and goal.target_amount > 0:
+        progress_pct = float(goal.current_amount / goal.target_amount * 100)
+        progress_pct = min(progress_pct, 100.0)
+
+    d = {
+        "id": goal.id,
+        "name": goal.name,
+        "description": goal.description,
+        "target_amount": float(goal.target_amount),
+        "current_amount": float(goal.current_amount),
+        "currency": goal.currency,
+        "deadline": goal.deadline.isoformat() if goal.deadline else None,
+        "status": goal.status,
+        "progress_pct": round(progress_pct, 2),
+        "created_at": goal.created_at.isoformat(),
+    }
+    if include_milestones:
+        d["milestones"] = [_milestone_to_dict(m) for m in goal.milestones]
+    return d
+
+
+def _milestone_to_dict(m: SavingsMilestone) -> dict:
+    return {
+        "id": m.id,
+        "goal_id": m.goal_id,
+        "label": m.label,
+        "target_pct": float(m.target_pct),
+        "reached": m.reached,
+        "reached_at": m.reached_at.isoformat() if m.reached_at else None,
+    }
+
+
+def _deposit_to_dict(d: SavingsDeposit) -> dict:
+    return {
+        "id": d.id,
+        "goal_id": d.goal_id,
+        "amount": float(d.amount),
+        "note": d.note,
+        "deposited_at": d.deposited_at.isoformat(),
+    }
+
+
+def _sync_milestones(goal: SavingsGoal) -> list[SavingsMilestone]:
+    """Mark any milestones that have been reached by the current progress."""
+    if not goal.target_amount or goal.target_amount == 0:
+        return []
+    pct_reached = goal.current_amount / goal.target_amount * 100
+    newly_reached = []
+    for m in goal.milestones:
+        if not m.reached and pct_reached >= m.target_pct:
+            m.reached = True
+            m.reached_at = datetime.utcnow()
+            newly_reached.append(m)
+    return newly_reached
+
+
+def _update_goal_status(goal: SavingsGoal) -> None:
+    """Auto-complete goal when target is reached; set active otherwise."""
+    if goal.current_amount >= goal.target_amount:
+        goal.status = "COMPLETED"
+    elif goal.status == "COMPLETED":
+        # Amount decreased below target — revert to active
+        goal.status = "ACTIVE"
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    status_filter = request.args.get("status")
+    q = db.session.query(SavingsGoal).filter_by(user_id=uid)
+    if status_filter:
+        q = q.filter(SavingsGoal.status == status_filter.upper())
+    goals = q.order_by(SavingsGoal.created_at.desc()).all()
+    logger.info("List goals user=%s count=%s", uid, len(goals))
+    return jsonify([_goal_to_dict(g) for g in goals])
+
+
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+
+    target = _parse_amount(data.get("target_amount"))
+    if target is None or target <= 0:
+        return jsonify(error="target_amount must be a positive number"), 400
+
+    deadline = None
+    if data.get("deadline"):
+        try:
+            deadline = date.fromisoformat(data["deadline"])
+        except ValueError:
+            return jsonify(error="invalid deadline date"), 400
+
+    goal = SavingsGoal(
+        user_id=uid,
+        name=name,
+        description=(data.get("description") or "").strip() or None,
+        target_amount=target,
+        current_amount=Decimal("0.00"),
+        currency=str(data.get("currency") or "INR")[:10],
+        deadline=deadline,
+        status="ACTIVE",
+    )
+    db.session.add(goal)
+    db.session.flush()  # get goal.id before adding milestones
+
+    # Optionally seed default milestones (25 / 50 / 75 / 100 %)
+    if data.get("auto_milestones", True):
+        for pct, label in [
+            (25, "25% reached"),
+            (50, "Halfway there!"),
+            (75, "75% reached"),
+            (100, "Goal complete! 🎉"),
+        ]:
+            db.session.add(
+                SavingsMilestone(
+                    goal_id=goal.id,
+                    label=label,
+                    target_pct=Decimal(str(pct)),
+                    reached=False,
+                )
+            )
+
+    db.session.commit()
+    logger.info("Created goal id=%s user=%s target=%s", goal.id, uid, target)
+    return jsonify(_goal_to_dict(goal)), 201
+
+
+@bp.get("/<int:goal_id>")
+@jwt_required()
+def get_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.patch("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+
+    if "name" in data:
+        name = (data["name"] or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        goal.name = name
+
+    if "description" in data:
+        goal.description = (data["description"] or "").strip() or None
+
+    if "target_amount" in data:
+        target = _parse_amount(data["target_amount"])
+        if target is None or target <= 0:
+            return jsonify(error="target_amount must be positive"), 400
+        goal.target_amount = target
+
+    if "currency" in data:
+        goal.currency = str(data["currency"] or "INR")[:10]
+
+    if "deadline" in data:
+        if data["deadline"] is None:
+            goal.deadline = None
+        else:
+            try:
+                goal.deadline = date.fromisoformat(data["deadline"])
+            except ValueError:
+                return jsonify(error="invalid deadline date"), 400
+
+    if "status" in data:
+        status = str(data["status"]).upper()
+        if status not in ("ACTIVE", "PAUSED", "COMPLETED", "CANCELLED"):
+            return jsonify(error="invalid status"), 400
+        goal.status = status
+
+    _update_goal_status(goal)
+    db.session.commit()
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(goal)
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+# ---------------------------------------------------------------------------
+# Deposits
+# ---------------------------------------------------------------------------
+
+@bp.post("/<int:goal_id>/deposit")
+@jwt_required()
+def deposit_to_goal(goal_id: int):
+    """Add funds toward a savings goal."""
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    if goal.status in ("CANCELLED",):
+        return jsonify(error="cannot deposit into a cancelled goal"), 400
+
+    data = request.get_json() or {}
+    amount = _parse_amount(data.get("amount"))
+    if amount is None or amount <= 0:
+        return jsonify(error="amount must be a positive number"), 400
+
+    deposit = SavingsDeposit(
+        goal_id=goal.id,
+        amount=amount,
+        note=(data.get("note") or "").strip() or None,
+        deposited_at=date.today(),
+    )
+    db.session.add(deposit)
+
+    goal.current_amount = goal.current_amount + amount
+    newly_reached = _sync_milestones(goal)
+    _update_goal_status(goal)
+
+    db.session.commit()
+    logger.info(
+        "Deposit goal=%s user=%s amount=%s newly_reached=%s",
+        goal.id, uid, amount, len(newly_reached),
+    )
+    return jsonify(
+        goal=_goal_to_dict(goal),
+        deposit=_deposit_to_dict(deposit),
+        milestones_reached=[_milestone_to_dict(m) for m in newly_reached],
+    ), 200
+
+
+@bp.get("/<int:goal_id>/deposits")
+@jwt_required()
+def list_deposits(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    deposits = (
+        db.session.query(SavingsDeposit)
+        .filter_by(goal_id=goal_id)
+        .order_by(SavingsDeposit.deposited_at.desc())
+        .all()
+    )
+    return jsonify([_deposit_to_dict(d) for d in deposits])
+
+
+# ---------------------------------------------------------------------------
+# Milestones
+# ---------------------------------------------------------------------------
+
+@bp.post("/<int:goal_id>/milestones")
+@jwt_required()
+def add_milestone(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    label = (data.get("label") or "").strip()
+    if not label:
+        return jsonify(error="label required"), 400
+
+    try:
+        target_pct = Decimal(str(data.get("target_pct", 0)))
+    except (InvalidOperation, ValueError):
+        return jsonify(error="invalid target_pct"), 400
+
+    if target_pct <= 0 or target_pct > 100:
+        return jsonify(error="target_pct must be between 1 and 100"), 400
+
+    m = SavingsMilestone(
+        goal_id=goal.id,
+        label=label,
+        target_pct=target_pct,
+        reached=False,
+    )
+    db.session.add(m)
+    db.session.flush()
+    # Immediately check if already reached
+    _sync_milestones(goal)
+    db.session.commit()
+    return jsonify(_milestone_to_dict(m)), 201
+
+
+@bp.delete("/<int:goal_id>/milestones/<int:milestone_id>")
+@jwt_required()
+def delete_milestone(goal_id: int, milestone_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    m = db.session.get(SavingsMilestone, milestone_id)
+    if not m or m.goal_id != goal_id:
+        return jsonify(error="not found"), 404
+    db.session.delete(m)
+    db.session.commit()
+    return jsonify(message="deleted")

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
 import pytest
+import fakeredis
+from unittest.mock import patch
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
 
 
@@ -20,7 +21,13 @@ def _setup_db(app):
 
 
 @pytest.fixture()
-def app_fixture():
+def fake_redis():
+    """Provide a fake in-memory Redis client for all tests."""
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture()
+def app_fixture(fake_redis):
     # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
     settings = TestSettings(
@@ -28,21 +35,16 @@ def app_fixture():
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
-    app = create_app(settings)
-    app.config.update(TESTING=True)
-    _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
-    yield app
-    with app.app_context():
-        db.session.remove()
-        db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    with patch("app.extensions.redis_client", fake_redis), \
+         patch("app.routes.auth.redis_client", fake_redis), \
+         patch("app.services.cache.redis_client", fake_redis):
+        app = create_app(settings)
+        app.config.update(TESTING=True)
+        _setup_db(app)
+        yield app
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
 
 
 @pytest.fixture()
@@ -63,6 +65,6 @@ def auth_header(client):
         409,
     ), register_debug  # 409 if already exists
     r = client.post("/auth/login", json={"email": email, "password": password})
-    assert r.status_code == 200
+    assert r.status_code == 200, f"login failed: {r.get_json()}"
     access = r.get_json()["access_token"]
     return {"Authorization": f"Bearer {access}"}

--- a/packages/backend/tests/test_goals.py
+++ b/packages/backend/tests/test_goals.py
@@ -1,0 +1,301 @@
+"""Tests for goal-based savings tracking — issue #133."""
+
+from datetime import date, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_goal(client, auth_header, **overrides):
+    payload = {
+        "name": "Emergency Fund",
+        "target_amount": 1000.00,
+        "currency": "USD",
+        "auto_milestones": False,
+        **overrides,
+    }
+    return client.post("/goals", json=payload, headers=auth_header)
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+def test_create_and_list_goal(client, auth_header):
+    r = _create_goal(client, auth_header)
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["name"] == "Emergency Fund"
+    assert data["target_amount"] == 1000.00
+    assert data["current_amount"] == 0.00
+    assert data["status"] == "ACTIVE"
+    assert data["progress_pct"] == 0.0
+
+    r = client.get("/goals", headers=auth_header)
+    assert r.status_code == 200
+    goals = r.get_json()
+    assert any(g["name"] == "Emergency Fund" for g in goals)
+
+
+def test_get_goal(client, auth_header):
+    r = _create_goal(client, auth_header)
+    goal_id = r.get_json()["id"]
+
+    r = client.get(f"/goals/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["id"] == goal_id
+
+
+def test_get_goal_not_found(client, auth_header):
+    r = client.get("/goals/99999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_update_goal(client, auth_header):
+    r = _create_goal(client, auth_header)
+    goal_id = r.get_json()["id"]
+
+    r = client.patch(
+        f"/goals/{goal_id}",
+        json={"name": "Vacation Fund", "target_amount": 2000},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["name"] == "Vacation Fund"
+    assert data["target_amount"] == 2000.00
+
+
+def test_delete_goal(client, auth_header):
+    r = _create_goal(client, auth_header)
+    goal_id = r.get_json()["id"]
+
+    r = client.delete(f"/goals/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "deleted"
+
+    r = client.get(f"/goals/{goal_id}", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_create_goal_missing_name(client, auth_header):
+    r = client.post(
+        "/goals",
+        json={"target_amount": 500},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "name" in r.get_json()["error"]
+
+
+def test_create_goal_invalid_target(client, auth_header):
+    r = client.post(
+        "/goals",
+        json={"name": "Bad Goal", "target_amount": -100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_create_goal_with_deadline(client, auth_header):
+    future = (date.today() + timedelta(days=90)).isoformat()
+    r = _create_goal(client, auth_header, deadline=future)
+    assert r.status_code == 201
+    assert r.get_json()["deadline"] == future
+
+
+def test_filter_goals_by_status(client, auth_header):
+    _create_goal(client, auth_header, name="Active Goal")
+    r = client.get("/goals?status=active", headers=auth_header)
+    assert r.status_code == 200
+    for g in r.get_json():
+        assert g["status"] == "ACTIVE"
+
+
+# ---------------------------------------------------------------------------
+# Deposits
+# ---------------------------------------------------------------------------
+
+def test_deposit_updates_current_amount(client, auth_header):
+    r = _create_goal(client, auth_header, target_amount=1000)
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/goals/{goal_id}/deposit",
+        json={"amount": 250, "note": "First paycheck"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["goal"]["current_amount"] == 250.00
+    assert body["goal"]["progress_pct"] == 25.0
+    assert body["deposit"]["amount"] == 250.00
+    assert body["deposit"]["note"] == "First paycheck"
+
+
+def test_multiple_deposits_accumulate(client, auth_header):
+    r = _create_goal(client, auth_header, target_amount=1000)
+    goal_id = r.get_json()["id"]
+
+    client.post(f"/goals/{goal_id}/deposit", json={"amount": 300}, headers=auth_header)
+    client.post(f"/goals/{goal_id}/deposit", json={"amount": 200}, headers=auth_header)
+    r = client.post(
+        f"/goals/{goal_id}/deposit", json={"amount": 100}, headers=auth_header
+    )
+    assert r.get_json()["goal"]["current_amount"] == 600.00
+
+
+def test_deposit_auto_completes_goal(client, auth_header):
+    r = _create_goal(client, auth_header, target_amount=500)
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/goals/{goal_id}/deposit", json={"amount": 500}, headers=auth_header
+    )
+    assert r.status_code == 200
+    assert r.get_json()["goal"]["status"] == "COMPLETED"
+
+
+def test_deposit_invalid_amount(client, auth_header):
+    r = _create_goal(client, auth_header)
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/goals/{goal_id}/deposit", json={"amount": -50}, headers=auth_header
+    )
+    assert r.status_code == 400
+
+
+def test_list_deposits(client, auth_header):
+    r = _create_goal(client, auth_header)
+    goal_id = r.get_json()["id"]
+
+    client.post(f"/goals/{goal_id}/deposit", json={"amount": 100}, headers=auth_header)
+    client.post(f"/goals/{goal_id}/deposit", json={"amount": 200}, headers=auth_header)
+
+    r = client.get(f"/goals/{goal_id}/deposits", headers=auth_header)
+    assert r.status_code == 200
+    deposits = r.get_json()
+    assert len(deposits) == 2
+    amounts = {d["amount"] for d in deposits}
+    assert amounts == {100.0, 200.0}
+
+
+def test_deposit_to_cancelled_goal_blocked(client, auth_header):
+    r = _create_goal(client, auth_header)
+    goal_id = r.get_json()["id"]
+
+    client.patch(
+        f"/goals/{goal_id}", json={"status": "CANCELLED"}, headers=auth_header
+    )
+    r = client.post(
+        f"/goals/{goal_id}/deposit", json={"amount": 50}, headers=auth_header
+    )
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Milestones
+# ---------------------------------------------------------------------------
+
+def test_auto_milestones_created(client, auth_header):
+    r = _create_goal(client, auth_header, auto_milestones=True)
+    assert r.status_code == 201
+    milestones = r.get_json()["milestones"]
+    pcts = {m["target_pct"] for m in milestones}
+    assert pcts == {25.0, 50.0, 75.0, 100.0}
+
+
+def test_milestone_reached_on_deposit(client, auth_header):
+    r = _create_goal(client, auth_header, target_amount=1000, auto_milestones=True)
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/goals/{goal_id}/deposit", json={"amount": 250}, headers=auth_header
+    )
+    body = r.get_json()
+    # 25% milestone should be reached
+    reached = body["milestones_reached"]
+    assert any(m["target_pct"] == 25.0 for m in reached)
+
+    # Check the goal's milestone list reflects the change
+    goal_data = body["goal"]
+    reached_ms = [m for m in goal_data["milestones"] if m["reached"]]
+    assert any(m["target_pct"] == 25.0 for m in reached_ms)
+
+
+def test_add_custom_milestone(client, auth_header):
+    r = _create_goal(client, auth_header, auto_milestones=False)
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/goals/{goal_id}/milestones",
+        json={"label": "Half way", "target_pct": 50},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    m = r.get_json()
+    assert m["label"] == "Half way"
+    assert m["target_pct"] == 50.0
+
+
+def test_delete_milestone(client, auth_header):
+    r = _create_goal(client, auth_header, auto_milestones=True)
+    goal_id = r.get_json()["id"]
+    milestone_id = r.get_json()["milestones"][0]["id"]
+
+    r = client.delete(
+        f"/goals/{goal_id}/milestones/{milestone_id}", headers=auth_header
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"/goals/{goal_id}", headers=auth_header)
+    remaining_ids = [m["id"] for m in r.get_json()["milestones"]]
+    assert milestone_id not in remaining_ids
+
+
+def test_add_milestone_invalid_pct(client, auth_header):
+    r = _create_goal(client, auth_header)
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/goals/{goal_id}/milestones",
+        json={"label": "Too high", "target_pct": 150},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Isolation — user A cannot see user B's goals
+# ---------------------------------------------------------------------------
+
+def test_goal_isolation_between_users(client):
+    # Register user A
+    client.post("/auth/register", json={"email": "a@test.com", "password": "pw123456"})
+    r = client.post("/auth/login", json={"email": "a@test.com", "password": "pw123456"})
+    token_a = r.get_json()["access_token"]
+    header_a = {"Authorization": f"Bearer {token_a}"}
+
+    # Register user B
+    client.post("/auth/register", json={"email": "b@test.com", "password": "pw123456"})
+    r = client.post("/auth/login", json={"email": "b@test.com", "password": "pw123456"})
+    token_b = r.get_json()["access_token"]
+    header_b = {"Authorization": f"Bearer {token_b}"}
+
+    # A creates a goal
+    r = client.post(
+        "/goals",
+        json={"name": "A's Secret Fund", "target_amount": 999},
+        headers=header_a,
+    )
+    goal_id = r.get_json()["id"]
+
+    # B cannot see A's goal
+    r = client.get(f"/goals/{goal_id}", headers=header_b)
+    assert r.status_code == 404
+
+    # B's goal list is empty
+    r = client.get("/goals", headers=header_b)
+    assert r.get_json() == []


### PR DESCRIPTION
## Summary

Closes #133

Implements full goal-based savings tracking with milestone detection.

## What's included

### Backend (Flask + SQLAlchemy)
**New models** ():
- `SavingsGoal` — name, target_amount, current_amount, currency, deadline, status
- `SavingsMilestone` — label, target_pct (0–100), reached, reached_at
- `SavingsDeposit` — amount, note, deposited_at

**New endpoints** (`/goals`):
| Method | Path | Description |
|--------|------|-------------|
| GET | `/goals` | List goals (supports `?status=` filter) |
| POST | `/goals` | Create goal (with optional auto 25/50/75/100% milestones) |
| GET | `/goals/{id}` | Get single goal with milestones |
| PATCH | `/goals/{id}` | Update name/target/deadline/status |
| DELETE | `/goals/{id}` | Delete goal |
| POST | `/goals/{id}/deposit` | Deposit funds, auto-syncs milestones, auto-completes goal |
| GET | `/goals/{id}/deposits` | List deposit history |
| POST | `/goals/{id}/milestones` | Add custom milestone |
| DELETE | `/goals/{id}/milestones/{ms_id}` | Remove milestone |

**DB migration** (`app/db/schema.sql`):
- `savings_goals`, `savings_milestones`, `savings_deposits` tables

### Tests (21 passing, all existing 22 still pass)
- Full CRUD coverage
- Deposit accumulation & auto-completion when target reached
- Milestone reached detection & response payload
- Blocked deposit on cancelled goals
- User isolation (User B cannot access User A's goals)
- Uses `fakeredis` for CI-friendly testing (no real Redis required)

## Acceptance Criteria
- [x] Production ready implementation
- [x] Includes tests (21 new tests, 100% passing)
- [x] Documentation inline via docstrings and OpenAPI-compatible route structure