### PR TITLE
feat: Login anomaly detection system (#124)

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from flask import Flask, jsonify
 from .config import Settings
 from .extensions import db, jwt

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,30 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Login anomaly detection tables
+CREATE TABLE IF NOT EXISTS login_attempts (
+  id SERIAL PRIMARY KEY,
+  user_id INT REFERENCES users(id) ON DELETE SET NULL,
+  email VARCHAR(255) NOT NULL,
+  ip_address VARCHAR(45) NOT NULL,
+  user_agent VARCHAR(500),
+  success BOOLEAN NOT NULL,
+  country VARCHAR(100),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_login_attempts_user ON login_attempts(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_login_attempts_email ON login_attempts(email, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS login_alerts (
+  id SERIAL PRIMARY KEY,
+  user_id INT REFERENCES users(id) ON DELETE CASCADE,
+  alert_type VARCHAR(50) NOT NULL,
+  severity VARCHAR(10) NOT NULL DEFAULT 'MEDIUM',
+  message VARCHAR(500) NOT NULL,
+  metadata_json TEXT,
+  acknowledged BOOLEAN NOT NULL DEFAULT FALSE,
+  login_attempt_id INT REFERENCES login_attempts(id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_login_alerts_user ON login_alerts(user_id, acknowledged, created_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,37 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class LoginAttempt(db.Model):
+    __tablename__ = "login_attempts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    email = db.Column(db.String(255), nullable=False)
+    ip_address = db.Column(db.String(45), nullable=False)
+    user_agent = db.Column(db.String(500), nullable=True)
+    success = db.Column(db.Boolean, nullable=False)
+    country = db.Column(db.String(100), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AlertSeverity(str, Enum):
+    LOW = "LOW"
+    MEDIUM = "MEDIUM"
+    HIGH = "HIGH"
+    CRITICAL = "CRITICAL"
+
+
+class LoginAlert(db.Model):
+    __tablename__ = "login_alerts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    alert_type = db.Column(db.String(50), nullable=False)
+    severity = db.Column(db.String(10), nullable=False, default=AlertSeverity.MEDIUM.value)
+    message = db.Column(db.String(500), nullable=False)
+    metadata_json = db.Column(db.Text, nullable=True)
+    acknowledged = db.Column(db.Boolean, default=False, nullable=False)
+    login_attempt_id = db.Column(
+        db.Integer, db.ForeignKey("login_attempts.id"), nullable=True
+    )
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -444,6 +444,87 @@ paths:
                 properties:
                   created: { type: integer }
 
+  /auth/security/history:
+    get:
+      summary: Login history
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: limit
+          required: false
+          schema: { type: integer, default: 20, minimum: 1, maximum: 100 }
+      responses:
+        '200':
+          description: Recent login attempts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LoginAttempt'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /auth/security/alerts:
+    get:
+      summary: Login security alerts
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: include_acknowledged
+          required: false
+          schema: { type: string, enum: ['true', 'false'], default: 'false' }
+      responses:
+        '200':
+          description: Login alerts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LoginAlert'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /auth/security/alerts/{alertId}/acknowledge:
+    post:
+      summary: Acknowledge a login alert
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: alertId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Acknowledged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+                  alert_id: { type: integer }
+        '404':
+          description: Alert not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
   /insights/budget-suggestion:
     get:
       summary: Get monthly budget suggestion
@@ -587,3 +668,22 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    LoginAttempt:
+      type: object
+      properties:
+        id: { type: integer }
+        ip_address: { type: string }
+        user_agent: { type: string, nullable: true }
+        success: { type: boolean }
+        country: { type: string, nullable: true }
+        created_at: { type: string, format: date-time }
+    LoginAlert:
+      type: object
+      properties:
+        id: { type: integer }
+        alert_type: { type: string, enum: [BRUTE_FORCE, NEW_IP, NEW_DEVICE, ODD_HOUR, IMPOSSIBLE_TRAVEL] }
+        severity: { type: string, enum: [LOW, MEDIUM, HIGH, CRITICAL] }
+        message: { type: string }
+        metadata: { type: object, nullable: true }
+        acknowledged: { type: boolean }
+        created_at: { type: string, format: date-time }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .login_security import bp as login_security_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(login_security_bp, url_prefix="/auth/security")

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -10,6 +10,11 @@ from flask_jwt_extended import (
 )
 from ..extensions import db, redis_client
 from ..models import User
+from ..services.login_anomaly import (
+    analyse_login,
+    check_account_locked,
+    record_login_attempt,
+)
 import logging
 import time
 
@@ -55,15 +60,53 @@ def login():
     data = request.get_json() or {}
     email = data.get("email")
     password = data.get("password")
+    ip_address = request.remote_addr or "unknown"
+    user_agent = request.headers.get("User-Agent")
+
+    # Check account lockout (brute-force protection)
+    if email and check_account_locked(email):
+        logger.warning("Login blocked – account locked for email=%s", email)
+        return jsonify(error="account temporarily locked, try again later"), 429
+
     user = db.session.query(User).filter_by(email=email).first()
     if not user or not check_password_hash(user.password_hash, password):
         logger.warning("Login failed for email=%s", email)
+        # Record failed attempt
+        attempt = record_login_attempt(
+            email=email or "",
+            ip_address=ip_address,
+            user_agent=user_agent,
+            success=False,
+            user_id=user.id if user else None,
+        )
+        analyse_login(attempt)
         return jsonify(error="invalid credentials"), 401
+
+    # Record successful attempt and run anomaly checks
+    attempt = record_login_attempt(
+        email=email,
+        ip_address=ip_address,
+        user_agent=user_agent,
+        success=True,
+        user_id=user.id,
+    )
+    alerts = analyse_login(attempt)
+
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
     logger.info("Login success user_id=%s", user.id)
-    return jsonify(access_token=access, refresh_token=refresh)
+
+    response_body: dict = {
+        "access_token": access,
+        "refresh_token": refresh,
+    }
+    if alerts:
+        response_body["security_alerts"] = [
+            {"alert_type": a.alert_type, "severity": a.severity, "message": a.message}
+            for a in alerts
+        ]
+    return jsonify(response_body)
 
 
 @bp.get("/me")

--- a/packages/backend/app/routes/login_security.py
+++ b/packages/backend/app/routes/login_security.py
@@ -1,0 +1,68 @@
+"""Routes for login security: history, alerts, and acknowledgement."""
+
+from __future__ import annotations
+
+import json
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.login_anomaly import (
+    acknowledge_alert,
+    get_alerts,
+    get_recent_attempts,
+)
+
+bp = Blueprint("login_security", __name__)
+
+
+@bp.get("/history")
+@jwt_required()
+def login_history():
+    """Return recent login attempts for the authenticated user."""
+    uid = int(get_jwt_identity())
+    limit = request.args.get("limit", 20, type=int)
+    limit = min(max(limit, 1), 100)
+    attempts = get_recent_attempts(uid, limit=limit)
+    return jsonify([
+        {
+            "id": a.id,
+            "ip_address": a.ip_address,
+            "user_agent": a.user_agent,
+            "success": a.success,
+            "country": a.country,
+            "created_at": a.created_at.isoformat() + "Z",
+        }
+        for a in attempts
+    ])
+
+
+@bp.get("/alerts")
+@jwt_required()
+def login_alerts():
+    """Return unacknowledged login alerts for the authenticated user."""
+    uid = int(get_jwt_identity())
+    include_ack = request.args.get("include_acknowledged", "false").lower() == "true"
+    alerts = get_alerts(uid, include_acknowledged=include_ack)
+    return jsonify([
+        {
+            "id": a.id,
+            "alert_type": a.alert_type,
+            "severity": a.severity,
+            "message": a.message,
+            "metadata": json.loads(a.metadata_json) if a.metadata_json else None,
+            "acknowledged": a.acknowledged,
+            "created_at": a.created_at.isoformat() + "Z",
+        }
+        for a in alerts
+    ])
+
+
+@bp.post("/alerts/<int:alert_id>/acknowledge")
+@jwt_required()
+def acknowledge(alert_id: int):
+    """Mark a specific alert as acknowledged."""
+    uid = int(get_jwt_identity())
+    alert = acknowledge_alert(alert_id, uid)
+    if alert is None:
+        return jsonify(error="alert not found"), 404
+    return jsonify(message="acknowledged", alert_id=alert.id)

--- a/packages/backend/app/services/login_anomaly.py
+++ b/packages/backend/app/services/login_anomaly.py
@@ -1,0 +1,301 @@
+"""Login anomaly detection service.
+
+Detects suspicious login behaviour and creates alerts:
+- BRUTE_FORCE: Many failed attempts in a short window
+- NEW_IP: Successful login from an IP never seen for this user
+- NEW_DEVICE: Successful login from an unrecognised user-agent
+- IMPOSSIBLE_TRAVEL: Two successful logins from different countries within
+  a suspiciously short time span
+- ODD_HOUR: Login outside the user's typical active hours
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Sequence
+
+from ..extensions import db, redis_client
+from ..models import LoginAlert, LoginAttempt
+
+logger = logging.getLogger("finmind.login_anomaly")
+
+# ---------------------------------------------------------------------------
+# Configurable thresholds
+# ---------------------------------------------------------------------------
+FAILED_ATTEMPT_WINDOW_MINUTES = 15
+FAILED_ATTEMPT_THRESHOLD = 5
+LOCKOUT_DURATION_MINUTES = 30
+ODD_HOUR_START = 1   # 01:00
+ODD_HOUR_END = 5     # 05:00
+IMPOSSIBLE_TRAVEL_MINUTES = 60
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+def record_login_attempt(
+    *,
+    email: str,
+    ip_address: str,
+    user_agent: str | None,
+    success: bool,
+    user_id: int | None = None,
+    country: str | None = None,
+) -> LoginAttempt:
+    """Persist a login attempt and return the row."""
+    attempt = LoginAttempt(
+        user_id=user_id,
+        email=email,
+        ip_address=ip_address,
+        user_agent=user_agent,
+        success=success,
+        country=country,
+    )
+    db.session.add(attempt)
+    db.session.commit()
+    return attempt
+
+
+def check_account_locked(email: str) -> bool:
+    """Return True if the account is temporarily locked due to brute-force."""
+    try:
+        key = _lockout_key(email)
+        return redis_client.get(key) is not None
+    except Exception:
+        logger.warning("Redis unavailable for lockout check, allowing login")
+        return False
+
+
+def lock_account(email: str) -> None:
+    """Lock an account for LOCKOUT_DURATION_MINUTES."""
+    try:
+        key = _lockout_key(email)
+        redis_client.setex(key, LOCKOUT_DURATION_MINUTES * 60, "1")
+        logger.warning("Account locked for email=%s", email)
+    except Exception:
+        logger.error("Redis unavailable, could not lock account for email=%s", email)
+
+
+def analyse_login(attempt: LoginAttempt) -> list[LoginAlert]:
+    """Run all anomaly detectors against *attempt* and return created alerts."""
+    alerts: list[LoginAlert] = []
+
+    if not attempt.success:
+        alert = _check_brute_force(attempt)
+        if alert:
+            alerts.append(alert)
+        return alerts
+
+    # Only run these checks on successful logins
+    for checker in (_check_new_ip, _check_new_device, _check_odd_hour, _check_impossible_travel):
+        alert = checker(attempt)
+        if alert:
+            alerts.append(alert)
+
+    return alerts
+
+
+def get_recent_attempts(user_id: int, limit: int = 20) -> Sequence[LoginAttempt]:
+    """Return the most recent login attempts for a user."""
+    return (
+        db.session.query(LoginAttempt)
+        .filter_by(user_id=user_id)
+        .order_by(LoginAttempt.created_at.desc())
+        .limit(limit)
+        .all()
+    )
+
+
+def get_alerts(user_id: int, *, include_acknowledged: bool = False) -> Sequence[LoginAlert]:
+    """Return alerts for a user, newest first."""
+    query = db.session.query(LoginAlert).filter_by(user_id=user_id)
+    if not include_acknowledged:
+        query = query.filter_by(acknowledged=False)
+    return query.order_by(LoginAlert.created_at.desc()).all()
+
+
+def acknowledge_alert(alert_id: int, user_id: int) -> LoginAlert | None:
+    """Mark an alert as acknowledged. Returns None if not found."""
+    alert = (
+        db.session.query(LoginAlert)
+        .filter_by(id=alert_id, user_id=user_id)
+        .first()
+    )
+    if alert is None:
+        return None
+    alert.acknowledged = True
+    db.session.commit()
+    return alert
+
+
+# ---------------------------------------------------------------------------
+# Internal checkers
+# ---------------------------------------------------------------------------
+
+def _check_brute_force(attempt: LoginAttempt) -> LoginAlert | None:
+    """Detect many consecutive failed attempts within a short window."""
+    cutoff = datetime.utcnow() - timedelta(minutes=FAILED_ATTEMPT_WINDOW_MINUTES)
+    recent_failures = (
+        db.session.query(LoginAttempt)
+        .filter(
+            LoginAttempt.email == attempt.email,
+            LoginAttempt.success.is_(False),
+            LoginAttempt.created_at >= cutoff,
+        )
+        .count()
+    )
+    if recent_failures >= FAILED_ATTEMPT_THRESHOLD:
+        lock_account(attempt.email)
+        return _create_alert(
+            user_id=attempt.user_id,
+            attempt_id=attempt.id,
+            alert_type="BRUTE_FORCE",
+            severity="CRITICAL",
+            message=(
+                f"Possible brute-force attack: {recent_failures} failed login attempts "
+                f"from IP {attempt.ip_address} in the last {FAILED_ATTEMPT_WINDOW_MINUTES} minutes. "
+                "Account has been temporarily locked."
+            ),
+            metadata={"failed_count": recent_failures, "ip": attempt.ip_address},
+        )
+    return None
+
+
+def _check_new_ip(attempt: LoginAttempt) -> LoginAlert | None:
+    """Alert when a user logs in from an IP never seen before."""
+    previous = (
+        db.session.query(LoginAttempt)
+        .filter(
+            LoginAttempt.user_id == attempt.user_id,
+            LoginAttempt.success.is_(True),
+            LoginAttempt.ip_address == attempt.ip_address,
+            LoginAttempt.id != attempt.id,
+        )
+        .first()
+    )
+    if previous is None:
+        return _create_alert(
+            user_id=attempt.user_id,
+            attempt_id=attempt.id,
+            alert_type="NEW_IP",
+            severity="MEDIUM",
+            message=f"Login from new IP address: {attempt.ip_address}",
+            metadata={"ip": attempt.ip_address},
+        )
+    return None
+
+
+def _check_new_device(attempt: LoginAttempt) -> LoginAlert | None:
+    """Alert when user-agent has not been seen before for this user."""
+    if not attempt.user_agent:
+        return None
+    previous = (
+        db.session.query(LoginAttempt)
+        .filter(
+            LoginAttempt.user_id == attempt.user_id,
+            LoginAttempt.success.is_(True),
+            LoginAttempt.user_agent == attempt.user_agent,
+            LoginAttempt.id != attempt.id,
+        )
+        .first()
+    )
+    if previous is None:
+        return _create_alert(
+            user_id=attempt.user_id,
+            attempt_id=attempt.id,
+            alert_type="NEW_DEVICE",
+            severity="MEDIUM",
+            message=f"Login from new device: {attempt.user_agent[:80]}",
+            metadata={"user_agent": attempt.user_agent},
+        )
+    return None
+
+
+def _check_odd_hour(attempt: LoginAttempt) -> LoginAlert | None:
+    """Alert when login happens during unusual hours (01:00-05:00 UTC)."""
+    hour = attempt.created_at.hour
+    if ODD_HOUR_START <= hour < ODD_HOUR_END:
+        return _create_alert(
+            user_id=attempt.user_id,
+            attempt_id=attempt.id,
+            alert_type="ODD_HOUR",
+            severity="LOW",
+            message=f"Login at unusual hour ({hour:02d}:00 UTC)",
+            metadata={"hour": hour},
+        )
+    return None
+
+
+def _check_impossible_travel(attempt: LoginAttempt) -> LoginAlert | None:
+    """Alert when two successful logins from different countries happen too quickly."""
+    if not attempt.country:
+        return None
+    cutoff = datetime.utcnow() - timedelta(minutes=IMPOSSIBLE_TRAVEL_MINUTES)
+    previous = (
+        db.session.query(LoginAttempt)
+        .filter(
+            LoginAttempt.user_id == attempt.user_id,
+            LoginAttempt.success.is_(True),
+            LoginAttempt.id != attempt.id,
+            LoginAttempt.created_at >= cutoff,
+            LoginAttempt.country.isnot(None),
+            LoginAttempt.country != attempt.country,
+        )
+        .order_by(LoginAttempt.created_at.desc())
+        .first()
+    )
+    if previous is not None:
+        return _create_alert(
+            user_id=attempt.user_id,
+            attempt_id=attempt.id,
+            alert_type="IMPOSSIBLE_TRAVEL",
+            severity="HIGH",
+            message=(
+                f"Successive logins from {previous.country} and {attempt.country} "
+                f"within {IMPOSSIBLE_TRAVEL_MINUTES} minutes."
+            ),
+            metadata={
+                "previous_country": previous.country,
+                "current_country": attempt.country,
+            },
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _lockout_key(email: str) -> str:
+    return f"auth:lockout:{email}"
+
+
+def _create_alert(
+    *,
+    user_id: int | None,
+    attempt_id: int | None,
+    alert_type: str,
+    severity: str,
+    message: str,
+    metadata: dict | None = None,
+) -> LoginAlert:
+    alert = LoginAlert(
+        user_id=user_id,
+        login_attempt_id=attempt_id,
+        alert_type=alert_type,
+        severity=severity,
+        message=message,
+        metadata_json=json.dumps(metadata) if metadata else None,
+    )
+    db.session.add(alert)
+    db.session.commit()
+    logger.info(
+        "Login alert created: type=%s severity=%s user_id=%s",
+        alert_type,
+        severity,
+        user_id,
+    )
+    return alert

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,27 @@
 import os
+import hashlib
 import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
 from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+# Patch: macOS Python 3.9 may lack hashlib.scrypt used by Werkzeug's default
+# password hashing.  Monkey-patch the internal function so that all callers
+# (including those that imported generate_password_hash at module load)
+# transparently fall back to pbkdf2:sha256.
+if not hasattr(hashlib, "scrypt"):
+    import werkzeug.security as _ws
+
+    _orig_hash_internal = _ws._hash_internal
+
+    def _safe_hash_internal(method, salt, password):
+        if method.startswith("scrypt"):
+            method = "pbkdf2:sha256"
+        return _orig_hash_internal(method, salt, password)
+
+    _ws._hash_internal = _safe_hash_internal
 
 
 class TestSettings(Settings):

--- a/packages/backend/tests/test_login_anomaly.py
+++ b/packages/backend/tests/test_login_anomaly.py
@@ -1,0 +1,442 @@
+"""Tests for login anomaly detection and suspicious activity alerts."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.models import LoginAlert, LoginAttempt
+from app.services.login_anomaly import (
+    FAILED_ATTEMPT_THRESHOLD,
+    FAILED_ATTEMPT_WINDOW_MINUTES,
+    analyse_login,
+    check_account_locked,
+    get_alerts,
+    get_recent_attempts,
+    record_login_attempt,
+    acknowledge_alert,
+)
+from app.extensions import db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_redis():
+    """Mock redis_client for all tests so we don't need a running Redis."""
+    store = {}
+
+    class FakeRedis:
+        def get(self, key):
+            return store.get(key)
+
+        def setex(self, key, ttl, value):
+            store[key] = value
+
+        def delete(self, key):
+            store.pop(key, None)
+
+        def flushdb(self):
+            store.clear()
+
+    fake = FakeRedis()
+    with patch("app.services.login_anomaly.redis_client", fake), \
+         patch("app.routes.auth.redis_client", fake), \
+         patch("app.extensions.redis_client", fake):
+        yield fake
+
+
+def _make_user(app_fixture, email="test@test.com"):
+    """Create a user directly in the DB and return (user, password)."""
+    from app.models import User
+    from werkzeug.security import generate_password_hash
+
+    with app_fixture.app_context():
+        password = "testpass123"
+        user = User(
+            email=email,
+            password_hash=generate_password_hash(password, method="pbkdf2:sha256"),
+            preferred_currency="INR",
+        )
+        db.session.add(user)
+        db.session.commit()
+        uid = user.id
+    return uid, password
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - record_login_attempt
+# ---------------------------------------------------------------------------
+
+class TestRecordLoginAttempt:
+    def test_records_successful_attempt(self, app_fixture):
+        with app_fixture.app_context():
+            attempt = record_login_attempt(
+                email="u@example.com",
+                ip_address="1.2.3.4",
+                user_agent="TestAgent",
+                success=True,
+                user_id=None,
+            )
+            assert attempt.id is not None
+            assert attempt.success is True
+            assert attempt.ip_address == "1.2.3.4"
+
+    def test_records_failed_attempt(self, app_fixture):
+        with app_fixture.app_context():
+            attempt = record_login_attempt(
+                email="u@example.com",
+                ip_address="5.6.7.8",
+                user_agent=None,
+                success=False,
+            )
+            assert attempt.success is False
+            assert attempt.user_agent is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - brute force detection
+# ---------------------------------------------------------------------------
+
+class TestBruteForceDetection:
+    def test_triggers_after_threshold(self, app_fixture):
+        with app_fixture.app_context():
+            for _ in range(FAILED_ATTEMPT_THRESHOLD):
+                attempt = record_login_attempt(
+                    email="victim@test.com",
+                    ip_address="10.0.0.1",
+                    user_agent="Bot",
+                    success=False,
+                )
+            alerts = analyse_login(attempt)
+            assert len(alerts) == 1
+            assert alerts[0].alert_type == "BRUTE_FORCE"
+            assert alerts[0].severity == "CRITICAL"
+
+    def test_no_alert_below_threshold(self, app_fixture):
+        with app_fixture.app_context():
+            for _ in range(FAILED_ATTEMPT_THRESHOLD - 1):
+                attempt = record_login_attempt(
+                    email="safe@test.com",
+                    ip_address="10.0.0.2",
+                    user_agent="Bot",
+                    success=False,
+                )
+            alerts = analyse_login(attempt)
+            assert len(alerts) == 0
+
+    def test_lockout_after_brute_force(self, app_fixture):
+        with app_fixture.app_context():
+            for _ in range(FAILED_ATTEMPT_THRESHOLD):
+                record_login_attempt(
+                    email="locked@test.com",
+                    ip_address="10.0.0.3",
+                    user_agent="Bot",
+                    success=False,
+                )
+            last = record_login_attempt(
+                email="locked@test.com",
+                ip_address="10.0.0.3",
+                user_agent="Bot",
+                success=False,
+            )
+            analyse_login(last)
+            assert check_account_locked("locked@test.com") is True
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - new IP detection
+# ---------------------------------------------------------------------------
+
+class TestNewIpDetection:
+    def test_first_login_creates_new_ip_alert(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "newip@test.com")
+        with app_fixture.app_context():
+            attempt = record_login_attempt(
+                email="newip@test.com",
+                ip_address="192.168.1.1",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+            )
+            alerts = analyse_login(attempt)
+            types = [a.alert_type for a in alerts]
+            assert "NEW_IP" in types
+
+    def test_known_ip_no_alert(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "knownip@test.com")
+        with app_fixture.app_context():
+            record_login_attempt(
+                email="knownip@test.com",
+                ip_address="192.168.1.1",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+            )
+            attempt2 = record_login_attempt(
+                email="knownip@test.com",
+                ip_address="192.168.1.1",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+            )
+            alerts = analyse_login(attempt2)
+            types = [a.alert_type for a in alerts]
+            assert "NEW_IP" not in types
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - new device detection
+# ---------------------------------------------------------------------------
+
+class TestNewDeviceDetection:
+    def test_new_user_agent_triggers_alert(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "newdev@test.com")
+        with app_fixture.app_context():
+            record_login_attempt(
+                email="newdev@test.com",
+                ip_address="10.0.0.1",
+                user_agent="Chrome/100",
+                success=True,
+                user_id=uid,
+            )
+            attempt2 = record_login_attempt(
+                email="newdev@test.com",
+                ip_address="10.0.0.1",
+                user_agent="Firefox/110",
+                success=True,
+                user_id=uid,
+            )
+            alerts = analyse_login(attempt2)
+            types = [a.alert_type for a in alerts]
+            assert "NEW_DEVICE" in types
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - odd hour detection
+# ---------------------------------------------------------------------------
+
+class TestOddHourDetection:
+    def test_login_at_3am_triggers_alert(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "oddhr@test.com")
+        with app_fixture.app_context():
+            attempt = record_login_attempt(
+                email="oddhr@test.com",
+                ip_address="10.0.0.1",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+            )
+            attempt.created_at = datetime.utcnow().replace(hour=3, minute=0, second=0)
+            db.session.commit()
+
+            alerts = analyse_login(attempt)
+            types = [a.alert_type for a in alerts]
+            assert "ODD_HOUR" in types
+
+    def test_login_at_noon_no_odd_hour_alert(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "noon@test.com")
+        with app_fixture.app_context():
+            attempt = record_login_attempt(
+                email="noon@test.com",
+                ip_address="10.0.0.1",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+            )
+            attempt.created_at = datetime.utcnow().replace(hour=12, minute=0, second=0)
+            db.session.commit()
+
+            alerts = analyse_login(attempt)
+            types = [a.alert_type for a in alerts]
+            assert "ODD_HOUR" not in types
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - impossible travel detection
+# ---------------------------------------------------------------------------
+
+class TestImpossibleTravelDetection:
+    def test_different_countries_in_short_window(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "travel@test.com")
+        with app_fixture.app_context():
+            record_login_attempt(
+                email="travel@test.com",
+                ip_address="10.0.0.1",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+                country="US",
+            )
+            attempt2 = record_login_attempt(
+                email="travel@test.com",
+                ip_address="10.0.0.2",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+                country="JP",
+            )
+            alerts = analyse_login(attempt2)
+            types = [a.alert_type for a in alerts]
+            assert "IMPOSSIBLE_TRAVEL" in types
+
+
+# ---------------------------------------------------------------------------
+# Unit tests - query helpers
+# ---------------------------------------------------------------------------
+
+class TestGetRecentAttempts:
+    def test_returns_attempts_for_user(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "hist@test.com")
+        with app_fixture.app_context():
+            for i in range(3):
+                record_login_attempt(
+                    email="hist@test.com",
+                    ip_address=f"10.0.0.{i}",
+                    user_agent="Chrome",
+                    success=True,
+                    user_id=uid,
+                )
+            attempts = get_recent_attempts(uid, limit=10)
+            assert len(attempts) == 3
+
+
+class TestAlertManagement:
+    def test_get_and_acknowledge_alerts(self, app_fixture):
+        uid, _ = _make_user(app_fixture, "ack@test.com")
+        with app_fixture.app_context():
+            attempt = record_login_attempt(
+                email="ack@test.com",
+                ip_address="172.16.0.1",
+                user_agent="Chrome",
+                success=True,
+                user_id=uid,
+            )
+            alerts = analyse_login(attempt)
+            assert len(alerts) > 0
+
+            unacked = get_alerts(uid)
+            assert len(unacked) > 0
+
+            ack = acknowledge_alert(unacked[0].id, uid)
+            assert ack.acknowledged is True
+
+            remaining = get_alerts(uid, include_acknowledged=False)
+            acked_ids = [a.id for a in remaining]
+            assert ack.id not in acked_ids
+
+
+# ---------------------------------------------------------------------------
+# Integration tests - HTTP endpoints
+# ---------------------------------------------------------------------------
+
+class TestLoginRecordsAttempt:
+    def test_successful_login_creates_attempt(self, client):
+        email = "integ_ok@test.com"
+        client.post("/auth/register", json={"email": email, "password": "pass123"})
+        r = client.post("/auth/login", json={"email": email, "password": "pass123"})
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "access_token" in data
+
+    def test_failed_login_creates_attempt(self, client):
+        r = client.post(
+            "/auth/login", json={"email": "nobody@test.com", "password": "wrong"}
+        )
+        assert r.status_code == 401
+
+    def test_brute_force_locks_account(self, client):
+        email = "brute@test.com"
+        client.post("/auth/register", json={"email": email, "password": "pass123"})
+        for _ in range(FAILED_ATTEMPT_THRESHOLD + 1):
+            client.post("/auth/login", json={"email": email, "password": "wrong"})
+
+        # Next attempt should be blocked with 429
+        r = client.post("/auth/login", json={"email": email, "password": "pass123"})
+        assert r.status_code == 429
+        assert "locked" in r.get_json()["error"]
+
+
+class TestSecurityEndpoints:
+    def test_login_history(self, client):
+        email = "hist_ep@test.com"
+        password = "pass123"
+        client.post("/auth/register", json={"email": email, "password": password})
+        r = client.post("/auth/login", json={"email": email, "password": password})
+        access = r.get_json()["access_token"]
+        auth = {"Authorization": f"Bearer {access}"}
+
+        r = client.get("/auth/security/history", headers=auth)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert isinstance(data, list)
+        assert len(data) >= 1
+        assert data[0]["success"] is True
+
+    def test_login_alerts(self, client):
+        email = "alert_ep@test.com"
+        password = "pass123"
+        client.post("/auth/register", json={"email": email, "password": password})
+        r = client.post("/auth/login", json={"email": email, "password": password})
+        access = r.get_json()["access_token"]
+        auth = {"Authorization": f"Bearer {access}"}
+
+        r = client.get("/auth/security/alerts", headers=auth)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert isinstance(data, list)
+        # First login creates NEW_IP and NEW_DEVICE alerts
+        assert len(data) >= 1
+
+    def test_acknowledge_alert(self, client):
+        email = "ack_ep@test.com"
+        password = "pass123"
+        client.post("/auth/register", json={"email": email, "password": password})
+        r = client.post("/auth/login", json={"email": email, "password": password})
+        access = r.get_json()["access_token"]
+        auth = {"Authorization": f"Bearer {access}"}
+
+        r = client.get("/auth/security/alerts", headers=auth)
+        alerts = r.get_json()
+        if len(alerts) > 0:
+            alert_id = alerts[0]["id"]
+            r = client.post(
+                f"/auth/security/alerts/{alert_id}/acknowledge", headers=auth
+            )
+            assert r.status_code == 200
+            assert r.get_json()["message"] == "acknowledged"
+
+    def test_acknowledge_nonexistent_alert(self, client):
+        email = "ack404@test.com"
+        password = "pass123"
+        client.post("/auth/register", json={"email": email, "password": password})
+        r = client.post("/auth/login", json={"email": email, "password": password})
+        access = r.get_json()["access_token"]
+        auth = {"Authorization": f"Bearer {access}"}
+
+        r = client.post("/auth/security/alerts/99999/acknowledge", headers=auth)
+        assert r.status_code == 404
+
+    def test_security_alerts_in_login_response(self, client):
+        email = "alerts_resp@test.com"
+        password = "pass123"
+        client.post("/auth/register", json={"email": email, "password": password})
+        r = client.post("/auth/login", json={"email": email, "password": password})
+        data = r.get_json()
+        # First login from a new IP/device should include security_alerts
+        if "security_alerts" in data:
+            assert isinstance(data["security_alerts"], list)
+            for alert in data["security_alerts"]:
+                assert "alert_type" in alert
+                assert "severity" in alert
+                assert "message" in alert
+
+    def test_endpoints_require_auth(self, client):
+        r = client.get("/auth/security/history")
+        assert r.status_code == 401
+        r = client.get("/auth/security/alerts")
+        assert r.status_code == 401
+        r = client.post("/auth/security/alerts/1/acknowledge")
+        assert r.status_code == 401


### PR DESCRIPTION
## Summary

Implements login anomaly detection and suspicious activity alerts to detect unusual login behavior and alert users.

Closes #124

### What's included

- **LoginAttempt model** — records every login attempt with IP address, user-agent, country, success/failure, and timestamp
- **LoginAlert model** — stores security alerts with severity levels (LOW/MEDIUM/HIGH/CRITICAL) and acknowledgement support
- **Anomaly detection service** (`login_anomaly.py`) with five real-time detectors:
  - **BRUTE_FORCE** — detects rapid failed login attempts (5+ in 15 min), triggers account lockout via Redis
  - **NEW_IP** — alerts when a user logs in from a previously unseen IP address
  - **NEW_DEVICE** — alerts on login from an unrecognized user-agent
  - **IMPOSSIBLE_TRAVEL** — flags successive logins from different countries within 60 minutes
  - **ODD_HOUR** — low-severity alert for logins during unusual hours (01:00-05:00 UTC)
- **Account lockout** — temporary 30-minute lockout after brute-force detection, backed by Redis with graceful fallback
- **Security alerts in login response** — the `/auth/login` endpoint now returns `security_alerts` array when anomalies are detected
- **Three new API endpoints** under `/auth/security/`:
  - `GET /auth/security/history` — paginated login attempt history
  - `GET /auth/security/alerts` — unacknowledged security alerts (with `?include_acknowledged=true` option)
  - `POST /auth/security/alerts/{id}/acknowledge` — dismiss an alert
- **Database schema** — SQL migration for `login_attempts` and `login_alerts` tables with proper indexes
- **OpenAPI spec** — full documentation for all new endpoints and schemas

### Tests

22 test cases covering:
- Unit tests for each anomaly detector (brute force, new IP, new device, odd hour, impossible travel)
- Unit tests for alert management (create, query, acknowledge)
- Integration tests for all HTTP endpoints (history, alerts, acknowledge, auth-required checks)
- Integration test for brute-force account lockout via the login endpoint

## Test plan

- [ ] All 22 new tests pass (`pytest tests/test_login_anomaly.py`)
- [ ] Existing tests unaffected (no regressions introduced)
- [ ] Login endpoint still returns tokens on successful auth
- [ ] Brute-force lockout returns HTTP 429 after threshold
- [ ] Security endpoints require JWT authentication
- [ ] Redis graceful degradation (lockout silently skipped if Redis unavailable)