### PR TITLE
feat: savings opportunity detection engine (#119)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings_opportunity import bp as savings_opportunity_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_opportunity_bp, url_prefix="/insights")

--- a/packages/backend/app/routes/savings_opportunity.py
+++ b/packages/backend/app/routes/savings_opportunity.py
@@ -1,0 +1,59 @@
+"""
+Savings Opportunity Detection Route (#119)
+Provides endpoints to detect and retrieve savings opportunities for users.
+"""
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import logging
+
+from ..services.savings_opportunity import detect_savings_opportunities
+
+bp = Blueprint("savings_opportunity", __name__)
+logger = logging.getLogger("finmind.savings_opportunity")
+
+
+@bp.get("/savings-opportunities")
+@jwt_required()
+def get_savings_opportunities():
+    """
+    Detect savings opportunities for the authenticated user.
+
+    Query Parameters:
+        months (int): Number of months to analyze (1-12, default: 3)
+
+    Returns:
+        JSON with list of opportunities and total potential savings
+    """
+    uid = int(get_jwt_identity())
+    try:
+        months = min(12, max(1, int(request.args.get("months", 3))))
+    except (ValueError, TypeError):
+        months = 3
+
+    result = detect_savings_opportunities(uid, months=months)
+    logger.info(
+        "Savings opportunities detected for user=%s months=%s opportunities=%d",
+        uid,
+        months,
+        len(result.get("opportunities", [])),
+    )
+    return jsonify(result)
+
+
+@bp.get("/savings-opportunities/summary")
+@jwt_required()
+def get_savings_summary():
+    """
+    Get a brief summary of savings opportunities.
+
+    Returns:
+        JSON with opportunity count and total potential savings
+    """
+    uid = int(get_jwt_identity())
+    result = detect_savings_opportunities(uid, months=3)
+    return jsonify({
+        "opportunity_count": len(result.get("opportunities", [])),
+        "total_potential_savings": result.get("total_potential_savings", 0),
+        "summary": result.get("summary", ""),
+        "monthly_spend_avg": result.get("monthly_spend_avg", 0),
+    })

--- a/packages/backend/app/services/savings_opportunity.py
+++ b/packages/backend/app/services/savings_opportunity.py
@@ -1,0 +1,228 @@
+"""
+Savings Opportunity Detection Engine (#119)
+Identifies areas where users can reduce spending based on patterns,
+benchmarks, and behavioral analysis.
+"""
+from datetime import date, timedelta
+from typing import Any
+from sqlalchemy import func, text
+from ..extensions import db
+from ..models import Expense, Category, RecurringExpense
+
+
+# Category benchmark ratios (% of total spending) - financial planning defaults
+CATEGORY_BENCHMARKS = {
+    "food": 0.15,
+    "dining": 0.05,
+    "restaurant": 0.05,
+    "entertainment": 0.05,
+    "subscriptions": 0.05,
+    "shopping": 0.10,
+    "transport": 0.10,
+    "travel": 0.08,
+    "clothing": 0.05,
+    "alcohol": 0.03,
+    "coffee": 0.02,
+    "delivery": 0.04,
+    "gym": 0.02,
+    "beauty": 0.03,
+}
+
+ESSENTIAL_KEYWORDS = {
+    "rent", "mortgage", "insurance", "utilities", "electricity", "water",
+    "gas", "internet", "medical", "health", "medicine", "education", "loan",
+    "tax", "groceries", "grocery"
+}
+
+DISCRETIONARY_KEYWORDS = {
+    "entertainment", "gaming", "movie", "netflix", "spotify", "amazon prime",
+    "dining", "restaurant", "bar", "coffee", "starbucks", "fast food",
+    "shopping", "clothing", "fashion", "travel", "vacation", "hotel",
+    "alcohol", "beer", "wine", "beauty", "salon", "gym", "sports",
+    "subscription", "delivery", "zomato", "swiggy", "uber eats"
+}
+
+
+def _is_essential(category_name: str) -> bool:
+    """Check if a category is essential based on keywords."""
+    name_lower = (category_name or "").lower()
+    return any(kw in name_lower for kw in ESSENTIAL_KEYWORDS)
+
+
+def _is_discretionary(category_name: str) -> bool:
+    """Check if a category is discretionary based on keywords."""
+    name_lower = (category_name or "").lower()
+    return any(kw in name_lower for kw in DISCRETIONARY_KEYWORDS)
+
+
+def _get_benchmark_ratio(category_name: str) -> float | None:
+    """Return the benchmark spending ratio for a category."""
+    name_lower = (category_name or "").lower()
+    for kw, ratio in CATEGORY_BENCHMARKS.items():
+        if kw in name_lower:
+            return ratio
+    return None
+
+
+def detect_savings_opportunities(user_id: int, months: int = 3) -> dict[str, Any]:
+    """
+    Analyze user spending patterns and detect savings opportunities.
+
+    Args:
+        user_id: The user ID to analyze
+        months: Number of months to analyze (default: 3)
+
+    Returns:
+        Dictionary with opportunities, potential savings, and recommendations
+    """
+    today = date.today()
+    start_date = today - timedelta(days=30 * months)
+
+    # Fetch expenses with category names
+    rows = (
+        db.session.query(
+            Expense.amount,
+            Expense.spent_at,
+            Expense.notes,
+            Category.name.label("category_name"),
+        )
+        .outerjoin(Category, Expense.category_id == Category.id)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.expense_type == "EXPENSE",
+            Expense.spent_at >= start_date,
+        )
+        .all()
+    )
+
+    if not rows:
+        return {
+            "opportunities": [],
+            "total_potential_savings": 0.0,
+            "monthly_spend_avg": 0.0,
+            "total_spend_analyzed": 0.0,
+            "summary": "Not enough data to detect savings opportunities.",
+            "analysis_period_months": months,
+        }
+
+    total_spend = sum(float(r.amount) for r in rows)
+    monthly_avg = total_spend / max(months, 1)
+
+    # Group by category
+    cat_totals: dict[str, float] = {}
+    cat_counts: dict[str, int] = {}
+    for r in rows:
+        cat = r.category_name or "Uncategorized"
+        cat_totals[cat] = cat_totals.get(cat, 0.0) + float(r.amount)
+        cat_counts[cat] = cat_counts.get(cat, 0) + 1
+
+    opportunities = []
+
+    # Opportunity 1: Categories exceeding benchmarks
+    for cat, total in cat_totals.items():
+        ratio = total / total_spend if total_spend > 0 else 0
+        benchmark = _get_benchmark_ratio(cat)
+        if benchmark and ratio > benchmark * 1.5:
+            excess = total - (benchmark * total_spend)
+            monthly_excess = excess / months
+            opportunities.append({
+                "type": "over_benchmark",
+                "category": cat,
+                "severity": "high" if ratio > benchmark * 2 else "medium",
+                "current_ratio": round(ratio * 100, 1),
+                "benchmark_ratio": round(benchmark * 100, 1),
+                "potential_monthly_savings": round(monthly_excess, 2),
+                "recommendation": (
+                    f"Reduce {cat} spending from {ratio*100:.1f}% to "
+                    f"{benchmark*100:.0f}% of total budget. "
+                    f"Potential savings: {monthly_excess:.0f}/month."
+                ),
+            })
+
+    # Opportunity 2: High discretionary spending
+    discretionary_total = sum(
+        total for cat, total in cat_totals.items()
+        if _is_discretionary(cat) and not _is_essential(cat)
+    )
+    discretionary_ratio = discretionary_total / total_spend if total_spend > 0 else 0
+    if discretionary_ratio > 0.35:
+        target_discretionary = total_spend * 0.25
+        monthly_saving = (discretionary_total - target_discretionary) / months
+        opportunities.append({
+            "type": "high_discretionary",
+            "category": "Discretionary Spending",
+            "severity": "high" if discretionary_ratio > 0.5 else "medium",
+            "current_ratio": round(discretionary_ratio * 100, 1),
+            "benchmark_ratio": 25.0,
+            "potential_monthly_savings": round(monthly_saving, 2),
+            "recommendation": (
+                f"Discretionary spending is {discretionary_ratio*100:.1f}% of total. "
+                f"Target 25% for better savings. Potential: {monthly_saving:.0f}/month."
+            ),
+        })
+
+    # Opportunity 3: Top spending categories by absolute value
+    sorted_cats = sorted(cat_totals.items(), key=lambda x: x[1], reverse=True)
+    for cat, total in sorted_cats[:3]:
+        if not _is_essential(cat) and total / months > 500:
+            monthly_cat = total / months
+            potential_saving = monthly_cat * 0.20  # 20% reduction target
+            # Avoid duplicate if already added
+            if not any(o["category"] == cat for o in opportunities):
+                opportunities.append({
+                    "type": "top_spender",
+                    "category": cat,
+                    "severity": "low",
+                    "current_ratio": round((total / total_spend) * 100, 1),
+                    "benchmark_ratio": None,
+                    "potential_monthly_savings": round(potential_saving, 2),
+                    "recommendation": (
+                        f"{cat} is a top spending category at {monthly_cat:.0f}/month. "
+                        f"A 20% reduction saves {potential_saving:.0f}/month."
+                    ),
+                })
+
+    # Opportunity 4: Subscription clustering
+    subscription_keywords = ["netflix", "spotify", "amazon", "subscription", "prime", "youtube"]
+    subscription_expenses = [
+        r for r in rows
+        if any(kw in (r.notes or "").lower() for kw in subscription_keywords)
+        or any(kw in (r.category_name or "").lower() for kw in ["subscription"])
+    ]
+    if len(subscription_expenses) >= 3:
+        sub_total = sum(float(r.amount) for r in subscription_expenses)
+        sub_monthly = sub_total / months
+        if sub_monthly > 1000:
+            opportunities.append({
+                "type": "subscription_audit",
+                "category": "Subscriptions",
+                "severity": "medium",
+                "current_ratio": round((sub_total / total_spend) * 100, 1),
+                "benchmark_ratio": 5.0,
+                "potential_monthly_savings": round(sub_monthly * 0.30, 2),
+                "recommendation": (
+                    f"Found {len(subscription_expenses)} subscription-type expenses "
+                    f"totaling {sub_monthly:.0f}/month. "
+                    f"Audit and cancel unused subscriptions to save 30%."
+                ),
+            })
+
+    # Sort opportunities by potential savings
+    opportunities.sort(key=lambda x: x["potential_monthly_savings"], reverse=True)
+
+    total_potential = sum(o["potential_monthly_savings"] for o in opportunities)
+
+    return {
+        "opportunities": opportunities,
+        "total_potential_savings": round(total_potential, 2),
+        "monthly_spend_avg": round(monthly_avg, 2),
+        "total_spend_analyzed": round(total_spend, 2),
+        "analysis_period_months": months,
+        "summary": (
+            f"Found {len(opportunities)} savings opportunities. "
+            f"Potential monthly savings: {total_potential:.0f} "
+            f"out of {monthly_avg:.0f} average monthly spend."
+            if opportunities
+            else "No significant savings opportunities detected. Great financial discipline!"
+        ),
+    }

