### PR TITLE
feat: keyboard-first navigation & shortcuts with customization (#106)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .keyboard_shortcuts import bp as keyboard_shortcuts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(keyboard_shortcuts_bp, url_prefix="")

--- a/packages/backend/app/routes/keyboard_shortcuts.py
+++ b/packages/backend/app/routes/keyboard_shortcuts.py
@@ -1,0 +1,73 @@
+"""Routes for Keyboard Shortcuts Management (issue #106)."""
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from app.services.keyboard_shortcuts import (
+    get_all_shortcuts,
+    get_shortcuts_by_category,
+    get_user_shortcut_config,
+    update_shortcut,
+    reset_shortcut,
+    reset_all_shortcuts,
+    DEFAULT_SHORTCUTS,
+)
+
+bp = Blueprint("keyboard_shortcuts", __name__)
+
+
+@bp.route("/keyboard-shortcuts", methods=["GET"])
+def list_shortcuts():
+    """List all available keyboard shortcuts (public)."""
+    by_category = request.args.get("by_category", "false").lower() == "true"
+    if by_category:
+        return jsonify(get_shortcuts_by_category()), 200
+    return jsonify({"shortcuts": get_all_shortcuts(), "count": len(DEFAULT_SHORTCUTS)}), 200
+
+
+@bp.route("/keyboard-shortcuts/user", methods=["GET"])
+@jwt_required()
+def get_user_shortcuts():
+    """Get resolved shortcuts for the current user (merged defaults + custom)."""
+    user_id = int(get_jwt_identity())
+    config = get_user_shortcut_config(user_id)
+    return jsonify({"shortcuts": config, "count": len(config)}), 200
+
+
+@bp.route("/keyboard-shortcuts/user/<string:action>", methods=["PUT"])
+@jwt_required()
+def set_shortcut(action: str):
+    """Set a custom keybinding for an action."""
+    user_id = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    custom_key = (data.get("key") or "").strip()
+    if not custom_key:
+        return jsonify({"error": "key is required"}), 400
+
+    enabled = bool(data.get("enabled", True))
+    result = update_shortcut(user_id, action, custom_key, enabled)
+    if result is None:
+        return jsonify({"error": f"Unknown action: {action}"}), 404
+    if "error" in result:
+        return jsonify(result), 409  # Conflict
+
+    return jsonify(result), 200
+
+
+@bp.route("/keyboard-shortcuts/user/<string:action>", methods=["DELETE"])
+@jwt_required()
+def reset_shortcut_route(action: str):
+    """Reset a shortcut to its default keybinding."""
+    user_id = int(get_jwt_identity())
+    result = reset_shortcut(user_id, action)
+    if result is None:
+        return jsonify({"error": f"Unknown action: {action}"}), 404
+    return jsonify(result), 200
+
+
+@bp.route("/keyboard-shortcuts/user/reset-all", methods=["POST"])
+@jwt_required()
+def reset_all_route():
+    """Reset all shortcuts to defaults."""
+    user_id = int(get_jwt_identity())
+    count = reset_all_shortcuts(user_id)
+    return jsonify({"message": f"Reset {count} custom shortcut(s) to defaults", "count": count}), 200

--- a/packages/backend/app/services/keyboard_shortcuts.py
+++ b/packages/backend/app/services/keyboard_shortcuts.py
@@ -1,0 +1,260 @@
+"""
+Keyboard Navigation & Shortcuts (issue #106)
+
+Backend service for managing user-configurable keyboard shortcuts.
+Provides a registry of available shortcuts and user preferences.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Optional
+from app.extensions import db
+
+
+# -----------------------------------------------------------------------
+# Default shortcut definitions (action -> default keybinding)
+# -----------------------------------------------------------------------
+
+DEFAULT_SHORTCUTS: dict[str, dict] = {
+    # Navigation
+    "nav.dashboard": {
+        "action": "nav.dashboard",
+        "label": "Go to Dashboard",
+        "default_key": "g d",
+        "category": "navigation",
+        "description": "Navigate to the main dashboard",
+    },
+    "nav.expenses": {
+        "action": "nav.expenses",
+        "label": "Go to Expenses",
+        "default_key": "g e",
+        "category": "navigation",
+        "description": "Navigate to expense list",
+    },
+    "nav.bills": {
+        "action": "nav.bills",
+        "label": "Go to Bills",
+        "default_key": "g b",
+        "category": "navigation",
+        "description": "Navigate to bills",
+    },
+    "nav.insights": {
+        "action": "nav.insights",
+        "label": "Go to Insights",
+        "default_key": "g i",
+        "category": "navigation",
+        "description": "Navigate to financial insights",
+    },
+    "nav.categories": {
+        "action": "nav.categories",
+        "label": "Go to Categories",
+        "default_key": "g c",
+        "category": "navigation",
+        "description": "Navigate to category management",
+    },
+    # Actions
+    "action.new_expense": {
+        "action": "action.new_expense",
+        "label": "New Expense",
+        "default_key": "n e",
+        "category": "actions",
+        "description": "Open new expense dialog",
+    },
+    "action.new_bill": {
+        "action": "action.new_bill",
+        "label": "New Bill",
+        "default_key": "n b",
+        "category": "actions",
+        "description": "Open new bill dialog",
+    },
+    "action.search": {
+        "action": "action.search",
+        "label": "Global Search",
+        "default_key": "/",
+        "category": "actions",
+        "description": "Open global search",
+    },
+    "action.import": {
+        "action": "action.import",
+        "label": "Import Transactions",
+        "default_key": "ctrl+i",
+        "category": "actions",
+        "description": "Open import dialog",
+    },
+    "action.export": {
+        "action": "action.export",
+        "label": "Export Data",
+        "default_key": "ctrl+e",
+        "category": "actions",
+        "description": "Export user data",
+    },
+    # UI controls
+    "ui.toggle_sidebar": {
+        "action": "ui.toggle_sidebar",
+        "label": "Toggle Sidebar",
+        "default_key": "ctrl+\\",
+        "category": "ui",
+        "description": "Show/hide the sidebar",
+    },
+    "ui.toggle_dark_mode": {
+        "action": "ui.toggle_dark_mode",
+        "label": "Toggle Dark Mode",
+        "default_key": "ctrl+shift+d",
+        "category": "ui",
+        "description": "Toggle dark/light theme",
+    },
+    "ui.help": {
+        "action": "ui.help",
+        "label": "Show Keyboard Help",
+        "default_key": "?",
+        "category": "ui",
+        "description": "Show keyboard shortcuts reference",
+    },
+    "ui.close_modal": {
+        "action": "ui.close_modal",
+        "label": "Close Modal",
+        "default_key": "Escape",
+        "category": "ui",
+        "description": "Close the current modal or dialog",
+    },
+    "ui.next_item": {
+        "action": "ui.next_item",
+        "label": "Next Item",
+        "default_key": "j",
+        "category": "ui",
+        "description": "Move to next item in list (vim-style)",
+    },
+    "ui.prev_item": {
+        "action": "ui.prev_item",
+        "label": "Previous Item",
+        "default_key": "k",
+        "category": "ui",
+        "description": "Move to previous item in list (vim-style)",
+    },
+}
+
+
+class UserShortcutPreference(db.Model):
+    """User-specific keyboard shortcut customizations."""
+
+    __tablename__ = "user_shortcut_preferences"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    action = db.Column(db.String(100), nullable=False)
+    custom_key = db.Column(db.String(50), nullable=False)
+    enabled = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "action": self.action,
+            "custom_key": self.custom_key,
+            "enabled": self.enabled,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+def get_all_shortcuts() -> list[dict]:
+    """Return the full list of available shortcuts with metadata."""
+    return list(DEFAULT_SHORTCUTS.values())
+
+
+def get_shortcuts_by_category() -> dict[str, list[dict]]:
+    """Group shortcuts by category."""
+    result: dict[str, list] = {}
+    for shortcut in DEFAULT_SHORTCUTS.values():
+        cat = shortcut["category"]
+        result.setdefault(cat, []).append(shortcut)
+    return result
+
+
+def get_user_shortcut_config(user_id: int) -> list[dict]:
+    """
+    Get resolved keyboard shortcuts for a user.
+    Merges defaults with user customizations.
+    """
+    prefs = UserShortcutPreference.query.filter_by(user_id=user_id).all()
+    pref_map = {p.action: p for p in prefs}
+
+    result = []
+    for action, shortcut in DEFAULT_SHORTCUTS.items():
+        entry = dict(shortcut)
+        if action in pref_map:
+            pref = pref_map[action]
+            entry["custom_key"] = pref.custom_key
+            entry["enabled"] = pref.enabled
+            entry["active_key"] = pref.custom_key if pref.enabled else None
+            entry["is_customized"] = True
+        else:
+            entry["custom_key"] = None
+            entry["enabled"] = True
+            entry["active_key"] = shortcut["default_key"]
+            entry["is_customized"] = False
+        result.append(entry)
+    return result
+
+
+def update_shortcut(user_id: int, action: str, custom_key: str, enabled: bool = True) -> Optional[dict]:
+    """
+    Set a custom key binding for an action.
+    Returns updated shortcut config or None if action doesn't exist.
+    """
+    if action not in DEFAULT_SHORTCUTS:
+        return None
+
+    # Check for conflicts with other custom bindings
+    conflict = UserShortcutPreference.query.filter(
+        UserShortcutPreference.user_id == user_id,
+        UserShortcutPreference.custom_key == custom_key,
+        UserShortcutPreference.action != action,
+        UserShortcutPreference.enabled == True,
+    ).first()
+    if conflict:
+        return {"error": f"Key '{custom_key}' is already assigned to '{conflict.action}'"}
+
+    pref = UserShortcutPreference.query.filter_by(user_id=user_id, action=action).first()
+    if pref:
+        pref.custom_key = custom_key
+        pref.enabled = enabled
+    else:
+        pref = UserShortcutPreference(
+            user_id=user_id,
+            action=action,
+            custom_key=custom_key,
+            enabled=enabled,
+        )
+        db.session.add(pref)
+    db.session.commit()
+
+    shortcut = dict(DEFAULT_SHORTCUTS[action])
+    shortcut["custom_key"] = custom_key
+    shortcut["enabled"] = enabled
+    shortcut["active_key"] = custom_key if enabled else None
+    shortcut["is_customized"] = True
+    return shortcut
+
+
+def reset_shortcut(user_id: int, action: str) -> Optional[dict]:
+    """Reset a shortcut to its default key binding."""
+    if action not in DEFAULT_SHORTCUTS:
+        return None
+    pref = UserShortcutPreference.query.filter_by(user_id=user_id, action=action).first()
+    if pref:
+        db.session.delete(pref)
+        db.session.commit()
+    return {**DEFAULT_SHORTCUTS[action], "is_customized": False, "active_key": DEFAULT_SHORTCUTS[action]["default_key"]}
+
+
+def reset_all_shortcuts(user_id: int) -> int:
+    """Reset all shortcuts for a user to defaults. Returns count deleted."""
+    prefs = UserShortcutPreference.query.filter_by(user_id=user_id).all()
+    count = len(prefs)
+    for p in prefs:
+        db.session.delete(p)
+    db.session.commit()
+    return count

--- a/packages/backend/tests/test_keyboard_shortcuts.py
+++ b/packages/backend/tests/test_keyboard_shortcuts.py
@@ -1,0 +1,232 @@
+"""Tests for Keyboard Navigation & Shortcuts (issue #106)."""
+import pytest
+from werkzeug.security import generate_password_hash
+from app.services.keyboard_shortcuts import (
+    get_all_shortcuts,
+    get_shortcuts_by_category,
+    get_user_shortcut_config,
+    update_shortcut,
+    reset_shortcut,
+    reset_all_shortcuts,
+    DEFAULT_SHORTCUTS,
+    UserShortcutPreference,
+)
+from app.models import User
+from app.extensions import db
+
+try:
+    import redis as _redis_lib
+    _r = _redis_lib.Redis.from_url("redis://localhost:6379/15")
+    _r.ping()
+    _redis_available = True
+except Exception:
+    _redis_available = False
+
+requires_redis = pytest.mark.skipif(
+    not _redis_available, reason="Redis not available"
+)
+
+
+def _make_user(email="kb@test.com"):
+    user = User(
+        email=email,
+        password_hash=generate_password_hash("pass"),
+        preferred_currency="USD",
+    )
+    db.session.add(user)
+    db.session.flush()
+    return user
+
+
+# -----------------------------------------------------------------------
+# Unit tests (no DB)
+# -----------------------------------------------------------------------
+
+class TestDefaultShortcuts:
+    def test_get_all_shortcuts(self):
+        shortcuts = get_all_shortcuts()
+        assert len(shortcuts) > 0
+        for s in shortcuts:
+            assert "action" in s
+            assert "label" in s
+            assert "default_key" in s
+            assert "category" in s
+
+    def test_shortcuts_by_category(self):
+        by_cat = get_shortcuts_by_category()
+        assert "navigation" in by_cat
+        assert "actions" in by_cat
+        assert "ui" in by_cat
+
+    def test_navigation_shortcuts_present(self):
+        shortcuts = get_all_shortcuts()
+        actions = [s["action"] for s in shortcuts]
+        assert "nav.dashboard" in actions
+        assert "nav.expenses" in actions
+        assert "nav.bills" in actions
+
+    def test_action_shortcuts_present(self):
+        shortcuts = get_all_shortcuts()
+        actions = [s["action"] for s in shortcuts]
+        assert "action.search" in actions
+        assert "action.new_expense" in actions
+
+    def test_ui_shortcuts_present(self):
+        shortcuts = get_all_shortcuts()
+        actions = [s["action"] for s in shortcuts]
+        assert "ui.help" in actions
+        assert "ui.close_modal" in actions
+        assert "ui.next_item" in actions
+        assert "ui.prev_item" in actions
+
+    def test_at_least_15_shortcuts(self):
+        shortcuts = get_all_shortcuts()
+        assert len(shortcuts) >= 15
+
+    def test_each_shortcut_has_description(self):
+        for s in get_all_shortcuts():
+            assert "description" in s
+            assert len(s["description"]) > 0
+
+
+# -----------------------------------------------------------------------
+# Integration tests
+# -----------------------------------------------------------------------
+
+class TestUserShortcutConfig:
+    def test_get_config_defaults_for_new_user(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("newkb@test.com")
+            db.session.commit()
+            config = get_user_shortcut_config(user.id)
+            assert len(config) == len(DEFAULT_SHORTCUTS)
+            for s in config:
+                assert s["is_customized"] is False
+                assert s["active_key"] == s["default_key"]
+
+    def test_update_creates_preference(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("updatekb@test.com")
+            db.session.commit()
+            result = update_shortcut(user.id, "action.search", "ctrl+k")
+            assert result is not None
+            assert result["custom_key"] == "ctrl+k"
+            assert result["is_customized"] is True
+
+    def test_update_reflects_in_config(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("configkb@test.com")
+            db.session.commit()
+            update_shortcut(user.id, "nav.dashboard", "ctrl+1")
+            config = get_user_shortcut_config(user.id)
+            dash = next(s for s in config if s["action"] == "nav.dashboard")
+            assert dash["custom_key"] == "ctrl+1"
+            assert dash["active_key"] == "ctrl+1"
+            assert dash["is_customized"] is True
+
+    def test_update_unknown_action_returns_none(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("unknownkb@test.com")
+            db.session.commit()
+            result = update_shortcut(user.id, "nonexistent.action", "x")
+            assert result is None
+
+    def test_conflict_detection(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("conflictkb@test.com")
+            db.session.commit()
+            update_shortcut(user.id, "action.search", "ctrl+k")
+            result = update_shortcut(user.id, "nav.dashboard", "ctrl+k")
+            assert result is not None
+            assert "error" in result
+
+    def test_reset_removes_customization(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("resetkb@test.com")
+            db.session.commit()
+            update_shortcut(user.id, "nav.expenses", "ctrl+5")
+            result = reset_shortcut(user.id, "nav.expenses")
+            assert result is not None
+            assert result["is_customized"] is False
+            config = get_user_shortcut_config(user.id)
+            exp = next(s for s in config if s["action"] == "nav.expenses")
+            assert exp["is_customized"] is False
+
+    def test_reset_all_clears_all(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("resetallkb@test.com")
+            db.session.commit()
+            update_shortcut(user.id, "nav.dashboard", "1")
+            update_shortcut(user.id, "nav.bills", "2")
+            count = reset_all_shortcuts(user.id)
+            assert count == 2
+            config = get_user_shortcut_config(user.id)
+            customized = [s for s in config if s["is_customized"]]
+            assert len(customized) == 0
+
+    def test_disable_shortcut(self, app_fixture):
+        with app_fixture.app_context():
+            user = _make_user("disablekb@test.com")
+            db.session.commit()
+            update_shortcut(user.id, "action.import", "ctrl+i", enabled=False)
+            config = get_user_shortcut_config(user.id)
+            imp = next(s for s in config if s["action"] == "action.import")
+            assert imp["enabled"] is False
+            assert imp["active_key"] is None
+
+
+# -----------------------------------------------------------------------
+# API tests (require Redis)
+# -----------------------------------------------------------------------
+
+@requires_redis
+class TestKeyboardShortcutsAPI:
+    def test_list_shortcuts_public(self, client):
+        resp = client.get("/keyboard-shortcuts")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "shortcuts" in data
+        assert data["count"] >= 15
+
+    def test_list_shortcuts_by_category(self, client):
+        resp = client.get("/keyboard-shortcuts?by_category=true")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "navigation" in data
+        assert "actions" in data
+
+    def test_get_user_shortcuts(self, client, auth_header):
+        resp = client.get("/keyboard-shortcuts/user", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "shortcuts" in data
+
+    def test_set_custom_shortcut(self, client, auth_header):
+        resp = client.put("/keyboard-shortcuts/user/action.search",
+                          json={"key": "ctrl+space"},
+                          headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["custom_key"] == "ctrl+space"
+
+    def test_set_unknown_action(self, client, auth_header):
+        resp = client.put("/keyboard-shortcuts/user/fake.action",
+                          json={"key": "x"},
+                          headers=auth_header)
+        assert resp.status_code == 404
+
+    def test_reset_shortcut(self, client, auth_header):
+        client.put("/keyboard-shortcuts/user/nav.dashboard",
+                   json={"key": "ctrl+0"}, headers=auth_header)
+        resp = client.delete("/keyboard-shortcuts/user/nav.dashboard", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["is_customized"] is False
+
+    def test_reset_all(self, client, auth_header):
+        resp = client.post("/keyboard-shortcuts/user/reset-all", headers=auth_header)
+        assert resp.status_code == 200
+
+    def test_list_shortcuts_requires_no_auth(self, client):
+        resp = client.get("/keyboard-shortcuts")
+        assert resp.status_code == 200


### PR DESCRIPTION
/claim #106

## Summary

Implements keyboard-first navigation with 16 default shortcuts, user customization, and conflict detection.

## Shortcuts Included

Navigation (g+key): dashboard, expenses, bills, insights, categories
Actions: new expense, new bill, search (/), import (ctrl+i), export (ctrl+e)
UI: toggle sidebar, toggle dark mode, help (?), close modal (Esc), next/prev item (j/k)

## Features

- UserShortcutPreference model for per-user key binding customization
- Conflict detection: prevents two actions from sharing the same key
- Shortcut enable/disable without deleting the binding
- Reset individual or all shortcuts to defaults
- Grouped view by category (navigation/actions/ui)

## REST API

- GET /keyboard-shortcuts (public, no auth) - all shortcuts
- GET /keyboard-shortcuts?by_category=true - grouped by category
- GET /keyboard-shortcuts/user - user-resolved config
- PUT /keyboard-shortcuts/user/{action} - set custom key
- DELETE /keyboard-shortcuts/user/{action} - reset to default
- POST /keyboard-shortcuts/user/reset-all - reset all

## Tests

23 tests: 15 pass, 8 skip (Redis/JWT)