### PR TITLE
feat: Goal-based savings tracking

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import SavingsGoals from "./pages/SavingsGoals";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="savings"
+              element={
+                <ProtectedRoute>
+                  <SavingsGoals />
                 </ProtectedRoute>
               }
             />

--- a/app/src/__tests__/SavingsGoals.integration.test.tsx
+++ b/app/src/__tests__/SavingsGoals.integration.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SavingsGoals from '@/pages/SavingsGoals';
+
+// Mock UI components
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.PropsWithChildren & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+jest.mock('@/components/ui/badge', () => ({
+  Badge: ({ children }: React.PropsWithChildren) => <span>{children}</span>,
+}));
+jest.mock('@/components/ui/progress', () => ({
+  Progress: ({ value }: { value: number }) => (
+    <div role="progressbar" aria-valuenow={value} />
+  ),
+}));
+jest.mock('@/components/ui/financial-card', () => ({
+  FinancialCard: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardTitle: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardDescription: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardFooter: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: React.PropsWithChildren<{ open: boolean }>) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogTitle: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogDescription: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogFooter: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  DialogTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}));
+jest.mock('@/components/ui/alert-dailog', () => ({
+  AlertDialog: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogTrigger: ({ children }: React.PropsWithChildren) => <>{children}</>,
+  AlertDialogContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  AlertDialogCancel: ({ children }: React.PropsWithChildren) => <button>{children}</button>,
+  AlertDialogAction: ({ children, ...props }: React.PropsWithChildren & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+const toastMock = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+const listSavingsGoalsMock = jest.fn();
+const getSavingsSummaryMock = jest.fn();
+const createSavingsGoalMock = jest.fn();
+const deleteSavingsGoalMock = jest.fn();
+
+jest.mock('@/api/savings', () => ({
+  listSavingsGoals: (...args: unknown[]) => listSavingsGoalsMock(...args),
+  getSavingsSummary: (...args: unknown[]) => getSavingsSummaryMock(...args),
+  createSavingsGoal: (...args: unknown[]) => createSavingsGoalMock(...args),
+  updateSavingsGoal: jest.fn(),
+  deleteSavingsGoal: (...args: unknown[]) => deleteSavingsGoalMock(...args),
+  addContribution: jest.fn(),
+  withdrawFromGoal: jest.fn(),
+  getSavingsGoal: jest.fn(),
+}));
+
+jest.mock('@/lib/currency', () => ({
+  formatMoney: (amount: number) => `$${amount.toFixed(2)}`,
+}));
+
+const mockSummary = {
+  total_goals: 2,
+  active_goals: 2,
+  completed_goals: 0,
+  total_saved: 2500,
+  total_target: 15000,
+  overall_progress_pct: 16.7,
+};
+
+const mockGoals = [
+  {
+    id: 1,
+    name: 'Emergency Fund',
+    description: '6 months of expenses',
+    target_amount: 10000,
+    current_amount: 2000,
+    currency: 'USD',
+    target_date: '2027-01-01',
+    icon: 'shield',
+    color: '#22c55e',
+    status: 'ACTIVE',
+    progress_pct: 20,
+    remaining: 8000,
+    days_remaining: 280,
+    monthly_needed: 857.14,
+  },
+  {
+    id: 2,
+    name: 'Vacation',
+    description: 'Summer trip',
+    target_amount: 5000,
+    current_amount: 500,
+    currency: 'USD',
+    target_date: null,
+    icon: 'piggy-bank',
+    color: '#6366f1',
+    status: 'ACTIVE',
+    progress_pct: 10,
+    remaining: 4500,
+  },
+];
+
+describe('SavingsGoals integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listSavingsGoalsMock.mockResolvedValue(mockGoals);
+    getSavingsSummaryMock.mockResolvedValue(mockSummary);
+  });
+
+  it('loads and renders savings goals and summary', async () => {
+    render(<SavingsGoals />);
+    await waitFor(() => expect(listSavingsGoalsMock).toHaveBeenCalled());
+    expect(screen.getByText('Savings Goals')).toBeInTheDocument();
+    expect(screen.getByText('Emergency Fund')).toBeInTheDocument();
+    expect(screen.getByText('Vacation')).toBeInTheDocument();
+    expect(screen.getByText('Total Saved')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no goals exist', async () => {
+    listSavingsGoalsMock.mockResolvedValue([]);
+    render(<SavingsGoals />);
+    await waitFor(() => expect(listSavingsGoalsMock).toHaveBeenCalled());
+    expect(screen.getByText('No savings goals yet')).toBeInTheDocument();
+  });
+
+  it('renders progress percentages', async () => {
+    render(<SavingsGoals />);
+    await waitFor(() => expect(listSavingsGoalsMock).toHaveBeenCalled());
+    expect(screen.getByText('20% complete')).toBeInTheDocument();
+    expect(screen.getByText('10% complete')).toBeInTheDocument();
+  });
+
+  it('renders target date and monthly needed', async () => {
+    render(<SavingsGoals />);
+    await waitFor(() => expect(listSavingsGoalsMock).toHaveBeenCalled());
+    expect(screen.getByText(/280 days left/)).toBeInTheDocument();
+    expect(screen.getByText(/\$857\.14/)).toBeInTheDocument();
+  });
+
+  it('filters goals by status', async () => {
+    render(<SavingsGoals />);
+    await waitFor(() => expect(listSavingsGoalsMock).toHaveBeenCalledWith('ACTIVE'));
+
+    const allButton = screen.getByRole('button', { name: /all goals/i });
+    await userEvent.click(allButton);
+    await waitFor(() => expect(listSavingsGoalsMock).toHaveBeenCalledWith('ALL'));
+  });
+});

--- a/app/src/api/savings.ts
+++ b/app/src/api/savings.ts
@@ -1,0 +1,112 @@
+import { api } from './client';
+
+export type SavingsGoalStatus = 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+
+export type SavingsGoal = {
+  id: number;
+  name: string;
+  description?: string | null;
+  target_amount: number;
+  current_amount: number;
+  currency: string;
+  target_date?: string | null;
+  icon: string;
+  color: string;
+  status: SavingsGoalStatus;
+  progress_pct: number;
+  remaining: number;
+  days_remaining?: number;
+  monthly_needed?: number;
+  created_at?: string;
+  updated_at?: string;
+  contributions?: SavingsContribution[];
+};
+
+export type SavingsContribution = {
+  id: number;
+  goal_id: number;
+  amount: number;
+  note?: string | null;
+  contributed_at?: string;
+  created_at?: string;
+};
+
+export type SavingsGoalCreate = {
+  name: string;
+  description?: string;
+  target_amount: number;
+  current_amount?: number;
+  currency?: string;
+  target_date?: string;
+  icon?: string;
+  color?: string;
+};
+
+export type SavingsGoalUpdate = Partial<SavingsGoalCreate> & {
+  status?: SavingsGoalStatus;
+};
+
+export type SavingsSummary = {
+  total_goals: number;
+  active_goals: number;
+  completed_goals: number;
+  total_saved: number;
+  total_target: number;
+  overall_progress_pct: number;
+};
+
+export async function listSavingsGoals(
+  status?: string,
+): Promise<SavingsGoal[]> {
+  const qs = new URLSearchParams();
+  if (status) qs.set('status', status);
+  const path = '/savings' + (qs.toString() ? `?${qs.toString()}` : '');
+  return api<SavingsGoal[]>(path);
+}
+
+export async function getSavingsGoal(id: number): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${id}`);
+}
+
+export async function createSavingsGoal(
+  payload: SavingsGoalCreate,
+): Promise<SavingsGoal> {
+  return api<SavingsGoal>('/savings', { method: 'POST', body: payload });
+}
+
+export async function updateSavingsGoal(
+  id: number,
+  payload: SavingsGoalUpdate,
+): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function deleteSavingsGoal(
+  id: number,
+): Promise<{ message: string }> {
+  return api(`/savings/${id}`, { method: 'DELETE' });
+}
+
+export async function addContribution(
+  goalId: number,
+  payload: { amount: number; note?: string; contributed_at?: string },
+): Promise<{ contribution: SavingsContribution; goal: SavingsGoal }> {
+  return api(`/savings/${goalId}/contributions`, {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export async function withdrawFromGoal(
+  goalId: number,
+  payload: { amount: number; note?: string },
+): Promise<{ contribution: SavingsContribution; goal: SavingsGoal }> {
+  return api(`/savings/${goalId}/withdraw`, {
+    method: 'POST',
+    body: payload,
+  });
+}
+
+export async function getSavingsSummary(): Promise<SavingsSummary> {
+  return api<SavingsSummary>('/savings/summary');
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -9,6 +9,7 @@ import { logout as logoutApi } from '@/api/auth';
 const navigation = [
   { name: 'Dashboard', href: '/dashboard' },
   { name: 'Budgets', href: '/budgets' },
+  { name: 'Savings', href: '/savings' },
   { name: 'Bills', href: '/bills' },
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },

--- a/app/src/pages/SavingsGoals.tsx
+++ b/app/src/pages/SavingsGoals.tsx
@@ -1,0 +1,882 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardDescription,
+  FinancialCardFooter,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import {
+  PiggyBank,
+  Plus,
+  Target,
+  TrendingUp,
+  Calendar,
+  DollarSign,
+  Trash2,
+  Edit,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  CheckCircle,
+  Clock,
+  Award,
+} from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import {
+  listSavingsGoals,
+  createSavingsGoal,
+  updateSavingsGoal,
+  deleteSavingsGoal,
+  addContribution,
+  withdrawFromGoal,
+  getSavingsSummary,
+  type SavingsGoal,
+  type SavingsSummary,
+} from '@/api/savings';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dailog';
+import { formatMoney } from '@/lib/currency';
+
+const GOAL_COLORS = [
+  '#6366f1',
+  '#22c55e',
+  '#f59e0b',
+  '#ef4444',
+  '#3b82f6',
+  '#8b5cf6',
+  '#ec4899',
+  '#14b8a6',
+];
+
+const GOAL_ICONS: { value: string; label: string }[] = [
+  { value: 'piggy-bank', label: 'Piggy Bank' },
+  { value: 'home', label: 'Home' },
+  { value: 'car', label: 'Car' },
+  { value: 'plane', label: 'Travel' },
+  { value: 'graduation', label: 'Education' },
+  { value: 'shield', label: 'Emergency' },
+  { value: 'gift', label: 'Gift' },
+  { value: 'star', label: 'Other' },
+];
+
+function GoalIcon({ icon, color }: { icon: string; color: string }) {
+  const style = { backgroundColor: color + '20', color };
+  const iconClass = 'w-6 h-6';
+  switch (icon) {
+    case 'home':
+      return (
+        <div
+          className="w-12 h-12 rounded-xl flex items-center justify-center"
+          style={style}
+        >
+          <Target className={iconClass} />
+        </div>
+      );
+    case 'shield':
+      return (
+        <div
+          className="w-12 h-12 rounded-xl flex items-center justify-center"
+          style={style}
+        >
+          <Award className={iconClass} />
+        </div>
+      );
+    case 'car':
+    case 'plane':
+    case 'graduation':
+    case 'gift':
+    case 'star':
+      return (
+        <div
+          className="w-12 h-12 rounded-xl flex items-center justify-center"
+          style={style}
+        >
+          <Target className={iconClass} />
+        </div>
+      );
+    default:
+      return (
+        <div
+          className="w-12 h-12 rounded-xl flex items-center justify-center"
+          style={style}
+        >
+          <PiggyBank className={iconClass} />
+        </div>
+      );
+  }
+}
+
+export default function SavingsGoals() {
+  const { toast } = useToast();
+  const [goals, setGoals] = useState<SavingsGoal[]>([]);
+  const [summary, setSummary] = useState<SavingsSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState('ACTIVE');
+
+  // Create dialog state
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [targetAmount, setTargetAmount] = useState('');
+  const [targetDate, setTargetDate] = useState('');
+  const [selectedColor, setSelectedColor] = useState(GOAL_COLORS[0]);
+  const [selectedIcon, setSelectedIcon] = useState('piggy-bank');
+  const [saving, setSaving] = useState(false);
+
+  // Contribution dialog state
+  const [contribOpen, setContribOpen] = useState(false);
+  const [contribGoalId, setContribGoalId] = useState<number | null>(null);
+  const [contribAmount, setContribAmount] = useState('');
+  const [contribNote, setContribNote] = useState('');
+  const [contribMode, setContribMode] = useState<'deposit' | 'withdraw'>(
+    'deposit',
+  );
+
+  // Edit dialog state
+  const [editOpen, setEditOpen] = useState(false);
+  const [editGoal, setEditGoal] = useState<SavingsGoal | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+  const [editTarget, setEditTarget] = useState('');
+  const [editDate, setEditDate] = useState('');
+
+  const getErrorMessage = (error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback;
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [goalsData, summaryData] = await Promise.all([
+        listSavingsGoals(statusFilter),
+        getSavingsSummary(),
+      ]);
+      setGoals(goalsData);
+      setSummary(summaryData);
+    } catch (error: unknown) {
+      toast({
+        title: 'Failed to load savings goals',
+        description: getErrorMessage(error, 'Please try again.'),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast, statusFilter]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function onCreate() {
+    if (!name.trim() || !targetAmount) return;
+    setSaving(true);
+    try {
+      await createSavingsGoal({
+        name: name.trim(),
+        description: description.trim() || undefined,
+        target_amount: Number(targetAmount),
+        target_date: targetDate || undefined,
+        color: selectedColor,
+        icon: selectedIcon,
+      });
+      await refresh();
+      setCreateOpen(false);
+      setName('');
+      setDescription('');
+      setTargetAmount('');
+      setTargetDate('');
+      setSelectedColor(GOAL_COLORS[0]);
+      setSelectedIcon('piggy-bank');
+      toast({ title: 'Savings goal created' });
+    } catch (error: unknown) {
+      toast({
+        title: 'Failed to create goal',
+        description: getErrorMessage(error, 'Please try again.'),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onContribute() {
+    if (!contribGoalId || !contribAmount) return;
+    setSaving(true);
+    try {
+      if (contribMode === 'deposit') {
+        await addContribution(contribGoalId, {
+          amount: Number(contribAmount),
+          note: contribNote.trim() || undefined,
+        });
+        toast({ title: 'Contribution added' });
+      } else {
+        await withdrawFromGoal(contribGoalId, {
+          amount: Number(contribAmount),
+          note: contribNote.trim() || undefined,
+        });
+        toast({ title: 'Withdrawal processed' });
+      }
+      await refresh();
+      setContribOpen(false);
+      setContribAmount('');
+      setContribNote('');
+    } catch (error: unknown) {
+      toast({
+        title: contribMode === 'deposit' ? 'Failed to add' : 'Failed to withdraw',
+        description: getErrorMessage(error, 'Please try again.'),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onEdit() {
+    if (!editGoal) return;
+    setSaving(true);
+    try {
+      await updateSavingsGoal(editGoal.id, {
+        name: editName.trim(),
+        description: editDescription.trim() || undefined,
+        target_amount: Number(editTarget),
+        target_date: editDate || undefined,
+      });
+      await refresh();
+      setEditOpen(false);
+      toast({ title: 'Goal updated' });
+    } catch (error: unknown) {
+      toast({
+        title: 'Failed to update goal',
+        description: getErrorMessage(error, 'Please try again.'),
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function openContribDialog(goalId: number, mode: 'deposit' | 'withdraw') {
+    setContribGoalId(goalId);
+    setContribMode(mode);
+    setContribAmount('');
+    setContribNote('');
+    setContribOpen(true);
+  }
+
+  function openEditDialog(goal: SavingsGoal) {
+    setEditGoal(goal);
+    setEditName(goal.name);
+    setEditDescription(goal.description || '');
+    setEditTarget(String(goal.target_amount));
+    setEditDate(goal.target_date || '');
+    setEditOpen(true);
+  }
+
+  function getProgressColor(pct: number): string {
+    if (pct >= 100) return 'bg-green-500';
+    if (pct >= 75) return 'bg-emerald-500';
+    if (pct >= 50) return 'bg-blue-500';
+    if (pct >= 25) return 'bg-amber-500';
+    return 'bg-slate-400';
+  }
+
+  return (
+    <div className="page-wrap">
+      {/* Header */}
+      <div className="page-header">
+        <div className="relative flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+          <div>
+            <h1 className="page-title">Savings Goals</h1>
+            <p className="page-subtitle">
+              Track your savings progress and reach your financial milestones
+            </p>
+          </div>
+          <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+            <DialogTrigger asChild>
+              <Button variant="financial" size="sm">
+                <Plus className="w-4 h-4" />
+                New Goal
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-lg">
+              <DialogHeader>
+                <DialogTitle>Create Savings Goal</DialogTitle>
+                <DialogDescription>
+                  Set a financial target and track your progress toward it.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    Goal Name
+                  </label>
+                  <input
+                    className="input w-full"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="e.g., Emergency Fund, Vacation, New Car"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    Description (optional)
+                  </label>
+                  <input
+                    className="input w-full"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="What is this goal for?"
+                  />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-1">
+                      Target Amount
+                    </label>
+                    <input
+                      className="input w-full"
+                      type="number"
+                      min="1"
+                      step="0.01"
+                      value={targetAmount}
+                      onChange={(e) => setTargetAmount(e.target.value)}
+                      placeholder="10,000"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium mb-1">
+                      Target Date (optional)
+                    </label>
+                    <input
+                      className="input w-full"
+                      type="date"
+                      value={targetDate}
+                      onChange={(e) => setTargetDate(e.target.value)}
+                      min={new Date().toISOString().slice(0, 10)}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">Icon</label>
+                  <div className="flex flex-wrap gap-2">
+                    {GOAL_ICONS.map((ic) => (
+                      <button
+                        key={ic.value}
+                        type="button"
+                        onClick={() => setSelectedIcon(ic.value)}
+                        className={`px-3 py-1.5 text-xs rounded-full border transition ${
+                          selectedIcon === ic.value
+                            ? 'border-primary bg-primary/10 text-primary font-semibold'
+                            : 'border-border text-muted-foreground hover:bg-muted'
+                        }`}
+                      >
+                        {ic.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    Color
+                  </label>
+                  <div className="flex gap-2">
+                    {GOAL_COLORS.map((c) => (
+                      <button
+                        key={c}
+                        type="button"
+                        onClick={() => setSelectedColor(c)}
+                        className={`w-8 h-8 rounded-full border-2 transition ${
+                          selectedColor === c
+                            ? 'border-foreground scale-110'
+                            : 'border-transparent'
+                        }`}
+                        style={{ backgroundColor: c }}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setCreateOpen(false)}
+                  disabled={saving}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={onCreate}
+                  disabled={saving || !name.trim() || !targetAmount}
+                >
+                  {saving ? 'Creating...' : 'Create Goal'}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      {summary && (
+        <div className="grid gap-4 md:grid-cols-4 mb-8">
+          <FinancialCard variant="financial">
+            <FinancialCardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                  Total Saved
+                </FinancialCardTitle>
+                <PiggyBank className="w-5 h-5 text-muted-foreground" />
+              </div>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <div className="metric-value text-foreground mb-1">
+                {formatMoney(summary.total_saved)}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                across {summary.total_goals} goal
+                {summary.total_goals !== 1 ? 's' : ''}
+              </div>
+            </FinancialCardContent>
+          </FinancialCard>
+
+          <FinancialCard variant="financial">
+            <FinancialCardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                  Total Target
+                </FinancialCardTitle>
+                <Target className="w-5 h-5 text-muted-foreground" />
+              </div>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <div className="metric-value text-foreground mb-1">
+                {formatMoney(summary.total_target)}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                {summary.active_goals} active goal
+                {summary.active_goals !== 1 ? 's' : ''}
+              </div>
+            </FinancialCardContent>
+          </FinancialCard>
+
+          <FinancialCard
+            variant={
+              summary.overall_progress_pct >= 100 ? 'success' : 'financial'
+            }
+          >
+            <FinancialCardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                  Overall Progress
+                </FinancialCardTitle>
+                <TrendingUp className="w-5 h-5 text-muted-foreground" />
+              </div>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <div className="metric-value text-foreground mb-1">
+                {summary.overall_progress_pct}%
+              </div>
+              <Progress
+                value={Math.min(summary.overall_progress_pct, 100)}
+                className="h-2"
+              />
+            </FinancialCardContent>
+          </FinancialCard>
+
+          <FinancialCard variant="financial">
+            <FinancialCardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                  Completed
+                </FinancialCardTitle>
+                <CheckCircle className="w-5 h-5 text-muted-foreground" />
+              </div>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <div className="metric-value text-foreground mb-1">
+                {summary.completed_goals}
+              </div>
+              <div className="text-sm text-muted-foreground">
+                goal{summary.completed_goals !== 1 ? 's' : ''} achieved
+              </div>
+            </FinancialCardContent>
+          </FinancialCard>
+        </div>
+      )}
+
+      {/* Status Filter Tabs */}
+      <div className="flex gap-2 mb-6">
+        {(['ACTIVE', 'COMPLETED', 'ALL'] as const).map((s) => (
+          <Button
+            key={s}
+            variant={statusFilter === s ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setStatusFilter(s)}
+          >
+            {s === 'ALL' ? 'All Goals' : s.charAt(0) + s.slice(1).toLowerCase()}
+          </Button>
+        ))}
+      </div>
+
+      {/* Goals List */}
+      {loading ? (
+        <div className="text-center py-12 text-muted-foreground">
+          Loading savings goals...
+        </div>
+      ) : goals.length === 0 ? (
+        <FinancialCard variant="financial" className="fade-in-up">
+          <FinancialCardContent className="py-12 text-center">
+            <PiggyBank className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
+            <h3 className="text-lg font-semibold mb-2">No savings goals yet</h3>
+            <p className="text-muted-foreground mb-4">
+              Start by creating your first savings goal to track your progress
+              toward financial milestones.
+            </p>
+            <Button variant="financial" onClick={() => setCreateOpen(true)}>
+              <Plus className="w-4 h-4" />
+              Create Your First Goal
+            </Button>
+          </FinancialCardContent>
+        </FinancialCard>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {goals.map((goal) => (
+            <FinancialCard
+              key={goal.id}
+              variant="financial"
+              className="fade-in-up relative overflow-hidden"
+            >
+              {/* Color accent bar */}
+              <div
+                className="absolute top-0 left-0 right-0 h-1"
+                style={{ backgroundColor: goal.color }}
+              />
+
+              <FinancialCardHeader className="pt-5">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-3">
+                    <GoalIcon icon={goal.icon} color={goal.color} />
+                    <div>
+                      <FinancialCardTitle className="text-base font-semibold">
+                        {goal.name}
+                      </FinancialCardTitle>
+                      {goal.description && (
+                        <FinancialCardDescription className="text-xs mt-0.5">
+                          {goal.description}
+                        </FinancialCardDescription>
+                      )}
+                    </div>
+                  </div>
+                  <Badge
+                    variant={
+                      goal.status === 'COMPLETED' ? 'default' : 'secondary'
+                    }
+                    className="text-xs"
+                  >
+                    {goal.status === 'COMPLETED' ? (
+                      <>
+                        <CheckCircle className="w-3 h-3 mr-1" />
+                        Done
+                      </>
+                    ) : (
+                      <>
+                        <Clock className="w-3 h-3 mr-1" />
+                        Active
+                      </>
+                    )}
+                  </Badge>
+                </div>
+              </FinancialCardHeader>
+
+              <FinancialCardContent>
+                {/* Progress bar */}
+                <div className="mb-4">
+                  <div className="flex justify-between text-sm mb-1.5">
+                    <span className="font-semibold text-foreground">
+                      {formatMoney(goal.current_amount, goal.currency)}
+                    </span>
+                    <span className="text-muted-foreground">
+                      {formatMoney(goal.target_amount, goal.currency)}
+                    </span>
+                  </div>
+                  <div className="relative h-3 w-full overflow-hidden rounded-full bg-secondary">
+                    <div
+                      className={`h-full rounded-full transition-all duration-500 ${getProgressColor(goal.progress_pct)}`}
+                      style={{
+                        width: `${Math.min(goal.progress_pct, 100)}%`,
+                      }}
+                    />
+                  </div>
+                  <div className="flex justify-between mt-1.5">
+                    <span className="text-xs text-muted-foreground">
+                      {goal.progress_pct}% complete
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {formatMoney(goal.remaining, goal.currency)} left
+                    </span>
+                  </div>
+                </div>
+
+                {/* Meta info */}
+                <div className="space-y-2">
+                  {goal.target_date && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <Calendar className="w-4 h-4" />
+                      <span>
+                        Target:{' '}
+                        {new Date(goal.target_date).toLocaleDateString()}
+                      </span>
+                      {goal.days_remaining !== undefined && (
+                        <Badge variant="outline" className="text-xs ml-auto">
+                          {goal.days_remaining} days left
+                        </Badge>
+                      )}
+                    </div>
+                  )}
+                  {goal.monthly_needed !== undefined && goal.monthly_needed > 0 && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <DollarSign className="w-4 h-4" />
+                      <span>
+                        Save {formatMoney(goal.monthly_needed, goal.currency)}
+                        /mo to stay on track
+                      </span>
+                    </div>
+                  )}
+                </div>
+              </FinancialCardContent>
+
+              <FinancialCardFooter className="flex gap-2 pt-3 border-t">
+                {goal.status === 'ACTIVE' && (
+                  <>
+                    <Button
+                      variant="financial"
+                      size="sm"
+                      className="flex-1"
+                      onClick={() => openContribDialog(goal.id, 'deposit')}
+                    >
+                      <ArrowDownToLine className="w-3.5 h-3.5" />
+                      Deposit
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => openContribDialog(goal.id, 'withdraw')}
+                    >
+                      <ArrowUpFromLine className="w-3.5 h-3.5" />
+                    </Button>
+                  </>
+                )}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => openEditDialog(goal)}
+                >
+                  <Edit className="w-3.5 h-3.5" />
+                </Button>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button variant="ghost" size="sm">
+                      <Trash2 className="w-3.5 h-3.5 text-destructive" />
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete savings goal?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This will permanently delete &quot;{goal.name}&quot; and
+                        all its contribution history. This action cannot be
+                        undone.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        onClick={async () => {
+                          try {
+                            await deleteSavingsGoal(goal.id);
+                            await refresh();
+                            toast({ title: 'Savings goal deleted' });
+                          } catch (error: unknown) {
+                            toast({
+                              title: 'Failed to delete',
+                              description: getErrorMessage(
+                                error,
+                                'Please try again.',
+                              ),
+                            });
+                          }
+                        }}
+                      >
+                        Delete
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </FinancialCardFooter>
+            </FinancialCard>
+          ))}
+        </div>
+      )}
+
+      {/* Contribution / Withdraw Dialog */}
+      <Dialog open={contribOpen} onOpenChange={setContribOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {contribMode === 'deposit'
+                ? 'Add Contribution'
+                : 'Withdraw Funds'}
+            </DialogTitle>
+            <DialogDescription>
+              {contribMode === 'deposit'
+                ? 'Add money toward this savings goal.'
+                : 'Withdraw money from this savings goal.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Amount</label>
+              <input
+                className="input w-full"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={contribAmount}
+                onChange={(e) => setContribAmount(e.target.value)}
+                placeholder="0.00"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Note (optional)
+              </label>
+              <input
+                className="input w-full"
+                value={contribNote}
+                onChange={(e) => setContribNote(e.target.value)}
+                placeholder={
+                  contribMode === 'deposit'
+                    ? 'e.g., Monthly savings'
+                    : 'e.g., Emergency expense'
+                }
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setContribOpen(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={onContribute}
+              disabled={saving || !contribAmount}
+              variant={contribMode === 'deposit' ? 'default' : 'destructive'}
+            >
+              {saving
+                ? 'Processing...'
+                : contribMode === 'deposit'
+                  ? 'Add Contribution'
+                  : 'Withdraw'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit Goal Dialog */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Savings Goal</DialogTitle>
+            <DialogDescription>
+              Update the details of your savings goal.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Goal Name
+              </label>
+              <input
+                className="input w-full"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Description
+              </label>
+              <input
+                className="input w-full"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  Target Amount
+                </label>
+                <input
+                  className="input w-full"
+                  type="number"
+                  min="1"
+                  step="0.01"
+                  value={editTarget}
+                  onChange={(e) => setEditTarget(e.target.value)}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  Target Date
+                </label>
+                <input
+                  className="input w-full"
+                  type="date"
+                  value={editDate}
+                  onChange={(e) => setEditDate(e.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setEditOpen(false)}
+              disabled={saving}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={onEdit}
+              disabled={saving || !editName.trim() || !editTarget}
+            >
+              {saving ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,32 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Savings Goals
+CREATE TABLE IF NOT EXISTS savings_goals (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  description VARCHAR(500),
+  target_amount NUMERIC(12,2) NOT NULL,
+  current_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  target_date DATE,
+  icon VARCHAR(50) NOT NULL DEFAULT 'piggy-bank',
+  color VARCHAR(20) NOT NULL DEFAULT '#6366f1',
+  status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_goals_user ON savings_goals(user_id, status);
+
+CREATE TABLE IF NOT EXISTS savings_contributions (
+  id SERIAL PRIMARY KEY,
+  goal_id INT NOT NULL REFERENCES savings_goals(id) ON DELETE CASCADE,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  amount NUMERIC(12,2) NOT NULL,
+  note VARCHAR(300),
+  contributed_at DATE NOT NULL DEFAULT CURRENT_DATE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_contributions_goal ON savings_contributions(goal_id, contributed_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,37 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SavingsGoalStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
+
+
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.String(500), nullable=True)
+    target_amount = db.Column(db.Numeric(12, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    target_date = db.Column(db.Date, nullable=True)
+    icon = db.Column(db.String(50), default="piggy-bank", nullable=False)
+    color = db.Column(db.String(20), default="#6366f1", nullable=False)
+    status = db.Column(db.String(20), default=SavingsGoalStatus.ACTIVE.value, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+class SavingsContribution(db.Model):
+    __tablename__ = "savings_contributions"
+    id = db.Column(db.Integer, primary_key=True)
+    goal_id = db.Column(db.Integer, db.ForeignKey("savings_goals.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    amount = db.Column(db.Numeric(12, 2), nullable=False)
+    note = db.Column(db.String(300), nullable=True)
+    contributed_at = db.Column(db.Date, default=date.today, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -12,6 +12,7 @@ tags:
   - name: Bills
   - name: Reminders
   - name: Insights
+  - name: Savings
 paths:
   /auth/register:
     post:
@@ -444,6 +445,217 @@ paths:
                 properties:
                   created: { type: integer }
 
+  /savings:
+    get:
+      summary: List savings goals
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema: { type: string, enum: [ACTIVE, COMPLETED, CANCELLED, ALL], default: ACTIVE }
+      responses:
+        '200':
+          description: List of savings goals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SavingsGoal'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    post:
+      summary: Create savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewSavingsGoal'
+            example:
+              name: Emergency Fund
+              description: 6 months of expenses
+              target_amount: 10000
+              target_date: '2027-01-01'
+              icon: shield
+              color: '#22c55e'
+      responses:
+        '201': { description: Created }
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /savings/summary:
+    get:
+      summary: Get savings summary stats
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Summary statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavingsSummary'
+
+  /savings/{goalId}:
+    get:
+      summary: Get savings goal with contributions
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: goalId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Goal with contributions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavingsGoal'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    patch:
+      summary: Update savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: goalId
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateSavingsGoal'
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SavingsGoal'
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    delete:
+      summary: Delete savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: goalId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /savings/{goalId}/contributions:
+    post:
+      summary: Add contribution to savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: goalId
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewContribution'
+            example:
+              amount: 500
+              note: Monthly savings
+      responses:
+        '201':
+          description: Contribution added
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contribution: { $ref: '#/components/schemas/SavingsContribution' }
+                  goal: { $ref: '#/components/schemas/SavingsGoal' }
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /savings/{goalId}/withdraw:
+    post:
+      summary: Withdraw from savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: goalId
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [amount]
+              properties:
+                amount: { type: number, format: float }
+                note: { type: string, nullable: true }
+      responses:
+        '200':
+          description: Withdrawal processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contribution: { $ref: '#/components/schemas/SavingsContribution' }
+                  goal: { $ref: '#/components/schemas/SavingsGoal' }
+        '400':
+          description: Insufficient balance or validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
   /insights/budget-suggestion:
     get:
       summary: Get monthly budget suggestion
@@ -587,3 +799,73 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    SavingsGoal:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        description: { type: string, nullable: true }
+        target_amount: { type: number, format: float }
+        current_amount: { type: number, format: float }
+        currency: { type: string }
+        target_date: { type: string, format: date, nullable: true }
+        icon: { type: string }
+        color: { type: string }
+        status: { type: string, enum: [ACTIVE, COMPLETED, CANCELLED] }
+        progress_pct: { type: number }
+        remaining: { type: number }
+        days_remaining: { type: integer, nullable: true }
+        monthly_needed: { type: number, nullable: true }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        contributions:
+          type: array
+          items:
+            $ref: '#/components/schemas/SavingsContribution'
+    NewSavingsGoal:
+      type: object
+      required: [name, target_amount]
+      properties:
+        name: { type: string }
+        description: { type: string, nullable: true }
+        target_amount: { type: number, format: float }
+        current_amount: { type: number, format: float, default: 0 }
+        currency: { type: string, default: INR }
+        target_date: { type: string, format: date, nullable: true }
+        icon: { type: string, default: piggy-bank }
+        color: { type: string, default: '#6366f1' }
+    UpdateSavingsGoal:
+      type: object
+      properties:
+        name: { type: string }
+        description: { type: string, nullable: true }
+        target_amount: { type: number, format: float }
+        target_date: { type: string, format: date, nullable: true }
+        icon: { type: string }
+        color: { type: string }
+        status: { type: string, enum: [ACTIVE, COMPLETED, CANCELLED] }
+    SavingsContribution:
+      type: object
+      properties:
+        id: { type: integer }
+        goal_id: { type: integer }
+        amount: { type: number, format: float }
+        note: { type: string, nullable: true }
+        contributed_at: { type: string, format: date }
+        created_at: { type: string, format: date-time }
+    NewContribution:
+      type: object
+      required: [amount]
+      properties:
+        amount: { type: number, format: float }
+        note: { type: string, nullable: true }
+        contributed_at: { type: string, format: date, nullable: true }
+    SavingsSummary:
+      type: object
+      properties:
+        total_goals: { type: integer }
+        active_goals: { type: integer }
+        completed_goals: { type: integer }
+        total_saved: { type: number }
+        total_target: { type: number }
+        overall_progress_pct: { type: number }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings import bp as savings_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_bp, url_prefix="/savings")

--- a/packages/backend/app/routes/savings.py
+++ b/packages/backend/app/routes/savings.py
@@ -1,0 +1,330 @@
+from datetime import date, datetime
+from decimal import Decimal
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import SavingsGoal, SavingsGoalStatus, SavingsContribution, User
+from ..services.cache import cache_delete_patterns
+import logging
+
+bp = Blueprint("savings", __name__)
+logger = logging.getLogger("finmind.savings")
+
+
+def _goal_to_dict(g: SavingsGoal) -> dict:
+    target = float(g.target_amount)
+    current = float(g.current_amount)
+    progress = min((current / target) * 100, 100) if target > 0 else 0
+
+    result = {
+        "id": g.id,
+        "name": g.name,
+        "description": g.description,
+        "target_amount": target,
+        "current_amount": current,
+        "currency": g.currency,
+        "target_date": g.target_date.isoformat() if g.target_date else None,
+        "icon": g.icon,
+        "color": g.color,
+        "status": g.status,
+        "progress_pct": round(progress, 1),
+        "remaining": round(max(target - current, 0), 2),
+        "created_at": g.created_at.isoformat() if g.created_at else None,
+        "updated_at": g.updated_at.isoformat() if g.updated_at else None,
+    }
+
+    # Add days remaining if target_date is set and goal is active
+    if g.target_date and g.status == SavingsGoalStatus.ACTIVE.value:
+        days_left = (g.target_date - date.today()).days
+        result["days_remaining"] = max(days_left, 0)
+        # Monthly savings needed to hit target on time
+        if days_left > 0:
+            months_left = max(days_left / 30.0, 1)
+            result["monthly_needed"] = round(
+                float(max(target - current, 0)) / months_left, 2
+            )
+        else:
+            result["monthly_needed"] = 0
+    return result
+
+
+def _contribution_to_dict(c: SavingsContribution) -> dict:
+    return {
+        "id": c.id,
+        "goal_id": c.goal_id,
+        "amount": float(c.amount),
+        "note": c.note,
+        "contributed_at": c.contributed_at.isoformat() if c.contributed_at else None,
+        "created_at": c.created_at.isoformat() if c.created_at else None,
+    }
+
+
+def _invalidate_cache(uid: int):
+    cache_delete_patterns(
+        [f"user:{uid}:savings_goals*", f"user:{uid}:dashboard_summary:*"]
+    )
+
+
+# ── List all savings goals ──────────────────────────────────────────
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    status_filter = request.args.get("status", "ACTIVE")
+
+    query = db.session.query(SavingsGoal).filter_by(user_id=uid)
+    if status_filter and status_filter != "ALL":
+        query = query.filter_by(status=status_filter)
+    items = query.order_by(SavingsGoal.created_at.desc()).all()
+
+    logger.info("List savings goals user=%s count=%s", uid, len(items))
+    return jsonify([_goal_to_dict(g) for g in items])
+
+
+# ── Get single goal with contributions ──────────────────────────────
+@bp.get("/<int:goal_id>")
+@jwt_required()
+def get_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    g = db.session.get(SavingsGoal, goal_id)
+    if not g or g.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    result = _goal_to_dict(g)
+    contributions = (
+        db.session.query(SavingsContribution)
+        .filter_by(goal_id=goal_id)
+        .order_by(SavingsContribution.contributed_at.desc())
+        .all()
+    )
+    result["contributions"] = [_contribution_to_dict(c) for c in contributions]
+    return jsonify(result)
+
+
+# ── Create a savings goal ───────────────────────────────────────────
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+
+    if not data.get("name") or not data.get("target_amount"):
+        return jsonify(error="name and target_amount are required"), 400
+
+    target_amount = Decimal(str(data["target_amount"]))
+    if target_amount <= 0:
+        return jsonify(error="target_amount must be positive"), 400
+
+    g = SavingsGoal(
+        user_id=uid,
+        name=data["name"],
+        description=data.get("description"),
+        target_amount=target_amount,
+        current_amount=Decimal(str(data.get("current_amount", 0))),
+        currency=data.get("currency")
+        or (user.preferred_currency if user else "INR"),
+        target_date=(
+            date.fromisoformat(data["target_date"])
+            if data.get("target_date")
+            else None
+        ),
+        icon=data.get("icon", "piggy-bank"),
+        color=data.get("color", "#6366f1"),
+    )
+    db.session.add(g)
+    db.session.commit()
+    logger.info("Created savings goal id=%s user=%s name=%s", g.id, uid, g.name)
+    _invalidate_cache(uid)
+    return jsonify(_goal_to_dict(g)), 201
+
+
+# ── Update a savings goal ───────────────────────────────────────────
+@bp.patch("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    g = db.session.get(SavingsGoal, goal_id)
+    if not g or g.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    if "name" in data:
+        g.name = data["name"]
+    if "description" in data:
+        g.description = data["description"]
+    if "target_amount" in data:
+        g.target_amount = Decimal(str(data["target_amount"]))
+    if "target_date" in data:
+        g.target_date = (
+            date.fromisoformat(data["target_date"]) if data["target_date"] else None
+        )
+    if "icon" in data:
+        g.icon = data["icon"]
+    if "color" in data:
+        g.color = data["color"]
+    if "status" in data and data["status"] in [s.value for s in SavingsGoalStatus]:
+        g.status = data["status"]
+
+    g.updated_at = datetime.utcnow()
+    db.session.commit()
+    logger.info("Updated savings goal id=%s user=%s", g.id, uid)
+    _invalidate_cache(uid)
+    return jsonify(_goal_to_dict(g))
+
+
+# ── Delete a savings goal ───────────────────────────────────────────
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    g = db.session.get(SavingsGoal, goal_id)
+    if not g or g.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    db.session.delete(g)
+    db.session.commit()
+    logger.info("Deleted savings goal id=%s user=%s", g.id, uid)
+    _invalidate_cache(uid)
+    return jsonify(message="deleted")
+
+
+# ── Add contribution to a goal ──────────────────────────────────────
+@bp.post("/<int:goal_id>/contributions")
+@jwt_required()
+def add_contribution(goal_id: int):
+    uid = int(get_jwt_identity())
+    g = db.session.get(SavingsGoal, goal_id)
+    if not g or g.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    if g.status != SavingsGoalStatus.ACTIVE.value:
+        return jsonify(error="goal is not active"), 400
+
+    data = request.get_json() or {}
+    if not data.get("amount"):
+        return jsonify(error="amount is required"), 400
+
+    amount = Decimal(str(data["amount"]))
+    if amount <= 0:
+        return jsonify(error="amount must be positive"), 400
+
+    c = SavingsContribution(
+        goal_id=goal_id,
+        user_id=uid,
+        amount=amount,
+        note=data.get("note"),
+        contributed_at=(
+            date.fromisoformat(data["contributed_at"])
+            if data.get("contributed_at")
+            else date.today()
+        ),
+    )
+    db.session.add(c)
+
+    # Update goal's current_amount
+    g.current_amount = g.current_amount + amount
+    g.updated_at = datetime.utcnow()
+
+    # Auto-complete if target reached
+    if g.current_amount >= g.target_amount:
+        g.status = SavingsGoalStatus.COMPLETED.value
+
+    db.session.commit()
+    logger.info(
+        "Added contribution id=%s goal=%s user=%s amount=%s",
+        c.id,
+        goal_id,
+        uid,
+        amount,
+    )
+    _invalidate_cache(uid)
+    return jsonify(
+        {
+            "contribution": _contribution_to_dict(c),
+            "goal": _goal_to_dict(g),
+        }
+    ), 201
+
+
+# ── Withdraw from a goal ────────────────────────────────────────────
+@bp.post("/<int:goal_id>/withdraw")
+@jwt_required()
+def withdraw(goal_id: int):
+    uid = int(get_jwt_identity())
+    g = db.session.get(SavingsGoal, goal_id)
+    if not g or g.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    if not data.get("amount"):
+        return jsonify(error="amount is required"), 400
+
+    amount = Decimal(str(data["amount"]))
+    if amount <= 0:
+        return jsonify(error="amount must be positive"), 400
+    if amount > g.current_amount:
+        return jsonify(error="insufficient balance"), 400
+
+    c = SavingsContribution(
+        goal_id=goal_id,
+        user_id=uid,
+        amount=-amount,
+        note=data.get("note", "Withdrawal"),
+        contributed_at=date.today(),
+    )
+    db.session.add(c)
+
+    g.current_amount = g.current_amount - amount
+    g.updated_at = datetime.utcnow()
+
+    # Re-activate if was completed and now below target
+    if (
+        g.status == SavingsGoalStatus.COMPLETED.value
+        and g.current_amount < g.target_amount
+    ):
+        g.status = SavingsGoalStatus.ACTIVE.value
+
+    db.session.commit()
+    logger.info(
+        "Withdrew from goal id=%s user=%s amount=%s", goal_id, uid, amount
+    )
+    _invalidate_cache(uid)
+    return jsonify(
+        {
+            "contribution": _contribution_to_dict(c),
+            "goal": _goal_to_dict(g),
+        }
+    )
+
+
+# ── Savings summary / stats ─────────────────────────────────────────
+@bp.get("/summary")
+@jwt_required()
+def summary():
+    uid = int(get_jwt_identity())
+    goals = (
+        db.session.query(SavingsGoal)
+        .filter_by(user_id=uid)
+        .all()
+    )
+
+    active = [g for g in goals if g.status == SavingsGoalStatus.ACTIVE.value]
+    completed = [g for g in goals if g.status == SavingsGoalStatus.COMPLETED.value]
+
+    total_saved = sum(float(g.current_amount) for g in goals)
+    total_target = sum(float(g.target_amount) for g in active)
+    overall_progress = (
+        round((total_saved / total_target) * 100, 1) if total_target > 0 else 0
+    )
+
+    return jsonify(
+        {
+            "total_goals": len(goals),
+            "active_goals": len(active),
+            "completed_goals": len(completed),
+            "total_saved": round(total_saved, 2),
+            "total_target": round(total_target, 2),
+            "overall_progress_pct": overall_progress,
+        }
+    )

--- a/packages/backend/tests/test_savings.py
+++ b/packages/backend/tests/test_savings.py
@@ -1,0 +1,268 @@
+from datetime import date, timedelta
+
+
+def test_savings_goals_crud(client, auth_header):
+    """Full CRUD lifecycle for savings goals."""
+    # Initially empty
+    r = client.get("/savings", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+    # Create a savings goal
+    payload = {
+        "name": "Emergency Fund",
+        "description": "6 months of expenses",
+        "target_amount": 10000.00,
+        "currency": "USD",
+        "target_date": (date.today() + timedelta(days=365)).isoformat(),
+        "icon": "shield",
+        "color": "#22c55e",
+    }
+    r = client.post("/savings", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    goal = r.get_json()
+    goal_id = goal["id"]
+    assert goal["name"] == "Emergency Fund"
+    assert goal["target_amount"] == 10000.00
+    assert goal["current_amount"] == 0
+    assert goal["progress_pct"] == 0
+    assert goal["status"] == "ACTIVE"
+    assert goal["remaining"] == 10000.00
+
+    # List goals — should have 1
+    r = client.get("/savings", headers=auth_header)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert len(items) == 1
+    assert items[0]["id"] == goal_id
+
+    # Get single goal
+    r = client.get(f"/savings/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    detail = r.get_json()
+    assert detail["name"] == "Emergency Fund"
+    assert "contributions" in detail
+    assert detail["contributions"] == []
+
+    # Update goal
+    r = client.patch(
+        f"/savings/{goal_id}",
+        json={"name": "Emergency Savings", "target_amount": 15000},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    updated = r.get_json()
+    assert updated["name"] == "Emergency Savings"
+    assert updated["target_amount"] == 15000.0
+
+    # Delete goal
+    r = client.delete(f"/savings/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "deleted"
+
+    # Verify deleted
+    r = client.get("/savings", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_savings_contributions(client, auth_header):
+    """Test adding contributions and progress tracking."""
+    # Create a goal
+    payload = {
+        "name": "Vacation Fund",
+        "target_amount": 5000.00,
+        "target_date": (date.today() + timedelta(days=180)).isoformat(),
+    }
+    r = client.post("/savings", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    goal_id = r.get_json()["id"]
+
+    # Add contribution
+    r = client.post(
+        f"/savings/{goal_id}/contributions",
+        json={"amount": 1000, "note": "First deposit"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    result = r.get_json()
+    assert result["contribution"]["amount"] == 1000
+    assert result["contribution"]["note"] == "First deposit"
+    assert result["goal"]["current_amount"] == 1000
+    assert result["goal"]["progress_pct"] == 20.0
+    assert result["goal"]["remaining"] == 4000.0
+
+    # Add another contribution
+    r = client.post(
+        f"/savings/{goal_id}/contributions",
+        json={"amount": 500, "note": "Second deposit"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    assert r.get_json()["goal"]["current_amount"] == 1500
+    assert r.get_json()["goal"]["progress_pct"] == 30.0
+
+    # Get goal detail — should have 2 contributions
+    r = client.get(f"/savings/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    detail = r.get_json()
+    assert len(detail["contributions"]) == 2
+    assert detail["current_amount"] == 1500
+
+
+def test_savings_auto_complete(client, auth_header):
+    """Goal should auto-complete when target is reached."""
+    payload = {
+        "name": "New Laptop",
+        "target_amount": 2000.00,
+    }
+    r = client.post("/savings", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    goal_id = r.get_json()["id"]
+
+    # Add contribution that reaches target
+    r = client.post(
+        f"/savings/{goal_id}/contributions",
+        json={"amount": 2000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    assert r.get_json()["goal"]["status"] == "COMPLETED"
+    assert r.get_json()["goal"]["progress_pct"] == 100
+
+
+def test_savings_withdraw(client, auth_header):
+    """Test withdrawing from a savings goal."""
+    payload = {
+        "name": "Car Fund",
+        "target_amount": 20000.00,
+        "current_amount": 5000.00,
+    }
+    r = client.post("/savings", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    goal_id = r.get_json()["id"]
+
+    # Withdraw
+    r = client.post(
+        f"/savings/{goal_id}/withdraw",
+        json={"amount": 1000, "note": "Emergency withdrawal"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["goal"]["current_amount"] == 4000
+
+    # Over-withdraw should fail
+    r = client.post(
+        f"/savings/{goal_id}/withdraw",
+        json={"amount": 50000},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "insufficient" in r.get_json()["error"]
+
+
+def test_savings_summary(client, auth_header):
+    """Test the summary endpoint."""
+    # Create two goals
+    client.post(
+        "/savings",
+        json={"name": "Goal 1", "target_amount": 1000, "current_amount": 500},
+        headers=auth_header,
+    )
+    client.post(
+        "/savings",
+        json={"name": "Goal 2", "target_amount": 2000, "current_amount": 300},
+        headers=auth_header,
+    )
+
+    r = client.get("/savings/summary", headers=auth_header)
+    assert r.status_code == 200
+    summary = r.get_json()
+    assert summary["total_goals"] == 2
+    assert summary["active_goals"] == 2
+    assert summary["completed_goals"] == 0
+    assert summary["total_saved"] == 800
+    assert summary["total_target"] == 3000
+
+
+def test_savings_validation(client, auth_header):
+    """Test input validation."""
+    # Missing required fields
+    r = client.post("/savings", json={}, headers=auth_header)
+    assert r.status_code == 400
+
+    # Negative target_amount
+    r = client.post(
+        "/savings",
+        json={"name": "Bad Goal", "target_amount": -100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    # Contribution to non-existent goal
+    r = client.post(
+        "/savings/99999/contributions",
+        json={"amount": 100},
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+def test_savings_status_filter(client, auth_header):
+    """Test filtering goals by status."""
+    # Create a goal and complete it
+    r = client.post(
+        "/savings",
+        json={"name": "Small Goal", "target_amount": 100},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+    client.post(
+        f"/savings/{goal_id}/contributions",
+        json={"amount": 100},
+        headers=auth_header,
+    )
+
+    # Create an active goal
+    client.post(
+        "/savings",
+        json={"name": "Active Goal", "target_amount": 5000},
+        headers=auth_header,
+    )
+
+    # Filter active only
+    r = client.get("/savings?status=ACTIVE", headers=auth_header)
+    assert r.status_code == 200
+    active = r.get_json()
+    assert len(active) == 1
+    assert active[0]["name"] == "Active Goal"
+
+    # Filter completed only
+    r = client.get("/savings?status=COMPLETED", headers=auth_header)
+    assert r.status_code == 200
+    completed = r.get_json()
+    assert len(completed) == 1
+    assert completed[0]["name"] == "Small Goal"
+
+    # All
+    r = client.get("/savings?status=ALL", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 2
+
+
+def test_savings_goal_defaults_to_user_currency(client, auth_header):
+    """Goal should use user's preferred currency if not specified."""
+    # Set user currency
+    r = client.patch(
+        "/auth/me", json={"preferred_currency": "EUR"}, headers=auth_header
+    )
+    assert r.status_code == 200
+
+    # Create goal without specifying currency
+    r = client.post(
+        "/savings",
+        json={"name": "Euro Goal", "target_amount": 1000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    assert r.get_json()["currency"] == "EUR"


### PR DESCRIPTION
## Summary

Implements goal-based savings tracking feature allowing users to create, manage, and visually track progress toward financial saving targets. Closes #133.

/claim #133

### Backend (Flask/SQLAlchemy/PostgreSQL)
- **Models**: `SavingsGoal` (name, description, target/current amount, currency, target date, icon, color, status) and `SavingsContribution` (amount, note, date) with full lifecycle management (ACTIVE → COMPLETED → CANCELLED)
- **API Endpoints** (`/savings`):
  - `GET /savings` — List goals with status filter (ACTIVE/COMPLETED/ALL)
  - `GET /savings/<id>` — Single goal with contribution history
  - `POST /savings` — Create goal (auto-defaults to user's preferred currency)
  - `PATCH /savings/<id>` — Update goal details
  - `DELETE /savings/<id>` — Delete goal and contributions
  - `POST /savings/<id>/contributions` — Add deposit (auto-completes at 100%)
  - `POST /savings/<id>/withdraw` — Withdraw with balance validation
  - `GET /savings/summary` — Aggregate stats across all goals
- **Schema**: PostgreSQL migration with indexed `savings_goals` and `savings_contributions` tables
- **Tests**: 9 comprehensive tests covering CRUD, contributions, auto-complete, withdrawals, validation, status filtering, and currency defaults

### Frontend (React/TypeScript/Tailwind)
- **API Client** (`api/savings.ts`): Type-safe client for all endpoints
- **SavingsGoals Page** (`pages/SavingsGoals.tsx`):
  - Summary cards: total saved, total target, overall progress bar, completed count
  - Goal cards with color-coded progress bars, deposit/withdraw/edit/delete actions
  - Target date tracking with days remaining + monthly savings needed calculation
  - Status filter tabs (Active / Completed / All)
  - Create/edit/contribute/withdraw dialogs with validation
  - Empty state with onboarding CTA
- **Navigation**: "Savings" link added to navbar between Budgets and Bills
- **Routing**: `/savings` route registered as protected route
- **Test**: Frontend integration test suite

### Documentation
- OpenAPI spec updated with all 8 savings endpoints and 6 new schemas

## Test plan
- [x] Backend: `pytest tests/test_savings.py` — 9 tests pass (CRUD, contributions, auto-complete, withdraw, validation, filtering, currency)
- [x] Frontend: `jest SavingsGoals.integration.test` — renders goals, empty state, progress bars, filtering
- [ ] Manual: Create goal → add contributions → verify progress bar updates → complete goal → verify status change
- [ ] Manual: Test withdraw with insufficient balance → verify error
- [ ] Manual: Navigate to /savings from navbar → verify protected route

Generated with [Claude Code](https://claude.com/claude-code)