### PR TITLE
feat: reminder reliability tracking & delivery metrics (#123)

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -100,6 +100,31 @@ class Reminder(db.Model):
     channel = db.Column(db.String(20), default="email", nullable=False)
 
 
+class ReminderDeliveryStatus(str, Enum):
+    SENT = "SENT"
+    FAILED = "FAILED"
+    PENDING = "PENDING"
+    BOUNCED = "BOUNCED"
+
+
+class ReminderDeliveryLog(db.Model):
+    """Tracks each delivery attempt for a Reminder."""
+    __tablename__ = "reminder_delivery_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    reminder_id = db.Column(db.Integer, db.ForeignKey("reminders.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    status = db.Column(
+        SAEnum(ReminderDeliveryStatus),
+        default=ReminderDeliveryStatus.PENDING,
+        nullable=False,
+    )
+    channel = db.Column(db.String(20), nullable=False)
+    attempted_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    delivered_at = db.Column(db.DateTime, nullable=True)
+    error_message = db.Column(db.String(500), nullable=True)
+    latency_ms = db.Column(db.Integer, nullable=True)  # ms from send_at to delivered_at
+
+
 class AdImpression(db.Model):
     __tablename__ = "ad_impressions"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/reminder_reliability.py
+++ b/packages/backend/app/routes/reminder_reliability.py
@@ -1,0 +1,63 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.reminder_reliability import get_reliability_metrics, log_delivery_attempt
+from ..models import ReminderDeliveryStatus
+
+bp = Blueprint("reminder_reliability", __name__, url_prefix="/reminders/reliability")
+
+
+@bp.get("/")
+@jwt_required()
+def reliability_metrics():
+    """
+    GET /reminders/reliability/
+    Query params:
+      - days (optional, default 30): number of days to analyse
+    Returns delivery reliability stats for the authenticated user.
+    """
+    user_id = int(get_jwt_identity())
+    try:
+        days = int(request.args.get("days", 30))
+        if days < 1 or days > 365:
+            raise ValueError
+    except (ValueError, TypeError):
+        return jsonify({"error": "days must be an integer between 1 and 365"}), 400
+
+    metrics = get_reliability_metrics(user_id, days)
+    return jsonify(metrics), 200
+
+
+@bp.post("/log")
+@jwt_required()
+def log_attempt():
+    """
+    POST /reminders/reliability/log
+    Body: {reminder_id, channel, status, error_message?, latency_ms?}
+    Records a delivery attempt for auditing purposes.
+    """
+    user_id = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+
+    reminder_id = data.get("reminder_id")
+    channel = data.get("channel")
+    status_str = data.get("status")
+
+    if not reminder_id or not channel or not status_str:
+        return jsonify({"error": "reminder_id, channel, and status are required"}), 400
+
+    try:
+        status = ReminderDeliveryStatus(status_str.upper())
+    except ValueError:
+        valid = [s.value for s in ReminderDeliveryStatus]
+        return jsonify({"error": f"status must be one of: {valid}"}), 400
+
+    log = log_delivery_attempt(
+        reminder_id=reminder_id,
+        user_id=user_id,
+        channel=channel,
+        status=status,
+        error_message=data.get("error_message"),
+        latency_ms=data.get("latency_ms"),
+    )
+    return jsonify({"id": log.id, "status": log.status.value}), 201

--- a/packages/backend/app/services/reminder_reliability.py
+++ b/packages/backend/app/services/reminder_reliability.py
@@ -1,0 +1,117 @@
+"""Reminder reliability tracking and delivery metrics (issue #123)."""
+from datetime import datetime, timedelta
+from typing import Optional
+from ..extensions import db
+from ..models import Reminder, ReminderDeliveryLog, ReminderDeliveryStatus
+
+
+def log_delivery_attempt(
+    reminder_id: int,
+    user_id: int,
+    channel: str,
+    status: ReminderDeliveryStatus,
+    error_message: Optional[str] = None,
+    latency_ms: Optional[int] = None,
+) -> ReminderDeliveryLog:
+    """Record a delivery attempt for a reminder."""
+    now = datetime.utcnow()
+    log = ReminderDeliveryLog(
+        reminder_id=reminder_id,
+        user_id=user_id,
+        channel=channel,
+        status=status,
+        attempted_at=now,
+        delivered_at=now if status == ReminderDeliveryStatus.SENT else None,
+        error_message=error_message,
+        latency_ms=latency_ms,
+    )
+    db.session.add(log)
+    db.session.commit()
+    return log
+
+
+def get_reliability_metrics(user_id: int, days: int = 30) -> dict:
+    """
+    Compute delivery reliability metrics for a user's reminders over the last *days* days.
+
+    Returns:
+      - total_attempts   (int)
+      - sent             (int)
+      - failed           (int)
+      - bounced          (int)
+      - pending          (int)
+      - delivery_rate    (float, 0-1)
+      - failure_rate     (float, 0-1)
+      - avg_latency_ms   (float | None)
+      - channel_breakdown (list of {channel, sent, failed, delivery_rate})
+      - recent_failures  (list of {reminder_id, channel, error, attempted_at})
+    """
+    since = datetime.utcnow() - timedelta(days=days)
+    logs = (
+        db.session.query(ReminderDeliveryLog)
+        .filter(
+            ReminderDeliveryLog.user_id == user_id,
+            ReminderDeliveryLog.attempted_at >= since,
+        )
+        .all()
+    )
+
+    total = len(logs)
+    sent = sum(1 for l in logs if l.status == ReminderDeliveryStatus.SENT)
+    failed = sum(1 for l in logs if l.status == ReminderDeliveryStatus.FAILED)
+    bounced = sum(1 for l in logs if l.status == ReminderDeliveryStatus.BOUNCED)
+    pending = sum(1 for l in logs if l.status == ReminderDeliveryStatus.PENDING)
+
+    delivery_rate = round(sent / total, 4) if total else 0.0
+    failure_rate = round((failed + bounced) / total, 4) if total else 0.0
+
+    latencies = [l.latency_ms for l in logs if l.latency_ms is not None]
+    avg_latency = round(sum(latencies) / len(latencies), 1) if latencies else None
+
+    # Channel breakdown
+    channels: dict[str, dict] = {}
+    for l in logs:
+        ch = l.channel
+        if ch not in channels:
+            channels[ch] = {"sent": 0, "failed": 0, "total": 0}
+        channels[ch]["total"] += 1
+        if l.status == ReminderDeliveryStatus.SENT:
+            channels[ch]["sent"] += 1
+        elif l.status in (ReminderDeliveryStatus.FAILED, ReminderDeliveryStatus.BOUNCED):
+            channels[ch]["failed"] += 1
+
+    channel_breakdown = [
+        {
+            "channel": ch,
+            "sent": v["sent"],
+            "failed": v["failed"],
+            "delivery_rate": round(v["sent"] / v["total"], 4) if v["total"] else 0.0,
+        }
+        for ch, v in sorted(channels.items())
+    ]
+
+    # Recent failures
+    recent_failures = [
+        {
+            "reminder_id": l.reminder_id,
+            "channel": l.channel,
+            "error": l.error_message,
+            "attempted_at": l.attempted_at.isoformat(),
+        }
+        for l in sorted(logs, key=lambda x: x.attempted_at, reverse=True)
+        if l.status in (ReminderDeliveryStatus.FAILED, ReminderDeliveryStatus.BOUNCED)
+    ][:10]
+
+    return {
+        "period_days": days,
+        "total_attempts": total,
+        "sent": sent,
+        "failed": failed,
+        "bounced": bounced,
+        "pending": pending,
+        "delivery_rate": delivery_rate,
+        "failure_rate": failure_rate,
+        "avg_latency_ms": avg_latency,
+        "channel_breakdown": channel_breakdown,
+        "recent_failures": recent_failures,
+    }

--- a/packages/backend/tests/test_reminder_reliability.py
+++ b/packages/backend/tests/test_reminder_reliability.py
@@ -1,0 +1,130 @@
+"""Tests for reminder reliability tracking & delivery metrics (issue #123)."""
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock, call
+
+
+# ---------------------------------------------------------------------------
+# DB availability guard
+# ---------------------------------------------------------------------------
+try:
+    from app.extensions import db  # noqa: F401
+    _db_available = True
+except Exception:
+    _db_available = False
+
+requires_db = pytest.mark.skipif(not _db_available, reason="Database not configured")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - no DB required
+# ---------------------------------------------------------------------------
+
+class TestReminderDeliveryStatusEnum:
+    def test_all_statuses_valid(self):
+        from app.models import ReminderDeliveryStatus
+        assert ReminderDeliveryStatus.SENT.value == "SENT"
+        assert ReminderDeliveryStatus.FAILED.value == "FAILED"
+        assert ReminderDeliveryStatus.PENDING.value == "PENDING"
+        assert ReminderDeliveryStatus.BOUNCED.value == "BOUNCED"
+
+    def test_from_string(self):
+        from app.models import ReminderDeliveryStatus
+        s = ReminderDeliveryStatus("SENT")
+        assert s == ReminderDeliveryStatus.SENT
+
+
+class TestGetReliabilityMetricsMocked:
+    def _make_log(self, status, channel="email", latency_ms=None):
+        from app.models import ReminderDeliveryStatus
+        log = MagicMock()
+        log.status = ReminderDeliveryStatus(status)
+        log.channel = channel
+        log.latency_ms = latency_ms
+        log.reminder_id = 1
+        log.error_message = None
+        log.attempted_at = datetime(2024, 4, 1, 12, 0, 0)
+        return log
+
+    def test_empty_logs(self):
+        from app.services.reminder_reliability import get_reliability_metrics
+        with patch("app.services.reminder_reliability.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            result = get_reliability_metrics(user_id=1, days=30)
+        assert result["total_attempts"] == 0
+        assert result["delivery_rate"] == 0.0
+        assert result["failure_rate"] == 0.0
+        assert result["avg_latency_ms"] is None
+
+    def test_all_sent(self):
+        from app.services.reminder_reliability import get_reliability_metrics
+        logs = [self._make_log("SENT", latency_ms=120) for _ in range(5)]
+        with patch("app.services.reminder_reliability.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = logs
+            result = get_reliability_metrics(user_id=1, days=30)
+        assert result["sent"] == 5
+        assert result["failed"] == 0
+        assert result["delivery_rate"] == 1.0
+        assert result["avg_latency_ms"] == 120.0
+
+    def test_mixed_statuses(self):
+        from app.services.reminder_reliability import get_reliability_metrics
+        logs = [
+            self._make_log("SENT"),
+            self._make_log("SENT"),
+            self._make_log("FAILED"),
+            self._make_log("BOUNCED"),
+        ]
+        with patch("app.services.reminder_reliability.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = logs
+            result = get_reliability_metrics(user_id=1, days=30)
+        assert result["total_attempts"] == 4
+        assert result["sent"] == 2
+        assert result["failed"] == 1
+        assert result["bounced"] == 1
+        assert result["delivery_rate"] == 0.5
+        assert result["failure_rate"] == 0.5
+
+    def test_channel_breakdown(self):
+        from app.services.reminder_reliability import get_reliability_metrics
+        logs = [
+            self._make_log("SENT", channel="email"),
+            self._make_log("FAILED", channel="email"),
+            self._make_log("SENT", channel="whatsapp"),
+        ]
+        with patch("app.services.reminder_reliability.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = logs
+            result = get_reliability_metrics(user_id=1)
+        breakdown = {item["channel"]: item for item in result["channel_breakdown"]}
+        assert "email" in breakdown
+        assert "whatsapp" in breakdown
+        assert breakdown["whatsapp"]["delivery_rate"] == 1.0
+        assert breakdown["email"]["sent"] == 1
+        assert breakdown["email"]["failed"] == 1
+
+    def test_result_structure(self):
+        from app.services.reminder_reliability import get_reliability_metrics
+        with patch("app.services.reminder_reliability.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            result = get_reliability_metrics(user_id=1)
+        expected_keys = {
+            "period_days", "total_attempts", "sent", "failed", "bounced",
+            "pending", "delivery_rate", "failure_rate", "avg_latency_ms",
+            "channel_breakdown", "recent_failures",
+        }
+        assert expected_keys.issubset(result.keys())
+
+    def test_recent_failures_limited(self):
+        from app.services.reminder_reliability import get_reliability_metrics
+        logs = [self._make_log("FAILED") for _ in range(15)]
+        with patch("app.services.reminder_reliability.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = logs
+            result = get_reliability_metrics(user_id=1)
+        assert len(result["recent_failures"]) <= 10
+
+    def test_period_days_in_result(self):
+        from app.services.reminder_reliability import get_reliability_metrics
+        with patch("app.services.reminder_reliability.db") as mock_db:
+            mock_db.session.query.return_value.filter.return_value.all.return_value = []
+            result = get_reliability_metrics(user_id=1, days=7)
+        assert result["period_days"] == 7


### PR DESCRIPTION
## Summary

Implements reminder delivery reliability tracking with metrics endpoint.

## New Model: ReminderDeliveryLog

- reminder_id, user_id, channel, status (SENT/FAILED/PENDING/BOUNCED)
- attempted_at, delivered_at, error_message, latency_ms

## Endpoints

- GET /reminders/reliability/?days=30 - delivery stats for period
- POST /reminders/reliability/log - record a delivery attempt

## Metrics Returned

- total_attempts, sent, failed, bounced, pending
- delivery_rate, failure_rate (0-1 floats)
- avg_latency_ms
- channel_breakdown (per-channel delivery rates)
- recent_failures (last 10 failed/bounced with error details)

## Tests

9 passing

Closes #123
