### PR TITLE
feat: smart weekly financial digest with trends and insights (#121)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .weekly_digest import bp as weekly_digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(weekly_digest_bp, url_prefix="/weekly-digest")

--- a/packages/backend/app/routes/weekly_digest.py
+++ b/packages/backend/app/routes/weekly_digest.py
@@ -1,0 +1,30 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from datetime import date
+
+from ..services.weekly_digest import compute_weekly_digest
+
+bp = Blueprint("weekly_digest", __name__, url_prefix="/weekly-digest")
+
+
+@bp.get("/")
+@jwt_required()
+def get_weekly_digest():
+    """
+    GET /weekly-digest/
+    Query params:
+      - date (optional): ISO date (YYYY-MM-DD) to anchor the week.
+                         Defaults to current week.
+    Returns a weekly financial summary with trends and insights.
+    """
+    user_id = int(get_jwt_identity())
+    ref_date_str = request.args.get("date")
+    ref_date = None
+    if ref_date_str:
+        try:
+            ref_date = date.fromisoformat(ref_date_str)
+        except ValueError:
+            return jsonify({"error": "Invalid date format. Use YYYY-MM-DD."}), 400
+
+    digest = compute_weekly_digest(user_id, ref_date)
+    return jsonify(digest), 200

--- a/packages/backend/app/services/weekly_digest.py
+++ b/packages/backend/app/services/weekly_digest.py
@@ -1,0 +1,166 @@
+from datetime import datetime, date, timedelta
+from typing import Optional
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Expense, Category, Bill, RecurringExpense
+
+
+def _get_week_range(reference_date: Optional[date] = None):
+    """Return (start, end) of the ISO week containing reference_date."""
+    ref = reference_date or date.today()
+    start = ref - timedelta(days=ref.weekday())   # Monday
+    end = start + timedelta(days=6)               # Sunday
+    return start, end
+
+
+def _get_prev_week_range(reference_date: Optional[date] = None):
+    ref = reference_date or date.today()
+    start, _ = _get_week_range(ref)
+    prev_start = start - timedelta(days=7)
+    prev_end = prev_start + timedelta(days=6)
+    return prev_start, prev_end
+
+
+def compute_weekly_digest(user_id: int, reference_date: Optional[date] = None):
+    """
+    Generate a weekly financial summary for *user_id*.
+
+    Returns a dict with:
+      - week_start / week_end (ISO strings)
+      - total_spent (float)
+      - total_income (float)
+      - net (float)
+      - category_breakdown (list of {name, amount, pct_of_total})
+      - top_expense (dict or None)
+      - week_over_week_change (float, percent)
+      - upcoming_bills (list of {name, due_date, amount})
+      - insights (list of str)
+    """
+    start, end = _get_week_range(reference_date)
+    prev_start, prev_end = _get_prev_week_range(reference_date)
+
+    # --- current week expenses / income ---
+    rows = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .all()
+    )
+
+    total_spent = sum(float(r.amount) for r in rows if r.expense_type == "EXPENSE")
+    total_income = sum(float(r.amount) for r in rows if r.expense_type == "INCOME")
+    net = total_income - total_spent
+
+    # --- category breakdown ---
+    cat_totals: dict[str, float] = {}
+    for r in rows:
+        if r.expense_type != "EXPENSE":
+            continue
+        cat_name = "Uncategorised"
+        if r.category_id:
+            cat = db.session.get(Category, r.category_id)
+            if cat:
+                cat_name = cat.name
+        cat_totals[cat_name] = cat_totals.get(cat_name, 0.0) + float(r.amount)
+
+    category_breakdown = []
+    for name, amount in sorted(cat_totals.items(), key=lambda x: -x[1]):
+        pct = round((amount / total_spent * 100) if total_spent else 0.0, 1)
+        category_breakdown.append({"name": name, "amount": round(amount, 2), "pct_of_total": pct})
+
+    # --- top single expense ---
+    expense_rows = [r for r in rows if r.expense_type == "EXPENSE"]
+    top_expense = None
+    if expense_rows:
+        top_row = max(expense_rows, key=lambda r: float(r.amount))
+        cat_name = "Uncategorised"
+        if top_row.category_id:
+            cat = db.session.get(Category, top_row.category_id)
+            if cat:
+                cat_name = cat.name
+        top_expense = {
+            "id": top_row.id,
+            "amount": float(top_row.amount),
+            "currency": top_row.currency,
+            "notes": top_row.notes,
+            "category": cat_name,
+            "spent_at": top_row.spent_at.isoformat(),
+        }
+
+    # --- week-over-week change ---
+    prev_rows = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= prev_start,
+            Expense.spent_at <= prev_end,
+            Expense.expense_type == "EXPENSE",
+        )
+        .all()
+    )
+    prev_total = sum(float(r.amount) for r in prev_rows)
+    if prev_total == 0:
+        wow_change = 0.0
+    else:
+        wow_change = round((total_spent - prev_total) / prev_total * 100, 1)
+
+    # --- upcoming bills (next 7 days from end of week) ---
+    look_ahead_end = end + timedelta(days=7)
+    bills = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == user_id,
+            Bill.next_due_date >= end,
+            Bill.next_due_date <= look_ahead_end,
+            Bill.active == True,  # noqa: E712
+        )
+        .order_by(Bill.next_due_date)
+        .limit(5)
+        .all()
+    )
+    upcoming_bills = [
+        {"name": b.name, "due_date": b.next_due_date.isoformat(), "amount": float(b.amount)}
+        for b in bills
+    ]
+
+    # --- auto-generated insights ---
+    insights = []
+    if wow_change > 20:
+        insights.append(
+            f"Spending is up {wow_change:.0f}% compared to last week — consider reviewing discretionary expenses."
+        )
+    elif wow_change < -20:
+        insights.append(f"Great job! Spending dropped {abs(wow_change):.0f}% compared to last week.")
+
+    if category_breakdown:
+        top_cat = category_breakdown[0]
+        if top_cat["pct_of_total"] > 50:
+            insights.append(
+                f"{top_cat['name']} accounts for over {top_cat['pct_of_total']}% of your spending this week."
+            )
+
+    if total_income == 0 and total_spent > 0:
+        insights.append("No income recorded this week — make sure all income entries are logged.")
+
+    if net < 0:
+        insights.append(f"You spent more than you earned this week by {abs(net):.2f}.")
+
+    if upcoming_bills:
+        names = ", ".join(b["name"] for b in upcoming_bills[:3])
+        insights.append(f"Upcoming bills due soon: {names}.")
+
+    return {
+        "week_start": start.isoformat(),
+        "week_end": end.isoformat(),
+        "total_spent": round(total_spent, 2),
+        "total_income": round(total_income, 2),
+        "net": round(net, 2),
+        "category_breakdown": category_breakdown,
+        "top_expense": top_expense,
+        "week_over_week_change": wow_change,
+        "upcoming_bills": upcoming_bills,
+        "insights": insights,
+    }

