### PR TITLE
feat: customizable dashboard widgets & visibility (#103)

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -15,6 +15,7 @@ class User(db.Model):
     email = db.Column(db.String(255), unique=True, nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
     preferred_currency = db.Column(db.String(10), default="INR", nullable=False)
+    widget_prefs = db.Column(db.Text, nullable=True, default=None)
     role = db.Column(db.String(20), default=Role.USER.value, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .dashboard_widgets import bp as dashboard_widgets_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(dashboard_widgets_bp, url_prefix="/dashboard/widgets")

--- a/packages/backend/app/routes/dashboard_widgets.py
+++ b/packages/backend/app/routes/dashboard_widgets.py
@@ -1,0 +1,65 @@
+"""REST routes for dashboard widget customization."""
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.dashboard_widgets import (
+    get_widget_config,
+    update_widget_config,
+    reset_widget_config,
+    VALID_WIDGET_IDS,
+)
+import logging
+
+bp = Blueprint("dashboard_widgets", __name__)
+logger = logging.getLogger("finmind.dashboard_widgets")
+
+
+@bp.get("")
+@jwt_required()
+def get_widgets():
+    """GET /dashboard/widgets — Return user's widget configuration."""
+    uid = int(get_jwt_identity())
+    config = get_widget_config(uid)
+    return jsonify({"widgets": config}), 200
+
+
+@bp.patch("")
+@jwt_required()
+def update_widgets():
+    """
+    PATCH /dashboard/widgets — Update widget visibility and/or order.
+
+    Body: {"updates": [{"id": "monthly_summary", "visible": true, "order": 0}, ...]}
+    """
+    uid = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+    updates = data.get("updates", [])
+
+    if not isinstance(updates, list):
+        return jsonify(error="updates must be a list"), 400
+
+    for item in updates:
+        if not isinstance(item, dict):
+            return jsonify(error="each update must be an object"), 400
+        if "id" not in item:
+            return jsonify(error="each update must have an id field"), 400
+
+    config = update_widget_config(uid, updates)
+    logger.info("Widget config updated user=%s count=%s", uid, len(updates))
+    return jsonify({"widgets": config}), 200
+
+
+@bp.post("/reset")
+@jwt_required()
+def reset_widgets():
+    """POST /dashboard/widgets/reset — Reset to default configuration."""
+    uid = int(get_jwt_identity())
+    config = reset_widget_config(uid)
+    logger.info("Widget config reset user=%s", uid)
+    return jsonify({"widgets": config}), 200
+
+
+@bp.get("/available")
+@jwt_required()
+def list_available_widgets():
+    """GET /dashboard/widgets/available — List all available widget IDs."""
+    return jsonify({"widget_ids": sorted(VALID_WIDGET_IDS)}), 200

--- a/packages/backend/app/services/dashboard_widgets.py
+++ b/packages/backend/app/services/dashboard_widgets.py
@@ -1,0 +1,118 @@
+"""
+Dashboard widget preferences service.
+
+Allows users to customize which widgets are visible on their dashboard
+and reorder them to match their priorities.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.models import db, User
+from sqlalchemy import Text
+import json as _json
+
+# Default widget configuration
+DEFAULT_WIDGETS = [
+    {"id": "monthly_summary", "label": "Monthly Summary", "visible": True, "order": 0},
+    {"id": "expense_chart", "label": "Expense Chart", "visible": True, "order": 1},
+    {"id": "upcoming_bills", "label": "Upcoming Bills", "visible": True, "order": 2},
+    {"id": "budget_tracker", "label": "Budget Tracker", "visible": True, "order": 3},
+    {"id": "recent_expenses", "label": "Recent Expenses", "visible": True, "order": 4},
+    {"id": "savings_goals", "label": "Savings Goals", "visible": False, "order": 5},
+    {"id": "spending_insights", "label": "Spending Insights", "visible": True, "order": 6},
+    {"id": "cash_flow", "label": "Cash Flow", "visible": False, "order": 7},
+]
+
+VALID_WIDGET_IDS = {w["id"] for w in DEFAULT_WIDGETS}
+
+
+def _get_prefs_column(user: User) -> dict:
+    """Read widget prefs from user.widget_prefs JSON column."""
+    raw = getattr(user, "widget_prefs", None)
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        return _json.loads(raw)
+    except Exception:
+        return {}
+
+
+def _set_prefs_column(user: User, prefs: dict) -> None:
+    """Write widget prefs to user.widget_prefs JSON column."""
+    user.widget_prefs = _json.dumps(prefs)
+
+
+def get_widget_config(uid: int) -> list[dict[str, Any]]:
+    """
+    Return the user's widget configuration.
+    Merges saved preferences with defaults (new widgets are always added).
+    """
+    user = db.session.get(User, uid)
+    if user is None:
+        raise ValueError(f"User {uid} not found")
+
+    saved: dict[str, dict] = _get_prefs_column(user)
+
+    result = []
+    for default in DEFAULT_WIDGETS:
+        widget_id = default["id"]
+        if widget_id in saved:
+            # Merge: saved overrides visible/order; label always from defaults
+            w = dict(default)
+            w["visible"] = bool(saved[widget_id].get("visible", default["visible"]))
+            w["order"] = int(saved[widget_id].get("order", default["order"]))
+            result.append(w)
+        else:
+            result.append(dict(default))
+
+    result.sort(key=lambda x: x["order"])
+    return result
+
+
+def update_widget_config(uid: int, updates: list[dict]) -> list[dict[str, Any]]:
+    """
+    Update widget visibility and/or order for a user.
+
+    Each item in updates may contain:
+      - id (str, required): widget identifier
+      - visible (bool, optional): show/hide the widget
+      - order (int, optional): position index (0-based)
+
+    Unknown widget IDs are ignored.
+    Returns the full updated configuration.
+    """
+    user = db.session.get(User, uid)
+    if user is None:
+        raise ValueError(f"User {uid} not found")
+
+    saved: dict[str, dict] = _get_prefs_column(user)
+
+    for item in updates:
+        widget_id = item.get("id")
+        if not widget_id or widget_id not in VALID_WIDGET_IDS:
+            continue
+
+        entry = saved.get(widget_id, {})
+        if "visible" in item:
+            entry["visible"] = bool(item["visible"])
+        if "order" in item:
+            entry["order"] = int(item["order"])
+        saved[widget_id] = entry
+
+    _set_prefs_column(user, saved)
+    db.session.commit()
+
+    return get_widget_config(uid)
+
+
+def reset_widget_config(uid: int) -> list[dict[str, Any]]:
+    """Reset widget configuration to defaults."""
+    user = db.session.get(User, uid)
+    if user is None:
+        raise ValueError(f"User {uid} not found")
+    _set_prefs_column(user, {})
+    db.session.commit()
+    return get_widget_config(uid)

--- a/packages/backend/tests/test_dashboard_widgets.py
+++ b/packages/backend/tests/test_dashboard_widgets.py
@@ -1,0 +1,185 @@
+"""Tests for customizable dashboard widgets (issue #103)."""
+from __future__ import annotations
+
+import pytest
+
+
+# ── fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def auth_header(app_fixture):
+    """Generate JWT directly, bypassing Redis-dependent login."""
+    from flask_jwt_extended import create_access_token
+    from app.models import User
+    from app.extensions import db
+    from werkzeug.security import generate_password_hash
+
+    with app_fixture.app_context():
+        hashed = generate_password_hash("password123")
+        user = User(email="widgets_test@example.com", password_hash=hashed)
+        db.session.add(user)
+        db.session.commit()
+        token = create_access_token(identity=str(user.id))
+
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestGetWidgets:
+    """GET /dashboard/widgets tests."""
+
+    def test_requires_auth(self, client):
+        r = client.get("/dashboard/widgets")
+        assert r.status_code == 401
+
+    def test_returns_default_config(self, client, auth_header):
+        r = client.get("/dashboard/widgets", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "widgets" in data
+        assert isinstance(data["widgets"], list)
+        assert len(data["widgets"]) > 0
+
+    def test_default_config_has_required_fields(self, client, auth_header):
+        r = client.get("/dashboard/widgets", headers=auth_header)
+        widgets = r.get_json()["widgets"]
+        for w in widgets:
+            assert "id" in w
+            assert "label" in w
+            assert "visible" in w
+            assert "order" in w
+
+    def test_default_sorted_by_order(self, client, auth_header):
+        r = client.get("/dashboard/widgets", headers=auth_header)
+        widgets = r.get_json()["widgets"]
+        orders = [w["order"] for w in widgets]
+        assert orders == sorted(orders)
+
+    def test_monthly_summary_visible_by_default(self, client, auth_header):
+        r = client.get("/dashboard/widgets", headers=auth_header)
+        widgets = r.get_json()["widgets"]
+        monthly = next((w for w in widgets if w["id"] == "monthly_summary"), None)
+        assert monthly is not None
+        assert monthly["visible"] is True
+
+
+class TestUpdateWidgets:
+    """PATCH /dashboard/widgets tests."""
+
+    def test_requires_auth(self, client):
+        r = client.patch("/dashboard/widgets", json={"updates": []})
+        assert r.status_code == 401
+
+    def test_hide_widget(self, client, auth_header):
+        r = client.patch("/dashboard/widgets", json={
+            "updates": [{"id": "monthly_summary", "visible": False}]
+        }, headers=auth_header)
+        assert r.status_code == 200
+        widgets = r.get_json()["widgets"]
+        monthly = next(w for w in widgets if w["id"] == "monthly_summary")
+        assert monthly["visible"] is False
+
+    def test_reorder_widget(self, client, auth_header):
+        r = client.patch("/dashboard/widgets", json={
+            "updates": [{"id": "upcoming_bills", "order": 0}]
+        }, headers=auth_header)
+        assert r.status_code == 200
+        widgets = r.get_json()["widgets"]
+        bills = next(w for w in widgets if w["id"] == "upcoming_bills")
+        assert bills["order"] == 0
+
+    def test_update_multiple_widgets(self, client, auth_header):
+        r = client.patch("/dashboard/widgets", json={
+            "updates": [
+                {"id": "expense_chart", "visible": False},
+                {"id": "savings_goals", "visible": True, "order": 1},
+            ]
+        }, headers=auth_header)
+        assert r.status_code == 200
+        widgets = r.get_json()["widgets"]
+        chart = next(w for w in widgets if w["id"] == "expense_chart")
+        savings = next(w for w in widgets if w["id"] == "savings_goals")
+        assert chart["visible"] is False
+        assert savings["visible"] is True
+        assert savings["order"] == 1
+
+    def test_ignores_unknown_widget_id(self, client, auth_header):
+        r = client.patch("/dashboard/widgets", json={
+            "updates": [{"id": "nonexistent_widget", "visible": False}]
+        }, headers=auth_header)
+        # Should succeed, just ignore unknown IDs
+        assert r.status_code == 200
+
+    def test_invalid_updates_not_list(self, client, auth_header):
+        r = client.patch("/dashboard/widgets", json={
+            "updates": "not_a_list"
+        }, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_update_missing_id(self, client, auth_header):
+        r = client.patch("/dashboard/widgets", json={
+            "updates": [{"visible": False}]
+        }, headers=auth_header)
+        assert r.status_code == 400
+
+    def test_preferences_persist(self, client, auth_header):
+        """Changes should be persisted across requests."""
+        client.patch("/dashboard/widgets", json={
+            "updates": [{"id": "cash_flow", "visible": True, "order": 0}]
+        }, headers=auth_header)
+
+        r = client.get("/dashboard/widgets", headers=auth_header)
+        widgets = r.get_json()["widgets"]
+        cash_flow = next(w for w in widgets if w["id"] == "cash_flow")
+        assert cash_flow["visible"] is True
+        assert cash_flow["order"] == 0
+
+
+class TestResetWidgets:
+    """POST /dashboard/widgets/reset tests."""
+
+    def test_requires_auth(self, client):
+        r = client.post("/dashboard/widgets/reset")
+        assert r.status_code == 401
+
+    def test_reset_returns_defaults(self, client, auth_header):
+        """After hiding widgets, reset should restore defaults."""
+        # Hide some widgets first
+        client.patch("/dashboard/widgets", json={
+            "updates": [
+                {"id": "monthly_summary", "visible": False},
+                {"id": "expense_chart", "visible": False},
+            ]
+        }, headers=auth_header)
+
+        # Reset
+        r = client.post("/dashboard/widgets/reset", headers=auth_header)
+        assert r.status_code == 200
+        widgets = r.get_json()["widgets"]
+
+        monthly = next(w for w in widgets if w["id"] == "monthly_summary")
+        chart = next(w for w in widgets if w["id"] == "expense_chart")
+        assert monthly["visible"] is True
+        assert chart["visible"] is True
+
+    def test_reset_response_has_widgets_key(self, client, auth_header):
+        r = client.post("/dashboard/widgets/reset", headers=auth_header)
+        assert r.status_code == 200
+        assert "widgets" in r.get_json()
+
+
+class TestAvailableWidgets:
+    """GET /dashboard/widgets/available tests."""
+
+    def test_requires_auth(self, client):
+        r = client.get("/dashboard/widgets/available")
+        assert r.status_code == 401
+
+    def test_returns_list_of_ids(self, client, auth_header):
+        r = client.get("/dashboard/widgets/available", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "widget_ids" in data
+        assert isinstance(data["widget_ids"], list)
+        assert "monthly_summary" in data["widget_ids"]


### PR DESCRIPTION
## Summary

Adds user-configurable dashboard widget system allowing show/hide and reordering of dashboard sections.

## Changes

- `User.widget_prefs` column (Text/JSON): stores per-user widget preferences
- `dashboard_widgets` service: get/update/reset widget configuration with 8 built-in widgets (monthly_summary, expense_chart, upcoming_bills, budget_tracker, recent_expenses, savings_goals, spending_insights, cash_flow)
- Merges saved prefs with defaults (new widgets always visible with sane defaults)
- Returns config sorted by order field

## Routes (under /dashboard/widgets)

- `GET /dashboard/widgets` - return current config
- `PATCH /dashboard/widgets` - update visibility/order for one or more widgets
- `POST /dashboard/widgets/reset` - restore all defaults
- `GET /dashboard/widgets/available` - list available widget IDs

## Tests

18 tests all passing:
- Auth guards for all 4 endpoints
- Default config shape (required fields, sort order)
- Hide/show individual widgets
- Reorder widgets
- Multiple simultaneous updates
- Unknown widget ID ignored gracefully
- Input validation errors (non-list updates, missing id)
- Preference persistence across requests
- Reset restores defaults after modifications

Closes #103