### PR TITLE
feat: auto-detect subscriptions from recurring charges (#109)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .subscription_detect import bp as subscription_detect_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(subscription_detect_bp, url_prefix="/subscriptions/detected")

--- a/packages/backend/app/routes/subscription_detect.py
+++ b/packages/backend/app/routes/subscription_detect.py
@@ -1,0 +1,33 @@
+"""REST routes for subscription auto-detection."""
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.subscription_detector import detect_subscriptions
+import logging
+
+bp = Blueprint("subscriptions_detect", __name__)
+logger = logging.getLogger("finmind.subscriptions_detect")
+
+
+@bp.get("")
+@jwt_required()
+def list_detected_subscriptions():
+    """
+    GET /subscriptions/detected
+
+    Scans the user's expense history and returns auto-detected subscriptions.
+
+    Query params:
+      months (int, 1-24): look-back window in months (default 6)
+    """
+    uid = int(get_jwt_identity())
+    try:
+        months = int(request.args.get("months", 6))
+    except (TypeError, ValueError):
+        months = 6
+
+    result = detect_subscriptions(uid, months=months)
+    logger.info(
+        "Subscription detection: user=%s months=%s found=%s",
+        uid, months, len(result["subscriptions"])
+    )
+    return jsonify(result), 200

--- a/packages/backend/app/services/subscription_detector.py
+++ b/packages/backend/app/services/subscription_detector.py
@@ -1,0 +1,153 @@
+"""
+Subscription auto-detection service.
+
+Scans the user's expense history and identifies recurring charges that match
+subscription patterns (keyword match + monthly/weekly cadence detection).
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+
+from app.models import db, Expense
+
+# Keywords that strongly suggest a subscription service
+_SUBSCRIPTION_KEYWORDS = [
+    "netflix", "spotify", "hulu", "disney+", "disney plus", "amazon prime",
+    "apple music", "apple tv", "icloud", "dropbox", "adobe",
+    "microsoft 365", "office 365", "slack", "zoom", "notion",
+    "github", "heroku", "aws", "gcp", "azure", "digitalocean",
+    "linode", "cloudflare", "vpn", "antivirus", "grammarly",
+    "chatgpt", "openai", "claude", "subscription", "monthly", "annual",
+    "yearly", "plan", "premium", "pro plan", "basic plan",
+]
+
+# Tolerance window (days) for considering charges as "monthly"
+_MONTHLY_TOLERANCE = 7
+_WEEKLY_TOLERANCE = 2
+
+
+def _normalize(text: str) -> str:
+    return (text or "").lower().strip()
+
+
+def _is_keyword_match(note: str) -> bool:
+    n = _normalize(note)
+    return any(kw in n for kw in _SUBSCRIPTION_KEYWORDS)
+
+
+def _detect_cadence(sorted_dates: list[date]) -> str | None:
+    """
+    Given a sorted list of expense dates, determine if they follow a
+    weekly or monthly cadence within the allowed tolerance.
+    Returns 'weekly', 'monthly', or None.
+    """
+    if len(sorted_dates) < 2:
+        return None
+
+    gaps = [(sorted_dates[i + 1] - sorted_dates[i]).days for i in range(len(sorted_dates) - 1)]
+    avg_gap = sum(gaps) / len(gaps)
+
+    if all(abs(g - 7) <= _WEEKLY_TOLERANCE for g in gaps):
+        return "weekly"
+    if all(abs(g - 30) <= _MONTHLY_TOLERANCE for g in gaps):
+        return "monthly"
+    # Looser check for monthly if avg is close and most gaps are in range
+    monthly_count = sum(1 for g in gaps if abs(g - 30) <= _MONTHLY_TOLERANCE)
+    if monthly_count >= len(gaps) * 0.7 and 20 <= avg_gap <= 40:
+        return "monthly"
+    return None
+
+
+def detect_subscriptions(uid: int, months: int = 6) -> dict[str, Any]:
+    """
+    Auto-detect subscriptions from recurring charges in the user's expense history.
+
+    Strategy:
+    1. Group expenses by normalized note/merchant (case-insensitive).
+    2. Retain groups with >= 2 occurrences.
+    3. For each group, check for keyword match OR recurring cadence (weekly/monthly).
+    4. Compute estimated monthly cost and confidence score.
+
+    Returns a dict with:
+      - subscriptions: list of detected subscription objects
+      - total_monthly_estimate: sum of estimated monthly costs (Decimal)
+      - analysis_period_months: the requested look-back period
+    """
+    months = max(1, min(months, 24))
+    cutoff = date.today() - timedelta(days=30 * months)
+
+    expenses = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type == "EXPENSE",
+            Expense.spent_at >= cutoff,
+        )
+        .order_by(Expense.spent_at)
+        .all()
+    )
+
+    # Group by normalized notes
+    groups: dict[str, list[Expense]] = defaultdict(list)
+    for exp in expenses:
+        note = _normalize(exp.notes or "")
+        if note:
+            groups[note].append(exp)
+
+    subscriptions = []
+    for note, exps in groups.items():
+        if len(exps) < 2:
+            continue
+
+        sorted_dates = sorted(e.spent_at for e in exps)
+        cadence = _detect_cadence(sorted_dates)
+        kw_match = _is_keyword_match(note)
+
+        if cadence is None and not kw_match:
+            continue
+
+        amounts = [Decimal(str(e.amount)) for e in exps]
+        avg_amount = sum(amounts) / len(amounts)
+
+        # Estimate monthly cost
+        if cadence == "weekly":
+            monthly_estimate = avg_amount * Decimal("4.33")
+        else:
+            monthly_estimate = avg_amount
+
+        # Confidence: higher if both keyword match + cadence detected
+        if cadence and kw_match:
+            confidence = "high"
+        elif cadence:
+            confidence = "medium"
+        else:
+            confidence = "low"
+
+        subscriptions.append(
+            {
+                "merchant": note,
+                "cadence": cadence or "irregular",
+                "occurrences": len(exps),
+                "average_amount": float(round(avg_amount, 2)),
+                "currency": exps[0].currency,
+                "monthly_estimate": float(round(monthly_estimate, 2)),
+                "confidence": confidence,
+                "keyword_match": kw_match,
+                "last_charge": sorted_dates[-1].isoformat(),
+                "first_charge": sorted_dates[0].isoformat(),
+            }
+        )
+
+    # Sort by monthly estimate descending
+    subscriptions.sort(key=lambda s: s["monthly_estimate"], reverse=True)
+
+    total_monthly = sum(Decimal(str(s["monthly_estimate"])) for s in subscriptions)
+
+    return {
+        "subscriptions": subscriptions,
+        "total_monthly_estimate": float(round(total_monthly, 2)),
+        "analysis_period_months": months,
+    }

--- a/packages/backend/tests/test_subscription_detect.py
+++ b/packages/backend/tests/test_subscription_detect.py
@@ -1,0 +1,241 @@
+"""Tests for subscription auto-detection service (issue #109)."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def auth_header(app_fixture):
+    """Generate JWT directly, bypassing Redis-dependent login."""
+    from flask_jwt_extended import create_access_token
+    from app.models import User
+    from app.extensions import db
+    from werkzeug.security import generate_password_hash
+
+    with app_fixture.app_context():
+        hashed = generate_password_hash("password123")
+        user = User(email="sub_test@example.com", password_hash=hashed)
+        db.session.add(user)
+        db.session.commit()
+        token = create_access_token(identity=str(user.id))
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def user_id(app_fixture):
+    """Return the test user ID."""
+    from app.models import User
+    from app.extensions import db
+    from werkzeug.security import generate_password_hash
+
+    with app_fixture.app_context():
+        existing = User.query.filter_by(email="sub_test@example.com").first()
+        if existing:
+            return existing.id
+        hashed = generate_password_hash("password123")
+        user = User(email="sub_test@example.com", password_hash=hashed)
+        db.session.add(user)
+        db.session.commit()
+        return user.id
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _insert_expense(app_fixture, uid: int, amount: float, notes: str, days_ago: int = 0):
+    """Insert expense directly into DB, bypassing Redis cache invalidation."""
+    from app.models import Expense
+    from app.extensions import db
+
+    exp_date = date.today() - timedelta(days=days_ago)
+    with app_fixture.app_context():
+        exp = Expense(
+            user_id=uid,
+            amount=Decimal(str(amount)),
+            notes=notes,
+            spent_at=exp_date,
+            expense_type="EXPENSE",
+            currency="INR",
+        )
+        db.session.add(exp)
+        db.session.commit()
+
+
+def _get_uid(auth_header: dict) -> int:
+    """Extract user ID from JWT."""
+    import base64, json
+    token = auth_header["Authorization"].split(" ")[1]
+    payload_b64 = token.split(".")[1]
+    # Add padding
+    payload_b64 += "=" * (4 - len(payload_b64) % 4)
+    payload = json.loads(base64.b64decode(payload_b64))
+    return int(payload.get("sub", payload.get("identity", 0)))
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestSubscriptionDetectionEndpoint:
+    """Tests for GET /subscriptions/detected."""
+
+    def test_requires_auth(self, client):
+        r = client.get("/subscriptions/detected")
+        assert r.status_code == 401
+
+    def test_empty_history_returns_empty(self, client, auth_header):
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["subscriptions"] == []
+        assert data["total_monthly_estimate"] == 0.0
+        assert data["analysis_period_months"] == 6
+
+    def test_custom_months_param(self, client, auth_header):
+        r = client.get("/subscriptions/detected?months=3", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["analysis_period_months"] == 3
+
+    def test_invalid_months_defaults_to_6(self, client, auth_header):
+        r = client.get("/subscriptions/detected?months=abc", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["analysis_period_months"] == 6
+
+    def test_detects_keyword_match_monthly(self, client, auth_header, app_fixture):
+        """Netflix keyword + monthly cadence = detected subscription."""
+        uid = _get_uid(auth_header)
+        for i in [0, 30, 60]:
+            _insert_expense(app_fixture, uid, 15.99, "netflix", days_ago=i)
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        assert r.status_code == 200
+        subs = r.get_json()["subscriptions"]
+        netflix = next((s for s in subs if "netflix" in s["merchant"]), None)
+        assert netflix is not None
+        assert netflix["occurrences"] == 3
+        assert netflix["keyword_match"] is True
+
+    def test_detects_monthly_cadence_no_keyword(self, client, auth_header, app_fixture):
+        """Regular monthly charges without keyword detected via cadence."""
+        uid = _get_uid(auth_header)
+        for i in [0, 30, 60, 90]:
+            _insert_expense(app_fixture, uid, 9.99, "SomeCustomService", days_ago=i)
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        assert r.status_code == 200
+        subs = r.get_json()["subscriptions"]
+        custom = next((s for s in subs if "somecustomservice" in s["merchant"]), None)
+        assert custom is not None
+        assert custom["cadence"] == "monthly"
+        assert custom["confidence"] == "medium"
+
+    def test_ignores_single_occurrence(self, client, auth_header, app_fixture):
+        """One-time charges should not be flagged as subscriptions."""
+        uid = _get_uid(auth_header)
+        _insert_expense(app_fixture, uid, 99.99, "one-time-purchase", days_ago=5)
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        assert r.status_code == 200
+        subs = r.get_json()["subscriptions"]
+        one_time = next((s for s in subs if "one-time" in s["merchant"]), None)
+        assert one_time is None
+
+    def test_response_schema(self, client, auth_header, app_fixture):
+        """Response includes all required fields."""
+        uid = _get_uid(auth_header)
+        for i in [0, 30, 60]:
+            _insert_expense(app_fixture, uid, 9.99, "spotify", days_ago=i)
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "subscriptions" in data
+        assert "total_monthly_estimate" in data
+        assert "analysis_period_months" in data
+
+        if data["subscriptions"]:
+            sub = data["subscriptions"][0]
+            for field in ["merchant", "cadence", "occurrences", "average_amount",
+                          "currency", "monthly_estimate", "confidence",
+                          "keyword_match", "last_charge", "first_charge"]:
+                assert field in sub, f"Missing field: {field}"
+
+    def test_high_confidence_keyword_plus_cadence(self, client, auth_header, app_fixture):
+        """Both keyword + cadence = high confidence."""
+        uid = _get_uid(auth_header)
+        for i in [0, 30, 60]:
+            _insert_expense(app_fixture, uid, 12.99, "spotify premium", days_ago=i)
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        subs = r.get_json()["subscriptions"]
+        spotify = next((s for s in subs if "spotify" in s["merchant"]), None)
+        assert spotify is not None
+        assert spotify["confidence"] == "high"
+
+    def test_total_monthly_estimate_is_sum_of_subscriptions(self, client, auth_header, app_fixture):
+        """total_monthly_estimate = sum of individual monthly_estimate values."""
+        uid = _get_uid(auth_header)
+        for i in [0, 30, 60]:
+            _insert_expense(app_fixture, uid, 10.00, "netflix", days_ago=i)
+        for i in [0, 30, 60]:
+            _insert_expense(app_fixture, uid, 5.00, "spotify", days_ago=i)
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        data = r.get_json()
+        subs = data["subscriptions"]
+        computed = sum(s["monthly_estimate"] for s in subs)
+        assert abs(data["total_monthly_estimate"] - computed) < 0.01
+
+    def test_sorted_by_monthly_estimate_desc(self, client, auth_header, app_fixture):
+        """Results sorted by monthly_estimate descending."""
+        uid = _get_uid(auth_header)
+        for i in [0, 30, 60]:
+            _insert_expense(app_fixture, uid, 50.00, "expensive-service", days_ago=i)
+        for i in [0, 30, 60]:
+            _insert_expense(app_fixture, uid, 5.00, "cheap-service", days_ago=i)
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        subs = r.get_json()["subscriptions"]
+        if len(subs) >= 2:
+            estimates = [s["monthly_estimate"] for s in subs]
+            assert estimates == sorted(estimates, reverse=True)
+
+    def test_income_type_excluded(self, client, auth_header, app_fixture):
+        """INCOME type transactions should not be treated as subscriptions."""
+        from app.models import Expense
+        from app.extensions import db
+
+        uid = _get_uid(auth_header)
+        with app_fixture.app_context():
+            for i in [0, 30, 60]:
+                exp_date = date.today() - timedelta(days=i)
+                exp = Expense(
+                    user_id=uid,
+                    amount=Decimal("15.99"),
+                    notes="netflix",
+                    spent_at=exp_date,
+                    expense_type="INCOME",
+                    currency="INR",
+                )
+                db.session.add(exp)
+            db.session.commit()
+
+        r = client.get("/subscriptions/detected", headers=auth_header)
+        subs = r.get_json()["subscriptions"]
+        netflix = next((s for s in subs if s["merchant"] == "netflix"), None)
+        assert netflix is None
+
+    def test_expenses_outside_period_excluded(self, client, auth_header, app_fixture):
+        """Expenses outside analysis window should not be included."""
+        uid = _get_uid(auth_header)
+        # Add expenses 8 months ago (outside 6-month window)
+        for i in [240, 270, 300]:
+            _insert_expense(app_fixture, uid, 9.99, "old-service", days_ago=i)
+
+        r = client.get("/subscriptions/detected?months=6", headers=auth_header)
+        subs = r.get_json()["subscriptions"]
+        old = next((s for s in subs if "old-service" in s["merchant"]), None)
+        assert old is None


### PR DESCRIPTION
## Summary

Implements automatic subscription detection from the user expense history using a dual-strategy approach: keyword matching (netflix, spotify, AWS, etc.) and recurring cadence analysis (weekly/monthly pattern detection).

## Changes

- `subscription_detector.py` service: scans expenses for recurring patterns over configurable look-back window (1-24 months). Groups by merchant note, detects weekly/monthly cadence with tolerance windows (7d for monthly, 2d for weekly). Estimates monthly cost (weekly * 4.33). Confidence scoring: high (keyword+cadence), medium (cadence only), low (keyword only).
- `subscription_detect.py` route: GET /subscriptions/detected with JWT auth and optional ?months param
- Routes registered in __init__.py

## Tests

13 tests all passing:
- auth guard (401 without JWT)
- empty history returns empty list
- custom and invalid months params
- keyword detection (netflix, spotify)
- monthly cadence detection without keywords
- single-occurrence exclusion
- full response schema validation
- confidence level assignment
- total_monthly_estimate math
- sort order (descending by cost)
- INCOME type exclusion
- period boundary enforcement

Closes #109