### PR TITLE
feat: smart payee & merchant alias management (#114)

### DIFF
--- a/packages/backend/app/routes/payee_alias.py
+++ b/packages/backend/app/routes/payee_alias.py
@@ -1,0 +1,59 @@
+from flask import Blueprint, request, jsonify, g
+from ..services.payee_alias import PayeeAliasService
+from ..middleware.auth import require_auth
+
+payee_alias_bp = Blueprint("payee_alias", __name__)
+svc = PayeeAliasService()
+
+@payee_alias_bp.route("/api/payees/aliases", methods=["GET"])
+@require_auth
+def list_aliases():
+    """List all custom payee aliases for the user."""
+    user_id = g.user_id
+    aliases = svc.list_aliases(user_id)
+    return jsonify({"aliases": aliases, "count": len(aliases)})
+
+@payee_alias_bp.route("/api/payees/aliases", methods=["POST"])
+@require_auth
+def create_alias():
+    """Create or update a custom alias for a payee."""
+    user_id = g.user_id
+    data = request.get_json() or {}
+    raw_name = data.get("raw_name", "").strip()
+    alias = data.get("alias", "").strip()
+    if not raw_name or not alias:
+        return jsonify({"error": "raw_name and alias are required"}), 400
+    record = svc.set_alias(user_id, raw_name, alias)
+    return jsonify(record), 201
+
+@payee_alias_bp.route("/api/payees/aliases/<canonical>", methods=["DELETE"])
+@require_auth
+def delete_alias(canonical):
+    """Delete a custom alias by canonical name."""
+    user_id = g.user_id
+    success = svc.delete_alias(user_id, canonical)
+    if not success:
+        return jsonify({"error": "alias not found"}), 404
+    return jsonify({"deleted": True, "canonical": canonical})
+
+@payee_alias_bp.route("/api/payees/normalize", methods=["POST"])
+@require_auth
+def normalize_payees():
+    """Bulk normalize raw merchant names to display names."""
+    user_id = g.user_id
+    data = request.get_json() or {}
+    raw_names = data.get("raw_names", [])
+    if not isinstance(raw_names, list):
+        return jsonify({"error": "raw_names must be a list"}), 400
+    results = svc.bulk_normalize(user_id, raw_names)
+    return jsonify({"results": results})
+
+@payee_alias_bp.route("/api/payees/suggestions", methods=["POST"])
+@require_auth
+def suggest_aliases():
+    """Get alias suggestions for a list of raw merchant names."""
+    user_id = g.user_id
+    data = request.get_json() or {}
+    raw_names = data.get("raw_names", [])
+    suggestions = svc.suggest_aliases(user_id, raw_names)
+    return jsonify({"suggestions": suggestions, "count": len(suggestions)})

--- a/packages/backend/app/services/payee_alias.py
+++ b/packages/backend/app/services/payee_alias.py
@@ -1,0 +1,107 @@
+from typing import Dict, List, Optional, Any
+from collections import defaultdict
+import uuid
+import re
+from datetime import datetime
+
+# In-memory stores
+_payee_aliases: Dict[str, Dict[str, Dict]] = defaultdict(dict)  # user_id -> {canonical: alias_info}
+
+class PayeeAliasService:
+    """
+    Manages smart payee and merchant alias mappings.
+    Normalizes messy merchant names (e.g., "AMZN*MKTP US" -> "Amazon") and
+    allows users to create custom aliases.
+    """
+
+    NORMALIZATION_RULES = [
+        ("amzn", "Amazon"),
+        ("amazon", "Amazon"),
+        ("netflix", "Netflix"),
+        ("spotify", "Spotify"),
+        ("apple.com/bill", "Apple"),
+        ("apple itunes", "Apple"),
+        ("google play", "Google"),
+        ("google storage", "Google"),
+        ("uber eats", "Uber Eats"),
+        ("doordash", "DoorDash"),
+        ("grubhub", "Grubhub"),
+        ("airbnb", "Airbnb"),
+        ("starbucks", "Starbucks"),
+        ("mcdonald", "McDonald's"),
+        ("whole foods", "Whole Foods"),
+        ("costco", "Costco"),
+        ("walmart", "Walmart"),
+        ("chevron", "Chevron"),
+        ("hulu", "Hulu"),
+        ("disney", "Disney+"),
+        ("paypal", "PayPal"),
+        ("venmo", "Venmo"),
+    ]
+
+    def normalize(self, raw_name: str) -> str:
+        cleaned = raw_name.strip().lower()
+        cleaned = re.sub(r"^(tst\*|sq\*|pp\*|pos\*|pmt\*|debit\*)", "", cleaned)
+        cleaned = re.sub(r"\s+(llc|inc|corp|co)\.?$", "", cleaned)
+        cleaned = re.sub(r"\s+\d{4,}$", "", cleaned)
+        cleaned = cleaned.strip()
+
+        for pattern, canonical in self.NORMALIZATION_RULES:
+            if pattern in cleaned:
+                return canonical
+
+        return raw_name.strip().title()
+
+    def get_alias(self, user_id: str, raw_name: str) -> str:
+        canonical = self.normalize(raw_name)
+        user_aliases = _payee_aliases.get(user_id, {})
+        if canonical in user_aliases:
+            return user_aliases[canonical]["alias"]
+        return canonical
+
+    def set_alias(self, user_id: str, raw_name: str, alias: str) -> Dict:
+        canonical = self.normalize(raw_name)
+        record = {
+            "id": str(uuid.uuid4()),
+            "canonical": canonical,
+            "alias": alias,
+            "raw_name": raw_name,
+            "created_at": datetime.utcnow().isoformat(),
+            "updated_at": datetime.utcnow().isoformat(),
+        }
+        _payee_aliases[user_id][canonical] = record
+        return record
+
+    def delete_alias(self, user_id: str, canonical: str) -> bool:
+        if canonical in _payee_aliases.get(user_id, {}):
+            del _payee_aliases[user_id][canonical]
+            return True
+        return False
+
+    def list_aliases(self, user_id: str) -> List[Dict]:
+        return sorted(_payee_aliases.get(user_id, {}).values(), key=lambda x: x["alias"])
+
+    def bulk_normalize(self, user_id: str, raw_names: List[str]) -> List[Dict]:
+        results = []
+        seen: Dict[str, str] = {}
+        for raw in raw_names:
+            if raw not in seen:
+                seen[raw] = self.get_alias(user_id, raw)
+            results.append({"raw": raw, "display": seen[raw]})
+        return results
+
+    def suggest_aliases(self, user_id: str, raw_names: List[str]) -> List[Dict]:
+        suggestions = []
+        seen = set()
+        for raw in raw_names:
+            if raw in seen:
+                continue
+            seen.add(raw)
+            normalized = self.normalize(raw)
+            if normalized != raw.strip().title() and normalized != raw.strip():
+                suggestions.append({
+                    "raw": raw,
+                    "suggested": normalized,
+                    "user_alias": _payee_aliases.get(user_id, {}).get(normalized, {}).get("alias"),
+                })
+        return suggestions

--- a/packages/backend/tests/test_payee_alias.py
+++ b/packages/backend/tests/test_payee_alias.py
@@ -1,0 +1,57 @@
+import pytest
+from app.services.payee_alias import PayeeAliasService, _payee_aliases
+
+@pytest.fixture(autouse=True)
+def clear_data():
+    _payee_aliases.clear()
+    yield
+    _payee_aliases.clear()
+
+@pytest.fixture
+def svc():
+    return PayeeAliasService()
+
+def test_normalize_amazon(svc):
+    assert svc.normalize("AMZN*MKTP US") == "Amazon"
+
+def test_normalize_netflix(svc):
+    assert svc.normalize("NETFLIX.COM") == "Netflix"
+
+def test_normalize_starbucks(svc):
+    assert svc.normalize("STARBUCKS STORE 12345") == "Starbucks"
+
+def test_normalize_unknown_title_cases(svc):
+    result = svc.normalize("local bakery")
+    assert result == "Local Bakery"
+
+def test_set_and_get_alias(svc):
+    svc.set_alias("user1", "AMZN*MKTP US", "My Amazon")
+    result = svc.get_alias("user1", "AMZN*MKTP US")
+    assert result == "My Amazon"
+
+def test_delete_alias(svc):
+    svc.set_alias("user2", "NETFLIX.COM", "Streaming")
+    success = svc.delete_alias("user2", "Netflix")
+    assert success is True
+    result = svc.get_alias("user2", "NETFLIX.COM")
+    assert result == "Netflix"  # Falls back to auto-normalized
+
+def test_bulk_normalize(svc):
+    raw_names = ["AMZN*MKTP US", "NETFLIX.COM", "unknown store"]
+    results = svc.bulk_normalize("user3", raw_names)
+    display_map = {r["raw"]: r["display"] for r in results}
+    assert display_map["AMZN*MKTP US"] == "Amazon"
+    assert display_map["NETFLIX.COM"] == "Netflix"
+
+def test_suggest_aliases(svc):
+    raw_names = ["AMZN*MKTP US", "NETFLIX.COM", "local bakery"]
+    suggestions = svc.suggest_aliases("user4", raw_names)
+    suggested_raws = [s["raw"] for s in suggestions]
+    assert "AMZN*MKTP US" in suggested_raws
+    assert "NETFLIX.COM" in suggested_raws
+
+def test_list_aliases(svc):
+    svc.set_alias("user5", "AMZN*MKTP US", "Shopping")
+    svc.set_alias("user5", "NETFLIX.COM", "Movies")
+    aliases = svc.list_aliases("user5")
+    assert len(aliases) == 2


### PR DESCRIPTION
## Summary

Implements smart payee normalization and custom alias management for clean merchant names.

## Features

- Auto-normalization: 20+ built-in rules (AMZN*MKTP US -> Amazon, NETFLIX.COM -> Netflix)
- Strips common prefixes (TST*, SQ*, PP*) and suffixes (LLC, Inc, reference numbers)
- Custom alias CRUD: override any canonical name with a personal alias
- Bulk normalization API for processing entire transaction lists
- Alias suggestions: auto-surfaces normalization candidates for user confirmation
- Per-user alias storage for personalization

## API Endpoints

- GET /api/payees/aliases — list all custom aliases
- POST /api/payees/aliases — create/update alias {raw_name, alias}
- DELETE /api/payees/aliases/{canonical} — remove alias
- POST /api/payees/normalize — bulk normalize {raw_names: [...]}
- POST /api/payees/suggestions — get alias suggestions {raw_names: [...]}

## Tests

9 tests: normalization rules, custom CRUD, bulk normalize, suggestions.

Closes #114