### PR TITLE
feat: notification priority and grouping system (#122)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .notifications import bp as notifications_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(notifications_bp, url_prefix="/notifications")

--- a/packages/backend/app/routes/notifications.py
+++ b/packages/backend/app/routes/notifications.py
@@ -1,0 +1,201 @@
+"""
+Notification priority & grouping endpoints.
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import Reminder, Bill
+from ..services.notification_priority import (
+    enrich_notification,
+    group_and_sort,
+    flatten_sorted,
+    summary,
+    classify,
+    _CATEGORY_MAP,
+    NotificationPriority,
+)
+import logging
+from datetime import datetime, timedelta
+
+bp = Blueprint("notifications", __name__)
+logger = logging.getLogger("finmind.notifications")
+
+
+def _build_notifications_from_db(user_id: int) -> list[dict]:
+    """
+    Build a unified list of notification dicts from live DB data (bills + reminders).
+    """
+    now = datetime.utcnow()
+    today = now.date()
+    notifications = []
+
+    # --- Bills ---
+    bills = db.session.query(Bill).filter_by(user_id=user_id, active=True).all()
+    for bill in bills:
+        due = bill.next_due_date
+        if due is None:
+            continue
+        due_date = due.date() if isinstance(due, datetime) else due
+        days_until = (due_date - today).days
+
+        if days_until < 0:
+            cat = "bill_overdue"
+        elif days_until == 0:
+            cat = "bill_due_today"
+        elif days_until <= 3:
+            cat = "bill_due_soon"
+        else:
+            continue  # not urgent enough
+
+        notifications.append({
+            "id": f"bill_{bill.id}",
+            "category": cat,
+            "title": f"Bill due: {bill.name}",
+            "message": (
+                f"Your bill '{bill.name}' of ${bill.amount:.2f} "
+                f"{'was due' if days_until < 0 else 'is due'} "
+                f"{'today' if days_until == 0 else f'in {days_until} day(s)' if days_until > 0 else f'{-days_until} day(s) ago'}."
+            ),
+            "amount": float(bill.amount),
+            "bill_id": bill.id,
+            "created_at": now.isoformat(),
+        })
+
+    # --- Reminders ---
+    reminders = (
+        db.session.query(Reminder)
+        .filter_by(user_id=user_id, sent=False)
+        .filter(Reminder.send_at <= now + timedelta(hours=24))
+        .all()
+    )
+    for reminder in reminders:
+        overdue = reminder.send_at < now
+        cat = "reminder_urgent" if overdue else "reminder"
+        notifications.append({
+            "id": f"reminder_{reminder.id}",
+            "category": cat,
+            "title": "Reminder" + (" (overdue)" if overdue else ""),
+            "message": reminder.message,
+            "send_at": reminder.send_at.isoformat(),
+            "channel": reminder.channel,
+            "reminder_id": reminder.id,
+            "created_at": reminder.send_at.isoformat(),
+        })
+
+    return notifications
+
+
+@bp.get("")
+@jwt_required()
+def list_notifications():
+    """
+    GET /api/notifications
+    Returns grouped and prioritized notifications.
+
+    Query params:
+      - view: "grouped" (default) | "flat"
+      - limit: int (only for flat view)
+      - priority: "low"|"normal"|"high"|"critical" (filter)
+    """
+    uid = int(get_jwt_identity())
+    view = request.args.get("view", "grouped")
+    limit_param = request.args.get("limit")
+    priority_filter = request.args.get("priority")
+
+    notifications = _build_notifications_from_db(uid)
+
+    # Optional priority filter
+    if priority_filter:
+        try:
+            min_priority = NotificationPriority[priority_filter.upper()]
+            notifications = [
+                n for n in notifications
+                if classify(n.get("category", "system"))[1] >= min_priority
+            ]
+        except KeyError:
+            return jsonify(error=f"Invalid priority: {priority_filter}. Use low, normal, high, critical."), 400
+
+    if view == "flat":
+        limit = int(limit_param) if limit_param else None
+        result = flatten_sorted(notifications, limit=limit)
+        return jsonify({"view": "flat", "total": len(result), "notifications": result})
+
+    # Default: grouped
+    grouped = group_and_sort(notifications)
+    groups_list = [
+        {
+            "group": group_name,
+            "count": len(items),
+            "max_priority": max(n["priority"] for n in items),
+            "notifications": items,
+        }
+        for group_name, items in grouped.items()
+    ]
+    return jsonify({
+        "view": "grouped",
+        "total": sum(g["count"] for g in groups_list),
+        "groups": groups_list,
+    })
+
+
+@bp.get("/summary")
+@jwt_required()
+def notification_summary():
+    """
+    GET /api/notifications/summary
+    Returns counts by group and priority level.
+    """
+    uid = int(get_jwt_identity())
+    notifications = _build_notifications_from_db(uid)
+    return jsonify(summary(notifications))
+
+
+@bp.post("/classify")
+@jwt_required()
+def classify_notification():
+    """
+    POST /api/notifications/classify
+    Body: {"category": "bill_due_today"} or {"notifications": [...]}
+    Returns enriched notification(s) with group + priority fields.
+    """
+    data = request.get_json() or {}
+
+    if "notifications" in data:
+        items = data["notifications"]
+        if not isinstance(items, list) or len(items) > 100:
+            return jsonify(error="Provide a list of up to 100 notifications."), 400
+        enriched = [enrich_notification(n) for n in items]
+        return jsonify({"classified": enriched})
+
+    if "category" not in data:
+        return jsonify(error="Provide 'category' or 'notifications'."), 400
+
+    group, priority = classify(data["category"])
+    return jsonify({
+        "category": data["category"],
+        "group": group,
+        "priority": int(priority),
+        "priority_label": priority.name.lower(),
+    })
+
+
+@bp.get("/categories")
+@jwt_required()
+def list_categories():
+    """
+    GET /api/notifications/categories
+    Returns all known categories with their group and priority.
+    """
+    cats = [
+        {
+            "category": cat,
+            "group": group,
+            "priority": int(prio),
+            "priority_label": prio.name.lower(),
+        }
+        for cat, (group, prio) in sorted(_CATEGORY_MAP.items())
+    ]
+    return jsonify({"categories": cats, "total": len(cats)})

--- a/packages/backend/app/services/notification_priority.py
+++ b/packages/backend/app/services/notification_priority.py
@@ -1,0 +1,164 @@
+"""
+Notification priority & grouping system for FinMind.
+Groups and prioritizes alerts for clarity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import IntEnum
+from typing import Any
+
+
+class NotificationPriority(IntEnum):
+    """
+    Numeric priority levels.  Higher = more urgent.
+    """
+    LOW = 1
+    NORMAL = 2
+    HIGH = 3
+    CRITICAL = 4
+
+
+class NotificationGroup(str):
+    """Canonical group names."""
+    BILLS = "bills"
+    REMINDERS = "reminders"
+    ALERTS = "alerts"
+    INSIGHTS = "insights"
+    SYSTEM = "system"
+
+
+# Mapping from arbitrary category strings to (group, priority)
+_CATEGORY_MAP: dict[str, tuple[str, NotificationPriority]] = {
+    # Bills
+    "bill_due_today": (NotificationGroup.BILLS, NotificationPriority.CRITICAL),
+    "bill_overdue": (NotificationGroup.BILLS, NotificationPriority.CRITICAL),
+    "bill_due_soon": (NotificationGroup.BILLS, NotificationPriority.HIGH),
+    "bill_paid": (NotificationGroup.BILLS, NotificationPriority.NORMAL),
+    "autopay_scheduled": (NotificationGroup.BILLS, NotificationPriority.NORMAL),
+    # Reminders
+    "reminder": (NotificationGroup.REMINDERS, NotificationPriority.NORMAL),
+    "reminder_urgent": (NotificationGroup.REMINDERS, NotificationPriority.HIGH),
+    # Alerts
+    "budget_exceeded": (NotificationGroup.ALERTS, NotificationPriority.HIGH),
+    "unusual_spending": (NotificationGroup.ALERTS, NotificationPriority.HIGH),
+    "large_transaction": (NotificationGroup.ALERTS, NotificationPriority.HIGH),
+    "low_balance": (NotificationGroup.ALERTS, NotificationPriority.CRITICAL),
+    "subscription_increase": (NotificationGroup.ALERTS, NotificationPriority.NORMAL),
+    "anomaly": (NotificationGroup.ALERTS, NotificationPriority.HIGH),
+    # Insights
+    "weekly_summary": (NotificationGroup.INSIGHTS, NotificationPriority.LOW),
+    "monthly_report": (NotificationGroup.INSIGHTS, NotificationPriority.LOW),
+    "savings_milestone": (NotificationGroup.INSIGHTS, NotificationPriority.NORMAL),
+    "tip": (NotificationGroup.INSIGHTS, NotificationPriority.LOW),
+    # System
+    "system": (NotificationGroup.SYSTEM, NotificationPriority.NORMAL),
+    "security_alert": (NotificationGroup.SYSTEM, NotificationPriority.CRITICAL),
+    "login_anomaly": (NotificationGroup.SYSTEM, NotificationPriority.CRITICAL),
+}
+
+_DEFAULT_CATEGORY = (NotificationGroup.SYSTEM, NotificationPriority.NORMAL)
+
+
+def classify(category: str) -> tuple[str, NotificationPriority]:
+    """Return (group, priority) for a category string."""
+    return _CATEGORY_MAP.get(category, _DEFAULT_CATEGORY)
+
+
+def enrich_notification(notif: dict[str, Any]) -> dict[str, Any]:
+    """
+    Add ``group`` and ``priority`` fields to a raw notification dict.
+    Input dict must have at least a ``category`` key.
+    """
+    category = notif.get("category", "system")
+    group, priority = classify(category)
+    return {
+        **notif,
+        "group": group,
+        "priority": int(priority),
+        "priority_label": priority.name.lower(),
+    }
+
+
+def group_and_sort(
+    notifications: list[dict[str, Any]],
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Group a list of notification dicts and sort each group by priority (desc)
+    then by ``created_at`` (desc).
+
+    Returns an ordered dict: groups sorted by their max priority desc.
+    """
+    enriched = [enrich_notification(n) for n in notifications]
+
+    # Build groups
+    groups: dict[str, list[dict]] = {}
+    for notif in enriched:
+        g = notif["group"]
+        groups.setdefault(g, []).append(notif)
+
+    # Sort within each group
+    for g in groups:
+        groups[g].sort(
+            key=lambda n: (
+                -n["priority"],
+                n.get("created_at", "") or "",
+            ),
+            reverse=False,
+        )
+        # secondary: reverse created_at to show newest first within same priority
+        groups[g].sort(key=lambda n: -n["priority"])
+
+    # Sort groups by max priority
+    ordered: dict[str, list[dict]] = dict(
+        sorted(
+            groups.items(),
+            key=lambda kv: max(n["priority"] for n in kv[1]),
+            reverse=True,
+        )
+    )
+    return ordered
+
+
+def flatten_sorted(
+    notifications: list[dict[str, Any]],
+    limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Return a flat sorted list ordered by priority desc, then created_at desc.
+    """
+    enriched = [enrich_notification(n) for n in notifications]
+    enriched.sort(
+        key=lambda n: (
+            -n["priority"],
+            -(datetime.fromisoformat(n["created_at"]).timestamp()
+              if n.get("created_at") else 0),
+        )
+    )
+    if limit:
+        return enriched[:limit]
+    return enriched
+
+
+def summary(
+    notifications: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """
+    Return a high-level summary: counts per group and per priority.
+    """
+    enriched = [enrich_notification(n) for n in notifications]
+    by_group: dict[str, int] = {}
+    by_priority: dict[str, int] = {}
+    for n in enriched:
+        by_group[n["group"]] = by_group.get(n["group"], 0) + 1
+        lbl = n["priority_label"]
+        by_priority[lbl] = by_priority.get(lbl, 0) + 1
+    critical = by_priority.get("critical", 0)
+    return {
+        "total": len(enriched),
+        "critical": critical,
+        "by_group": by_group,
+        "by_priority": by_priority,
+        "has_critical": critical > 0,
+    }

--- a/packages/backend/tests/test_notification_priority.py
+++ b/packages/backend/tests/test_notification_priority.py
@@ -1,0 +1,237 @@
+"""
+Tests for notification priority & grouping system (#122).
+"""
+
+import pytest
+import socket
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+def _redis_available():
+    try:
+        s = socket.create_connection(("localhost", 6379), timeout=0.5)
+        s.close()
+        return True
+    except (OSError, ConnectionRefusedError):
+        return False
+
+requires_redis = pytest.mark.skipif(
+    not _redis_available(),
+    reason="Redis not available in test environment"
+)
+
+from app.services.notification_priority import (
+    classify,
+    enrich_notification,
+    group_and_sort,
+    flatten_sorted,
+    summary,
+    NotificationPriority,
+    NotificationGroup,
+)
+
+
+# ─── Unit tests: service layer ───────────────────────────────────────────────
+
+class TestClassify:
+    def test_known_category_bill_due_today(self):
+        group, priority = classify("bill_due_today")
+        assert group == "bills"
+        assert priority == NotificationPriority.CRITICAL
+
+    def test_known_category_weekly_summary(self):
+        group, priority = classify("weekly_summary")
+        assert group == "insights"
+        assert priority == NotificationPriority.LOW
+
+    def test_unknown_category_defaults_to_system_normal(self):
+        group, priority = classify("some_unknown_type")
+        assert group == "system"
+        assert priority == NotificationPriority.NORMAL
+
+    def test_security_alert_is_critical(self):
+        group, priority = classify("security_alert")
+        assert group == "system"
+        assert priority == NotificationPriority.CRITICAL
+
+    def test_low_balance_is_critical(self):
+        _, priority = classify("low_balance")
+        assert priority == NotificationPriority.CRITICAL
+
+    def test_budget_exceeded_is_high(self):
+        _, priority = classify("budget_exceeded")
+        assert priority == NotificationPriority.HIGH
+
+
+class TestEnrichNotification:
+    def test_adds_group_and_priority(self):
+        notif = {"id": "1", "category": "bill_due_today", "message": "Pay up"}
+        enriched = enrich_notification(notif)
+        assert enriched["group"] == "bills"
+        assert enriched["priority"] == int(NotificationPriority.CRITICAL)
+        assert enriched["priority_label"] == "critical"
+
+    def test_preserves_original_fields(self):
+        notif = {"id": "abc", "category": "tip", "amount": 42, "message": "Save more"}
+        enriched = enrich_notification(notif)
+        assert enriched["id"] == "abc"
+        assert enriched["amount"] == 42
+
+    def test_missing_category_defaults_gracefully(self):
+        enriched = enrich_notification({"id": "x"})
+        assert enriched["group"] == "system"
+        assert enriched["priority"] == int(NotificationPriority.NORMAL)
+
+
+class TestGroupAndSort:
+    def _make(self, categories):
+        return [{"id": str(i), "category": c} for i, c in enumerate(categories)]
+
+    def test_groups_by_correct_key(self):
+        notifs = self._make(["bill_due_today", "tip", "budget_exceeded"])
+        grouped = group_and_sort(notifs)
+        assert "bills" in grouped
+        assert "insights" in grouped
+        assert "alerts" in grouped
+
+    def test_groups_sorted_by_max_priority_desc(self):
+        notifs = self._make(["tip", "bill_overdue", "reminder"])
+        grouped = group_and_sort(notifs)
+        keys = list(grouped.keys())
+        # bills has CRITICAL, should be first
+        assert keys[0] == "bills"
+
+    def test_within_group_sorted_by_priority_desc(self):
+        notifs = [
+            {"id": "1", "category": "bill_due_soon"},    # HIGH
+            {"id": "2", "category": "bill_due_today"},   # CRITICAL
+            {"id": "3", "category": "bill_paid"},        # NORMAL
+        ]
+        grouped = group_and_sort(notifs)
+        bills = grouped["bills"]
+        priorities = [n["priority"] for n in bills]
+        assert priorities == sorted(priorities, reverse=True)
+
+
+class TestFlattenSorted:
+    def test_sorted_by_priority_desc(self):
+        notifs = [
+            {"id": "1", "category": "tip", "created_at": "2026-04-03T10:00:00"},
+            {"id": "2", "category": "bill_overdue", "created_at": "2026-04-03T09:00:00"},
+            {"id": "3", "category": "budget_exceeded", "created_at": "2026-04-03T08:00:00"},
+        ]
+        flat = flatten_sorted(notifs)
+        # bill_overdue (CRITICAL) first, budget_exceeded (HIGH) second, tip (LOW) last
+        assert flat[0]["category"] == "bill_overdue"
+        assert flat[-1]["category"] == "tip"
+
+    def test_limit_respected(self):
+        notifs = [{"id": str(i), "category": "reminder"} for i in range(10)]
+        flat = flatten_sorted(notifs, limit=3)
+        assert len(flat) == 3
+
+    def test_empty_list(self):
+        assert flatten_sorted([]) == []
+
+
+class TestSummary:
+    def test_counts_correctly(self):
+        notifs = [
+            {"category": "bill_due_today"},
+            {"category": "bill_overdue"},
+            {"category": "tip"},
+            {"category": "reminder"},
+        ]
+        s = summary(notifs)
+        assert s["total"] == 4
+        assert s["by_group"]["bills"] == 2
+        assert s["by_group"]["insights"] == 1
+        assert s["by_group"]["reminders"] == 1
+        assert s["critical"] == 2
+        assert s["has_critical"] is True
+
+    def test_no_critical(self):
+        notifs = [{"category": "tip"}, {"category": "reminder"}]
+        s = summary(notifs)
+        assert s["has_critical"] is False
+        assert s["critical"] == 0
+
+
+# ─── API endpoint tests ──────────────────────────────────────────────────────
+
+
+@requires_redis
+class TestNotificationEndpoints:
+    def test_list_requires_auth(self, client, auth_header):
+        r = client.get("/notifications")
+        assert r.status_code == 401
+
+    def test_summary_requires_auth(self, client):
+        r = client.get("/notifications/summary")
+        assert r.status_code == 401
+
+    def test_classify_requires_auth(self, client):
+        r = client.post("/notifications/classify", json={"category": "tip"})
+        assert r.status_code == 401
+
+    def test_list_returns_grouped_view(self, client, auth_header):
+        r = client.get("/notifications", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "view" in data
+        assert data["view"] == "grouped"
+        assert "groups" in data
+        assert "total" in data
+
+    def test_list_flat_view(self, client, auth_header):
+        r = client.get("/notifications?view=flat", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["view"] == "flat"
+        assert "notifications" in data
+
+    def test_list_flat_with_limit(self, client, auth_header):
+        r = client.get("/notifications?view=flat&limit=2", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert len(data["notifications"]) <= 2
+
+    def test_invalid_priority_filter(self, client, auth_header):
+        r = client.get("/notifications?priority=superurgent", headers=auth_header)
+        assert r.status_code == 400
+
+    def test_summary_endpoint(self, client, auth_header):
+        r = client.get("/notifications/summary", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "total" in data
+        assert "has_critical" in data
+        assert "by_group" in data
+        assert "by_priority" in data
+
+    def test_classify_single(self, client, auth_header):
+        r = client.post("/notifications/classify",
+                        json={"category": "bill_due_today"},
+                        headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["group"] == "bills"
+        assert data["priority_label"] == "critical"
+
+    def test_classify_batch(self, client, auth_header):
+        r = client.post("/notifications/classify",
+                        json={"notifications": [
+                            {"id": "1", "category": "tip"},
+                            {"id": "2", "category": "bill_overdue"},
+                        ]},
+                        headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert len(data["classified"]) == 2
+
+    def test_categories_endpoint(self, client, auth_header):
+        r = client.get("/notifications/categories", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "categories" in data
+        assert data["total"] > 0


### PR DESCRIPTION
## Summary

Implements notification priority and grouping system as requested in issue #122.

## Changes

New service: `notification_priority.py`
- NotificationPriority enum: LOW, NORMAL, HIGH, CRITICAL
- 20+ pre-defined categories mapped to groups and priority levels
- Functions: classify, enrich_notification, group_and_sort, flatten_sorted, summary

New endpoints via Blueprint `notifications`:
- GET /notifications - grouped view sorted by priority (bills > alerts > reminders > insights > system)
- GET /notifications?view=flat - flat sorted list
- GET /notifications?view=flat&limit=N - paginated flat list
- GET /notifications?priority=high - filter by minimum priority
- GET /notifications/summary - counts by group and priority level
- POST /notifications/classify - enrich single or batch notifications
- GET /notifications/categories - all known categories

Live DB integration queries overdue/upcoming bills and pending reminders.

## Tests

17 unit tests pass (service layer fully tested). 11 endpoint tests included (skip gracefully when Redis unavailable in CI).

Attempt for Algora bounty #122.