### PR TITLE
feat: recurring transaction anomaly alerts (#108)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .recurring_anomaly import bp as recurring_anomaly_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(recurring_anomaly_bp, url_prefix="/recurring/anomalies")

--- a/packages/backend/app/routes/recurring_anomaly.py
+++ b/packages/backend/app/routes/recurring_anomaly.py
@@ -1,0 +1,153 @@
+"""
+Recurring transaction anomaly alert endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import RecurringExpense, Expense
+from ..services.recurring_anomaly import (
+    RecurringConfig,
+    ExpenseRecord,
+    analyze_recurring_expense,
+    batch_analyze,
+    anomaly_summary,
+    AMOUNT_DEVIATION_THRESHOLD,
+    AMOUNT_LARGE_DEVIATION,
+)
+import logging
+
+bp = Blueprint("recurring_anomaly", __name__)
+logger = logging.getLogger("finmind.recurring_anomaly")
+
+
+def _build_config(rec: RecurringExpense) -> RecurringConfig:
+    return RecurringConfig(
+        id=rec.id,
+        expected_amount=rec.amount,
+        cadence=rec.cadence.value if hasattr(rec.cadence, "value") else rec.cadence,
+        active=rec.active,
+        notes=rec.notes or "",
+    )
+
+
+def _load_expense_records(user_id: int, recurring_id: int | None = None) -> dict[int, list[ExpenseRecord]]:
+    """Load expenses grouped by source_recurring_id."""
+    q = (
+        db.session.query(Expense)
+        .filter_by(user_id=user_id)
+        .filter(Expense.source_recurring_id.isnot(None))
+    )
+    if recurring_id is not None:
+        q = q.filter_by(source_recurring_id=recurring_id)
+
+    by_id: dict[int, list[ExpenseRecord]] = {}
+    for exp in q.all():
+        rid = exp.source_recurring_id
+        by_id.setdefault(rid, []).append(
+            ExpenseRecord(
+                id=exp.id,
+                amount=Decimal(str(exp.amount)),
+                date=exp.spent_at.date() if hasattr(exp.spent_at, "date") else exp.spent_at,
+                recurring_id=rid,
+                notes=exp.notes or "",
+            )
+        )
+    return by_id
+
+
+@bp.get("")
+@jwt_required()
+def list_anomalies():
+    """
+    GET /api/recurring/anomalies
+    Scan all active recurring expenses for the current user and return anomalies.
+
+    Query params:
+      - severity: low|medium|high|critical (filter)
+      - type: amount|missing|frequency|timing (filter)
+    """
+    uid = int(get_jwt_identity())
+    severity_filter = request.args.get("severity")
+    type_filter = request.args.get("type")
+
+    recurring = (
+        db.session.query(RecurringExpense)
+        .filter_by(user_id=uid, active=True)
+        .all()
+    )
+    if not recurring:
+        return jsonify({"anomalies": [], "summary": anomaly_summary([])})
+
+    configs = [_build_config(r) for r in recurring]
+    expenses_map = _load_expense_records(uid)
+
+    batch = batch_analyze(configs, expenses_map)
+
+    all_anomalies = [a for alerts in batch.values() for a in alerts]
+
+    # Apply filters
+    if severity_filter:
+        all_anomalies = [a for a in all_anomalies if a.severity == severity_filter]
+    if type_filter:
+        all_anomalies = [a for a in all_anomalies if a.anomaly_type == type_filter]
+
+    # Sort by severity desc
+    sev_order = {"critical": 4, "high": 3, "medium": 2, "low": 1}
+    all_anomalies.sort(key=lambda a: sev_order.get(a.severity, 0), reverse=True)
+
+    logger.info("Anomaly scan user=%s found=%s", uid, len(all_anomalies))
+    return jsonify({
+        "anomalies": [a.to_dict() for a in all_anomalies],
+        "summary": anomaly_summary(all_anomalies),
+    })
+
+
+@bp.get("/<int:recurring_id>")
+@jwt_required()
+def get_anomalies_for_recurring(recurring_id: int):
+    """
+    GET /api/recurring/anomalies/<recurring_id>
+    Check anomalies for a specific recurring expense.
+    """
+    uid = int(get_jwt_identity())
+
+    rec = db.session.query(RecurringExpense).filter_by(id=recurring_id, user_id=uid).first()
+    if rec is None:
+        return jsonify(error="Recurring expense not found"), 404
+
+    config = _build_config(rec)
+    expenses_map = _load_expense_records(uid, recurring_id=recurring_id)
+    expenses = expenses_map.get(recurring_id, [])
+
+    anomalies = analyze_recurring_expense(config, expenses)
+
+    return jsonify({
+        "recurring_id": recurring_id,
+        "anomalies": [a.to_dict() for a in anomalies],
+        "summary": anomaly_summary(anomalies),
+        "expense_count_analyzed": len(expenses),
+    })
+
+
+@bp.get("/thresholds")
+@jwt_required()
+def get_thresholds():
+    """
+    GET /api/recurring/anomalies/thresholds
+    Returns current detection thresholds.
+    """
+    return jsonify({
+        "amount_deviation_threshold": AMOUNT_DEVIATION_THRESHOLD,
+        "amount_large_deviation": AMOUNT_LARGE_DEVIATION,
+        "description": {
+            "amount_deviation_threshold": f">{AMOUNT_DEVIATION_THRESHOLD*100:.0f}% amount change triggers anomaly",
+            "amount_large_deviation": f">{AMOUNT_LARGE_DEVIATION*100:.0f}% amount change triggers critical anomaly",
+        },
+    })

--- a/packages/backend/app/services/recurring_anomaly.py
+++ b/packages/backend/app/services/recurring_anomaly.py
@@ -1,0 +1,288 @@
+"""
+Recurring transaction anomaly detection service.
+
+Detects when recurring expenses deviate from their historical pattern:
+- Amount anomaly: expense differs from expected amount by more than threshold
+- Timing anomaly: expense generated at unexpected time
+- Frequency anomaly: more/fewer occurrences than expected in a period
+- Missing anomaly: expected recurring expense not found
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+import statistics
+
+
+# ─── Config ──────────────────────────────────────────────────────────────────
+
+# Default thresholds (percentage)
+AMOUNT_DEVIATION_THRESHOLD = 0.20   # >20% change = anomaly
+AMOUNT_LARGE_DEVIATION = 0.50       # >50% change = critical anomaly
+MIN_HISTORY_SAMPLES = 3              # need at least 3 occurrences to detect anomalies
+
+
+# ─── Data structures ─────────────────────────────────────────────────────────
+
+@dataclass
+class ExpenseRecord:
+    """Lightweight representation of a single expense transaction."""
+    id: int
+    amount: Decimal
+    date: date
+    recurring_id: int | None = None
+    notes: str = ""
+
+
+@dataclass
+class RecurringConfig:
+    """Expected configuration for a recurring expense."""
+    id: int
+    expected_amount: Decimal
+    cadence: str          # DAILY, WEEKLY, MONTHLY, YEARLY
+    active: bool = True
+    notes: str = ""
+
+
+@dataclass
+class AnomalyAlert:
+    """A detected anomaly in a recurring expense pattern."""
+    recurring_id: int
+    anomaly_type: str           # amount | missing | frequency | timing
+    severity: str               # low | medium | high | critical
+    message: str
+    expected_value: Any = None
+    actual_value: Any = None
+    affected_expense_id: int | None = None
+    detected_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+    def to_dict(self) -> dict:
+        return {
+            "recurring_id": self.recurring_id,
+            "anomaly_type": self.anomaly_type,
+            "severity": self.severity,
+            "message": self.message,
+            "expected_value": str(self.expected_value) if self.expected_value is not None else None,
+            "actual_value": str(self.actual_value) if self.actual_value is not None else None,
+            "affected_expense_id": self.affected_expense_id,
+            "detected_at": self.detected_at,
+        }
+
+
+# ─── Core detection logic ─────────────────────────────────────────────────────
+
+def detect_amount_anomalies(
+    config: RecurringConfig,
+    recent_expenses: list[ExpenseRecord],
+    threshold: float = AMOUNT_DEVIATION_THRESHOLD,
+    critical_threshold: float = AMOUNT_LARGE_DEVIATION,
+) -> list[AnomalyAlert]:
+    """
+    Compare recent expense amounts against expected and historical mean.
+    Returns list of AnomalyAlert objects (empty = no anomalies).
+    """
+    if not recent_expenses:
+        return []
+
+    alerts = []
+    expected = float(config.expected_amount)
+
+    # Use historical mean if enough samples available
+    if len(recent_expenses) >= MIN_HISTORY_SAMPLES:
+        historical_amounts = [float(e.amount) for e in recent_expenses[:-1]]  # exclude last
+        historical_mean = statistics.mean(historical_amounts)
+        baseline = historical_mean
+    else:
+        baseline = expected
+
+    # Check most recent expense
+    latest = recent_expenses[-1]
+    actual = float(latest.amount)
+
+    if baseline == 0:
+        return []
+
+    deviation = abs(actual - baseline) / baseline
+
+    if deviation >= critical_threshold:
+        severity = "critical"
+        message = (
+            f"Recurring expense #{config.id} amount deviated critically: "
+            f"expected ~{baseline:.2f}, got {actual:.2f} "
+            f"({deviation*100:.1f}% change)"
+        )
+    elif deviation >= threshold:
+        severity = "high" if deviation >= threshold * 2 else "medium"
+        message = (
+            f"Recurring expense #{config.id} amount anomaly: "
+            f"expected ~{baseline:.2f}, got {actual:.2f} "
+            f"({deviation*100:.1f}% change)"
+        )
+    else:
+        return []
+
+    alerts.append(AnomalyAlert(
+        recurring_id=config.id,
+        anomaly_type="amount",
+        severity=severity,
+        message=message,
+        expected_value=round(baseline, 2),
+        actual_value=actual,
+        affected_expense_id=latest.id,
+    ))
+    return alerts
+
+
+def _expected_period_days(cadence: str) -> int:
+    """Return expected number of days between occurrences."""
+    return {"DAILY": 1, "WEEKLY": 7, "MONTHLY": 30, "YEARLY": 365}.get(cadence, 30)
+
+
+def detect_missing_anomalies(
+    config: RecurringConfig,
+    recent_expenses: list[ExpenseRecord],
+    check_date: date | None = None,
+) -> list[AnomalyAlert]:
+    """
+    Detect if a recurring expense is overdue (should have occurred but didn't).
+    """
+    if not config.active:
+        return []
+
+    check_date = check_date or date.today()
+    period_days = _expected_period_days(config.cadence)
+    tolerance = max(2, period_days // 5)  # 20% tolerance
+
+    if not recent_expenses:
+        return []
+
+    last_occurrence = max(e.date for e in recent_expenses)
+    days_since = (check_date - last_occurrence).days
+
+    if days_since > period_days + tolerance:
+        overdue_by = days_since - period_days
+        severity = "high" if overdue_by > period_days else "medium"
+        return [AnomalyAlert(
+            recurring_id=config.id,
+            anomaly_type="missing",
+            severity=severity,
+            message=(
+                f"Recurring expense #{config.id} ({config.cadence}) "
+                f"is overdue by {overdue_by} day(s). "
+                f"Last occurrence: {last_occurrence.isoformat()}"
+            ),
+            expected_value=f"occurrence by {(last_occurrence + timedelta(days=period_days)).isoformat()}",
+            actual_value=f"not seen as of {check_date.isoformat()}",
+        )]
+    return []
+
+
+def detect_frequency_anomalies(
+    config: RecurringConfig,
+    expenses_last_30_days: list[ExpenseRecord],
+) -> list[AnomalyAlert]:
+    """
+    Detect unexpected frequency: too many or too few occurrences in last 30 days.
+    """
+    period_days = _expected_period_days(config.cadence)
+    expected_count = max(1, round(30 / period_days))
+    actual_count = len(expenses_last_30_days)
+
+    if actual_count == 0 or expected_count == 0:
+        return []
+
+    ratio = actual_count / expected_count
+
+    if ratio > 2.0:
+        return [AnomalyAlert(
+            recurring_id=config.id,
+            anomaly_type="frequency",
+            severity="high",
+            message=(
+                f"Recurring expense #{config.id} occurred {actual_count}x in 30 days, "
+                f"expected ~{expected_count}x (possible duplicate charges)"
+            ),
+            expected_value=expected_count,
+            actual_value=actual_count,
+        )]
+    elif ratio < 0.4 and expected_count >= 2:
+        return [AnomalyAlert(
+            recurring_id=config.id,
+            anomaly_type="frequency",
+            severity="medium",
+            message=(
+                f"Recurring expense #{config.id} only occurred {actual_count}x in 30 days, "
+                f"expected ~{expected_count}x"
+            ),
+            expected_value=expected_count,
+            actual_value=actual_count,
+        )]
+    return []
+
+
+def analyze_recurring_expense(
+    config: RecurringConfig,
+    all_expenses: list[ExpenseRecord],
+    check_date: date | None = None,
+) -> list[AnomalyAlert]:
+    """
+    Run all anomaly checks for a single recurring expense config.
+    Returns combined list of anomalies.
+    """
+    if not config.active or not all_expenses:
+        return []
+
+    check_date = check_date or date.today()
+
+    # Last 90 days of matching expenses
+    cutoff_90 = check_date - timedelta(days=90)
+    recent = sorted(
+        [e for e in all_expenses if e.date >= cutoff_90],
+        key=lambda e: e.date,
+    )
+
+    # Last 30 days for frequency check
+    cutoff_30 = check_date - timedelta(days=30)
+    last_30 = [e for e in recent if e.date >= cutoff_30]
+
+    alerts: list[AnomalyAlert] = []
+    alerts.extend(detect_amount_anomalies(config, recent))
+    alerts.extend(detect_missing_anomalies(config, recent, check_date=check_date))
+    alerts.extend(detect_frequency_anomalies(config, last_30))
+    return alerts
+
+
+def batch_analyze(
+    configs: list[RecurringConfig],
+    expenses_by_recurring_id: dict[int, list[ExpenseRecord]],
+    check_date: date | None = None,
+) -> dict[int, list[AnomalyAlert]]:
+    """
+    Analyze multiple recurring expense configs at once.
+    Returns dict mapping recurring_id -> list of anomalies.
+    """
+    result: dict[int, list[AnomalyAlert]] = {}
+    for config in configs:
+        expenses = expenses_by_recurring_id.get(config.id, [])
+        anomalies = analyze_recurring_expense(config, expenses, check_date=check_date)
+        if anomalies:
+            result[config.id] = anomalies
+    return result
+
+
+def anomaly_summary(all_anomalies: list[AnomalyAlert]) -> dict:
+    """Summarize anomalies by type and severity."""
+    by_type: dict[str, int] = {}
+    by_severity: dict[str, int] = {}
+    for a in all_anomalies:
+        by_type[a.anomaly_type] = by_type.get(a.anomaly_type, 0) + 1
+        by_severity[a.severity] = by_severity.get(a.severity, 0) + 1
+    return {
+        "total": len(all_anomalies),
+        "by_type": by_type,
+        "by_severity": by_severity,
+        "has_critical": by_severity.get("critical", 0) > 0,
+    }

--- a/packages/backend/tests/test_recurring_anomaly.py
+++ b/packages/backend/tests/test_recurring_anomaly.py
@@ -1,0 +1,274 @@
+"""
+Tests for recurring transaction anomaly detection (#108).
+"""
+
+import pytest
+import socket
+from decimal import Decimal
+from datetime import date, timedelta
+
+from app.services.recurring_anomaly import (
+    RecurringConfig,
+    ExpenseRecord,
+    AnomalyAlert,
+    detect_amount_anomalies,
+    detect_missing_anomalies,
+    detect_frequency_anomalies,
+    analyze_recurring_expense,
+    batch_analyze,
+    anomaly_summary,
+)
+
+
+def _config(id=1, amount="100.00", cadence="MONTHLY", active=True):
+    return RecurringConfig(
+        id=id, expected_amount=Decimal(amount), cadence=cadence, active=active
+    )
+
+
+def _expense(id, amount, days_ago=0, rid=1):
+    return ExpenseRecord(
+        id=id,
+        amount=Decimal(amount),
+        date=date.today() - timedelta(days=days_ago),
+        recurring_id=rid,
+    )
+
+
+def _redis_available():
+    try:
+        s = socket.create_connection(("localhost", 6379), timeout=0.5)
+        s.close()
+        return True
+    except (OSError, ConnectionRefusedError):
+        return False
+
+
+requires_redis = pytest.mark.skipif(
+    not _redis_available(), reason="Redis not available"
+)
+
+
+# ─── Amount anomaly tests ─────────────────────────────────────────────────────
+
+class TestDetectAmountAnomalies:
+    def test_no_anomaly_within_threshold(self):
+        cfg = _config(amount="100.00")
+        expenses = [_expense(i, "100.00", days_ago=i*30) for i in range(5, 0, -1)]
+        alerts = detect_amount_anomalies(cfg, expenses)
+        assert alerts == []
+
+    def test_small_deviation_no_alert(self):
+        cfg = _config(amount="100.00")
+        expenses = [
+            _expense(1, "100.00", days_ago=90),
+            _expense(2, "100.00", days_ago=60),
+            _expense(3, "100.00", days_ago=30),
+            _expense(4, "115.00"),  # 15% up — under threshold
+        ]
+        alerts = detect_amount_anomalies(cfg, expenses)
+        assert alerts == []
+
+    def test_medium_deviation_triggers_alert(self):
+        cfg = _config(amount="100.00")
+        expenses = [
+            _expense(1, "100.00", days_ago=90),
+            _expense(2, "100.00", days_ago=60),
+            _expense(3, "100.00", days_ago=30),
+            _expense(4, "130.00"),  # 30% up — above 20% threshold
+        ]
+        alerts = detect_amount_anomalies(cfg, expenses)
+        assert len(alerts) == 1
+        assert alerts[0].anomaly_type == "amount"
+        assert alerts[0].severity in ("medium", "high")
+
+    def test_critical_deviation_triggers_critical(self):
+        cfg = _config(amount="100.00")
+        expenses = [
+            _expense(1, "100.00", days_ago=90),
+            _expense(2, "100.00", days_ago=60),
+            _expense(3, "100.00", days_ago=30),
+            _expense(4, "200.00"),  # 100% up — critical
+        ]
+        alerts = detect_amount_anomalies(cfg, expenses)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "critical"
+
+    def test_empty_expenses_returns_no_alert(self):
+        cfg = _config()
+        assert detect_amount_anomalies(cfg, []) == []
+
+    def test_single_expense_uses_expected_as_baseline(self):
+        cfg = _config(amount="100.00")
+        expenses = [_expense(1, "200.00")]  # 100% over expected
+        alerts = detect_amount_anomalies(cfg, expenses)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "critical"
+
+
+# ─── Missing anomaly tests ────────────────────────────────────────────────────
+
+class TestDetectMissingAnomalies:
+    def test_no_anomaly_when_on_time(self):
+        cfg = _config(cadence="MONTHLY")
+        expenses = [_expense(1, "100.00", days_ago=28)]  # within 30 day window
+        alerts = detect_missing_anomalies(cfg, expenses)
+        assert alerts == []
+
+    def test_detects_overdue_monthly(self):
+        cfg = _config(cadence="MONTHLY")
+        expenses = [_expense(1, "100.00", days_ago=40)]  # 10 days overdue
+        alerts = detect_missing_anomalies(cfg, expenses)
+        assert len(alerts) == 1
+        assert alerts[0].anomaly_type == "missing"
+
+    def test_detects_overdue_weekly(self):
+        cfg = _config(cadence="WEEKLY")
+        expenses = [_expense(1, "50.00", days_ago=14)]  # 7 days overdue
+        alerts = detect_missing_anomalies(cfg, expenses)
+        assert len(alerts) == 1
+
+    def test_inactive_config_no_alert(self):
+        cfg = _config(active=False, cadence="MONTHLY")
+        expenses = [_expense(1, "100.00", days_ago=60)]
+        alerts = detect_missing_anomalies(cfg, expenses)
+        assert alerts == []
+
+    def test_no_expenses_returns_empty(self):
+        cfg = _config(cadence="MONTHLY")
+        assert detect_missing_anomalies(cfg, []) == []
+
+
+# ─── Frequency anomaly tests ──────────────────────────────────────────────────
+
+class TestDetectFrequencyAnomalies:
+    def test_normal_frequency_no_alert(self):
+        cfg = _config(cadence="MONTHLY")
+        expenses = [_expense(1, "100.00", days_ago=15)]  # 1 in 30 days = expected
+        alerts = detect_frequency_anomalies(cfg, expenses)
+        assert alerts == []
+
+    def test_too_many_triggers_alert(self):
+        cfg = _config(cadence="MONTHLY")
+        # 3 charges in 30 days when only 1 expected
+        expenses = [_expense(i, "100.00", days_ago=i*7) for i in range(1, 4)]
+        alerts = detect_frequency_anomalies(cfg, expenses)
+        assert len(alerts) == 1
+        assert alerts[0].anomaly_type == "frequency"
+        assert alerts[0].severity == "high"
+
+    def test_weekly_normal_frequency(self):
+        cfg = _config(cadence="WEEKLY")
+        # 4-5 weekly expenses in 30 days = normal
+        expenses = [_expense(i, "50.00", days_ago=i*7) for i in range(1, 5)]
+        alerts = detect_frequency_anomalies(cfg, expenses)
+        assert alerts == []
+
+    def test_empty_expenses_no_alert(self):
+        cfg = _config(cadence="MONTHLY")
+        assert detect_frequency_anomalies(cfg, []) == []
+
+
+# ─── Full analysis tests ──────────────────────────────────────────────────────
+
+class TestAnalyzeRecurringExpense:
+    def test_no_anomalies_clean_history(self):
+        cfg = _config(amount="100.00", cadence="MONTHLY")
+        expenses = [
+            _expense(i, "100.00", days_ago=(5-i)*30)
+            for i in range(1, 5)
+        ]
+        alerts = analyze_recurring_expense(cfg, expenses)
+        assert alerts == []
+
+    def test_combined_anomalies_detected(self):
+        cfg = _config(amount="100.00", cadence="MONTHLY")
+        # Old history normal, then large amount spike
+        expenses = [
+            _expense(1, "100.00", days_ago=90),
+            _expense(2, "100.00", days_ago=60),
+            _expense(3, "100.00", days_ago=30),
+            _expense(4, "250.00"),  # critical amount anomaly
+        ]
+        alerts = analyze_recurring_expense(cfg, expenses)
+        types = {a.anomaly_type for a in alerts}
+        assert "amount" in types
+
+    def test_inactive_config_returns_empty(self):
+        cfg = _config(active=False)
+        expenses = [_expense(1, "100.00", days_ago=40)]
+        assert analyze_recurring_expense(cfg, expenses) == []
+
+
+# ─── Batch analysis tests ─────────────────────────────────────────────────────
+
+class TestBatchAnalyze:
+    def test_returns_only_configs_with_anomalies(self):
+        configs = [
+            _config(id=1, amount="100.00"),  # clean
+            _config(id=2, amount="50.00"),   # will have anomaly
+        ]
+        expenses_by_id = {
+            1: [_expense(i, "100.00", days_ago=i*30, rid=1) for i in range(1, 5)],
+            2: [
+                _expense(10, "50.00", days_ago=90, rid=2),
+                _expense(11, "50.00", days_ago=60, rid=2),
+                _expense(12, "50.00", days_ago=30, rid=2),
+                _expense(13, "200.00", rid=2),  # anomaly
+            ],
+        }
+        result = batch_analyze(configs, expenses_by_id)
+        assert 1 not in result   # no anomalies for config 1
+        assert 2 in result       # anomaly for config 2
+
+
+# ─── Summary tests ────────────────────────────────────────────────────────────
+
+class TestAnomalySummary:
+    def test_empty_list(self):
+        s = anomaly_summary([])
+        assert s["total"] == 0
+        assert s["has_critical"] is False
+
+    def test_counts_correctly(self):
+        alerts = [
+            AnomalyAlert(1, "amount", "critical", "msg"),
+            AnomalyAlert(2, "missing", "high", "msg"),
+            AnomalyAlert(3, "frequency", "medium", "msg"),
+        ]
+        s = anomaly_summary(alerts)
+        assert s["total"] == 3
+        assert s["has_critical"] is True
+        assert s["by_type"]["amount"] == 1
+        assert s["by_severity"]["critical"] == 1
+
+
+# ─── API tests ────────────────────────────────────────────────────────────────
+
+@requires_redis
+class TestRecurringAnomalyAPI:
+    def test_list_requires_auth(self, client):
+        r = client.get("/recurring/anomalies")
+        assert r.status_code == 401
+
+    def test_detail_requires_auth(self, client):
+        r = client.get("/recurring/anomalies/1")
+        assert r.status_code == 401
+
+    def test_list_returns_json(self, client, auth_header):
+        r = client.get("/recurring/anomalies", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "anomalies" in data
+        assert "summary" in data
+
+    def test_nonexistent_recurring_returns_404(self, client, auth_header):
+        r = client.get("/recurring/anomalies/99999", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_thresholds_endpoint(self, client, auth_header):
+        r = client.get("/recurring/anomalies/thresholds", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "amount_deviation_threshold" in data
+        assert "amount_large_deviation" in data


### PR DESCRIPTION
## Summary

Implements recurring transaction anomaly detection as requested in issue #108.

## Changes

New service: `recurring_anomaly.py`
- Amount anomaly: >20% deviation from historical mean triggers alert; >50% = critical
- Missing anomaly: recurring expense overdue beyond expected cadence (with 20% tolerance)
- Frequency anomaly: too many or too few occurrences in 30-day window
- Batch analysis across multiple recurring expense configs
- Statistical baseline: uses historical mean when 3+ samples available, falls back to configured amount

New endpoints via Blueprint `recurring_anomaly`:
- GET /recurring/anomalies - scan all active recurring expenses, returns grouped anomalies + summary
- GET /recurring/anomalies?severity=high - filter by severity level
- GET /recurring/anomalies?type=amount - filter by anomaly type
- GET /recurring/anomalies/<id> - check specific recurring expense
- GET /recurring/anomalies/thresholds - view current detection thresholds

## Tests

21 unit tests pass covering all detection functions, batch analysis, and summary. 5 endpoint tests skip gracefully when Redis unavailable in CI.

Attempt for Algora bounty #108.