### PR TITLE
feat(locale): locale-aware date, currency & number formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FinMind helps users control spending, track bills, and get smart financial insights. Built for free-tier friendly deployment with scalable architecture.
 
+- **Locale-aware formatting**: dates, currencies, and numbers adapt to the user's preferred locale (en-US, en-GB, en-IN, de-DE, ja-JP, fr-FR, ar-SA, zh-CN).
+
 ## System Architecture
 
 ```mermaid

--- a/app/src/lib/currency.ts
+++ b/app/src/lib/currency.ts
@@ -1,15 +1,5 @@
-import { getCurrency } from '@/lib/auth';
+import { formatCurrency } from '@/lib/locale';
 
 export function formatMoney(amount: number, currencyCode?: string): string {
-  const currency = (currencyCode || getCurrency() || 'USD').toUpperCase();
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: 'currency',
-      currency,
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(Number(amount || 0));
-  } catch {
-    return `${currency} ${Number(amount || 0).toFixed(2)}`;
-  }
+  return formatCurrency(amount, currencyCode);
 }

--- a/app/src/lib/locale.test.ts
+++ b/app/src/lib/locale.test.ts
@@ -1,0 +1,82 @@
+import { getLocale, setLocale, formatDate, formatCurrency, formatNumber } from '@/lib/locale';
+
+const LOCALE_KEY = 'fm_locale';
+
+beforeEach(() => localStorage.clear());
+
+describe('getLocale', () => {
+  it('defaults to navigator.language', () => {
+    expect(getLocale()).toBe(navigator.language);
+  });
+
+  it('returns stored locale', () => {
+    localStorage.setItem(LOCALE_KEY, 'de-DE');
+    expect(getLocale()).toBe('de-DE');
+  });
+});
+
+describe('setLocale', () => {
+  it('persists and dispatches event', () => {
+    const handler = jest.fn();
+    window.addEventListener('locale_changed', handler);
+    setLocale('fr-FR');
+    expect(localStorage.getItem(LOCALE_KEY)).toBe('fr-FR');
+    expect(handler).toHaveBeenCalled();
+    window.removeEventListener('locale_changed', handler);
+  });
+});
+
+describe('formatDate', () => {
+  const date = new Date('2026-01-15T00:00:00');
+
+  it('formats with en-US locale', () => {
+    setLocale('en-US');
+    expect(formatDate(date)).toContain('1');
+    expect(formatDate(date)).toContain('2026');
+  });
+
+  it('formats with de-DE locale', () => {
+    setLocale('de-DE');
+    expect(formatDate(date)).toContain('15');
+    expect(formatDate(date)).toContain('2026');
+  });
+
+  it('accepts string dates', () => {
+    setLocale('en-US');
+    expect(formatDate('2026-01-15')).toContain('2026');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('formats USD', () => {
+    setLocale('en-US');
+    const result = formatCurrency(1234.56, 'USD');
+    expect(result).toContain('1');
+    expect(result).toMatch(/1.*234/);
+  });
+
+  it('formats EUR', () => {
+    setLocale('de-DE');
+    const result = formatCurrency(1234.56, 'EUR');
+    expect(result).toContain('€');
+  });
+
+  it('formats JPY', () => {
+    setLocale('ja-JP');
+    const result = formatCurrency(1234, 'JPY');
+    expect(result).toMatch(/[¥￥]/);
+  });
+});
+
+describe('formatNumber', () => {
+  it('formats large numbers with en-US', () => {
+    setLocale('en-US');
+    expect(formatNumber(1234567.89)).toBe('1,234,567.89');
+  });
+
+  it('formats large numbers with de-DE', () => {
+    setLocale('de-DE');
+    const result = formatNumber(1234567.89);
+    expect(result).toContain('1.234.567');
+  });
+});

--- a/app/src/lib/locale.ts
+++ b/app/src/lib/locale.ts
@@ -1,0 +1,38 @@
+import { getCurrency } from '@/lib/auth';
+
+const LOCALE_KEY = 'fm_locale';
+
+export const SUPPORTED_LOCALES = [
+  'en-US', 'en-GB', 'en-IN', 'de-DE', 'ja-JP', 'fr-FR', 'ar-SA', 'zh-CN',
+] as const;
+
+export function getLocale(): string {
+  return localStorage.getItem(LOCALE_KEY) || navigator.language;
+}
+
+export function setLocale(locale: string) {
+  localStorage.setItem(LOCALE_KEY, locale);
+  window.dispatchEvent(new Event('locale_changed'));
+}
+
+export function formatDate(date: Date | string, options?: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat(getLocale(), options).format(typeof date === 'string' ? new Date(date) : date);
+}
+
+export function formatCurrency(amount: number, currencyCode?: string): string {
+  const currency = (currencyCode || getCurrency() || 'USD').toUpperCase();
+  try {
+    return new Intl.NumberFormat(getLocale(), {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(Number(amount || 0));
+  } catch {
+    return `${currency} ${Number(amount || 0).toFixed(2)}`;
+  }
+}
+
+export function formatNumber(n: number, options?: Intl.NumberFormatOptions): string {
+  return new Intl.NumberFormat(getLocale(), options).format(n);
+}

--- a/app/src/pages/Account.tsx
+++ b/app/src/pages/Account.tsx
@@ -4,6 +4,7 @@ import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { me, updateMe } from '@/api/auth';
 import { setCurrency } from '@/lib/auth';
+import { SUPPORTED_LOCALES, getLocale, setLocale, formatCurrency, formatDate } from '@/lib/locale';
 
 const SUPPORTED_CURRENCIES = [
   { code: 'INR', label: 'Indian Rupee (INR)' },
@@ -21,6 +22,7 @@ export default function Account() {
   const { toast } = useToast();
   const [email, setEmail] = useState('');
   const [currency, setCurrencyState] = useState('INR');
+  const [locale, setLocaleState] = useState(getLocale);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
@@ -95,6 +97,22 @@ export default function Account() {
                   </option>
                 ))}
               </select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="preferred_locale">Preferred Locale</Label>
+              <select
+                id="preferred_locale"
+                className="input"
+                value={locale}
+                onChange={(e) => { setLocale(e.target.value); setLocaleState(e.target.value); }}
+              >
+                {SUPPORTED_LOCALES.map((l) => (
+                  <option key={l} value={l}>{l}</option>
+                ))}
+              </select>
+              <p className="text-xs text-muted-foreground">
+                Preview: {formatCurrency(12345.67, currency)} | {formatDate(new Date())}
+              </p>
             </div>
             <div className="flex justify-end">
               <Button


### PR DESCRIPTION
Closes #131

## Summary
Adds full locale-aware formatting for dates, currencies, and numbers.

## Features
- locale.ts utility with getLocale/setLocale/formatDate/formatCurrency/formatNumber
- SUPPORTED_LOCALES: en-US, en-GB, en-IN, de-DE, ja-JP, fr-FR, ar-SA, zh-CN
- Account page: locale selector with live preview
- formatMoney updated to use locale-aware formatter
- Unit tests for all locale functions

## Files Changed
- app/src/lib/locale.ts (new)
- app/src/lib/currency.ts (updated)
- app/src/pages/Account.tsx (locale selector added)
- app/src/lib/locale.test.ts (new tests)