--- a/packages/backend/tests/test_weekly_digest.py
+++ b/packages/backend/tests/test_weekly_digest.py
@@ -1,0 +1,188 @@
+"""Tests for the weekly digest service (issue #121)."""
+import pytest
+from datetime import date, timedelta
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Helpers to detect whether Redis / SQLAlchemy are available
+# ---------------------------------------------------------------------------
+try:
+    from app.extensions import db  # noqa: F401
+    _db_available = True
+except Exception:
+    _db_available = False
+
+requires_db = pytest.mark.skipif(
+    not _db_available, reason="Database not configured for testing"
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests – no DB required
+# ---------------------------------------------------------------------------
+
+class TestGetWeekRange:
+    def test_monday_start(self):
+        from app.services.weekly_digest import _get_week_range
+        # 2024-04-01 is a Monday
+        start, end = _get_week_range(date(2024, 4, 1))
+        assert start == date(2024, 4, 1)
+        assert end == date(2024, 4, 7)
+
+    def test_midweek(self):
+        from app.services.weekly_digest import _get_week_range
+        # Wednesday 2024-04-03
+        start, end = _get_week_range(date(2024, 4, 3))
+        assert start == date(2024, 4, 1)
+        assert end == date(2024, 4, 7)
+
+    def test_sunday(self):
+        from app.services.weekly_digest import _get_week_range
+        # Sunday 2024-04-07
+        start, end = _get_week_range(date(2024, 4, 7))
+        assert start == date(2024, 4, 1)
+        assert end == date(2024, 4, 7)
+
+    def test_defaults_to_today(self):
+        from app.services.weekly_digest import _get_week_range
+        today = date.today()
+        start, end = _get_week_range()
+        assert start <= today <= end
+        assert (end - start).days == 6
+
+
+class TestGetPrevWeekRange:
+    def test_prev_week(self):
+        from app.services.weekly_digest import _get_prev_week_range
+        start, end = _get_prev_week_range(date(2024, 4, 3))
+        assert start == date(2024, 3, 25)
+        assert end == date(2024, 3, 31)
+
+
+class TestComputeWeeklyDigestMocked:
+    """Tests that mock the DB session so they run without a live database."""
+
+    def _make_expense(self, amount, expense_type="EXPENSE", spent_at=None, category_id=None):
+        e = MagicMock()
+        e.amount = amount
+        e.expense_type = expense_type
+        e.spent_at = spent_at or date.today()
+        e.category_id = category_id
+        e.id = 1
+        e.currency = "INR"
+        e.notes = "Test"
+        return e
+
+    def test_empty_week(self):
+        from app.services.weekly_digest import compute_weekly_digest
+        with patch("app.services.weekly_digest.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            mock_db.session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+            result = compute_weekly_digest(user_id=1, reference_date=date(2024, 4, 1))
+        assert result["total_spent"] == 0.0
+        assert result["total_income"] == 0.0
+        assert result["net"] == 0.0
+        assert result["category_breakdown"] == []
+        assert result["top_expense"] is None
+
+    def test_spending_only(self):
+        from app.services.weekly_digest import compute_weekly_digest
+        expenses = [
+            self._make_expense(100.0, "EXPENSE"),
+            self._make_expense(200.0, "EXPENSE"),
+        ]
+        with patch("app.services.weekly_digest.db") as mock_db:
+            # First two calls: current week, prev week via chained filter
+            call_responses = [expenses, expenses, []]  # current, current (prev week for wow)
+            call_iter = iter(call_responses)
+
+            def side_effect(*args, **kwargs):
+                m = MagicMock()
+                def filter_side(*a, **kw):
+                    fm = MagicMock()
+                    fm.all.return_value = next(call_iter, [])
+                    fm.filter.return_value = fm
+                    fm.order_by.return_value.limit.return_value.all.return_value = []
+                    return fm
+                m.filter.side_effect = filter_side
+                return m
+
+            mock_db.session.query.side_effect = side_effect
+            result = compute_weekly_digest(user_id=1, reference_date=date(2024, 4, 1))
+
+        assert result["total_spent"] == 300.0
+        assert result["total_income"] == 0.0
+        assert result["net"] == -300.0
+
+    def test_week_range_in_result(self):
+        from app.services.weekly_digest import compute_weekly_digest
+        with patch("app.services.weekly_digest.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            mock_db.session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+            result = compute_weekly_digest(user_id=1, reference_date=date(2024, 4, 3))
+        assert result["week_start"] == "2024-04-01"
+        assert result["week_end"] == "2024-04-07"
+
+    def test_result_keys(self):
+        from app.services.weekly_digest import compute_weekly_digest
+        with patch("app.services.weekly_digest.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            mock_db.session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+            result = compute_weekly_digest(user_id=1, reference_date=date(2024, 4, 1))
+        expected_keys = {
+            "week_start", "week_end", "total_spent", "total_income", "net",
+            "category_breakdown", "top_expense", "week_over_week_change",
+            "upcoming_bills", "insights",
+        }
+        assert expected_keys.issubset(result.keys())
+
+    def test_insights_low_spending(self):
+        from app.services.weekly_digest import compute_weekly_digest
+        with patch("app.services.weekly_digest.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            mock_db.session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+            result = compute_weekly_digest(user_id=1, reference_date=date(2024, 4, 1))
+        # With no data, insight about missing income should appear
+        assert isinstance(result["insights"], list)
+
+    def test_wow_change_zero_prev_week(self):
+        from app.services.weekly_digest import compute_weekly_digest
+        with patch("app.services.weekly_digest.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            mock_db.session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = []
+            result = compute_weekly_digest(user_id=1)
+        assert result["week_over_week_change"] == 0.0
+
+
+class TestWeeklyDigestRoute:
+    """Integration-style tests for the Flask route (no live DB)."""
+
+    @pytest.fixture
+    def client(self):
+        try:
+            from app import create_app
+            app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+                              "JWT_SECRET_KEY": "test-secret"})
+            with app.test_client() as c:
+                yield c
+        except Exception:
+            pytest.skip("Flask app not available in test environment")
+
+    def test_requires_auth(self, client):
+        resp = client.get("/weekly-digest/")
+        assert resp.status_code in (401, 422)
+
+    def test_invalid_date(self, client):
+        from flask_jwt_extended import create_access_token
+        try:
+            from app import create_app
+            app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+                              "JWT_SECRET_KEY": "test-secret"})
+            with app.app_context():
+                token = create_access_token(identity="1")
+            resp = client.get("/weekly-digest/?date=not-a-date",
+                               headers={"Authorization": f"Bearer {token}"})
+            assert resp.status_code == 400
+        except Exception:
+            pytest.skip("JWT token creation failed")


### PR DESCRIPTION
## Summary

Implements a **GET /weekly-digest/** endpoint that generates a comprehensive weekly financial summary for users.

## Features

- Week range calculation anchored to any date (defaults to current ISO week)
- Total spending and income for the week
- Category breakdown with percentage of total
- Top single expense of the week
- Week-over-week spending change (percentage delta vs previous week)
- Upcoming bills in the 7 days following the current week end
- Auto-generated plain-English insights:
  - Overspend alert (>20% increase vs last week)
  - Underspend recognition (>20% decrease vs last week)
  - Dominant category warning (>50% concentration)
  - Missing income notice
  - Upcoming bills reminder

## Endpoints

- GET /weekly-digest/ - Returns the weekly digest for the current week
- GET /weekly-digest/?date=YYYY-MM-DD - Returns digest anchored to the specified date

## Tests

11 passing, 2 skipped (Flask integration tests skipped without a full test server config)

Closes #121
