### PR TITLE
feat: natural language finance query with date/category parsing (#74)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .nl_query import bp as nl_query_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(nl_query_bp, url_prefix="/query")

--- a/packages/backend/app/routes/nl_query.py
+++ b/packages/backend/app/routes/nl_query.py
@@ -1,0 +1,56 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.nl_query import execute_nl_query, parse_date_range, extract_category
+
+bp = Blueprint("nl_query", __name__, url_prefix="/query")
+
+
+@bp.route("/", methods=["POST"])
+@jwt_required()
+def natural_language_query():
+    """
+    Accept a natural language finance query and return structured spending data.
+    
+    Body: {"query": "How much did I spend on food last quarter?"}
+    """
+    body = request.get_json(force=True) or {}
+    query = body.get("query", "").strip()
+    
+    if not query:
+        return jsonify({"error": "query is required"}), 400
+    if len(query) > 500:
+        return jsonify({"error": "query too long (max 500 chars)"}), 400
+    
+    user_id = int(get_jwt_identity())
+    result = execute_nl_query(query, user_id)
+    return jsonify(result), 200
+
+
+@bp.route("/parse", methods=["POST"])
+@jwt_required()
+def parse_query():
+    """
+    Dry-run: parse a query and return interpreted date range and category
+    without hitting the database.
+    
+    Body: {"query": "spending last month on food"}
+    """
+    body = request.get_json(force=True) or {}
+    query = body.get("query", "").strip()
+    
+    if not query:
+        return jsonify({"error": "query is required"}), 400
+    
+    from datetime import date
+    start, end = parse_date_range(query)
+    category = extract_category(query)
+    
+    return jsonify({
+        "query": query,
+        "interpreted": {
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "category": category,
+        },
+    }), 200

--- a/packages/backend/app/services/nl_query.py
+++ b/packages/backend/app/services/nl_query.py
@@ -1,0 +1,217 @@
+import re
+import json
+from datetime import date, timedelta
+from typing import Optional
+from calendar import monthrange
+
+
+# ─────────────────────────── Date parsing helpers ─────────────────────────────
+
+_MONTHS = {
+    "january": 1, "february": 2, "march": 3, "april": 4,
+    "may": 5, "june": 6, "july": 7, "august": 8,
+    "september": 9, "october": 10, "november": 11, "december": 12,
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4,
+    "jun": 6, "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+_QUARTER_MAP = {"q1": (1, 3), "q2": (4, 6), "q3": (7, 9), "q4": (10, 12)}
+
+
+def _current_quarter_range(today: date):
+    quarter = (today.month - 1) // 3 + 1
+    start_month, end_month = _QUARTER_MAP[f"q{quarter}"]
+    start = date(today.year, start_month, 1)
+    _, last_day = monthrange(today.year, end_month)
+    end = date(today.year, end_month, last_day)
+    return start, end
+
+
+def _last_quarter_range(today: date):
+    quarter = (today.month - 1) // 3 + 1
+    prev_q = quarter - 1 if quarter > 1 else 4
+    year = today.year if quarter > 1 else today.year - 1
+    start_month, end_month = _QUARTER_MAP[f"q{prev_q}"]
+    start = date(year, start_month, 1)
+    _, last_day = monthrange(year, end_month)
+    end = date(year, end_month, last_day)
+    return start, end
+
+
+def _specific_quarter_range(q_num: int, year: int):
+    start_month, end_month = _QUARTER_MAP[f"q{q_num}"]
+    start = date(year, start_month, 1)
+    _, last_day = monthrange(year, end_month)
+    end = date(year, end_month, last_day)
+    return start, end
+
+
+def _this_month_range(today: date):
+    start = date(today.year, today.month, 1)
+    _, last_day = monthrange(today.year, today.month)
+    end = date(today.year, today.month, last_day)
+    return start, end
+
+
+def _last_month_range(today: date):
+    first_of_this = date(today.year, today.month, 1)
+    last_of_prev = first_of_this - timedelta(days=1)
+    start = date(last_of_prev.year, last_of_prev.month, 1)
+    return start, last_of_prev
+
+
+def _this_year_range(today: date):
+    return date(today.year, 1, 1), date(today.year, 12, 31)
+
+
+def _last_n_days(n: int, today: date):
+    return today - timedelta(days=n - 1), today
+
+
+def parse_date_range(query: str, today: Optional[date] = None) -> tuple[date, date]:
+    """Extract a (start, end) date range from a natural language query."""
+    today = today or date.today()
+    q = query.lower()
+
+    # "last N days"
+    m = re.search(r"last\s+(\d+)\s+days?", q)
+    if m:
+        return _last_n_days(int(m.group(1)), today)
+
+    # "last N weeks"
+    m = re.search(r"last\s+(\d+)\s+weeks?", q)
+    if m:
+        days = int(m.group(1)) * 7
+        return _last_n_days(days, today)
+
+    # "last N months"
+    m = re.search(r"last\s+(\d+)\s+months?", q)
+    if m:
+        months = int(m.group(1))
+        start = date(today.year - (months // 12), today.month - (months % 12) or 12, 1)
+        # simple approximation
+        start = today.replace(day=1) - timedelta(days=months * 30)
+        start = date(start.year, start.month, 1)
+        return start, today
+
+    # "Q1 2025" / "Q2 last year"
+    m = re.search(r"q([1-4])\s+(\d{4})", q)
+    if m:
+        return _specific_quarter_range(int(m.group(1)), int(m.group(2)))
+
+    # "last quarter"
+    if "last quarter" in q:
+        return _last_quarter_range(today)
+
+    # "this quarter"
+    if "this quarter" in q or "current quarter" in q:
+        return _current_quarter_range(today)
+
+    # "last month"
+    if "last month" in q:
+        return _last_month_range(today)
+
+    # "this month" / "current month"
+    if "this month" in q or "current month" in q:
+        return _this_month_range(today)
+
+    # "this year"
+    if "this year" in q or "current year" in q:
+        return _this_year_range(today)
+
+    # "last year"
+    if "last year" in q:
+        return date(today.year - 1, 1, 1), date(today.year - 1, 12, 31)
+
+    # Specific month name "in april" / "in april 2024"
+    for month_name, month_num in _MONTHS.items():
+        pattern = rf"\bin\s+{month_name}(?:\s+(\d{{4}}))?(?:\b|$)"
+        m = re.search(pattern, q)
+        if m:
+            year = int(m.group(1)) if m.group(1) else today.year
+            _, last_day = monthrange(year, month_num)
+            return date(year, month_num, 1), date(year, month_num, last_day)
+
+    # Default: last 30 days
+    return _last_n_days(30, today)
+
+
+# ─────────────────────────── Category extraction ─────────────────────────────
+
+_CATEGORY_KEYWORDS = {
+    "food": ["food", "eat", "restaurant", "lunch", "dinner", "breakfast", "groceries", "grocery", "meal", "coffee", "cafe"],
+    "transport": ["transport", "travel", "uber", "cab", "taxi", "fuel", "petrol", "gas", "commute", "bus", "train", "metro", "flight"],
+    "entertainment": ["entertainment", "movie", "netflix", "spotify", "gaming", "game", "subscription", "concert", "sport"],
+    "health": ["health", "medical", "pharmacy", "doctor", "gym", "fitness", "medicine", "hospital"],
+    "shopping": ["shopping", "clothes", "clothing", "amazon", "purchase", "buy", "bought", "store"],
+    "bills": ["bill", "bills", "utility", "utilities", "electricity", "water", "internet", "rent"],
+    "education": ["education", "course", "book", "tuition", "school", "college", "university", "learning"],
+}
+
+
+def extract_category(query: str) -> Optional[str]:
+    """Extract the most likely spending category from a natural language query."""
+    q = query.lower()
+    for category, keywords in _CATEGORY_KEYWORDS.items():
+        if any(kw in q for kw in keywords):
+            return category
+    return None
+
+
+# ─────────────────────────── Main query executor ─────────────────────────────
+
+def execute_nl_query(query: str, user_id: int, today: Optional[date] = None):
+    """
+    Execute a natural language finance query and return structured results.
+    Returns a dict with: query, start_date, end_date, category, total, transaction_count, transactions.
+    """
+    from ..models import Expense
+    from ..extensions import db
+    from sqlalchemy import func
+
+    today = today or date.today()
+    start_date, end_date = parse_date_range(query, today)
+    category_hint = extract_category(query)
+
+    # Build base query
+    expense_query = Expense.query.filter(
+        Expense.user_id == user_id,
+        Expense.spent_at >= start_date,
+        Expense.spent_at <= end_date,
+    )
+
+    # Apply category filter if we found a category keyword
+    if category_hint:
+        from ..models import Category
+        category_objs = Category.query.filter(
+            Category.user_id == user_id,
+            Category.name.ilike(f"%{category_hint}%"),
+        ).all()
+        if category_objs:
+            cat_ids = [c.id for c in category_objs]
+            expense_query = expense_query.filter(Expense.category_id.in_(cat_ids))
+
+    expenses = expense_query.order_by(Expense.spent_at.desc()).limit(50).all()
+    total = sum(float(e.amount) for e in expenses)
+
+    return {
+        "query": query,
+        "interpreted": {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+            "category": category_hint,
+        },
+        "total": round(total, 2),
+        "transaction_count": len(expenses),
+        "transactions": [
+            {
+                "id": e.id,
+                "amount": float(e.amount),
+                "currency": e.currency,
+                "notes": e.notes,
+                "spent_at": e.spent_at.isoformat(),
+                "category_id": e.category_id,
+            }
+            for e in expenses
+        ],
+    }

--- a/packages/backend/tests/test_nl_query.py
+++ b/packages/backend/tests/test_nl_query.py
@@ -1,0 +1,155 @@
+"""Tests for Natural Language Finance Query (issue #74)."""
+from datetime import date
+import pytest
+from flask_jwt_extended import create_access_token
+
+from app.services.nl_query import parse_date_range, extract_category
+
+
+@pytest.fixture()
+def auth_header(app_fixture):
+    with app_fixture.app_context():
+        from app.extensions import db
+        from app.models import User
+        from werkzeug.security import generate_password_hash
+        user = User(email="nltest@test.com", password_hash=generate_password_hash("Pass1234!"))
+        db.session.add(user)
+        db.session.commit()
+        token = create_access_token(identity=str(user.id))
+        return {"Authorization": f"Bearer {token}"}
+
+
+class TestDateParsing:
+    TODAY = date(2026, 4, 3)
+
+    def test_default_last_30_days(self):
+        start, end = parse_date_range("what did I spend", self.TODAY)
+        assert (end - start).days == 29
+
+    def test_last_7_days(self):
+        start, end = parse_date_range("spending last 7 days", self.TODAY)
+        assert (end - start).days == 6
+
+    def test_last_quarter(self):
+        start, end = parse_date_range("last quarter spending", self.TODAY)
+        assert start.month == 1
+        assert end.month == 3
+
+    def test_this_month(self):
+        start, end = parse_date_range("this month spending", self.TODAY)
+        assert start.month == self.TODAY.month
+        assert start.day == 1
+
+    def test_last_month(self):
+        start, end = parse_date_range("last month total", self.TODAY)
+        assert start.month == 3
+        assert end.month == 3
+
+    def test_this_year(self):
+        start, end = parse_date_range("this year summary", self.TODAY)
+        assert start == date(2026, 1, 1)
+
+    def test_specific_quarter_year(self):
+        start, end = parse_date_range("q1 2025", self.TODAY)
+        assert start == date(2025, 1, 1)
+        assert end == date(2025, 3, 31)
+
+    def test_specific_month_name(self):
+        start, end = parse_date_range("in january", self.TODAY)
+        assert start.month == 1
+        assert start.day == 1
+
+    def test_last_2_weeks(self):
+        start, end = parse_date_range("last 2 weeks", self.TODAY)
+        assert (end - start).days == 13
+
+    def test_q4_2024(self):
+        start, end = parse_date_range("q4 2024", self.TODAY)
+        assert start == date(2024, 10, 1)
+        assert end == date(2024, 12, 31)
+
+    def test_last_year(self):
+        start, end = parse_date_range("last year total", self.TODAY)
+        assert start.year == 2025
+        assert end.year == 2025
+
+
+class TestCategoryExtraction:
+    def test_food_category(self):
+        assert extract_category("how much on food") == "food"
+
+    def test_groceries_maps_to_food(self):
+        assert extract_category("grocery spending") == "food"
+
+    def test_restaurant_maps_to_food(self):
+        assert extract_category("restaurant bills") == "food"
+
+    def test_transport_category(self):
+        assert extract_category("uber and taxi expenses") == "transport"
+
+    def test_fuel_maps_to_transport(self):
+        assert extract_category("fuel costs last month") == "transport"
+
+    def test_entertainment_category(self):
+        assert extract_category("netflix subscription") == "entertainment"
+
+    def test_health_category(self):
+        assert extract_category("medical expenses") == "health"
+
+    def test_gym_maps_to_health(self):
+        assert extract_category("gym membership") == "health"
+
+    def test_shopping_category(self):
+        assert extract_category("amazon purchases") == "shopping"
+
+    def test_bills_category(self):
+        assert extract_category("electricity and water bills") == "bills"
+
+    def test_no_category_returns_none(self):
+        assert extract_category("total spending last month") is None
+
+    def test_education_category(self):
+        assert extract_category("course fees this month") == "education"
+
+
+class TestNLQueryAPI:
+    def test_query_returns_structured_result(self, client, auth_header):
+        resp = client.post("/query/", json={"query": "how much did I spend last month"}, headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "total" in data
+        assert "transaction_count" in data
+        assert "interpreted" in data
+        assert "start_date" in data["interpreted"]
+        assert "end_date" in data["interpreted"]
+
+    def test_query_missing_returns_400(self, client, auth_header):
+        resp = client.post("/query/", json={}, headers=auth_header)
+        assert resp.status_code == 400
+
+    def test_query_too_long_returns_400(self, client, auth_header):
+        resp = client.post("/query/", json={"query": "x" * 501}, headers=auth_header)
+        assert resp.status_code == 400
+
+    def test_parse_endpoint(self, client, auth_header):
+        resp = client.post("/query/parse", json={"query": "food spending last quarter"}, headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["interpreted"]["category"] == "food"
+
+    def test_query_empty_for_new_user(self, client, auth_header):
+        resp = client.post("/query/", json={"query": "total spending this month"}, headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 0.0
+        assert data["transactions"] == []
+
+    def test_requires_auth(self, client):
+        resp = client.post("/query/", json={"query": "spending"})
+        assert resp.status_code == 401
+
+    def test_category_interpreted_in_result(self, client, auth_header):
+        resp = client.post("/query/", json={"query": "food spending last month"}, headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["interpreted"]["category"] == "food"


### PR DESCRIPTION
## Summary

Implements natural language finance query supporting conversational date ranges and category extraction.

## Features

- Date range parsing: "last N days/weeks/months", "this/last month/quarter/year", "Q1 2025", "in January"
- Category extraction: maps query keywords to food, transport, entertainment, health, shopping, bills, education
- POST /query/ - executes NL query, returns total, transaction count, and matched transactions
- POST /query/parse - dry-run interpretation (date range + category) without DB query

## Example

Query: "How much did I spend on food last quarter?"
Returns: {interpreted: {start_date, end_date, category: food}, total, transactions}

## Tests

```
Tests: 30 passed, 30 total
```

Closes #74