### PR TITLE
feat: multi-account financial overview dashboard (#132)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import { MultiAccountDashboard } from "./pages/MultiAccountDashboard";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="accounts"
+              element={
+                <ProtectedRoute>
+                  <MultiAccountDashboard />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/accounts.ts
+++ b/app/src/api/accounts.ts
@@ -1,0 +1,105 @@
+import { api } from './client';
+
+export type AccountType =
+  | 'CHECKING'
+  | 'SAVINGS'
+  | 'CREDIT_CARD'
+  | 'INVESTMENT'
+  | 'LOAN'
+  | 'CASH'
+  | 'OTHER';
+
+export type FinancialAccount = {
+  id: number;
+  name: string;
+  account_type: AccountType;
+  balance: number;
+  currency: string;
+  institution: string | null;
+  last_four: string | null;
+  color: string | null;
+  include_in_overview: boolean;
+  active: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MultiAccountOverview = {
+  period: { month: string };
+  accounts: FinancialAccount[];
+  totals: {
+    net_worth: number;
+    total_assets: number;
+    total_liabilities: number;
+  };
+  monthly_summary: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+  };
+  upcoming_bills: Array<{
+    id: number;
+    name: string;
+    amount: number;
+    currency: string;
+    next_due_date: string;
+    cadence: string;
+  }>;
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    share_pct: number;
+  }>;
+  errors?: string[];
+};
+
+export type CreateAccountPayload = {
+  name: string;
+  account_type?: AccountType;
+  balance?: number;
+  currency?: string;
+  institution?: string;
+  last_four?: string;
+  color?: string;
+  include_in_overview?: boolean;
+};
+
+export type UpdateAccountPayload = Partial<CreateAccountPayload>;
+
+export async function listAccounts(includeInactive = false): Promise<FinancialAccount[]> {
+  const q = includeInactive ? '?include_inactive=true' : '';
+  return api<FinancialAccount[]>(`/accounts${q}`);
+}
+
+export async function getAccount(id: number): Promise<FinancialAccount> {
+  return api<FinancialAccount>(`/accounts/${id}`);
+}
+
+export async function createAccount(payload: CreateAccountPayload): Promise<FinancialAccount> {
+  return api<FinancialAccount>('/accounts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function updateAccount(
+  id: number,
+  payload: UpdateAccountPayload
+): Promise<FinancialAccount> {
+  return api<FinancialAccount>(`/accounts/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteAccount(id: number): Promise<{ message: string }> {
+  return api<{ message: string }>(`/accounts/${id}`, { method: 'DELETE' });
+}
+
+export async function getMultiAccountOverview(month?: string): Promise<MultiAccountOverview> {
+  const q = month ? `?month=${encodeURIComponent(month)}` : '';
+  return api<MultiAccountOverview>(`/accounts/overview${q}`);
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -8,6 +8,7 @@ import { logout as logoutApi } from '@/api/auth';
 
 const navigation = [
   { name: 'Dashboard', href: '/dashboard' },
+  { name: 'Accounts', href: '/accounts' },
   { name: 'Budgets', href: '/budgets' },
   { name: 'Bills', href: '/bills' },
   { name: 'Reminders', href: '/reminders' },

--- a/app/src/pages/MultiAccountDashboard.tsx
+++ b/app/src/pages/MultiAccountDashboard.tsx
@@ -1,0 +1,718 @@
+import { useEffect, useState, useCallback } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+  FinancialCardDescription,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from '@/hooks/use-toast';
+import { formatMoney } from '@/lib/currency';
+import {
+  type FinancialAccount,
+  type AccountType,
+  type MultiAccountOverview,
+  type CreateAccountPayload,
+  listAccounts,
+  createAccount,
+  updateAccount,
+  deleteAccount,
+  getMultiAccountOverview,
+} from '@/api/accounts';
+import {
+  Wallet,
+  TrendingUp,
+  TrendingDown,
+  CreditCard,
+  PiggyBank,
+  Banknote,
+  BarChart3,
+  Plus,
+  Pencil,
+  Trash2,
+  RefreshCw,
+  Building2,
+  Eye,
+  EyeOff,
+} from 'lucide-react';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_TYPE_OPTIONS: { value: AccountType; label: string }[] = [
+  { value: 'CHECKING', label: 'Checking' },
+  { value: 'SAVINGS', label: 'Savings' },
+  { value: 'CREDIT_CARD', label: 'Credit Card' },
+  { value: 'INVESTMENT', label: 'Investment' },
+  { value: 'LOAN', label: 'Loan' },
+  { value: 'CASH', label: 'Cash' },
+  { value: 'OTHER', label: 'Other' },
+];
+
+const SUPPORTED_CURRENCIES = [
+  'INR', 'USD', 'EUR', 'GBP', 'AED', 'SGD', 'AUD', 'CAD', 'JPY',
+];
+
+function accountTypeIcon(type: AccountType) {
+  switch (type) {
+    case 'CHECKING': return <Banknote className="h-4 w-4" />;
+    case 'SAVINGS': return <PiggyBank className="h-4 w-4" />;
+    case 'CREDIT_CARD': return <CreditCard className="h-4 w-4" />;
+    case 'INVESTMENT': return <BarChart3 className="h-4 w-4" />;
+    case 'LOAN': return <TrendingDown className="h-4 w-4" />;
+    case 'CASH': return <Wallet className="h-4 w-4" />;
+    default: return <Building2 className="h-4 w-4" />;
+  }
+}
+
+const LIABILITY_TYPES: AccountType[] = ['CREDIT_CARD', 'LOAN'];
+
+function isLiability(type: AccountType) {
+  return LIABILITY_TYPES.includes(type);
+}
+
+// ---------------------------------------------------------------------------
+// Account Form (create / edit)
+// ---------------------------------------------------------------------------
+
+type AccountFormState = {
+  name: string;
+  account_type: AccountType;
+  balance: string;
+  currency: string;
+  institution: string;
+  last_four: string;
+  color: string;
+  include_in_overview: boolean;
+};
+
+const DEFAULT_FORM: AccountFormState = {
+  name: '',
+  account_type: 'CHECKING',
+  balance: '0',
+  currency: 'INR',
+  institution: '',
+  last_four: '',
+  color: '#4f46e5',
+  include_in_overview: true,
+};
+
+function AccountFormDialog({
+  open,
+  onClose,
+  initial,
+  onSave,
+}: {
+  open: boolean;
+  onClose: () => void;
+  initial?: AccountFormState;
+  onSave: (data: AccountFormState) => Promise<void>;
+}) {
+  const [form, setForm] = useState<AccountFormState>(initial ?? DEFAULT_FORM);
+  const [saving, setSaving] = useState(false);
+
+  // Sync form when initial changes (editing different account)
+  useEffect(() => {
+    setForm(initial ?? DEFAULT_FORM);
+  }, [initial, open]);
+
+  const set = (key: keyof AccountFormState, value: string | boolean) =>
+    setForm((f) => ({ ...f, [key]: value }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(form);
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{initial ? 'Edit Account' : 'Add Account'}</DialogTitle>
+          <DialogDescription>
+            {initial ? 'Update your financial account details.' : 'Add a new financial account to track.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          {/* Name */}
+          <div className="space-y-1">
+            <Label htmlFor="acc-name">Account Name *</Label>
+            <Input
+              id="acc-name"
+              placeholder="e.g. HDFC Savings"
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+            />
+          </div>
+
+          {/* Type */}
+          <div className="space-y-1">
+            <Label htmlFor="acc-type">Account Type</Label>
+            <Select
+              value={form.account_type}
+              onValueChange={(v) => set('account_type', v)}
+            >
+              <SelectTrigger id="acc-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ACCOUNT_TYPE_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Balance + Currency row */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="acc-balance">Balance</Label>
+              <Input
+                id="acc-balance"
+                type="number"
+                step="0.01"
+                value={form.balance}
+                onChange={(e) => set('balance', e.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="acc-currency">Currency</Label>
+              <Select
+                value={form.currency}
+                onValueChange={(v) => set('currency', v)}
+              >
+                <SelectTrigger id="acc-currency">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SUPPORTED_CURRENCIES.map((c) => (
+                    <SelectItem key={c} value={c}>{c}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Institution */}
+          <div className="space-y-1">
+            <Label htmlFor="acc-institution">Institution (optional)</Label>
+            <Input
+              id="acc-institution"
+              placeholder="e.g. HDFC Bank"
+              value={form.institution}
+              onChange={(e) => set('institution', e.target.value)}
+            />
+          </div>
+
+          {/* Last four */}
+          <div className="space-y-1">
+            <Label htmlFor="acc-last4">Last 4 digits (optional)</Label>
+            <Input
+              id="acc-last4"
+              placeholder="1234"
+              maxLength={4}
+              value={form.last_four}
+              onChange={(e) => set('last_four', e.target.value.replace(/\D/g, ''))}
+            />
+          </div>
+
+          {/* Color + Include in overview row */}
+          <div className="grid grid-cols-2 gap-3 items-center">
+            <div className="space-y-1">
+              <Label htmlFor="acc-color">Color tag</Label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="acc-color"
+                  type="color"
+                  value={form.color}
+                  onChange={(e) => set('color', e.target.value)}
+                  className="h-9 w-9 rounded cursor-pointer border border-input"
+                />
+                <span className="text-xs text-muted-foreground">{form.color}</span>
+              </div>
+            </div>
+            <div className="space-y-1">
+              <Label>Include in overview</Label>
+              <div className="flex items-center gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={() => set('include_in_overview', !form.include_in_overview)}
+                  className={`flex items-center gap-1 text-sm font-medium rounded px-3 py-1.5 border transition ${
+                    form.include_in_overview
+                      ? 'bg-primary text-primary-foreground border-primary'
+                      : 'bg-muted text-muted-foreground border-border'
+                  }`}
+                >
+                  {form.include_in_overview ? (
+                    <><Eye className="h-3.5 w-3.5" /> Yes</>
+                  ) : (
+                    <><EyeOff className="h-3.5 w-3.5" /> No</>
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving || !form.name.trim()}>
+            {saving ? 'Saving…' : initial ? 'Update' : 'Add Account'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Account card
+// ---------------------------------------------------------------------------
+
+function AccountCard({
+  account,
+  onEdit,
+  onDelete,
+}: {
+  account: FinancialAccount;
+  onEdit: (a: FinancialAccount) => void;
+  onDelete: (a: FinancialAccount) => void;
+}) {
+  const liability = isLiability(account.account_type);
+  const colorStyle = account.color ? { borderLeftColor: account.color } : {};
+
+  return (
+    <div
+      className="relative rounded-xl border-l-4 bg-card p-4 shadow-sm hover:shadow-md transition-shadow"
+      style={colorStyle}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <div
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-primary-foreground"
+            style={{ backgroundColor: account.color ?? '#4f46e5' }}
+          >
+            {accountTypeIcon(account.account_type)}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-semibold">{account.name}</p>
+            {account.institution && (
+              <p className="truncate text-xs text-muted-foreground">{account.institution}</p>
+            )}
+            {account.last_four && (
+              <p className="text-xs text-muted-foreground">••••&nbsp;{account.last_four}</p>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 gap-1">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7"
+            onClick={() => onEdit(account)}
+            aria-label="Edit account"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-7 w-7 text-destructive hover:text-destructive"
+            onClick={() => onDelete(account)}
+            aria-label="Delete account"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-end justify-between">
+        <div>
+          <p className="text-xs text-muted-foreground uppercase tracking-wide">
+            {ACCOUNT_TYPE_OPTIONS.find((o) => o.value === account.account_type)?.label ?? account.account_type}
+          </p>
+          <p
+            className={`text-lg font-bold tabular-nums ${
+              liability ? 'text-destructive' : 'text-foreground'
+            }`}
+          >
+            {liability ? '-' : ''}
+            {formatMoney(Math.abs(account.balance), account.currency)}
+          </p>
+        </div>
+        {!account.include_in_overview && (
+          <span className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+            <EyeOff className="h-2.5 w-2.5" /> Hidden
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main page
+// ---------------------------------------------------------------------------
+
+export function MultiAccountDashboard() {
+  const { toast } = useToast();
+  const [overview, setOverview] = useState<MultiAccountOverview | null>(null);
+  const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<FinancialAccount | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [ov, accs] = await Promise.all([
+        getMultiAccountOverview(month),
+        listAccounts(),
+      ]);
+      setOverview(ov);
+      setAccounts(accs);
+    } catch (err) {
+      toast({
+        title: 'Failed to load accounts',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [month, toast]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleSave = async (form: AccountFormState) => {
+    const payload: CreateAccountPayload = {
+      name: form.name.trim(),
+      account_type: form.account_type,
+      balance: parseFloat(form.balance) || 0,
+      currency: form.currency,
+      institution: form.institution.trim() || undefined,
+      last_four: form.last_four.trim() || undefined,
+      color: form.color || undefined,
+      include_in_overview: form.include_in_overview,
+    };
+
+    try {
+      if (editTarget) {
+        await updateAccount(editTarget.id, payload);
+        toast({ title: 'Account updated' });
+      } else {
+        await createAccount(payload);
+        toast({ title: 'Account added' });
+      }
+      await load();
+    } catch (err) {
+      toast({
+        title: 'Error',
+        description: err instanceof Error ? err.message : 'Failed to save account',
+        variant: 'destructive',
+      });
+      throw err; // re-throw so dialog stays open on error
+    }
+  };
+
+  const handleEdit = (account: FinancialAccount) => {
+    setEditTarget(account);
+    setDialogOpen(true);
+  };
+
+  const handleDelete = async (account: FinancialAccount) => {
+    if (!window.confirm(`Deactivate "${account.name}"? It will be hidden from your dashboard.`)) return;
+    try {
+      await deleteAccount(account.id);
+      toast({ title: 'Account deactivated', description: account.name });
+      await load();
+    } catch (err) {
+      toast({
+        title: 'Failed to deactivate',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const editFormInitial: AccountFormState | undefined = editTarget
+    ? {
+        name: editTarget.name,
+        account_type: editTarget.account_type,
+        balance: String(editTarget.balance),
+        currency: editTarget.currency,
+        institution: editTarget.institution ?? '',
+        last_four: editTarget.last_four ?? '',
+        color: editTarget.color ?? '#4f46e5',
+        include_in_overview: editTarget.include_in_overview,
+      }
+    : undefined;
+
+  const totals = overview?.totals;
+  const ms = overview?.monthly_summary;
+
+  return (
+    <div className="container-financial py-8 space-y-8">
+      {/* Header */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Multi-Account Overview</h1>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            All your financial accounts in one place
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            type="month"
+            value={month}
+            onChange={(e) => setMonth(e.target.value)}
+            className="rounded-md border border-input bg-background px-3 py-1.5 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <Button size="sm" variant="outline" onClick={load} disabled={loading}>
+            <RefreshCw className={`h-3.5 w-3.5 mr-1 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditTarget(null);
+              setDialogOpen(true);
+            }}
+          >
+            <Plus className="h-3.5 w-3.5 mr-1" />
+            Add Account
+          </Button>
+        </div>
+      </div>
+
+      {/* Net Worth Summary Cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle className="flex items-center gap-1.5">
+              <Wallet className="h-4 w-4 text-primary" />
+              Net Worth
+            </FinancialCardTitle>
+            <FinancialCardDescription>Assets minus liabilities</FinancialCardDescription>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <p className={`text-2xl font-bold tabular-nums ${(totals?.net_worth ?? 0) >= 0 ? 'text-green-600' : 'text-destructive'}`}>
+              {loading ? '—' : formatMoney(totals?.net_worth ?? 0)}
+            </p>
+          </FinancialCardContent>
+        </FinancialCard>
+
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle className="flex items-center gap-1.5">
+              <TrendingUp className="h-4 w-4 text-green-500" />
+              Total Assets
+            </FinancialCardTitle>
+            <FinancialCardDescription>Checking, savings, investments</FinancialCardDescription>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <p className="text-2xl font-bold tabular-nums text-green-600">
+              {loading ? '—' : formatMoney(totals?.total_assets ?? 0)}
+            </p>
+          </FinancialCardContent>
+        </FinancialCard>
+
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle className="flex items-center gap-1.5">
+              <TrendingDown className="h-4 w-4 text-destructive" />
+              Total Liabilities
+            </FinancialCardTitle>
+            <FinancialCardDescription>Credit cards, loans</FinancialCardDescription>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <p className="text-2xl font-bold tabular-nums text-destructive">
+              {loading ? '—' : formatMoney(totals?.total_liabilities ?? 0)}
+            </p>
+          </FinancialCardContent>
+        </FinancialCard>
+      </div>
+
+      {/* Monthly Summary */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle>Monthly Income</FinancialCardTitle>
+            <FinancialCardDescription>{month}</FinancialCardDescription>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <p className="text-xl font-semibold tabular-nums text-green-600">
+              {loading ? '—' : formatMoney(ms?.income ?? 0)}
+            </p>
+          </FinancialCardContent>
+        </FinancialCard>
+
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle>Monthly Expenses</FinancialCardTitle>
+            <FinancialCardDescription>{month}</FinancialCardDescription>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <p className="text-xl font-semibold tabular-nums text-destructive">
+              {loading ? '—' : formatMoney(ms?.expenses ?? 0)}
+            </p>
+          </FinancialCardContent>
+        </FinancialCard>
+
+        <FinancialCard>
+          <FinancialCardHeader>
+            <FinancialCardTitle>Net Cash Flow</FinancialCardTitle>
+            <FinancialCardDescription>{month}</FinancialCardDescription>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <p className={`text-xl font-semibold tabular-nums ${(ms?.net_flow ?? 0) >= 0 ? 'text-green-600' : 'text-destructive'}`}>
+              {loading ? '—' : formatMoney(ms?.net_flow ?? 0)}
+            </p>
+          </FinancialCardContent>
+        </FinancialCard>
+      </div>
+
+      {/* Accounts Grid */}
+      <div>
+        <h2 className="text-lg font-semibold mb-4">Your Accounts</h2>
+        {loading ? (
+          <p className="text-muted-foreground text-sm">Loading…</p>
+        ) : accounts.length === 0 ? (
+          <div className="rounded-xl border border-dashed p-8 text-center">
+            <Wallet className="mx-auto h-10 w-10 text-muted-foreground/50 mb-3" />
+            <p className="text-muted-foreground">No accounts yet.</p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => {
+                setEditTarget(null);
+                setDialogOpen(true);
+              }}
+            >
+              <Plus className="h-3.5 w-3.5 mr-1" />
+              Add your first account
+            </Button>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {accounts.map((acct) => (
+              <AccountCard
+                key={acct.id}
+                account={acct}
+                onEdit={handleEdit}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Upcoming Bills (from overview) */}
+      {(overview?.upcoming_bills?.length ?? 0) > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Upcoming Bills</h2>
+          <div className="grid gap-2 sm:grid-cols-2">
+            {overview!.upcoming_bills.map((b) => (
+              <div
+                key={b.id}
+                className="flex items-center justify-between rounded-lg border bg-card px-4 py-3"
+              >
+                <div>
+                  <p className="text-sm font-medium">{b.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Due {new Date(b.next_due_date).toLocaleDateString()} · {b.cadence}
+                  </p>
+                </div>
+                <p className="text-sm font-semibold tabular-nums">
+                  {formatMoney(b.amount, b.currency)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Category Breakdown */}
+      {(overview?.category_breakdown?.length ?? 0) > 0 && (
+        <div>
+          <h2 className="text-lg font-semibold mb-4">Expense Breakdown — {month}</h2>
+          <FinancialCard>
+            <FinancialCardContent className="pt-4">
+              <div className="space-y-2">
+                {overview!.category_breakdown.map((c) => (
+                  <div key={c.category_id ?? 'uncategorized'} className="flex items-center gap-3">
+                    <div className="w-28 shrink-0 text-xs text-muted-foreground truncate">
+                      {c.category_name}
+                    </div>
+                    <div className="flex-1">
+                      <div className="h-2 rounded-full bg-muted overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-primary transition-all"
+                          style={{ width: `${c.share_pct}%` }}
+                        />
+                      </div>
+                    </div>
+                    <div className="w-16 shrink-0 text-right text-xs font-medium tabular-nums">
+                      {formatMoney(c.amount)}
+                    </div>
+                    <div className="w-10 shrink-0 text-right text-xs text-muted-foreground">
+                      {c.share_pct.toFixed(1)}%
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </FinancialCardContent>
+          </FinancialCard>
+        </div>
+      )}
+
+      {/* Account form dialog */}
+      <AccountFormDialog
+        open={dialogOpen}
+        onClose={() => {
+          setDialogOpen(false);
+          setEditTarget(null);
+        }}
+        initial={editFormInitial}
+        onSave={handleSave}
+      />
+    </div>
+  );
+}
+
+export default MultiAccountDashboard;

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,30 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Multi-account dashboard: financial accounts
+DO $$ BEGIN
+  CREATE TYPE account_type AS ENUM (
+    'CHECKING', 'SAVINGS', 'CREDIT_CARD', 'INVESTMENT', 'LOAN', 'CASH', 'OTHER'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE TABLE IF NOT EXISTS financial_accounts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  account_type account_type NOT NULL DEFAULT 'CHECKING',
+  balance NUMERIC(15, 2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  institution VARCHAR(200),
+  last_four CHAR(4),
+  color VARCHAR(20),
+  include_in_overview BOOLEAN NOT NULL DEFAULT TRUE,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_financial_accounts_user ON financial_accounts(user_id, active);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,42 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AccountType(str, Enum):
+    CHECKING = "CHECKING"
+    SAVINGS = "SAVINGS"
+    CREDIT_CARD = "CREDIT_CARD"
+    INVESTMENT = "INVESTMENT"
+    LOAN = "LOAN"
+    CASH = "CASH"
+    OTHER = "OTHER"
+
+
+class FinancialAccount(db.Model):
+    """Represents a financial account owned by a user (bank, credit card, etc.)."""
+
+    __tablename__ = "financial_accounts"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    account_type = db.Column(
+        SAEnum(AccountType), nullable=False, default=AccountType.CHECKING
+    )
+    # Current balance (positive = asset, negative = liability e.g. credit card debt)
+    balance = db.Column(db.Numeric(15, 2), nullable=False, default=0)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    # Optional institution / bank name
+    institution = db.Column(db.String(200), nullable=True)
+    # Optional last-four digits of account / card number
+    last_four = db.Column(db.String(4), nullable=True)
+    # Color tag for UI (hex, e.g. "#4f46e5")
+    color = db.Column(db.String(20), nullable=True)
+    # Whether to include this account in the multi-account overview
+    include_in_overview = db.Column(db.Boolean, default=True, nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,408 @@
+"""
+Routes for managing financial accounts (multi-account dashboard feature).
+
+Endpoints:
+  GET    /accounts               – list all active accounts for the current user
+  POST   /accounts               – create a new financial account
+  GET    /accounts/<id>          – get a specific account
+  PATCH  /accounts/<id>          – update a financial account
+  DELETE /accounts/<id>          – soft-delete (deactivate) an account
+  GET    /accounts/overview      – aggregate multi-account dashboard summary
+"""
+
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import AccountType, Bill, Expense, FinancialAccount
+
+bp = Blueprint("accounts", __name__)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_ACCOUNT_TYPES = {t.value for t in AccountType}
+
+
+def _account_to_dict(acct: FinancialAccount) -> dict:
+    return {
+        "id": acct.id,
+        "name": acct.name,
+        "account_type": acct.account_type.value if acct.account_type else None,
+        "balance": float(acct.balance or 0),
+        "currency": acct.currency,
+        "institution": acct.institution,
+        "last_four": acct.last_four,
+        "color": acct.color,
+        "include_in_overview": acct.include_in_overview,
+        "active": acct.active,
+        "created_at": acct.created_at.isoformat() if acct.created_at else None,
+        "updated_at": acct.updated_at.isoformat() if acct.updated_at else None,
+    }
+
+
+def _parse_decimal(value, field: str):
+    """Return (Decimal, None) on success or (None, error_response) on failure."""
+    try:
+        d = Decimal(str(value))
+        return d, None
+    except (InvalidOperation, TypeError, ValueError):
+        return None, (jsonify(error=f"invalid {field}"), 400)
+
+
+# ---------------------------------------------------------------------------
+# List accounts
+# ---------------------------------------------------------------------------
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    include_inactive = request.args.get("include_inactive", "false").lower() == "true"
+    q = db.session.query(FinancialAccount).filter_by(user_id=uid)
+    if not include_inactive:
+        q = q.filter(FinancialAccount.active.is_(True))
+    accounts = q.order_by(FinancialAccount.created_at.asc()).all()
+    return jsonify([_account_to_dict(a) for a in accounts])
+
+
+# ---------------------------------------------------------------------------
+# Create account
+# ---------------------------------------------------------------------------
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name is required"), 400
+
+    acct_type_raw = (data.get("account_type") or "CHECKING").upper()
+    if acct_type_raw not in _VALID_ACCOUNT_TYPES:
+        return jsonify(
+            error=f"account_type must be one of: {', '.join(sorted(_VALID_ACCOUNT_TYPES))}"
+        ), 400
+
+    balance_raw = data.get("balance", 0)
+    balance, err = _parse_decimal(balance_raw, "balance")
+    if err:
+        return err
+
+    currency = (data.get("currency") or "INR").upper().strip()
+    institution = (data.get("institution") or "").strip() or None
+    last_four = (data.get("last_four") or "").strip() or None
+    if last_four and (len(last_four) != 4 or not last_four.isdigit()):
+        return jsonify(error="last_four must be exactly 4 digits"), 400
+    color = (data.get("color") or "").strip() or None
+    include_in_overview = bool(data.get("include_in_overview", True))
+
+    acct = FinancialAccount(
+        user_id=uid,
+        name=name,
+        account_type=AccountType(acct_type_raw),
+        balance=balance,
+        currency=currency,
+        institution=institution,
+        last_four=last_four,
+        color=color,
+        include_in_overview=include_in_overview,
+    )
+    db.session.add(acct)
+    db.session.commit()
+    return jsonify(_account_to_dict(acct)), 201
+
+
+# ---------------------------------------------------------------------------
+# Get single account
+# ---------------------------------------------------------------------------
+
+
+@bp.get("/<int:account_id>")
+@jwt_required()
+def get_account(account_id: int):
+    uid = int(get_jwt_identity())
+    acct = db.session.query(FinancialAccount).filter_by(
+        id=account_id, user_id=uid
+    ).first()
+    if not acct:
+        return jsonify(error="account not found"), 404
+    return jsonify(_account_to_dict(acct))
+
+
+# ---------------------------------------------------------------------------
+# Update account
+# ---------------------------------------------------------------------------
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id: int):
+    uid = int(get_jwt_identity())
+    acct = db.session.query(FinancialAccount).filter_by(
+        id=account_id, user_id=uid
+    ).first()
+    if not acct:
+        return jsonify(error="account not found"), 404
+
+    data = request.get_json() or {}
+
+    if "name" in data:
+        name = (data["name"] or "").strip()
+        if not name:
+            return jsonify(error="name cannot be empty"), 400
+        acct.name = name
+
+    if "account_type" in data:
+        acct_type_raw = (data["account_type"] or "").upper()
+        if acct_type_raw not in _VALID_ACCOUNT_TYPES:
+            return jsonify(
+                error=f"account_type must be one of: {', '.join(sorted(_VALID_ACCOUNT_TYPES))}"
+            ), 400
+        acct.account_type = AccountType(acct_type_raw)
+
+    if "balance" in data:
+        balance, err = _parse_decimal(data["balance"], "balance")
+        if err:
+            return err
+        acct.balance = balance
+
+    if "currency" in data:
+        acct.currency = (data["currency"] or "INR").upper().strip()
+
+    if "institution" in data:
+        acct.institution = (data["institution"] or "").strip() or None
+
+    if "last_four" in data:
+        last_four = (data["last_four"] or "").strip() or None
+        if last_four and (len(last_four) != 4 or not last_four.isdigit()):
+            return jsonify(error="last_four must be exactly 4 digits"), 400
+        acct.last_four = last_four
+
+    if "color" in data:
+        acct.color = (data["color"] or "").strip() or None
+
+    if "include_in_overview" in data:
+        acct.include_in_overview = bool(data["include_in_overview"])
+
+    db.session.commit()
+    return jsonify(_account_to_dict(acct))
+
+
+# ---------------------------------------------------------------------------
+# Delete (deactivate) account
+# ---------------------------------------------------------------------------
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def delete_account(account_id: int):
+    uid = int(get_jwt_identity())
+    acct = db.session.query(FinancialAccount).filter_by(
+        id=account_id, user_id=uid
+    ).first()
+    if not acct:
+        return jsonify(error="account not found"), 404
+    acct.active = False
+    db.session.commit()
+    return jsonify(message="account deactivated"), 200
+
+
+# ---------------------------------------------------------------------------
+# Multi-account overview
+# ---------------------------------------------------------------------------
+
+
+@bp.get("/overview")
+@jwt_required()
+def multi_account_overview():
+    """
+    Aggregated financial overview across all active accounts that have
+    ``include_in_overview=True``.
+
+    Returns:
+      - accounts: list of account details with individual balances
+      - totals: net_worth, total_assets, total_liabilities
+      - monthly_summary: income / expenses for the requested month
+      - upcoming_bills: next-due bills (across all accounts context)
+      - category_breakdown: expense breakdown for the requested month
+    """
+    uid = int(get_jwt_identity())
+    ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
+    if not _is_valid_month(ym):
+        return jsonify(error="invalid month, expected YYYY-MM"), 400
+
+    year, month = map(int, ym.split("-"))
+    today = date.today()
+
+    # --- accounts -----------------------------------------------------------
+    accounts = (
+        db.session.query(FinancialAccount)
+        .filter_by(user_id=uid, active=True)
+        .order_by(FinancialAccount.created_at.asc())
+        .all()
+    )
+
+    overview_accounts = [a for a in accounts if a.include_in_overview]
+
+    # Compute totals
+    # Liability account types carry negative contribution to net worth
+    _LIABILITY_TYPES = {AccountType.CREDIT_CARD, AccountType.LOAN}
+
+    total_assets: float = 0.0
+    total_liabilities: float = 0.0
+    for acct in overview_accounts:
+        bal = float(acct.balance or 0)
+        if acct.account_type in _LIABILITY_TYPES:
+            # A positive balance on a credit card / loan means money owed → liability
+            total_liabilities += abs(bal) if bal > 0 else 0
+            # If balance is negative (paid ahead) treat as 0 liability
+        else:
+            if bal > 0:
+                total_assets += bal
+
+    net_worth = round(total_assets - total_liabilities, 2)
+
+    # --- monthly income / expenses ------------------------------------------
+    monthly_income: float = 0.0
+    monthly_expenses: float = 0.0
+    errors = []
+
+    try:
+        income_q = (
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type == "INCOME",
+            )
+            .scalar()
+        )
+        expenses_q = (
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type != "INCOME",
+            )
+            .scalar()
+        )
+        monthly_income = float(income_q or 0)
+        monthly_expenses = float(expenses_q or 0)
+    except Exception:
+        errors.append("monthly_summary_unavailable")
+
+    # --- upcoming bills -----------------------------------------------------
+    upcoming_bills = []
+    try:
+        bills = (
+            db.session.query(Bill)
+            .filter(
+                Bill.user_id == uid,
+                Bill.active.is_(True),
+                Bill.next_due_date >= today,
+            )
+            .order_by(Bill.next_due_date.asc())
+            .limit(8)
+            .all()
+        )
+        upcoming_bills = [
+            {
+                "id": b.id,
+                "name": b.name,
+                "amount": float(b.amount),
+                "currency": b.currency,
+                "next_due_date": b.next_due_date.isoformat(),
+                "cadence": b.cadence.value,
+            }
+            for b in bills
+        ]
+    except Exception:
+        errors.append("upcoming_bills_unavailable")
+
+    # --- category breakdown -------------------------------------------------
+    category_breakdown = []
+    try:
+        from ..models import Category
+
+        cat_rows = (
+            db.session.query(
+                Expense.category_id,
+                func.coalesce(Category.name, "Uncategorized").label("category_name"),
+                func.coalesce(func.sum(Expense.amount), 0).label("total_amount"),
+            )
+            .outerjoin(
+                Category,
+                (Category.id == Expense.category_id) & (Category.user_id == uid),
+            )
+            .filter(
+                Expense.user_id == uid,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type != "INCOME",
+            )
+            .group_by(Expense.category_id, Category.name)
+            .order_by(func.sum(Expense.amount).desc())
+            .all()
+        )
+        total_cat = sum(float(r.total_amount or 0) for r in cat_rows)
+        category_breakdown = [
+            {
+                "category_id": r.category_id,
+                "category_name": r.category_name,
+                "amount": float(r.total_amount or 0),
+                "share_pct": (
+                    round((float(r.total_amount or 0) / total_cat) * 100, 2)
+                    if total_cat > 0
+                    else 0
+                ),
+            }
+            for r in cat_rows
+        ]
+    except Exception:
+        errors.append("category_breakdown_unavailable")
+
+    return jsonify(
+        {
+            "period": {"month": ym},
+            "accounts": [_account_to_dict(a) for a in accounts],
+            "totals": {
+                "net_worth": net_worth,
+                "total_assets": round(total_assets, 2),
+                "total_liabilities": round(total_liabilities, 2),
+            },
+            "monthly_summary": {
+                "income": monthly_income,
+                "expenses": monthly_expenses,
+                "net_flow": round(monthly_income - monthly_expenses, 2),
+            },
+            "upcoming_bills": upcoming_bills,
+            "category_breakdown": category_breakdown,
+            "errors": errors,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_valid_month(ym: str) -> bool:
+    if len(ym) != 7 or ym[4] != "-":
+        return False
+    year_part, month_part = ym.split("-")
+    if not (year_part.isdigit() and month_part.isdigit()):
+        return False
+    return 1 <= int(month_part) <= 12

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
 import pytest
+import fakeredis
+import app.extensions as _ext
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
 
 
@@ -19,8 +20,24 @@ def _setup_db(app):
         db.create_all()
 
 
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+    """Replace the global redis_client with an in-process fake for all tests."""
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    monkeypatch.setattr(_ext, "redis_client", fake)
+    # Also patch the imported name in every routes module that imported it.
+    import app.routes.auth as _auth
+    import app.routes.dashboard as _dashboard
+    import app.services.cache as _cache
+    monkeypatch.setattr(_auth, "redis_client", fake)
+    monkeypatch.setattr(_cache, "redis_client", fake)
+    # dashboard uses cache module indirectly – patching cache is sufficient
+    yield fake
+    fake.flushall()
+
+
 @pytest.fixture()
-def app_fixture():
+def app_fixture(_fake_redis):
     # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
     settings = TestSettings(
@@ -31,18 +48,12 @@ def app_fixture():
     app = create_app(settings)
     app.config.update(TESTING=True)
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    _fake_redis.flushall()
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    _fake_redis.flushall()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,350 @@
+"""Tests for financial accounts (multi-account dashboard) endpoints."""
+
+from datetime import date, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_account(client, auth_header, **kwargs):
+    payload = {
+        "name": "Main Checking",
+        "account_type": "CHECKING",
+        "balance": 1000.00,
+        "currency": "INR",
+    }
+    payload.update(kwargs)
+    return client.post("/accounts", json=payload, headers=auth_header)
+
+
+# ---------------------------------------------------------------------------
+# CRUD tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAccount:
+    def test_create_basic(self, client, auth_header):
+        r = _create_account(client, auth_header)
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["name"] == "Main Checking"
+        assert data["account_type"] == "CHECKING"
+        assert data["balance"] == 1000.0
+        assert data["currency"] == "INR"
+        assert data["active"] is True
+        assert "id" in data
+
+    def test_create_with_all_fields(self, client, auth_header):
+        r = _create_account(
+            client,
+            auth_header,
+            name="HDFC Savings",
+            account_type="SAVINGS",
+            balance=50000,
+            currency="INR",
+            institution="HDFC Bank",
+            last_four="4321",
+            color="#4f46e5",
+            include_in_overview=True,
+        )
+        assert r.status_code == 201
+        data = r.get_json()
+        assert data["institution"] == "HDFC Bank"
+        assert data["last_four"] == "4321"
+        assert data["color"] == "#4f46e5"
+
+    def test_create_credit_card(self, client, auth_header):
+        r = _create_account(
+            client,
+            auth_header,
+            name="Axis Credit Card",
+            account_type="CREDIT_CARD",
+            balance=5000,  # outstanding balance
+        )
+        assert r.status_code == 201
+        assert r.get_json()["account_type"] == "CREDIT_CARD"
+
+    def test_create_missing_name_returns_400(self, client, auth_header):
+        r = client.post(
+            "/accounts",
+            json={"account_type": "CHECKING", "balance": 100},
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+        assert "name" in r.get_json()["error"]
+
+    def test_create_invalid_account_type_returns_400(self, client, auth_header):
+        r = client.post(
+            "/accounts",
+            json={"name": "Test", "account_type": "INVALID"},
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+
+    def test_create_invalid_balance_returns_400(self, client, auth_header):
+        r = client.post(
+            "/accounts",
+            json={"name": "Test", "balance": "not_a_number"},
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+
+    def test_create_invalid_last_four_returns_400(self, client, auth_header):
+        r = client.post(
+            "/accounts",
+            json={"name": "Test", "last_four": "123"},  # only 3 digits
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+
+    def test_requires_auth(self, client):
+        r = client.post("/accounts", json={"name": "Test"})
+        assert r.status_code == 401
+
+
+class TestListAccounts:
+    def test_list_empty(self, client, auth_header):
+        r = client.get("/accounts", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json() == []
+
+    def test_list_returns_created_accounts(self, client, auth_header):
+        _create_account(client, auth_header, name="Acc A")
+        _create_account(client, auth_header, name="Acc B")
+        r = client.get("/accounts", headers=auth_header)
+        assert r.status_code == 200
+        names = [a["name"] for a in r.get_json()]
+        assert "Acc A" in names
+        assert "Acc B" in names
+
+    def test_list_excludes_inactive_by_default(self, client, auth_header):
+        r = _create_account(client, auth_header, name="Active")
+        acc_id = r.get_json()["id"]
+        # Deactivate it
+        client.delete(f"/accounts/{acc_id}", headers=auth_header)
+        r = client.get("/accounts", headers=auth_header)
+        assert r.status_code == 200
+        names = [a["name"] for a in r.get_json()]
+        assert "Active" not in names
+
+    def test_list_includes_inactive_when_flag_set(self, client, auth_header):
+        r = _create_account(client, auth_header, name="Deactivated")
+        acc_id = r.get_json()["id"]
+        client.delete(f"/accounts/{acc_id}", headers=auth_header)
+        r = client.get("/accounts?include_inactive=true", headers=auth_header)
+        assert r.status_code == 200
+        names = [a["name"] for a in r.get_json()]
+        assert "Deactivated" in names
+
+    def test_requires_auth(self, client):
+        r = client.get("/accounts")
+        assert r.status_code == 401
+
+
+class TestGetAccount:
+    def test_get_existing(self, client, auth_header):
+        r = _create_account(client, auth_header, name="My Account")
+        acc_id = r.get_json()["id"]
+        r = client.get(f"/accounts/{acc_id}", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["name"] == "My Account"
+
+    def test_get_not_found(self, client, auth_header):
+        r = client.get("/accounts/99999", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_cannot_get_other_users_account(self, client, auth_header):
+        # Create account for user1 then try to access as user2
+        r = _create_account(client, auth_header, name="User1 Account")
+        acc_id = r.get_json()["id"]
+
+        # Register/login as user2
+        client.post(
+            "/auth/register", json={"email": "user2@example.com", "password": "pass2222"}
+        )
+        r2 = client.post(
+            "/auth/login", json={"email": "user2@example.com", "password": "pass2222"}
+        )
+        token2 = r2.get_json()["access_token"]
+        h2 = {"Authorization": f"Bearer {token2}"}
+
+        r = client.get(f"/accounts/{acc_id}", headers=h2)
+        assert r.status_code == 404
+
+
+class TestUpdateAccount:
+    def test_update_name(self, client, auth_header):
+        acc_id = _create_account(client, auth_header).get_json()["id"]
+        r = client.patch(
+            f"/accounts/{acc_id}", json={"name": "Updated Name"}, headers=auth_header
+        )
+        assert r.status_code == 200
+        assert r.get_json()["name"] == "Updated Name"
+
+    def test_update_balance(self, client, auth_header):
+        acc_id = _create_account(client, auth_header, balance=500).get_json()["id"]
+        r = client.patch(
+            f"/accounts/{acc_id}", json={"balance": 1500}, headers=auth_header
+        )
+        assert r.status_code == 200
+        assert r.get_json()["balance"] == 1500.0
+
+    def test_update_multiple_fields(self, client, auth_header):
+        acc_id = _create_account(client, auth_header).get_json()["id"]
+        r = client.patch(
+            f"/accounts/{acc_id}",
+            json={
+                "name": "Renamed",
+                "institution": "ICICI",
+                "color": "#ff0000",
+                "include_in_overview": False,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["institution"] == "ICICI"
+        assert data["color"] == "#ff0000"
+        assert data["include_in_overview"] is False
+
+    def test_update_not_found(self, client, auth_header):
+        r = client.patch(
+            "/accounts/99999", json={"name": "Ghost"}, headers=auth_header
+        )
+        assert r.status_code == 404
+
+
+class TestDeleteAccount:
+    def test_soft_delete(self, client, auth_header):
+        acc_id = _create_account(client, auth_header).get_json()["id"]
+        r = client.delete(f"/accounts/{acc_id}", headers=auth_header)
+        assert r.status_code == 200
+        # Should not appear in default list
+        r = client.get("/accounts", headers=auth_header)
+        assert all(a["id"] != acc_id for a in r.get_json())
+        # But the record still exists
+        r = client.get(f"/accounts/{acc_id}", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["active"] is False
+
+    def test_delete_not_found(self, client, auth_header):
+        r = client.delete("/accounts/99999", headers=auth_header)
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Multi-account overview tests
+# ---------------------------------------------------------------------------
+
+
+class TestMultiAccountOverview:
+    def test_overview_empty(self, client, auth_header):
+        r = client.get("/accounts/overview", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "accounts" in data
+        assert "totals" in data
+        assert "monthly_summary" in data
+        assert "upcoming_bills" in data
+        assert "category_breakdown" in data
+
+    def test_overview_totals_assets(self, client, auth_header):
+        _create_account(client, auth_header, name="Savings", balance=10000, account_type="SAVINGS")
+        _create_account(client, auth_header, name="Checking", balance=5000, account_type="CHECKING")
+
+        r = client.get("/accounts/overview", headers=auth_header)
+        assert r.status_code == 200
+        totals = r.get_json()["totals"]
+        assert totals["total_assets"] == 15000.0
+        assert totals["total_liabilities"] == 0.0
+        assert totals["net_worth"] == 15000.0
+
+    def test_overview_totals_with_credit_card_liability(self, client, auth_header):
+        _create_account(
+            client, auth_header, name="Savings", balance=20000, account_type="SAVINGS"
+        )
+        _create_account(
+            client,
+            auth_header,
+            name="CC",
+            balance=5000,  # outstanding credit card balance = liability
+            account_type="CREDIT_CARD",
+        )
+
+        r = client.get("/accounts/overview", headers=auth_header)
+        assert r.status_code == 200
+        totals = r.get_json()["totals"]
+        assert totals["total_assets"] == 20000.0
+        assert totals["total_liabilities"] == 5000.0
+        assert totals["net_worth"] == 15000.0
+
+    def test_overview_exclude_account(self, client, auth_header):
+        _create_account(
+            client,
+            auth_header,
+            name="Hidden",
+            balance=999999,
+            include_in_overview=False,
+        )
+        _create_account(
+            client, auth_header, name="Visible", balance=1000, account_type="CHECKING"
+        )
+
+        r = client.get("/accounts/overview", headers=auth_header)
+        assert r.status_code == 200
+        totals = r.get_json()["totals"]
+        # Hidden account should not contribute to totals
+        assert totals["total_assets"] == 1000.0
+
+    def test_overview_monthly_summary(self, client, auth_header):
+        # Seed income and expense
+        today = date.today().isoformat()
+        client.post(
+            "/expenses",
+            json={"amount": 5000, "description": "Salary", "date": today, "expense_type": "INCOME"},
+            headers=auth_header,
+        )
+        client.post(
+            "/expenses",
+            json={"amount": 1000, "description": "Rent", "date": today, "expense_type": "EXPENSE"},
+            headers=auth_header,
+        )
+
+        r = client.get("/accounts/overview", headers=auth_header)
+        assert r.status_code == 200
+        ms = r.get_json()["monthly_summary"]
+        assert ms["income"] >= 5000
+        assert ms["expenses"] >= 1000
+        assert ms["net_flow"] >= 4000
+
+    def test_overview_upcoming_bills(self, client, auth_header):
+        due = (date.today() + timedelta(days=5)).isoformat()
+        client.post(
+            "/bills",
+            json={"name": "Netflix", "amount": 199, "next_due_date": due, "cadence": "MONTHLY"},
+            headers=auth_header,
+        )
+
+        r = client.get("/accounts/overview", headers=auth_header)
+        assert r.status_code == 200
+        bills = r.get_json()["upcoming_bills"]
+        assert any(b["name"] == "Netflix" for b in bills)
+
+    def test_overview_invalid_month(self, client, auth_header):
+        r = client.get("/accounts/overview?month=not-a-month", headers=auth_header)
+        assert r.status_code == 400
+
+    def test_overview_requires_auth(self, client):
+        r = client.get("/accounts/overview")
+        assert r.status_code == 401
+
+    def test_overview_returns_all_accounts_list(self, client, auth_header):
+        _create_account(client, auth_header, name="Alpha")
+        _create_account(client, auth_header, name="Beta")
+        r = client.get("/accounts/overview", headers=auth_header)
+        assert r.status_code == 200
+        names = [a["name"] for a in r.get_json()["accounts"]]
+        assert "Alpha" in names
+        assert "Beta" in names


### PR DESCRIPTION
## Summary

Closes #132

Implements a full multi-account financial overview dashboard, allowing users to manage and view all their financial accounts (bank accounts, credit cards, investments, loans, etc.) in a single unified view.

---

## What's Changed

### Backend

**New model:** `FinancialAccount`
- Fields: `name`, `account_type` (CHECKING / SAVINGS / CREDIT_CARD / INVESTMENT / LOAN / CASH / OTHER), `balance`, `currency`, `institution`, `last_four`, `color`, `include_in_overview`, `active`
- Soft-delete pattern (set `active=False`)

**New REST API `/accounts`:**
| Method | Path | Description |
|--------|------|-------------|
| GET | /accounts | List active accounts |
| POST | /accounts | Create account |
| GET | /accounts/`{id}` | Get account |
| PATCH | /accounts/`{id}` | Update account |
| DELETE | /accounts/`{id}` | Deactivate account |
| GET | /accounts/overview | Aggregated multi-account overview |

**`GET /accounts/overview`** returns:
- `totals`: net_worth, total_assets, total_liabilities
- `monthly_summary`: income, expenses, net_flow for selected month
- `accounts`: full list of accounts
- `upcoming_bills`: next due bills
- `category_breakdown`: expense breakdown by category

**Schema:** Added `financial_accounts` table to `db/schema.sql` with `account_type` enum and index.

**Tests:** 31 new tests in `tests/test_accounts.py` — all passing. Also updated `conftest.py` to use `fakeredis` for test isolation (fixes existing tests running without a Redis server).

---

### Frontend

**New API client:** `app/src/api/accounts.ts` — full TypeScript types + all API calls.

**New page:** `MultiAccountDashboard` at `/accounts`:
- **Net worth summary** — total assets, total liabilities, net worth cards
- **Monthly summary** — income, expenses, net cash flow (month picker)
- **Account grid** — color-coded cards per account with edit/delete actions
- **Add/Edit dialog** — full form (name, type, balance, currency, institution, last four, color, include in overview toggle)
- **Upcoming bills** list
- **Category breakdown** progress bar chart
- Refresh button

**Navbar:** Added _Accounts_ link.
**Router:** Registered `/accounts` route in App.tsx.

---

## Testing

```bash
cd packages/backend
pip install fakeredis  # one-time
pytest tests/test_accounts.py -v  # 31 tests, all pass
pytest tests/                     # 53 total tests, all pass
```

---

## Acceptance Criteria

- [x] Production-ready implementation
- [x] Includes tests (31 new backend tests)
- [x] Documentation updated (this PR description)
