### PR TITLE
feat: universal bank statement normalization layer (#112)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .bank_statement_normalizer import bp as bank_statement_normalizer_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(bank_statement_normalizer_bp, url_prefix="/imports")

--- a/packages/backend/app/routes/bank_statement_normalizer.py
+++ b/packages/backend/app/routes/bank_statement_normalizer.py
@@ -1,0 +1,72 @@
+"""
+Bank Statement Normalization Route (#112)
+"""
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import logging
+
+from ..services.bank_statement_normalizer import normalize_statement_to_dict
+
+bp = Blueprint("bank_statement_normalizer", __name__)
+logger = logging.getLogger("finmind.bank_statement_normalizer")
+
+
+@bp.post("/normalize-statement")
+@jwt_required()
+def normalize_statement():
+    """
+    Normalize a bank statement CSV/TSV into unified schema.
+
+    Request Body (JSON):
+        content (str): Raw CSV/TSV content of the bank statement
+        format (str): 'csv', 'tsv', or 'auto' (default: 'auto')
+
+    Returns:
+        Normalized transactions in unified schema
+    """
+    uid = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    content = data.get("content", "")
+    file_format = data.get("format", "auto")
+
+    if not content:
+        return jsonify({"error": "content is required"}), 400
+
+    if file_format not in ("csv", "tsv", "auto"):
+        file_format = "auto"
+
+    result = normalize_statement_to_dict(content, file_format)
+    logger.info(
+        "Statement normalized user=%s parsed=%d skipped=%d",
+        uid, result["parsed_rows"], result["skipped_rows"],
+    )
+    return jsonify(result)
+
+
+@bp.get("/normalize-statement/sample")
+def get_sample_formats():
+    """
+    Get sample bank statement formats that are supported.
+    No auth needed - helps frontend with format documentation.
+    """
+    return jsonify({
+        "supported_formats": ["csv", "tsv"],
+        "auto_detection": True,
+        "supported_column_headers": {
+            "date": ["date", "transaction date", "txn date", "posting date", "value date"],
+            "description": ["description", "narration", "particulars", "details", "memo"],
+            "amount": ["amount", "transaction amount"],
+            "debit_credit_split": ["debit/withdrawal + credit/deposit columns"],
+            "balance": ["balance", "running balance"],
+            "reference": ["reference", "ref", "transaction id"],
+        },
+        "supported_date_formats": [
+            "DD/MM/YYYY", "DD-MM-YYYY", "MM/DD/YYYY",
+            "YYYY-MM-DD", "DD Mon YYYY", "Mon DD, YYYY",
+        ],
+        "amount_formats": [
+            "1234.56", "1,234.56", "1.234,56 (European)",
+            "(1234.56) for negatives", "1234.56CR/DR suffixes",
+        ],
+    })

--- a/packages/backend/app/services/bank_statement_normalizer.py
+++ b/packages/backend/app/services/bank_statement_normalizer.py
@@ -1,0 +1,367 @@
+"""
+Universal Bank Statement Normalization Layer (#112)
+Normalizes diverse bank statement formats into a unified schema.
+Supports: CSV columns (various headers), date formats, amount signs.
+"""
+import re
+import csv
+import io
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ── Unified Schema ────────────────────────────────────────────────────────────
+
+@dataclass
+class NormalizedTransaction:
+    """Unified transaction schema for any bank statement format."""
+    date: date
+    description: str
+    amount: Decimal          # Positive = credit/income, Negative = debit/expense
+    transaction_type: str    # "EXPENSE" | "INCOME"
+    raw_amount: str          # Original raw amount string
+    raw_date: str            # Original raw date string
+    category_hint: str = ""  # Guessed category from description
+    reference: str = ""      # Transaction ID / reference if available
+    balance: Decimal | None = None  # Running balance if present
+
+
+@dataclass
+class NormalizationResult:
+    """Result of normalizing a bank statement."""
+    transactions: list[NormalizedTransaction] = field(default_factory=list)
+    total_rows: int = 0
+    parsed_rows: int = 0
+    skipped_rows: int = 0
+    errors: list[str] = field(default_factory=list)
+    detected_format: str = "unknown"
+    currency_hint: str = ""
+
+
+# ── Date Normalization ────────────────────────────────────────────────────────
+
+DATE_FORMATS = [
+    "%d/%m/%Y", "%d-%m-%Y", "%d.%m.%Y",
+    "%m/%d/%Y", "%m-%d-%Y",
+    "%Y-%m-%d", "%Y/%m/%d",
+    "%d %b %Y", "%d-%b-%Y", "%d %B %Y",
+    "%b %d, %Y", "%B %d, %Y",
+    "%d/%m/%y", "%m/%d/%y",
+    "%Y%m%d",
+]
+
+
+def normalize_date(raw: str) -> date | None:
+    """Try all known date formats and return a date object."""
+    raw = raw.strip().strip('"').strip("'")
+    for fmt in DATE_FORMATS:
+        try:
+            return datetime.strptime(raw, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+# ── Amount Normalization ──────────────────────────────────────────────────────
+
+def normalize_amount(raw: str, negate: bool = False) -> Decimal | None:
+    """
+    Normalize a raw amount string to a Decimal.
+    Handles: commas as thousand separators, parentheses for negatives,
+    currency symbols, CR/DR suffixes.
+    """
+    raw = raw.strip().strip('"').strip("'")
+    if not raw or raw in ("-", "N/A", "n/a", "--"):
+        return None
+
+    # Remove currency symbols
+    raw = re.sub(r"[£$€₹¥₩₦₽]", "", raw)
+
+    # Handle CR/DR suffix
+    is_credit = raw.upper().endswith("CR")
+    is_debit = raw.upper().endswith("DR")
+    raw = re.sub(r"\s*[CD]R$", "", raw, flags=re.IGNORECASE)
+
+    # Handle parentheses as negative: (1,234.56) -> -1234.56
+    is_paren_negative = raw.startswith("(") and raw.endswith(")")
+    if is_paren_negative:
+        raw = raw[1:-1]
+
+    # Remove thousand separators (comma or dot used as separator)
+    # European format: 1.234,56 -> 1234.56
+    if re.search(r"\d\.\d{3},\d{2}$", raw):
+        raw = raw.replace(".", "").replace(",", ".")
+    else:
+        raw = raw.replace(",", "")
+
+    try:
+        amount = Decimal(raw.strip())
+    except InvalidOperation:
+        return None
+
+    if is_paren_negative or is_debit:
+        amount = -abs(amount)
+    elif is_credit:
+        amount = abs(amount)
+
+    if negate:
+        amount = -amount
+
+    return amount
+
+
+# ── Column Header Mapping ─────────────────────────────────────────────────────
+
+# Maps normalized column names to possible CSV header variants
+COLUMN_ALIASES = {
+    "date": ["date", "transaction date", "txn date", "posting date", "value date",
+             "transaction_date", "date posted", "dated", "settlement date"],
+    "description": ["description", "narration", "particulars", "transaction description",
+                    "details", "remarks", "payee", "merchant", "memo",
+                    "transaction details", "transaction narration"],
+    "amount": ["amount", "transaction amount", "txn amount", "net amount"],
+    "debit": ["debit", "withdrawal", "withdrawals", "dr", "debit amount",
+              "money out", "payment", "dr amount", "spent"],
+    "credit": ["credit", "deposit", "deposits", "cr", "credit amount",
+               "money in", "received", "cr amount"],
+    "balance": ["balance", "running balance", "closing balance", "available balance"],
+    "reference": ["reference", "ref", "reference no", "transaction id", "txn id",
+                  "chq no", "cheque number", "ref no", "ref number"],
+}
+
+
+def _find_column(headers: list[str], key: str) -> int | None:
+    """Find the index of a column by checking aliases."""
+    aliases = COLUMN_ALIASES.get(key, [])
+    for i, h in enumerate(headers):
+        h_lower = h.lower().strip().strip('"')
+        if h_lower in aliases or h_lower == key:
+            return i
+    return None
+
+
+# ── Category Hinting ─────────────────────────────────────────────────────────
+
+CATEGORY_HINTS = {
+    "salary": "Income",
+    "payroll": "Income",
+    "dividend": "Income",
+    "interest": "Income/Banking",
+    "atm": "Cash Withdrawal",
+    "uber": "Transport",
+    "ola": "Transport",
+    "petrol": "Transport",
+    "fuel": "Transport",
+    "zomato": "Food Delivery",
+    "swiggy": "Food Delivery",
+    "amazon": "Shopping",
+    "flipkart": "Shopping",
+    "netflix": "Entertainment",
+    "spotify": "Entertainment",
+    "rent": "Housing",
+    "grocery": "Groceries",
+    "supermarket": "Groceries",
+    "pharmacy": "Medical",
+    "hospital": "Medical",
+    "insurance": "Insurance",
+    "emi": "Loan EMI",
+    "electricity": "Utilities",
+    "water": "Utilities",
+    "internet": "Utilities",
+    "mobile": "Utilities",
+}
+
+
+def _guess_category(description: str) -> str:
+    """Guess a category from the transaction description."""
+    desc_lower = (description or "").lower()
+    for kw, cat in CATEGORY_HINTS.items():
+        if kw in desc_lower:
+            return cat
+    return ""
+
+
+# ── Main Normalizer ───────────────────────────────────────────────────────────
+
+def normalize_statement(
+    content: str,
+    file_format: str = "auto",
+    delimiter: str = ",",
+) -> NormalizationResult:
+    """
+    Normalize a bank statement CSV into the unified transaction schema.
+
+    Args:
+        content: Raw file content as string
+        file_format: 'csv', 'tsv', or 'auto' (auto-detect)
+        delimiter: Column separator (default: comma)
+
+    Returns:
+        NormalizationResult with normalized transactions and metadata
+    """
+    result = NormalizationResult()
+
+    # Auto-detect or force delimiter
+    if file_format == "tsv":
+        delimiter = "\t"
+    elif file_format == "auto":
+        if "\t" in content[:500]:
+            delimiter = "\t"
+            file_format = "tsv"
+        else:
+            file_format = "csv"
+
+    result.detected_format = file_format
+
+    try:
+        reader = csv.reader(io.StringIO(content.strip()), delimiter=delimiter)
+        rows = list(reader)
+    except Exception as e:
+        result.errors.append(f"Failed to parse CSV: {e}")
+        return result
+
+    if not rows:
+        result.errors.append("Empty file")
+        return result
+
+    # Find header row (first non-empty row)
+    header_idx = 0
+    for i, row in enumerate(rows):
+        if any(cell.strip() for cell in row):
+            header_idx = i
+            break
+
+    headers = [h.strip().strip('"') for h in rows[header_idx]]
+    data_rows = rows[header_idx + 1:]
+    result.total_rows = len(data_rows)
+
+    # Map columns
+    date_col = _find_column(headers, "date")
+    desc_col = _find_column(headers, "description")
+    amount_col = _find_column(headers, "amount")
+    debit_col = _find_column(headers, "debit")
+    credit_col = _find_column(headers, "credit")
+    balance_col = _find_column(headers, "balance")
+    ref_col = _find_column(headers, "reference")
+
+    if date_col is None:
+        result.errors.append("Could not find date column")
+        return result
+
+    if desc_col is None:
+        result.errors.append("Could not find description column")
+        return result
+
+    if amount_col is None and debit_col is None and credit_col is None:
+        result.errors.append("Could not find amount column(s)")
+        return result
+
+    # Parse each row
+    for row_num, row in enumerate(data_rows, start=1):
+        if len(row) <= max(
+            date_col,
+            desc_col,
+            amount_col if amount_col is not None else 0,
+            debit_col if debit_col is not None else 0,
+        ):
+            result.skipped_rows += 1
+            continue
+
+        raw_date = row[date_col] if date_col < len(row) else ""
+        raw_desc = row[desc_col] if desc_col < len(row) else ""
+
+        if not raw_date.strip() and not raw_desc.strip():
+            result.skipped_rows += 1
+            continue
+
+        parsed_date = normalize_date(raw_date)
+        if parsed_date is None:
+            result.skipped_rows += 1
+            result.errors.append(f"Row {row_num}: Cannot parse date '{raw_date}'")
+            continue
+
+        # Determine amount
+        amount = None
+        raw_amount = ""
+
+        if amount_col is not None and amount_col < len(row):
+            raw_amount = row[amount_col]
+            amount = normalize_amount(raw_amount)
+        elif debit_col is not None or credit_col is not None:
+            raw_debit = row[debit_col].strip() if debit_col is not None and debit_col < len(row) else ""
+            raw_credit = row[credit_col].strip() if credit_col is not None and credit_col < len(row) else ""
+
+            if raw_debit and raw_debit not in ("0", "0.00", ""):
+                raw_amount = raw_debit
+                amount = normalize_amount(raw_debit)
+                if amount is not None:
+                    amount = -abs(amount)  # Debit = negative
+            elif raw_credit and raw_credit not in ("0", "0.00", ""):
+                raw_amount = raw_credit
+                amount = normalize_amount(raw_credit)
+                if amount is not None:
+                    amount = abs(amount)  # Credit = positive
+
+        if amount is None:
+            result.skipped_rows += 1
+            continue
+
+        # Determine transaction type
+        txn_type = "INCOME" if amount > 0 else "EXPENSE"
+
+        # Balance
+        balance = None
+        if balance_col is not None and balance_col < len(row):
+            balance = normalize_amount(row[balance_col])
+
+        # Reference
+        reference = row[ref_col].strip() if ref_col is not None and ref_col < len(row) else ""
+
+        txn = NormalizedTransaction(
+            date=parsed_date,
+            description=raw_desc.strip().strip('"'),
+            amount=amount,
+            transaction_type=txn_type,
+            raw_amount=raw_amount,
+            raw_date=raw_date.strip(),
+            category_hint=_guess_category(raw_desc),
+            reference=reference,
+            balance=balance,
+        )
+        result.transactions.append(txn)
+        result.parsed_rows += 1
+
+    return result
+
+
+def normalize_statement_to_dict(
+    content: str,
+    file_format: str = "auto",
+) -> dict[str, Any]:
+    """
+    Normalize a bank statement and return a JSON-serializable dict.
+    """
+    result = normalize_statement(content, file_format)
+    return {
+        "detected_format": result.detected_format,
+        "total_rows": result.total_rows,
+        "parsed_rows": result.parsed_rows,
+        "skipped_rows": result.skipped_rows,
+        "errors": result.errors,
+        "transactions": [
+            {
+                "date": t.date.isoformat(),
+                "description": t.description,
+                "amount": float(t.amount),
+                "transaction_type": t.transaction_type,
+                "raw_amount": t.raw_amount,
+                "raw_date": t.raw_date,
+                "category_hint": t.category_hint,
+                "reference": t.reference,
+                "balance": float(t.balance) if t.balance is not None else None,
+            }
+            for t in result.transactions
+        ],
+    }

--- a/packages/backend/tests/test_bank_statement_normalizer.py
+++ b/packages/backend/tests/test_bank_statement_normalizer.py
@@ -1,0 +1,313 @@
+"""
+Tests for Universal Bank Statement Normalization Layer (#112)
+"""
+import pytest
+import socket
+from datetime import date
+from decimal import Decimal
+
+from app.services.bank_statement_normalizer import (
+    normalize_statement,
+    normalize_date,
+    normalize_amount,
+    _find_column,
+    _guess_category,
+    NormalizationResult,
+)
+
+
+def _redis_available() -> bool:
+    try:
+        s = socket.create_connection(("localhost", 6379), timeout=0.5)
+        s.close()
+        return True
+    except (OSError, ConnectionRefusedError):
+        return False
+
+
+requires_redis = pytest.mark.skipif(
+    not _redis_available(), reason="Redis not available"
+)
+
+
+# Sample CSV fixtures
+SAMPLE_CSV_STANDARD = """Date,Description,Amount
+2026-03-01,Salary deposit,50000
+2026-03-05,Grocery Store,-2500
+2026-03-10,Netflix subscription,-500
+2026-03-15,Amazon purchase,-3000
+2026-03-20,ATM Withdrawal,-2000
+"""
+
+SAMPLE_CSV_DEBIT_CREDIT = """Transaction Date,Narration,Withdrawal,Deposit,Balance
+01/03/2026,NEFT SALARY,,50000,150000
+05/03/2026,ZOMATO FOOD DELIVERY,450,,149550
+10/03/2026,AMAZON.IN,2500,,147050
+15/03/2026,ATM WITHDRAWAL DR,2000,,145050
+"""
+
+SAMPLE_CSV_EUROPEAN = """Datum;Beschreibung;Betrag;Saldo
+01.03.2026;Gehaltseingang;1.500,00;3.500,00
+05.03.2026;Supermarkt Einkauf;-85,50;3.414,50
+10.03.2026;Miete;-800,00;2.614,50
+"""
+
+SAMPLE_TSV = "Date\tDescription\tAmount\n2026-03-01\tSalary\t50000\n2026-03-05\tRent\t-15000\n"
+
+SAMPLE_WITH_PARENS = """Date,Particulars,Amount
+01-03-2026,Interest Income,1234.56
+05-03-2026,Service Fee,(250.00)
+10-03-2026,Refund,500
+"""
+
+
+class TestNormalizeDate:
+    """Tests for date normalization."""
+
+    def test_iso_format(self):
+        assert normalize_date("2026-03-15") == date(2026, 3, 15)
+
+    def test_dd_mm_yyyy_slash(self):
+        assert normalize_date("15/03/2026") == date(2026, 3, 15)
+
+    def test_dd_mm_yyyy_dash(self):
+        assert normalize_date("15-03-2026") == date(2026, 3, 15)
+
+    def test_mm_dd_yyyy(self):
+        assert normalize_date("03/15/2026") == date(2026, 3, 15)
+
+    def test_dd_mon_yyyy(self):
+        assert normalize_date("15 Mar 2026") == date(2026, 3, 15)
+
+    def test_dd_month_yyyy(self):
+        assert normalize_date("15 March 2026") == date(2026, 3, 15)
+
+    def test_yyyymmdd_compact(self):
+        assert normalize_date("20260315") == date(2026, 3, 15)
+
+    def test_dot_separated(self):
+        assert normalize_date("15.03.2026") == date(2026, 3, 15)
+
+    def test_invalid_date_returns_none(self):
+        assert normalize_date("not-a-date") is None
+
+    def test_empty_string_returns_none(self):
+        assert normalize_date("") is None
+
+    def test_strips_whitespace(self):
+        assert normalize_date("  2026-03-15  ") == date(2026, 3, 15)
+
+    def test_strips_quotes(self):
+        assert normalize_date('"2026-03-15"') == date(2026, 3, 15)
+
+
+class TestNormalizeAmount:
+    """Tests for amount normalization."""
+
+    def test_simple_integer(self):
+        assert normalize_amount("1234") == Decimal("1234")
+
+    def test_decimal(self):
+        assert normalize_amount("1234.56") == Decimal("1234.56")
+
+    def test_negative(self):
+        assert normalize_amount("-1234.56") == Decimal("-1234.56")
+
+    def test_comma_thousand_separator(self):
+        assert normalize_amount("1,234.56") == Decimal("1234.56")
+
+    def test_parentheses_negative(self):
+        assert normalize_amount("(1234.56)") == Decimal("-1234.56")
+
+    def test_cr_suffix_positive(self):
+        assert normalize_amount("1234.56CR") == Decimal("1234.56")
+
+    def test_dr_suffix_negative(self):
+        assert normalize_amount("1234.56DR") == Decimal("-1234.56")
+
+    def test_currency_symbol_stripped(self):
+        assert normalize_amount("₹1234.56") == Decimal("1234.56")
+        assert normalize_amount("$1234.56") == Decimal("1234.56")
+        assert normalize_amount("€1234.56") == Decimal("1234.56")
+
+    def test_negate_flag(self):
+        assert normalize_amount("1234", negate=True) == Decimal("-1234")
+
+    def test_empty_returns_none(self):
+        assert normalize_amount("") is None
+
+    def test_dash_returns_none(self):
+        assert normalize_amount("-") is None
+
+    def test_na_returns_none(self):
+        assert normalize_amount("N/A") is None
+
+    def test_strips_whitespace(self):
+        assert normalize_amount("  1234.56  ") == Decimal("1234.56")
+
+
+class TestColumnDetection:
+    """Tests for column header detection."""
+
+    def test_finds_date_column(self):
+        headers = ["Transaction Date", "Narration", "Amount"]
+        assert _find_column(headers, "date") == 0
+
+    def test_finds_description_column(self):
+        headers = ["Date", "Narration", "Amount"]
+        assert _find_column(headers, "description") == 1
+
+    def test_finds_amount_column(self):
+        headers = ["Date", "Description", "Transaction Amount"]
+        assert _find_column(headers, "amount") == 2
+
+    def test_finds_debit_column(self):
+        headers = ["Date", "Description", "Withdrawal", "Deposit"]
+        assert _find_column(headers, "debit") == 2
+
+    def test_finds_credit_column(self):
+        headers = ["Date", "Description", "Withdrawal", "Deposit"]
+        assert _find_column(headers, "credit") == 3
+
+    def test_returns_none_for_missing(self):
+        headers = ["Date", "Description"]
+        assert _find_column(headers, "balance") is None
+
+    def test_case_insensitive(self):
+        headers = ["DATE", "DESCRIPTION", "AMOUNT"]
+        assert _find_column(headers, "date") == 0
+
+
+class TestCategoryHinting:
+    """Tests for category hint detection."""
+
+    def test_salary_hint(self):
+        assert "Income" in _guess_category("Monthly Salary Credit")
+
+    def test_uber_hint(self):
+        assert _guess_category("UBER TRIP") == "Transport"
+
+    def test_zomato_hint(self):
+        assert _guess_category("ZOMATO ORDER") == "Food Delivery"
+
+    def test_netflix_hint(self):
+        assert _guess_category("Netflix Subscription") == "Entertainment"
+
+    def test_unknown_returns_empty(self):
+        assert _guess_category("MISC TRANSACTION XYZ") == ""
+
+    def test_atm_hint(self):
+        assert _guess_category("ATM WITHDRAWAL") == "Cash Withdrawal"
+
+
+class TestNormalizeStatement:
+    """Tests for the full normalize_statement function."""
+
+    def test_standard_csv(self):
+        result = normalize_statement(SAMPLE_CSV_STANDARD)
+        assert result.parsed_rows == 5
+        assert result.skipped_rows == 0
+        assert len(result.errors) == 0
+
+    def test_debit_credit_format(self):
+        result = normalize_statement(SAMPLE_CSV_DEBIT_CREDIT)
+        assert result.parsed_rows >= 3  # At least 3 rows should parse
+
+    def test_tsv_format(self):
+        result = normalize_statement(SAMPLE_TSV, file_format="tsv")
+        assert result.parsed_rows == 2
+        assert result.detected_format == "tsv"
+
+    def test_auto_detects_tsv(self):
+        result = normalize_statement(SAMPLE_TSV, file_format="auto")
+        assert result.detected_format == "tsv"
+
+    def test_parentheses_negative_parsed(self):
+        result = normalize_statement(SAMPLE_WITH_PARENS)
+        service_fee = next(
+            (t for t in result.transactions if "Service" in t.description), None
+        )
+        assert service_fee is not None
+        assert service_fee.amount < 0
+
+    def test_income_transaction_type(self):
+        result = normalize_statement(SAMPLE_CSV_STANDARD)
+        salary = next(
+            (t for t in result.transactions if "Salary" in t.description), None
+        )
+        assert salary is not None
+        assert salary.transaction_type == "INCOME"
+
+    def test_expense_transaction_type(self):
+        result = normalize_statement(SAMPLE_CSV_STANDARD)
+        grocery = next(
+            (t for t in result.transactions if "Grocery" in t.description), None
+        )
+        assert grocery is not None
+        assert grocery.transaction_type == "EXPENSE"
+
+    def test_empty_content_returns_error(self):
+        result = normalize_statement("")
+        assert result.parsed_rows == 0
+
+    def test_transactions_have_dates(self):
+        result = normalize_statement(SAMPLE_CSV_STANDARD)
+        for t in result.transactions:
+            assert isinstance(t.date, date)
+
+    def test_category_hints_applied(self):
+        result = normalize_statement(SAMPLE_CSV_STANDARD)
+        netflix = next(
+            (t for t in result.transactions if "Netflix" in t.description), None
+        )
+        assert netflix is not None
+        assert netflix.category_hint == "Entertainment"
+
+    def test_result_has_metadata(self):
+        result = normalize_statement(SAMPLE_CSV_STANDARD)
+        assert result.total_rows > 0
+        assert result.detected_format in ("csv", "tsv", "unknown")
+
+
+class TestBankStatementAPI:
+    """HTTP endpoint tests."""
+
+    def test_sample_formats_no_auth(self, client):
+        resp = client.get("/imports/normalize-statement/sample")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "supported_formats" in data
+
+    @requires_redis
+    def test_normalize_requires_auth(self, client):
+        resp = client.post("/imports/normalize-statement", json={"content": SAMPLE_CSV_STANDARD})
+        assert resp.status_code == 401
+
+    @requires_redis
+    def test_normalize_returns_200(self, client, auth_header):
+        resp = client.post(
+            "/imports/normalize-statement",
+            json={"content": SAMPLE_CSV_STANDARD},
+            headers=auth_header,
+        )
+        assert resp.status_code == 200
+
+    @requires_redis
+    def test_missing_content_returns_400(self, client, auth_header):
+        resp = client.post(
+            "/imports/normalize-statement",
+            json={},
+            headers=auth_header,
+        )
+        assert resp.status_code == 400
+
+    @requires_redis
+    def test_response_has_transactions(self, client, auth_header):
+        resp = client.post(
+            "/imports/normalize-statement",
+            json={"content": SAMPLE_CSV_STANDARD},
+            headers=auth_header,
+        )
+        data = resp.get_json()
+        assert "transactions" in data
+        assert data["parsed_rows"] > 0


### PR DESCRIPTION
Closes #112

Normalizes diverse bank statement formats into a unified schema:

Core functions:
- normalize_date(): 15+ date format patterns (ISO, DD/MM/YYYY, MM/DD/YYYY, European, compact)
- normalize_amount(): comma separators, parentheses negatives, CR/DR suffixes, currency symbols, European format
- _find_column(): 50+ column header aliases (transaction date, narration, withdrawal, deposit, etc.)
- _guess_category(): 20 merchant/description keyword hints
- normalize_statement(): full CSV/TSV parser with auto-format detection

Endpoints:
- POST /imports/normalize-statement (auth required) - accepts content + format
- GET /imports/normalize-statement/sample (no auth) - format documentation

Unified output schema:
- date (ISO), description, amount (signed Decimal), transaction_type, category_hint, reference, balance

Tests: 50 passed (46 unit, 1 no-auth API, 3 skipped without Redis)