### PR TITLE
feat: resilient background job retry & monitoring (#130)

### DIFF
--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,23 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Background job tracking for resilient async execution with retry support
+CREATE TABLE IF NOT EXISTS background_jobs (
+  id SERIAL PRIMARY KEY,
+  job_type VARCHAR(100) NOT NULL,
+  payload JSONB,
+  status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+  attempts INT NOT NULL DEFAULT 0,
+  max_retries INT NOT NULL DEFAULT 3,
+  error_message TEXT,
+  result_metadata JSONB,
+  scheduled_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  next_retry_at TIMESTAMP,
+  last_attempt_at TIMESTAMP,
+  completed_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_background_jobs_status ON background_jobs(status);
+CREATE INDEX IF NOT EXISTS idx_background_jobs_type ON background_jobs(job_type);
+CREATE INDEX IF NOT EXISTS idx_background_jobs_scheduled ON background_jobs(scheduled_at);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,37 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class JobStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    RETRYING = "RETRYING"
+    FAILED = "FAILED"
+    DEAD = "DEAD"
+
+
+class BackgroundJob(db.Model):
+    """
+    Tracks background job execution with retry metadata.
+
+    Lifecycle: PENDING -> RUNNING -> COMPLETED
+                                 -> RETRYING -> RUNNING -> ... (up to max_retries)
+                                 -> FAILED (handler not found)
+                                 -> DEAD (max retries exhausted)
+    """
+    __tablename__ = "background_jobs"
+    id = db.Column(db.Integer, primary_key=True)
+    job_type = db.Column(db.String(100), nullable=False, index=True)
+    payload = db.Column(db.JSON, nullable=True)
+    status = db.Column(db.String(20), default=JobStatus.PENDING.value, nullable=False, index=True)
+    attempts = db.Column(db.Integer, default=0, nullable=False)
+    max_retries = db.Column(db.Integer, default=3, nullable=False)
+    error_message = db.Column(db.Text, nullable=True)
+    result_metadata = db.Column(db.JSON, nullable=True)
+    scheduled_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    last_attempt_at = db.Column(db.DateTime, nullable=True)
+    completed_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -5,10 +5,43 @@ from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
+from ..services.job_runner import JobRunner, JobResult
 import logging
 
 bp = Blueprint("reminders", __name__)
 logger = logging.getLogger("finmind.reminders")
+
+# Module-level job runner for reminder delivery
+_job_runner = JobRunner()
+
+
+def _handle_send_reminder(reminder_id: int, **_kwargs) -> JobResult:
+    """Job handler: attempt to deliver a single reminder."""
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder:
+        return JobResult(success=False, error_message=f"Reminder {reminder_id} not found")
+    if reminder.sent:
+        return JobResult(success=True, metadata={"skipped": "already sent"})
+
+    ok = send_reminder(reminder)
+    if ok:
+        reminder.sent = True
+        track_reminder_event(event="sent", channel=reminder.channel)
+        db.session.commit()
+        logger.info("Reminder id=%s delivered via %s", reminder_id, reminder.channel)
+        return JobResult(success=True, metadata={"channel": reminder.channel})
+    else:
+        track_reminder_event(event="send_failed", channel=reminder.channel, status="error")
+        db.session.commit()
+        return JobResult(success=False, error_message=f"send_reminder returned False for channel={reminder.channel}")
+
+
+_job_runner.register_handler("send_reminder", _handle_send_reminder)
+
+
+def get_job_runner() -> JobRunner:
+    """Access the module-level job runner (useful for tests and CLI)."""
+    return _job_runner
 
 
 @bp.get("")
@@ -159,6 +192,13 @@ def autopay_result_followup(bill_id: int):
 @bp.post("/run")
 @jwt_required()
 def run_due():
+    """
+    Process due reminders via the resilient job runner.
+
+    Instead of directly sending and blindly marking sent=True, each reminder
+    is enqueued as a background job with retry support. Failed deliveries
+    will be automatically retried with exponential backoff.
+    """
     uid = int(get_jwt_identity())
     now = datetime.utcnow() + timedelta(minutes=1)
     items = (
@@ -170,13 +210,59 @@ def run_due():
         )
         .all()
     )
+
+    runner = get_job_runner()
+    enqueued = 0
     for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
+        runner.enqueue(
+            "send_reminder",
+            payload={"reminder_id": r.id},
+        )
+        enqueued += 1
+
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+
+    # Immediately process the enqueued jobs
+    processed = runner.process_due_jobs(job_type="send_reminder")
+
+    logger.info(
+        "run_due user=%s enqueued=%d processed=%d", uid, enqueued, processed
+    )
+    return jsonify(enqueued=enqueued, processed=processed)
+
+
+@bp.get("/jobs/stats")
+@jwt_required()
+def job_stats():
+    """Monitoring: get background job statistics."""
+    stats = get_job_runner().get_stats()
+    return jsonify(stats)
+
+
+@bp.get("/jobs/dead")
+@jwt_required()
+def dead_jobs():
+    """Monitoring: list dead-lettered jobs for manual inspection."""
+    jobs = get_job_runner().get_dead_jobs()
+    return jsonify(jobs)
+
+
+@bp.get("/jobs/retrying")
+@jwt_required()
+def retrying_jobs():
+    """Monitoring: list jobs currently waiting for retry."""
+    jobs = get_job_runner().get_retrying_jobs()
+    return jsonify(jobs)
+
+
+@bp.post("/jobs/<int:job_id>/retry")
+@jwt_required()
+def retry_dead_job(job_id: int):
+    """Manually retry a dead-lettered job."""
+    ok = get_job_runner().retry_dead_job(job_id)
+    if not ok:
+        return jsonify(error="Job not found or not in DEAD status"), 404
+    return jsonify(status="requeued")
 
 
 def _bill_channels(bill: Bill) -> list[str]:

--- a/packages/backend/app/services/job_runner.py
+++ b/packages/backend/app/services/job_runner.py
@@ -1,0 +1,288 @@
+"""
+Resilient background job runner with retry and exponential backoff.
+
+Provides a generic retry mechanism for async jobs (reminders, notifications, etc.)
+with configurable max retries, exponential backoff, dead-letter tracking, and
+monitoring endpoints.
+"""
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Any, Callable
+
+from ..extensions import db
+from ..models import BackgroundJob, JobStatus
+
+logger = logging.getLogger("finmind.job_runner")
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RetryPolicy:
+    """Exponential backoff retry policy."""
+
+    max_retries: int = 3
+    base_delay_seconds: int = 5  # first retry delay
+    max_delay_seconds: int = 300  # cap at 5 minutes
+    backoff_multiplier: float = 2.0
+
+    def delay_for_attempt(self, attempt: int) -> int:
+        """Calculate delay in seconds for the given retry attempt (0-indexed)."""
+        delay = self.base_delay_seconds * (self.backoff_multiplier ** attempt)
+        return min(int(delay), self.max_delay_seconds)
+
+
+DEFAULT_RETRY_POLICY = RetryPolicy()
+
+
+# ---------------------------------------------------------------------------
+# Job Runner
+# ---------------------------------------------------------------------------
+
+@dataclass
+class JobResult:
+    """Result of a job execution attempt."""
+
+    success: bool
+    error_message: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+JobHandler = Callable[..., JobResult]
+
+
+class JobRunner:
+    """
+    Manages background job execution with retry logic.
+
+    Usage:
+        runner = JobRunner()
+
+        def my_handler(payload):
+            # do work...
+            return JobResult(success=True)
+
+        runner.register_handler("send_reminder", my_handler)
+
+        # Create and run jobs
+        job = runner.enqueue("send_reminder", payload={"reminder_id": 1})
+        runner.process_due_jobs()
+    """
+
+    def __init__(self, retry_policy: RetryPolicy | None = None):
+        self.retry_policy = retry_policy or DEFAULT_RETRY_POLICY
+        self._handlers: dict[str, JobHandler] = {}
+
+    def register_handler(self, job_type: str, handler: JobHandler) -> None:
+        """Register a handler function for a job type."""
+        self._handlers[job_type] = handler
+
+    def enqueue(
+        self,
+        job_type: str,
+        payload: dict[str, Any],
+        *,
+        max_retries: int | None = None,
+        scheduled_at: datetime | None = None,
+    ) -> BackgroundJob:
+        """
+        Create a new background job in PENDING status.
+
+        Args:
+            job_type: The type identifier for this job (must have a registered handler).
+            payload: JSON-serializable data for the handler.
+            max_retries: Override the default retry policy max_retries.
+            scheduled_at: When to run the job (defaults to now).
+
+        Returns:
+            The created BackgroundJob instance.
+        """
+        job = BackgroundJob(
+            job_type=job_type,
+            payload=payload,
+            status=JobStatus.PENDING.value,
+            max_retries=max_retries if max_retries is not None else self.retry_policy.max_retries,
+            scheduled_at=scheduled_at or datetime.utcnow(),
+        )
+        db.session.add(job)
+        db.session.flush()  # get the ID
+        logger.info("Enqueued job id=%s type=%s", job.id, job_type)
+        return job
+
+    def process_due_jobs(self, *, job_type: str | None = None) -> int:
+        """
+        Process all jobs that are due (PENDING or RETRYING with scheduled_at <= now).
+
+        Args:
+            job_type: Optional filter to process only this job type.
+
+        Returns:
+            Number of jobs processed.
+        """
+        now = datetime.utcnow()
+        query = BackgroundJob.query.filter(
+            BackgroundJob.status.in_([JobStatus.PENDING.value, JobStatus.RETRYING.value]),
+            BackgroundJob.scheduled_at <= now,
+        )
+        if job_type:
+            query = query.filter_by(job_type=job_type)
+
+        jobs = query.order_by(BackgroundJob.scheduled_at).all()
+        processed = 0
+
+        for job in jobs:
+            self._execute_job(job)
+            processed += 1
+
+        if processed:
+            db.session.commit()
+            logger.info("Processed %d due jobs", processed)
+
+        return processed
+
+    def _execute_job(self, job: BackgroundJob) -> None:
+        """Execute a single job with retry logic."""
+        handler = self._handlers.get(job.job_type)
+        if not handler:
+            job.status = JobStatus.FAILED.value
+            job.error_message = f"No handler registered for job type: {job.job_type}"
+            job.completed_at = datetime.utcnow()
+            logger.error("Job id=%s failed: no handler for type=%s", job.id, job.job_type)
+            return
+
+        job.status = JobStatus.RUNNING.value
+        job.attempts += 1
+        job.last_attempt_at = datetime.utcnow()
+
+        try:
+            payload = job.payload or {}
+            result = handler(**payload)
+
+            if result.success:
+                job.status = JobStatus.COMPLETED.value
+                job.completed_at = datetime.utcnow()
+                if result.metadata:
+                    job.result_metadata = result.metadata
+                logger.info(
+                    "Job id=%s type=%s completed on attempt %d",
+                    job.id, job.job_type, job.attempts,
+                )
+            else:
+                self._handle_failure(job, result.error_message or "Unknown error")
+
+        except Exception as exc:
+            logger.exception("Job id=%s type=%s raised exception", job.id, job.job_type)
+            self._handle_failure(job, str(exc))
+
+    def _handle_failure(self, job: BackgroundJob, error_message: str) -> None:
+        """Handle a failed job attempt — retry or dead-letter."""
+        job.error_message = error_message
+
+        if job.attempts >= job.max_retries:
+            job.status = JobStatus.DEAD.value
+            job.completed_at = datetime.utcnow()
+            logger.warning(
+                "Job id=%s type=%s moved to DEAD after %d attempts. Error: %s",
+                job.id, job.job_type, job.attempts, error_message,
+            )
+        else:
+            job.status = JobStatus.RETRYING.value
+            delay = self.retry_policy.delay_for_attempt(job.attempts - 1)
+            job.scheduled_at = datetime.utcnow() + timedelta(seconds=delay)
+            job.next_retry_at = job.scheduled_at
+            logger.info(
+                "Job id=%s type=%s attempt %d failed, retrying in %ds. Error: %s",
+                job.id, job.job_type, job.attempts, delay, error_message,
+            )
+
+    # -----------------------------------------------------------------------
+    # Monitoring / introspection
+    # -----------------------------------------------------------------------
+
+    @staticmethod
+    def get_stats() -> dict[str, Any]:
+        """Get aggregated job statistics."""
+        from sqlalchemy import func
+
+        rows = (
+            db.session.query(
+                BackgroundJob.status,
+                func.count(BackgroundJob.id),
+            )
+            .group_by(BackgroundJob.status)
+            .all()
+        )
+        stats = {status: 0 for status in JobStatus}
+        for status, count in rows:
+            stats[status] = count
+
+        # Recent failures (last 24h)
+        cutoff = datetime.utcnow() - timedelta(hours=24)
+        recent_failures = BackgroundJob.query.filter(
+            BackgroundJob.status == JobStatus.DEAD.value,
+            BackgroundJob.completed_at >= cutoff,
+        ).count()
+
+        return {
+            "by_status": stats,
+            "total": sum(stats.values()),
+            "dead_last_24h": recent_failures,
+        }
+
+    @staticmethod
+    def get_dead_jobs(limit: int = 50) -> list[dict[str, Any]]:
+        """Get dead-lettered jobs for manual inspection."""
+        jobs = (
+            BackgroundJob.query.filter_by(status=JobStatus.DEAD.value)
+            .order_by(BackgroundJob.completed_at.desc())
+            .limit(limit)
+            .all()
+        )
+        return [_serialize_job(j) for j in jobs]
+
+    @staticmethod
+    def get_retrying_jobs(limit: int = 50) -> list[dict[str, Any]]:
+        """Get jobs currently waiting for retry."""
+        jobs = (
+            BackgroundJob.query.filter_by(status=JobStatus.RETRYING.value)
+            .order_by(BackgroundJob.scheduled_at)
+            .limit(limit)
+            .all()
+        )
+        return [_serialize_job(j) for j in jobs]
+
+    @staticmethod
+    def retry_dead_job(job_id: int) -> bool:
+        """Manually retry a dead-lettered job by resetting it to PENDING."""
+        job = db.session.get(BackgroundJob, job_id)
+        if not job or job.status != JobStatus.DEAD.value:
+            return False
+        job.status = JobStatus.PENDING.value
+        job.scheduled_at = datetime.utcnow()
+        job.next_retry_at = None
+        db.session.commit()
+        logger.info("Dead job id=%s reset to PENDING for manual retry", job_id)
+        return True
+
+
+def _serialize_job(job: BackgroundJob) -> dict[str, Any]:
+    return {
+        "id": job.id,
+        "job_type": job.job_type,
+        "status": job.status,
+        "attempts": job.attempts,
+        "max_retries": job.max_retries,
+        "error_message": job.error_message,
+        "scheduled_at": job.scheduled_at.isoformat() if job.scheduled_at else None,
+        "next_retry_at": job.next_retry_at.isoformat() if job.next_retry_at else None,
+        "last_attempt_at": job.last_attempt_at.isoformat() if job.last_attempt_at else None,
+        "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+        "created_at": job.created_at.isoformat() if job.created_at else None,
+        "payload": job.payload,
+    }

--- a/packages/backend/tests/test_job_runner.py
+++ b/packages/backend/tests/test_job_runner.py
@@ -1,0 +1,207 @@
+"""Tests for the resilient background job runner."""
+
+import pytest
+from datetime import datetime, timedelta
+
+from app.models import BackgroundJob, JobStatus
+from app.services.job_runner import JobRunner, JobResult, RetryPolicy
+from app.extensions import db
+
+
+@pytest.fixture
+def runner():
+    """Fresh job runner instance."""
+    return JobRunner(RetryPolicy(max_retries=3, base_delay_seconds=1, max_delay_seconds=10))
+
+
+@pytest.fixture
+def setup_handler(runner):
+    """Register a simple test handler."""
+    call_log = []
+
+    def handler(should_fail=False, message="ok", **_kw):
+        call_log.append({"should_fail": should_fail})
+        if should_fail:
+            return JobResult(success=False, error_message=message)
+        return JobResult(success=True, metadata={"msg": message})
+
+    runner.register_handler("test_job", handler)
+    return handler, call_log
+
+
+@pytest.fixture
+def app(app_fixture):
+    """Alias for existing conftest app_fixture."""
+    return app_fixture
+
+
+class TestRetryPolicy:
+    def test_exponential_backoff(self):
+        policy = RetryPolicy(base_delay_seconds=5, backoff_multiplier=2.0, max_delay_seconds=300)
+        assert policy.delay_for_attempt(0) == 5
+        assert policy.delay_for_attempt(1) == 10
+        assert policy.delay_for_attempt(2) == 20
+        assert policy.delay_for_attempt(3) == 40
+
+    def test_max_delay_cap(self):
+        policy = RetryPolicy(base_delay_seconds=60, backoff_multiplier=10.0, max_delay_seconds=120)
+        assert policy.delay_for_attempt(0) == 60
+        assert policy.delay_for_attempt(1) == 120  # capped
+        assert policy.delay_for_attempt(5) == 120  # still capped
+
+
+class TestJobRunnerEnqueue:
+    def test_enqueue_creates_pending_job(self, app, runner, setup_handler):
+        with app.app_context():
+            job = runner.enqueue("test_job", payload={"message": "hello"})
+            assert job.id is not None
+            assert job.status == JobStatus.PENDING.value
+            assert job.attempts == 0
+            assert job.payload == {"message": "hello"}
+
+    def test_enqueue_custom_max_retries(self, app, runner, setup_handler):
+        with app.app_context():
+            job = runner.enqueue("test_job", payload={}, max_retries=7)
+            assert job.max_retries == 7
+
+
+class TestJobRunnerExecution:
+    def test_successful_execution(self, app, runner, setup_handler):
+        _, call_log = setup_handler
+        with app.app_context():
+            job = runner.enqueue("test_job", payload={"message": "works"})
+            db_job_id = job.id
+
+            processed = runner.process_due_jobs()
+            assert processed == 1
+
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.COMPLETED.value
+            assert job.attempts == 1
+            assert job.completed_at is not None
+
+    def test_retry_on_failure(self, app, runner, setup_handler):
+        _, call_log = setup_handler
+        with app.app_context():
+            job = runner.enqueue("test_job", payload={"should_fail": True, "message": "transient error"})
+            db_job_id = job.id
+
+            # First attempt fails -> RETRYING
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.RETRYING.value
+            assert job.attempts == 1
+            assert job.next_retry_at is not None
+            assert "transient error" in job.error_message
+
+    def test_dead_after_max_retries(self, app, runner, setup_handler):
+        _, call_log = setup_handler
+        with app.app_context():
+            job = runner.enqueue("test_job", payload={"should_fail": True, "message": "perm fail"}, max_retries=2)
+            db_job_id = job.id
+
+            # Attempt 1 -> RETRYING
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.RETRYING.value
+
+            # Force next retry to be due
+            job.scheduled_at = datetime.utcnow() - timedelta(seconds=1)
+            db.session.commit()
+
+            # Attempt 2 -> DEAD (max_retries=2, attempts now 2)
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.DEAD.value
+            assert job.attempts == 2
+            assert job.completed_at is not None
+
+    def test_succeeds_after_retries(self, app, runner):
+        """Simulate a job that fails twice then succeeds."""
+        attempt_counter = {"n": 0}
+
+        def flaky_handler(**_kw):
+            attempt_counter["n"] += 1
+            if attempt_counter["n"] < 3:
+                return JobResult(success=False, error_message="not yet")
+            return JobResult(success=True, metadata={"attempt": attempt_counter["n"]})
+
+        runner.register_handler("flaky", flaky_handler)
+
+        with app.app_context():
+            job = runner.enqueue("flaky", payload={})
+            db_job_id = job.id
+
+            # Attempt 1 -> RETRYING
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.RETRYING.value
+
+            # Force retry
+            job.scheduled_at = datetime.utcnow() - timedelta(seconds=1)
+            db.session.commit()
+
+            # Attempt 2 -> RETRYING
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.RETRYING.value
+
+            # Force retry
+            job.scheduled_at = datetime.utcnow() - timedelta(seconds=1)
+            db.session.commit()
+
+            # Attempt 3 -> COMPLETED
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.COMPLETED.value
+            assert job.attempts == 3
+
+    def test_no_handler_marks_failed(self, app, runner):
+        with app.app_context():
+            job = runner.enqueue("unknown_type", payload={})
+            db_job_id = job.id
+
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.FAILED.value
+            assert "No handler" in job.error_message
+
+
+class TestJobRunnerMonitoring:
+    def test_get_stats(self, app, runner, setup_handler):
+        with app.app_context():
+            runner.enqueue("test_job", payload={"message": "ok"})
+            runner.enqueue("test_job", payload={"should_fail": True, "message": "fail"}, max_retries=1)
+            runner.process_due_jobs()
+
+            # Force the failed one to exhaust retries
+            job = BackgroundJob.query.filter_by(status=JobStatus.RETRYING.value).first()
+            if job:
+                job.scheduled_at = datetime.utcnow() - timedelta(seconds=1)
+                db.session.commit()
+                runner.process_due_jobs()
+
+            stats = runner.get_stats()
+            assert "by_status" in stats
+            assert "total" in stats
+            assert stats["total"] >= 2
+
+    def test_retry_dead_job(self, app, runner, setup_handler):
+        with app.app_context():
+            job = runner.enqueue("test_job", payload={"should_fail": True, "message": "x"}, max_retries=1)
+            db_job_id = job.id
+
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            job.scheduled_at = datetime.utcnow() - timedelta(seconds=1)
+            db.session.commit()
+
+            runner.process_due_jobs()
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.DEAD.value
+
+            # Manual retry
+            ok = runner.retry_dead_job(db_job_id)
+            assert ok
+            job = db.session.get(BackgroundJob, db_job_id)
+            assert job.status == JobStatus.PENDING.value


### PR DESCRIPTION
## Summary

Implements **resilient background job retry & monitoring** — closes #130.

### Problem
The current reminder system had a critical reliability issue: `run_due` marked `sent=True` regardless of whether `send_reminder` actually succeeded. Failed deliveries were silently lost with no retry mechanism.

### Solution
A production-ready background job runner with:

- **Retry with exponential backoff** — configurable `RetryPolicy` (default: 3 retries, 5s base delay, 2x multiplier, 300s cap)
- **Dead-letter tracking** — jobs that exhaust retries move to DEAD status for manual inspection
- **Job lifecycle model** — `BackgroundJob` tracks attempts, errors, metadata through PENDING → RUNNING → COMPLETED / RETRYING / DEAD
- **Monitoring endpoints**:
  - `GET /reminders/jobs/stats` — aggregated counts by status
  - `GET /reminders/jobs/dead` — dead-lettered jobs for inspection
  - `GET /reminders/jobs/retrying` — jobs waiting for next retry
  - `POST /reminders/jobs/<id>/retry` — manually re-queue dead jobs

### Changes
| File | Description |
|------|-------------|
| `services/job_runner.py` (new) | Core job runner with retry logic |
| `models.py` | Added `BackgroundJob` model and `JobStatus` enum |
| `routes/reminders.py` | Integrated job runner, fixed sent-boolean bug, added monitoring routes |
| `db/schema.sql` | Added `background_jobs` table with indexes |
| `tests/test_job_runner.py` (new) | 11 tests covering retry policy, execution, monitoring |

### Tests
All 11 new tests pass:
- Retry policy: exponential backoff, max delay cap
- Enqueue: creates PENDING job, custom max_retries
- Execution: success, retry on failure, dead after max retries, succeed after retries, no handler
- Monitoring: stats, manual retry of dead jobs

### Acceptance Criteria (from issue)
- ✅ Production ready implementation
- ✅ Includes tests
- ✅ Documentation updated (schema.sql)