### PR TITLE
fix: Resilient background job retry & monitoring

### DIFF
--- a/core/celery_app.py
+++ b/core/celery_app.py
@@ -1,0 +1,26 @@
+import os
+from celery import Celery
+
+# Set default broker and backend if not in environment
+broker_url = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+result_backend = os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/1")
+
+app = Celery(
+    "finmind",
+    broker=broker_url,
+    backend=result_backend,
+    include=["tasks.tasks"]
+)
+
+app.conf.update(
+    task_serializer="json",
+    accept_content=["json"],
+    result_serializer="json",
+    timezone="UTC",
+    enable_utc=True,
+    task_track_started=True,
+    task_time_limit=3600,
+)
+
+if __name__ == "__main__":
+    app.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+celery==5.3.6
+redis==5.0.1
+flower==2.0.1
+requests==2.31.0
+pytest==8.0.0
+pytest-mock==3.12.0

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -1,0 +1,43 @@
+import celery
+import requests
+import logging
+from core.celery_app import app
+from utils.idempotency import is_processed, mark_processed
+from utils.dlq import save_to_dlq
+
+logger = logging.getLogger(__name__)
+
+class ResilientTask(celery.Task):
+    """Base task class that handles permanent failures by routing them to a Dead Letter Queue (DLQ)."""
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        save_to_dlq(task_id=task_id, payload=(args, kwargs), exception=str(exc))
+        super().on_failure(exc, task_id, args, kwargs, einfo)
+
+@app.task(
+    base=ResilientTask,
+    bind=True,
+    autoretry_for=(requests.exceptions.RequestException,), 
+    retry_kwargs={'max_retries': 5},
+    retry_backoff=2,       # Starts at 2 seconds
+    retry_backoff_max=120, # Caps at 2 minutes
+    retry_jitter=True      # Adds random jitter to prevent thundering herd when services recover
+)
+def fetch_financial_data(self, api_endpoint: str, idempotency_key: str):
+    """
+    Fetches financial data from an external API.
+    Retries automatically on network issues and checks idempotency before executing.
+    """
+    if is_processed(idempotency_key):
+        logger.info(f"Task already processed for key: {idempotency_key}")
+        return {"status": "Already processed", "idempotency_key": idempotency_key}
+        
+    logger.info(f"Fetching financial data from {api_endpoint}")
+    response = requests.get(api_endpoint, timeout=10)
+    response.raise_for_status()
+    
+    # Core logic (processing data...)
+    data = response.json()
+    
+    # Mark as processed at the end of successful execution
+    mark_processed(idempotency_key)
+    return {"status": "Success", "data": data}

--- a/utils/dlq.py
+++ b/utils/dlq.py
@@ -1,0 +1,22 @@
+import logging
+import json
+import os
+
+logger = logging.getLogger(__name__)
+
+# A simple file-based DLQ for demonstration; in production, route this to a DB table or alert service
+DLQ_FILE = os.getenv("DLQ_FILE_PATH", "dlq.log")
+
+def save_to_dlq(task_id: str, payload: tuple, exception: str):
+    """Save a failed task to the Dead Letter Queue after max retries are exceeded."""
+    dlq_entry = {
+        "task_id": task_id,
+        "payload": payload,
+        "exception": exception,
+    }
+    logger.error(f"Task {task_id} failed permanently. Routing to DLQ. Payload: {payload}, Exception: {exception}")
+    try:
+        with open(DLQ_FILE, "a") as f:
+            f.write(json.dumps(dlq_entry) + "\n")
+    except Exception as e:
+        logger.error(f"Failed to write to DLQ: {e}")

--- a/utils/idempotency.py
+++ b/utils/idempotency.py
@@ -1,0 +1,13 @@
+import redis
+import os
+
+redis_url = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+client = redis.from_url(redis_url)
+
+def is_processed(idempotency_key: str) -> bool:
+    """Check if a task with the given idempotency key was already processed."""
+    return client.get(f"task_idemp_{idempotency_key}") is not None
+
+def mark_processed(idempotency_key: str, ttl: int = 86400):
+    """Mark a task as processed using the idempotency key with a TTL."""
+    client.setex(f"task_idemp_{idempotency_key}", ttl, "true")


### PR DESCRIPTION
## Fix for #130: Resilient background job retry & monitoring

This PR addresses the issue described in #130.

### Approach

Here is the complete implementation of resilient background jobs using Celery and Redis as requested in the plan. This includes proper configuration for exponential backoff with jitter, idempotency safeguards, dead letter queue (DLQ) support for permanent failures, and Flower for monitoring.
**`requirements.txt`**
**`core/celery_app.py`**
**`utils/idempotency.py`**
**`utils/dlq.py`**
**`tasks/tasks.py`**
**`tests/test_tasks.py`**