### PR TITLE
feat: subscription cost increase detection (#110)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .subscription_detect import bp as subscription_detect_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(subscription_detect_bp, url_prefix="/subscriptions/price-changes")

--- a/packages/backend/app/routes/subscription_detect.py
+++ b/packages/backend/app/routes/subscription_detect.py
@@ -1,0 +1,139 @@
+"""
+Subscription cost increase detection endpoints (#110).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import and_
+
+from ..extensions import db
+from ..models import RecurringExpense, Expense
+from ..services.subscription_detect import (
+    SubscriptionConfig,
+    ChargeRecord,
+    detect_price_increase,
+    detect_vs_expected,
+    scan_all_subscriptions,
+    price_change_summary,
+)
+import logging
+
+bp = Blueprint("subscription_detect", __name__)
+logger = logging.getLogger("finmind.subscription_detect")
+
+
+def _load_subscription_configs(user_id: int, sub_id: int | None = None) -> list[SubscriptionConfig]:
+    """Load RecurringExpenses as SubscriptionConfig objects."""
+    q = db.session.query(RecurringExpense).filter_by(user_id=user_id, active=True)
+    if sub_id is not None:
+        q = q.filter_by(id=sub_id)
+    configs = []
+    for rec in q.all():
+        configs.append(SubscriptionConfig(
+            id=rec.id,
+            name=rec.notes or f"Subscription #{rec.id}",
+            expected_amount=Decimal(str(rec.amount)),
+            cadence=rec.cadence.value if hasattr(rec.cadence, "value") else rec.cadence,
+            currency=rec.currency or "USD",
+            active=rec.active,
+        ))
+    return configs
+
+
+def _load_charge_records(user_id: int, recurring_id: int | None = None) -> dict[int, list[ChargeRecord]]:
+    """Load expense charges grouped by source_recurring_id."""
+    q = (
+        db.session.query(Expense)
+        .filter_by(user_id=user_id)
+        .filter(Expense.source_recurring_id.isnot(None))
+    )
+    if recurring_id is not None:
+        q = q.filter_by(source_recurring_id=recurring_id)
+
+    by_id: dict[int, list[ChargeRecord]] = {}
+    for exp in q.all():
+        rid = exp.source_recurring_id
+        charge_date = exp.spent_at.date() if hasattr(exp.spent_at, "date") else exp.spent_at
+        by_id.setdefault(rid, []).append(
+            ChargeRecord(
+                id=exp.id,
+                amount=Decimal(str(exp.amount)),
+                charge_date=charge_date,
+                subscription_id=rid,
+            )
+        )
+    return by_id
+
+
+@bp.get("")
+@jwt_required()
+def list_price_changes():
+    """
+    GET /api/subscriptions/price-changes
+    Scan all active subscriptions for price increases.
+
+    Query params:
+      - severity: info|medium|high (filter)
+    """
+    uid = int(get_jwt_identity())
+    severity_filter = request.args.get("severity")
+
+    configs = _load_subscription_configs(uid)
+    if not configs:
+        return jsonify({
+            "alerts": [],
+            "summary": price_change_summary([]),
+        })
+
+    charges_map = _load_charge_records(uid)
+    alerts = scan_all_subscriptions(configs, charges_map)
+
+    if severity_filter:
+        alerts = [a for a in alerts if a.severity == severity_filter]
+
+    logger.info("Subscription price scan user=%s alerts=%s", uid, len(alerts))
+    return jsonify({
+        "alerts": [a.to_dict() for a in alerts],
+        "summary": price_change_summary(alerts),
+    })
+
+
+@bp.get("/<int:subscription_id>")
+@jwt_required()
+def get_price_changes_for_subscription(subscription_id: int):
+    """
+    GET /api/subscriptions/price-changes/<subscription_id>
+    Check price changes for a specific subscription.
+    """
+    uid = int(get_jwt_identity())
+
+    configs = _load_subscription_configs(uid, sub_id=subscription_id)
+    if not configs:
+        return jsonify(error="Subscription not found"), 404
+
+    config = configs[0]
+    charges_map = _load_charge_records(uid, recurring_id=subscription_id)
+    charges = charges_map.get(subscription_id, [])
+
+    alerts = detect_price_increase(config, charges)
+
+    latest = sorted(charges, key=lambda c: c.charge_date)[-1] if charges else None
+    vs_expected = detect_vs_expected(config, latest)
+    if vs_expected:
+        already_found = any(a.affected_charge_id == vs_expected.affected_charge_id for a in alerts)
+        if not already_found:
+            alerts.append(vs_expected)
+
+    return jsonify({
+        "subscription_id": subscription_id,
+        "subscription_name": config.name,
+        "current_expected_amount": str(config.expected_amount),
+        "alerts": [a.to_dict() for a in alerts],
+        "summary": price_change_summary(alerts),
+        "charge_count_analyzed": len(charges),
+    })

--- a/packages/backend/app/services/subscription_detect.py
+++ b/packages/backend/app/services/subscription_detect.py
@@ -1,0 +1,238 @@
+"""
+Subscription cost increase detection service.
+
+Detects when the cost of a subscription has increased compared to
+previous charges, notifying users of price changes.
+
+Integrates with RecurringExpense model (cadence=MONTHLY/YEARLY, notes like "Netflix", "Spotify").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+
+# ─── Configuration ───────────────────────────────────────────────────────────
+
+# Default thresholds
+DEFAULT_INCREASE_THRESHOLD = Decimal("0.01")   # Any increase > 1 cent
+SIGNIFICANT_INCREASE_PCT = Decimal("0.10")     # >= 10% = significant
+LARGE_INCREASE_PCT = Decimal("0.25")           # >= 25% = large / high severity
+
+
+# ─── Data structures ─────────────────────────────────────────────────────────
+
+@dataclass
+class ChargeRecord:
+    """A single subscription charge occurrence."""
+    id: int
+    amount: Decimal
+    charge_date: date
+    subscription_id: int
+
+
+@dataclass
+class SubscriptionConfig:
+    """Subscription definition (maps to a RecurringExpense)."""
+    id: int
+    name: str                    # e.g., "Netflix", "Spotify Premium"
+    expected_amount: Decimal     # Last known / configured amount
+    cadence: str                 # MONTHLY, YEARLY, etc.
+    currency: str = "USD"
+    active: bool = True
+
+
+@dataclass
+class PriceChangeAlert:
+    """Alert generated when a subscription price changes."""
+    subscription_id: int
+    subscription_name: str
+    old_amount: Decimal
+    new_amount: Decimal
+    change_pct: Decimal
+    severity: str               # info | medium | high | critical
+    message: str
+    affected_charge_id: int | None = None
+    detected_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+    @property
+    def increase_amount(self) -> Decimal:
+        return self.new_amount - self.old_amount
+
+    def to_dict(self) -> dict:
+        return {
+            "subscription_id": self.subscription_id,
+            "subscription_name": self.subscription_name,
+            "old_amount": str(self.old_amount),
+            "new_amount": str(self.new_amount),
+            "change_amount": str(self.increase_amount),
+            "change_pct": f"{self.change_pct * 100:.1f}%",
+            "severity": self.severity,
+            "message": self.message,
+            "affected_charge_id": self.affected_charge_id,
+            "detected_at": self.detected_at,
+        }
+
+
+# ─── Core detection logic ─────────────────────────────────────────────────────
+
+def _severity(change_pct: Decimal) -> str:
+    if change_pct >= LARGE_INCREASE_PCT:
+        return "high"
+    if change_pct >= SIGNIFICANT_INCREASE_PCT:
+        return "medium"
+    return "info"
+
+
+def detect_price_increase(
+    config: SubscriptionConfig,
+    charges: list[ChargeRecord],
+    min_history: int = 2,
+) -> list[PriceChangeAlert]:
+    """
+    Compare consecutive subscription charges to detect price increases.
+
+    Algorithm:
+    1. Sort charges by date ascending.
+    2. Compare each consecutive pair: (prev_amount, current_amount).
+    3. If current > prev + DEFAULT_INCREASE_THRESHOLD, emit an alert.
+    4. Also check most recent charge vs config.expected_amount.
+
+    Returns list of PriceChangeAlert (newest first).
+    """
+    if not config.active or len(charges) < 1:
+        return []
+
+    sorted_charges = sorted(charges, key=lambda c: c.charge_date)
+    alerts: list[PriceChangeAlert] = []
+
+    # Consecutive pair analysis
+    for i in range(1, len(sorted_charges)):
+        prev = sorted_charges[i - 1]
+        curr = sorted_charges[i]
+
+        if curr.amount <= prev.amount:
+            continue  # No increase, skip
+
+        increase = curr.amount - prev.amount
+        if increase < DEFAULT_INCREASE_THRESHOLD:
+            continue  # Rounding noise
+
+        if prev.amount == 0:
+            continue  # Avoid division by zero
+
+        change_pct = increase / prev.amount
+        severity = _severity(change_pct)
+
+        alerts.append(PriceChangeAlert(
+            subscription_id=config.id,
+            subscription_name=config.name,
+            old_amount=prev.amount,
+            new_amount=curr.amount,
+            change_pct=change_pct,
+            severity=severity,
+            message=(
+                f"'{config.name}' price increased from {config.currency} {prev.amount:.2f} "
+                f"to {config.currency} {curr.amount:.2f} "
+                f"(+{change_pct * 100:.1f}%, +{config.currency} {increase:.2f})"
+            ),
+            affected_charge_id=curr.id,
+        ))
+
+    # Sort newest first
+    alerts.sort(key=lambda a: a.detected_at, reverse=True)
+    return alerts
+
+
+def detect_vs_expected(
+    config: SubscriptionConfig,
+    latest_charge: ChargeRecord | None,
+) -> PriceChangeAlert | None:
+    """
+    Check if the most recent charge differs from the configured expected amount.
+    Useful when expected_amount was manually set or imported.
+    """
+    if latest_charge is None or not config.active:
+        return None
+
+    if latest_charge.amount <= config.expected_amount:
+        return None  # Same or cheaper
+
+    increase = latest_charge.amount - config.expected_amount
+    if increase < DEFAULT_INCREASE_THRESHOLD:
+        return None
+
+    if config.expected_amount == 0:
+        return None
+
+    change_pct = increase / config.expected_amount
+    severity = _severity(change_pct)
+
+    return PriceChangeAlert(
+        subscription_id=config.id,
+        subscription_name=config.name,
+        old_amount=config.expected_amount,
+        new_amount=latest_charge.amount,
+        change_pct=change_pct,
+        severity=severity,
+        message=(
+            f"'{config.name}' latest charge ({latest_charge.amount:.2f}) "
+            f"exceeds configured amount ({config.expected_amount:.2f}) "
+            f"by +{change_pct * 100:.1f}%"
+        ),
+        affected_charge_id=latest_charge.id,
+    )
+
+
+def scan_all_subscriptions(
+    configs: list[SubscriptionConfig],
+    charges_by_id: dict[int, list[ChargeRecord]],
+) -> list[PriceChangeAlert]:
+    """
+    Scan all subscriptions for price increases.
+    Returns sorted list of alerts (critical/high first).
+    """
+    all_alerts: list[PriceChangeAlert] = []
+
+    for config in configs:
+        charges = sorted(charges_by_id.get(config.id, []), key=lambda c: c.charge_date)
+
+        # Consecutive increase detection
+        alerts = detect_price_increase(config, charges)
+        all_alerts.extend(alerts)
+
+        # Also check vs expected
+        latest = charges[-1] if charges else None
+        vs_expected = detect_vs_expected(config, latest)
+        if vs_expected:
+            # Avoid duplicating if already found via consecutive check
+            already_found = any(
+                a.affected_charge_id == vs_expected.affected_charge_id
+                and a.subscription_id == vs_expected.subscription_id
+                for a in alerts
+            )
+            if not already_found:
+                all_alerts.append(vs_expected)
+
+    # Sort by severity
+    sev_order = {"high": 3, "medium": 2, "info": 1}
+    all_alerts.sort(key=lambda a: sev_order.get(a.severity, 0), reverse=True)
+    return all_alerts
+
+
+def price_change_summary(alerts: list[PriceChangeAlert]) -> dict:
+    """High-level summary of price change alerts."""
+    by_severity: dict[str, int] = {}
+    total_extra_spend = Decimal("0")
+    for a in alerts:
+        by_severity[a.severity] = by_severity.get(a.severity, 0) + 1
+        total_extra_spend += a.increase_amount
+    return {
+        "total_alerts": len(alerts),
+        "by_severity": by_severity,
+        "total_extra_monthly_spend": str(total_extra_spend.quantize(Decimal("0.01"))),
+        "has_high_severity": by_severity.get("high", 0) > 0,
+    }

--- a/packages/backend/tests/test_subscription_detect.py
+++ b/packages/backend/tests/test_subscription_detect.py
@@ -1,0 +1,231 @@
+"""
+Tests for subscription cost increase detection (#110).
+"""
+
+import pytest
+import socket
+from decimal import Decimal
+from datetime import date, timedelta
+
+from app.services.subscription_detect import (
+    SubscriptionConfig,
+    ChargeRecord,
+    PriceChangeAlert,
+    detect_price_increase,
+    detect_vs_expected,
+    scan_all_subscriptions,
+    price_change_summary,
+    DEFAULT_INCREASE_THRESHOLD,
+    SIGNIFICANT_INCREASE_PCT,
+    LARGE_INCREASE_PCT,
+)
+
+
+def _config(id=1, name="Netflix", amount="15.99", currency="USD", active=True):
+    return SubscriptionConfig(
+        id=id, name=name, expected_amount=Decimal(amount),
+        cadence="MONTHLY", currency=currency, active=active
+    )
+
+
+def _charge(id, amount, days_ago=0, sub_id=1):
+    return ChargeRecord(
+        id=id,
+        amount=Decimal(amount),
+        charge_date=date.today() - timedelta(days=days_ago),
+        subscription_id=sub_id,
+    )
+
+
+def _redis_available():
+    try:
+        s = socket.create_connection(("localhost", 6379), timeout=0.5)
+        s.close()
+        return True
+    except (OSError, ConnectionRefusedError):
+        return False
+
+
+requires_redis = pytest.mark.skipif(not _redis_available(), reason="Redis not available")
+
+
+# ─── detect_price_increase tests ─────────────────────────────────────────────
+
+class TestDetectPriceIncrease:
+    def test_no_increase_same_price(self):
+        cfg = _config(amount="15.99")
+        charges = [
+            _charge(1, "15.99", days_ago=60),
+            _charge(2, "15.99", days_ago=30),
+            _charge(3, "15.99"),
+        ]
+        alerts = detect_price_increase(cfg, charges)
+        assert alerts == []
+
+    def test_price_decrease_no_alert(self):
+        cfg = _config(amount="15.99")
+        charges = [_charge(1, "15.99", 60), _charge(2, "12.99", 30)]
+        assert detect_price_increase(cfg, charges) == []
+
+    def test_small_increase_triggers_info(self):
+        cfg = _config(amount="15.99")
+        charges = [_charge(1, "15.99", 30), _charge(2, "16.59")]  # ~3.75% increase - info
+        alerts = detect_price_increase(cfg, charges)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "info"  # < 10%
+        assert alerts[0].new_amount == Decimal("16.59")
+        assert alerts[0].old_amount == Decimal("15.99")
+
+    def test_10pct_increase_triggers_medium(self):
+        cfg = _config(amount="15.99")
+        charges = [_charge(1, "10.00", 60), _charge(2, "11.50", 30)]  # 15% increase
+        alerts = detect_price_increase(cfg, charges)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "medium"
+
+    def test_25pct_increase_triggers_high(self):
+        cfg = _config(amount="10.00")
+        charges = [_charge(1, "10.00", 30), _charge(2, "14.00")]  # 40% increase
+        alerts = detect_price_increase(cfg, charges)
+        assert len(alerts) == 1
+        assert alerts[0].severity == "high"
+
+    def test_multiple_increases_detected(self):
+        cfg = _config(amount="10.00")
+        charges = [
+            _charge(1, "10.00", days_ago=90),
+            _charge(2, "11.00", days_ago=60),  # +10%
+            _charge(3, "12.00", days_ago=30),  # +9%
+            _charge(4, "15.00"),               # +25%
+        ]
+        alerts = detect_price_increase(cfg, charges)
+        assert len(alerts) == 3
+
+    def test_empty_charges_no_alerts(self):
+        cfg = _config()
+        assert detect_price_increase(cfg, []) == []
+
+    def test_single_charge_no_alerts(self):
+        cfg = _config()
+        assert detect_price_increase(cfg, [_charge(1, "10.00")]) == []
+
+    def test_inactive_subscription_no_alert(self):
+        cfg = _config(active=False)
+        charges = [_charge(1, "10.00", 30), _charge(2, "15.00")]
+        assert detect_price_increase(cfg, charges) == []
+
+    def test_alert_contains_correct_change_amount(self):
+        cfg = _config(amount="10.00")
+        charges = [_charge(1, "10.00", 30), _charge(2, "13.00")]
+        alerts = detect_price_increase(cfg, charges)
+        assert len(alerts) == 1
+        assert alerts[0].increase_amount == Decimal("3.00")
+
+
+# ─── detect_vs_expected tests ─────────────────────────────────────────────────
+
+class TestDetectVsExpected:
+    def test_higher_than_expected_returns_alert(self):
+        cfg = _config(amount="15.99")
+        latest = _charge(1, "19.99")
+        alert = detect_vs_expected(cfg, latest)
+        assert alert is not None
+        assert alert.severity in ("info", "medium", "high")
+
+    def test_same_as_expected_returns_none(self):
+        cfg = _config(amount="15.99")
+        latest = _charge(1, "15.99")
+        assert detect_vs_expected(cfg, latest) is None
+
+    def test_lower_than_expected_returns_none(self):
+        cfg = _config(amount="15.99")
+        latest = _charge(1, "12.99")
+        assert detect_vs_expected(cfg, latest) is None
+
+    def test_none_latest_returns_none(self):
+        cfg = _config()
+        assert detect_vs_expected(cfg, None) is None
+
+
+# ─── scan_all_subscriptions tests ────────────────────────────────────────────
+
+class TestScanAll:
+    def test_returns_alerts_for_affected_subs(self):
+        configs = [
+            _config(id=1, name="Netflix", amount="15.99"),
+            _config(id=2, name="Spotify", amount="9.99"),
+        ]
+        charges = {
+            1: [_charge(1, "15.99", 30, sub_id=1), _charge(2, "19.99", 0, sub_id=1)],
+            2: [_charge(3, "9.99", 30, sub_id=2), _charge(4, "9.99", 0, sub_id=2)],
+        }
+        alerts = scan_all_subscriptions(configs, charges)
+        assert any(a.subscription_name == "Netflix" for a in alerts)
+        assert not any(a.subscription_name == "Spotify" for a in alerts)
+
+    def test_empty_no_alerts(self):
+        assert scan_all_subscriptions([], {}) == []
+
+    def test_sorted_high_severity_first(self):
+        configs = [
+            _config(id=1, name="A", amount="10.00"),
+            _config(id=2, name="B", amount="10.00"),
+        ]
+        charges = {
+            1: [_charge(1, "10.00", 30, 1), _charge(2, "11.00", 0, 1)],   # info
+            2: [_charge(3, "10.00", 30, 2), _charge(4, "15.00", 0, 2)],   # high (50%)
+        }
+        alerts = scan_all_subscriptions(configs, charges)
+        if len(alerts) >= 2:
+            sev_order = {"high": 3, "medium": 2, "info": 1}
+            sev_values = [sev_order[a.severity] for a in alerts]
+            assert sev_values == sorted(sev_values, reverse=True)
+
+
+# ─── price_change_summary tests ──────────────────────────────────────────────
+
+class TestPriceChangeSummary:
+    def test_empty_summary(self):
+        s = price_change_summary([])
+        assert s["total_alerts"] == 0
+        assert s["has_high_severity"] is False
+        assert s["total_extra_monthly_spend"] == "0.00"
+
+    def test_counts_and_totals(self):
+        alerts = [
+            PriceChangeAlert(1, "Netflix", Decimal("15.99"), Decimal("19.99"),
+                             Decimal("0.25"), "high", "msg"),
+            PriceChangeAlert(2, "Spotify", Decimal("9.99"), Decimal("10.99"),
+                             Decimal("0.10"), "medium", "msg"),
+        ]
+        s = price_change_summary(alerts)
+        assert s["total_alerts"] == 2
+        assert s["has_high_severity"] is True
+        assert s["by_severity"]["high"] == 1
+        assert s["by_severity"]["medium"] == 1
+        # Total extra = 4.00 + 1.00 = 5.00
+        assert s["total_extra_monthly_spend"] == "5.00"
+
+
+# ─── API endpoint tests ───────────────────────────────────────────────────────
+
+@requires_redis
+class TestSubscriptionDetectAPI:
+    def test_list_requires_auth(self, client):
+        r = client.get("/subscriptions/price-changes")
+        assert r.status_code == 401
+
+    def test_detail_requires_auth(self, client):
+        r = client.get("/subscriptions/price-changes/1")
+        assert r.status_code == 401
+
+    def test_list_returns_json(self, client, auth_header):
+        r = client.get("/subscriptions/price-changes", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "alerts" in data
+        assert "summary" in data
+
+    def test_nonexistent_subscription_returns_404(self, client, auth_header):
+        r = client.get("/subscriptions/price-changes/99999", headers=auth_header)
+        assert r.status_code == 404


### PR DESCRIPTION
## Summary

Implements subscription cost increase detection as requested in issue #110.

## Changes

New service: `subscription_detect.py`
- Detects price increases by comparing consecutive subscription charges
- Three severity levels: info (<10%), medium (10-25%), high (>25%)
- Also compares latest charge vs configured expected_amount
- Batch scan across multiple subscriptions with severity-sorted results
- Calculates total extra spend across all detected increases

New endpoints via Blueprint `subscription_detect`:
- GET /subscriptions/price-changes - scan all active subscriptions
- GET /subscriptions/price-changes?severity=high - filter by severity level
- GET /subscriptions/price-changes/<id> - single subscription price analysis

## Tests

19 unit tests pass. 4 endpoint tests skip gracefully when Redis unavailable in CI.

Attempt for Algora bounty #110.