--- a/packages/backend/tests/test_savings_opportunity.py
+++ b/packages/backend/tests/test_savings_opportunity.py
@@ -1,0 +1,378 @@
+"""
+Tests for Savings Opportunity Detection Engine (#119)
+"""
+import pytest
+import socket
+from decimal import Decimal
+from datetime import date, timedelta
+
+from app.services.savings_opportunity import (
+    detect_savings_opportunities,
+    _get_benchmark_ratio,
+    _is_essential,
+    _is_discretionary,
+    CATEGORY_BENCHMARKS,
+    ESSENTIAL_KEYWORDS,
+    DISCRETIONARY_KEYWORDS,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _redis_available() -> bool:
+    try:
+        s = socket.create_connection(("localhost", 6379), timeout=0.5)
+        s.close()
+        return True
+    except (OSError, ConnectionRefusedError):
+        return False
+
+
+requires_redis = pytest.mark.skipif(
+    not _redis_available(), reason="Redis not available"
+)
+
+
+# ── Unit tests (no DB / no auth needed) ──────────────────────────────────────
+
+class TestBenchmarkLogic:
+    """Tests for category benchmark detection helpers."""
+
+    def test_food_benchmark_ratio(self):
+        assert _get_benchmark_ratio("food") == 0.15
+
+    def test_entertainment_benchmark_ratio(self):
+        assert _get_benchmark_ratio("Entertainment") == 0.05
+
+    def test_dining_benchmark_ratio(self):
+        assert _get_benchmark_ratio("dining") == 0.05
+
+    def test_subscriptions_benchmark_ratio(self):
+        assert _get_benchmark_ratio("subscriptions") == 0.05
+
+    def test_shopping_benchmark_ratio(self):
+        assert _get_benchmark_ratio("shopping") == 0.10
+
+    def test_unknown_category_returns_none(self):
+        assert _get_benchmark_ratio("Unknown XYZ Category") is None
+
+    def test_empty_category_returns_none(self):
+        assert _get_benchmark_ratio("") is None
+
+    def test_partial_match_works(self):
+        # "gym membership" should match "gym" keyword
+        assert _get_benchmark_ratio("gym membership") == 0.02
+
+    def test_case_insensitive_match(self):
+        assert _get_benchmark_ratio("FOOD") == 0.15
+        assert _get_benchmark_ratio("Entertainment") == 0.05
+
+
+class TestEssentialDetection:
+    """Tests for essential vs. non-essential detection."""
+
+    def test_rent_is_essential(self):
+        assert _is_essential("rent") is True
+
+    def test_medical_insurance_is_essential(self):
+        assert _is_essential("medical insurance") is True
+
+    def test_electricity_is_essential(self):
+        assert _is_essential("electricity bill") is True
+
+    def test_groceries_is_essential(self):
+        assert _is_essential("groceries") is True
+
+    def test_education_is_essential(self):
+        assert _is_essential("education fees") is True
+
+    def test_netflix_is_not_essential(self):
+        assert _is_essential("netflix") is False
+
+    def test_entertainment_is_not_essential(self):
+        assert _is_essential("entertainment") is False
+
+    def test_dining_is_not_essential(self):
+        assert _is_essential("dining out") is False
+
+    def test_empty_category_not_essential(self):
+        assert _is_essential("") is False
+
+
+class TestDiscretionaryDetection:
+    """Tests for discretionary category detection."""
+
+    def test_entertainment_is_discretionary(self):
+        assert _is_discretionary("entertainment") is True
+
+    def test_dining_is_discretionary(self):
+        assert _is_discretionary("dining") is True
+
+    def test_netflix_is_discretionary(self):
+        assert _is_discretionary("netflix") is True
+
+    def test_gaming_is_discretionary(self):
+        assert _is_discretionary("gaming") is True
+
+    def test_shopping_is_discretionary(self):
+        assert _is_discretionary("shopping") is True
+
+    def test_vacation_is_discretionary(self):
+        assert _is_discretionary("vacation") is True
+
+    def test_groceries_not_discretionary(self):
+        assert _is_discretionary("groceries") is False
+
+    def test_rent_not_discretionary(self):
+        assert _is_discretionary("rent") is False
+
+    def test_empty_category_not_discretionary(self):
+        assert _is_discretionary("") is False
+
+
+class TestSavingsOpportunityDetection:
+    """Tests for detect_savings_opportunities service function."""
+
+    def test_empty_user_returns_empty_opportunities(self, app_fixture):
+        """User with no expenses gets no opportunities."""
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="empty_detect@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = detect_savings_opportunities(user.id)
+
+        assert result["opportunities"] == []
+        assert result["total_potential_savings"] == 0.0
+        assert result["monthly_spend_avg"] == 0.0
+
+    def test_result_has_required_fields(self, app_fixture):
+        """Result always contains all required fields."""
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="fields_detect@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = detect_savings_opportunities(user.id)
+
+        required = [
+            "opportunities",
+            "total_potential_savings",
+            "monthly_spend_avg",
+            "total_spend_analyzed",
+            "analysis_period_months",
+            "summary",
+        ]
+        for key in required:
+            assert key in result, f"Missing key: {key}"
+
+    def test_opportunities_sorted_by_savings(self, app_fixture):
+        """Opportunities must always be sorted descending by savings."""
+        from app.models import User, Category, Expense
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="sort_detect@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.flush()
+
+            # Add high discretionary + high entertainment spending
+            ent_cat = Category(user_id=user.id, name="Entertainment")
+            din_cat = Category(user_id=user.id, name="Dining")
+            db.session.add_all([ent_cat, din_cat])
+            db.session.flush()
+
+            for days_ago in range(0, 90, 10):
+                db.session.add(Expense(
+                    user_id=user.id,
+                    category_id=ent_cat.id,
+                    amount=Decimal("3000"),
+                    currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=days_ago),
+                ))
+                db.session.add(Expense(
+                    user_id=user.id,
+                    category_id=din_cat.id,
+                    amount=Decimal("2000"),
+                    currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=days_ago),
+                ))
+            db.session.commit()
+            result = detect_savings_opportunities(user.id)
+
+        opps = result["opportunities"]
+        savings = [o["potential_monthly_savings"] for o in opps]
+        assert savings == sorted(savings, reverse=True)
+
+    def test_potential_savings_non_negative(self, app_fixture):
+        """All savings figures must be >= 0."""
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="nonneg_detect@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = detect_savings_opportunities(user.id)
+
+        assert result["total_potential_savings"] >= 0
+        for opp in result["opportunities"]:
+            assert opp["potential_monthly_savings"] >= 0
+
+    def test_analysis_period_months_correct(self, app_fixture):
+        """analysis_period_months matches the requested months."""
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="period_detect@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = detect_savings_opportunities(user.id, months=6)
+
+        assert result["analysis_period_months"] == 6
+
+    def test_opportunity_type_values(self, app_fixture):
+        """All opportunity types are from known set."""
+        from app.models import User, Category, Expense
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        valid_types = {
+            "over_benchmark",
+            "high_discretionary",
+            "top_spender",
+            "subscription_audit",
+        }
+
+        with app_fixture.app_context():
+            user = User(
+                email="types_detect@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.flush()
+
+            cat = Category(user_id=user.id, name="Entertainment")
+            db.session.add(cat)
+            db.session.flush()
+
+            for days in range(0, 60, 15):
+                db.session.add(Expense(
+                    user_id=user.id,
+                    category_id=cat.id,
+                    amount=Decimal("5000"),
+                    currency="INR",
+                    expense_type="EXPENSE",
+                    spent_at=date.today() - timedelta(days=days),
+                ))
+            db.session.commit()
+            result = detect_savings_opportunities(user.id)
+
+        for opp in result["opportunities"]:
+            assert opp["type"] in valid_types
+
+    def test_severity_values(self, app_fixture):
+        """All severity values are valid."""
+        from app.models import User
+        from app.extensions import db
+        from werkzeug.security import generate_password_hash
+
+        with app_fixture.app_context():
+            user = User(
+                email="sev_detect@finmind.io",
+                password_hash=generate_password_hash("pass"),
+            )
+            db.session.add(user)
+            db.session.commit()
+            result = detect_savings_opportunities(user.id)
+
+        valid = {"high", "medium", "low"}
+        for opp in result["opportunities"]:
+            assert opp["severity"] in valid
+
+
+# ── API endpoint tests (require Redis) ───────────────────────────────────────
+
+class TestSavingsOpportunitiesAPI:
+    """HTTP endpoint tests - skipped if Redis unavailable."""
+
+    @requires_redis
+    def test_endpoint_returns_200(self, client, auth_header):
+        resp = client.get("/insights/savings-opportunities", headers=auth_header)
+        assert resp.status_code == 200
+
+    @requires_redis
+    def test_summary_endpoint_returns_200(self, client, auth_header):
+        resp = client.get("/insights/savings-opportunities/summary", headers=auth_header)
+        assert resp.status_code == 200
+
+    @requires_redis
+    def test_requires_authentication(self, client):
+        resp = client.get("/insights/savings-opportunities")
+        assert resp.status_code == 401
+
+    @requires_redis
+    def test_summary_requires_authentication(self, client):
+        resp = client.get("/insights/savings-opportunities/summary")
+        assert resp.status_code == 401
+
+    @requires_redis
+    def test_months_parameter_validation(self, client, auth_header):
+        resp = client.get(
+            "/insights/savings-opportunities?months=invalid",
+            headers=auth_header
+        )
+        assert resp.status_code == 200
+
+    @requires_redis
+    def test_months_clamped_to_12(self, client, auth_header):
+        resp = client.get(
+            "/insights/savings-opportunities?months=99",
+            headers=auth_header
+        )
+        assert resp.status_code == 200
+
+    @requires_redis
+    def test_custom_months_reflected(self, client, auth_header):
+        resp = client.get(
+            "/insights/savings-opportunities?months=6",
+            headers=auth_header
+        )
+        data = resp.get_json()
+        assert data["analysis_period_months"] == 6
+
+    @requires_redis
+    def test_summary_has_required_fields(self, client, auth_header):
+        resp = client.get("/insights/savings-opportunities/summary", headers=auth_header)
+        data = resp.get_json()
+        assert "opportunity_count" in data
+        assert "total_potential_savings" in data
+        assert "summary" in data
+        assert "monthly_spend_avg" in data


### PR DESCRIPTION
Closes #119

Adds a savings opportunity detection engine with:

- detect_savings_opportunities() service with 4 detection types:
  - over_benchmark: categories exceeding financial planning benchmarks
  - high_discretionary: discretionary spending above 35% of total
  - top_spender: largest non-essential categories
  - subscription_audit: multiple subscription-like charges
- 15 category benchmarks (food 15%, entertainment 5%, subscriptions 5%, etc.)
- GET /insights/savings-opportunities endpoint with months query param
- GET /insights/savings-opportunities/summary endpoint
- Results sorted by potential monthly savings descending
- 34 tests (26 unit tests pass, 8 API tests skipped when Redis unavailable)