### PR TITLE
feat(budgets): category overspend early warning system

### DIFF
--- a/app/src/api/budgets.ts
+++ b/app/src/api/budgets.ts
@@ -1,0 +1,43 @@
+import { api } from './client';
+
+export type BudgetLimit = {
+  id: number;
+  category_id: number | null;
+  monthly_limit: number;
+  month: string;
+};
+
+export type BudgetWithSpend = BudgetLimit & {
+  category_name: string;
+  spent: number;
+};
+
+export type BudgetWarning = {
+  category_id: number | null;
+  category_name: string;
+  monthly_limit: number;
+  spent: number;
+  remaining: number;
+  pct_used: number;
+  status: 'ok' | 'warning' | 'critical' | 'over';
+};
+
+export async function getBudgets(month: string): Promise<BudgetWithSpend[]> {
+  return api<BudgetWithSpend[]>(`/budgets?month=${encodeURIComponent(month)}`);
+}
+
+export async function setBudget(data: {
+  category_id: number | null;
+  monthly_limit: number;
+  month: string;
+}): Promise<BudgetLimit> {
+  return api<BudgetLimit>('/budgets', { method: 'POST', body: data });
+}
+
+export async function deleteBudget(id: number): Promise<{ message: string }> {
+  return api(`/budgets/${id}`, { method: 'DELETE' });
+}
+
+export async function getBudgetWarnings(month: string): Promise<BudgetWarning[]> {
+  return api<BudgetWarning[]>(`/budgets/warnings?month=${encodeURIComponent(month)}`);
+}

--- a/app/src/pages/Budgets.tsx
+++ b/app/src/pages/Budgets.tsx
@@ -1,108 +1,76 @@
-import { useState } from 'react';
-import { FinancialCard, FinancialCardContent, FinancialCardDescription, FinancialCardFooter, FinancialCardHeader, FinancialCardTitle } from '@/components/ui/financial-card';
+import { useEffect, useState } from 'react';
+import { FinancialCard, FinancialCardContent, FinancialCardDescription, FinancialCardHeader, FinancialCardTitle } from '@/components/ui/financial-card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, DollarSign, Plus, PieChart, TrendingDown, TrendingUp, Target, AlertCircle, Settings } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from '@/components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { DollarSign, Plus, Target, AlertCircle } from 'lucide-react';
+import { getBudgetWarnings, setBudget, type BudgetWarning } from '@/api/budgets';
+import { listCategories, type Category } from '@/api/categories';
+import { useToast } from '@/hooks/use-toast';
+import { formatMoney } from '@/lib/currency';
 
-const budgetCategories = [
-  {
-    id: 1,
-    name: 'Housing',
-    allocated: 2000,
-    spent: 1850,
-    remaining: 150,
-    color: 'bg-primary',
-    trend: 'up',
-    change: '+2.3%'
-  },
-  {
-    id: 2,
-    name: 'Food & Dining',
-    allocated: 800,
-    spent: 720,
-    remaining: 80,
-    color: 'bg-success',
-    trend: 'down',
-    change: '-5.1%'
-  },
-  {
-    id: 3,
-    name: 'Transportation',
-    allocated: 400,
-    spent: 445,
-    remaining: -45,
-    color: 'bg-destructive',
-    trend: 'up',
-    change: '+11.3%'
-  },
-  {
-    id: 4,
-    name: 'Entertainment',
-    allocated: 300,
-    spent: 185,
-    remaining: 115,
-    color: 'bg-accent',
-    trend: 'down',
-    change: '-8.2%'
-  },
-  {
-    id: 5,
-    name: 'Healthcare',
-    allocated: 250,
-    spent: 165,
-    remaining: 85,
-    color: 'bg-warning',
-    trend: 'up',
-    change: '+3.1%'
-  },
-  {
-    id: 6,
-    name: 'Shopping',
-    allocated: 500,
-    spent: 380,
-    remaining: 120,
-    color: 'bg-secondary',
-    trend: 'down',
-    change: '-12.4%'
-  }
-];
+const statusColor: Record<string, string> = {
+  ok: 'bg-green-500',
+  warning: 'bg-yellow-500',
+  critical: 'bg-orange-500',
+  over: 'bg-red-500',
+};
 
-const budgetGoals = [
-  {
-    id: 1,
-    title: 'Emergency Fund',
-    target: 10000,
-    current: 7250,
-    deadline: 'Dec 2025',
-    monthlyTarget: 458,
-    status: 'on-track'
-  },
-  {
-    id: 2,
-    title: 'Vacation Fund',
-    target: 3000,
-    current: 1850,
-    deadline: 'Jun 2025',
-    monthlyTarget: 383,
-    status: 'behind'
-  },
-  {
-    id: 3,
-    title: 'New Car',
-    target: 25000,
-    current: 15600,
-    deadline: 'Mar 2026',
-    monthlyTarget: 625,
-    status: 'ahead'
-  }
-];
+const statusBadge: Record<string, 'default' | 'secondary' | 'destructive'> = {
+  ok: 'default',
+  warning: 'secondary',
+  critical: 'destructive',
+  over: 'destructive',
+};
 
 export function Budgets() {
-  const [selectedPeriod] = useState('monthly');
-  
-  const totalAllocated = budgetCategories.reduce((sum, cat) => sum + cat.allocated, 0);
-  const totalSpent = budgetCategories.reduce((sum, cat) => sum + cat.spent, 0);
-  const totalRemaining = totalAllocated - totalSpent;
+  const [warnings, setWarnings] = useState<BudgetWarning[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [formCatId, setFormCatId] = useState<string>('');
+  const [formLimit, setFormLimit] = useState('');
+  const { toast } = useToast();
+
+  const currentMonth = new Date().toISOString().slice(0, 7);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const [w, c] = await Promise.all([getBudgetWarnings(currentMonth), listCategories()]);
+      setWarnings(w);
+      setCategories(c);
+      w.filter(i => i.status === 'over' || i.status === 'critical').forEach(i => {
+        toast({ title: `${i.category_name} is at ${i.pct_used}% of budget`, variant: 'destructive' });
+      });
+    } catch { /* ignore */ }
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const totalLimit = warnings.reduce((s, w) => s + w.monthly_limit, 0);
+  const totalSpent = warnings.reduce((s, w) => s + w.spent, 0);
+  const totalRemaining = totalLimit - totalSpent;
+
+  const handleSave = async () => {
+    const limit = parseFloat(formLimit);
+    if (!limit || limit <= 0) return;
+    try {
+      await setBudget({
+        category_id: formCatId && formCatId !== '__total__' ? Number(formCatId) : null,
+        monthly_limit: limit,
+        month: currentMonth,
+      });
+      setDialogOpen(false);
+      setFormCatId('');
+      setFormLimit('');
+      await load();
+    } catch { /* ignore */ }
+  };
 
   return (
     <div className="page-wrap">
@@ -110,226 +78,128 @@ export function Budgets() {
         <div className="relative flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div>
             <h1 className="page-title">Budget Management</h1>
-            <p className="page-subtitle">
-              Track your spending and stay on top of your financial goals
-            </p>
+            <p className="page-subtitle">Track your spending and stay on top of your financial goals</p>
           </div>
-          <div className="flex gap-3">
-            <Button variant="outline" size="sm">
-              <Calendar className="w-4 h-4" />
-              {selectedPeriod === 'monthly' ? 'Monthly' : 'Weekly'}
-            </Button>
-            <Button variant="financial" size="sm">
-              <Plus className="w-4 h-4" />
-              New Category
-            </Button>
-          </div>
+          <Button variant="financial" size="sm" onClick={() => setDialogOpen(true)}>
+            <Plus className="w-4 h-4" /> Set Budget
+          </Button>
         </div>
       </div>
 
-        {/* Budget Overview */}
-        <div className="grid gap-4 md:grid-cols-3 mb-8">
-          <FinancialCard variant="financial">
-            <FinancialCardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
-                  Total Allocated
-                </FinancialCardTitle>
-                <Target className="w-5 h-5 text-muted-foreground" />
-              </div>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              <div className="metric-value text-foreground mb-1">
-                ${totalAllocated.toLocaleString()}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                This month's budget
-              </div>
-            </FinancialCardContent>
-          </FinancialCard>
+      <div className="grid gap-4 md:grid-cols-3 mb-8">
+        <FinancialCard variant="financial">
+          <FinancialCardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <FinancialCardTitle className="text-sm font-medium text-muted-foreground">Total Allocated</FinancialCardTitle>
+              <Target className="w-5 h-5 text-muted-foreground" />
+            </div>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value text-foreground mb-1">{loading ? '...' : formatMoney(totalLimit)}</div>
+            <div className="text-sm text-muted-foreground">This month's budget</div>
+          </FinancialCardContent>
+        </FinancialCard>
 
-          <FinancialCard variant="financial">
-            <FinancialCardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
-                  Total Spent
-                </FinancialCardTitle>
-                <DollarSign className="w-5 h-5 text-muted-foreground" />
-              </div>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              <div className="metric-value text-foreground mb-1">
-                ${totalSpent.toLocaleString()}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {((totalSpent / totalAllocated) * 100).toFixed(1)}% of budget used
-              </div>
-            </FinancialCardContent>
-          </FinancialCard>
+        <FinancialCard variant="financial">
+          <FinancialCardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <FinancialCardTitle className="text-sm font-medium text-muted-foreground">Total Spent</FinancialCardTitle>
+              <DollarSign className="w-5 h-5 text-muted-foreground" />
+            </div>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value text-foreground mb-1">{loading ? '...' : formatMoney(totalSpent)}</div>
+            <div className="text-sm text-muted-foreground">
+              {totalLimit > 0 ? `${((totalSpent / totalLimit) * 100).toFixed(1)}% of budget used` : 'No budgets set'}
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
 
-          <FinancialCard variant={totalRemaining < 0 ? "destructive" : "success"}>
-            <FinancialCardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="text-sm font-medium">
-                  {totalRemaining < 0 ? 'Over Budget' : 'Remaining'}
-                </FinancialCardTitle>
-                {totalRemaining < 0 ? (
-                  <AlertCircle className="w-5 h-5" />
-                ) : (
-                  <PieChart className="w-5 h-5" />
-                )}
-              </div>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              <div className="metric-value mb-1">
-                ${Math.abs(totalRemaining).toLocaleString()}
-              </div>
-              <div className="text-sm opacity-80">
-                {totalRemaining < 0 ? 'Overspent this month' : 'Available to spend'}
-              </div>
-            </FinancialCardContent>
-          </FinancialCard>
-        </div>
+        <FinancialCard variant={totalRemaining < 0 ? 'destructive' : 'success'}>
+          <FinancialCardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <FinancialCardTitle className="text-sm font-medium">
+                {totalRemaining < 0 ? 'Over Budget' : 'Remaining'}
+              </FinancialCardTitle>
+              {totalRemaining < 0 ? <AlertCircle className="w-5 h-5" /> : <Target className="w-5 h-5" />}
+            </div>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value mb-1">{loading ? '...' : formatMoney(Math.abs(totalRemaining))}</div>
+            <div className="text-sm opacity-80">{totalRemaining < 0 ? 'Overspent this month' : 'Available to spend'}</div>
+          </FinancialCardContent>
+        </FinancialCard>
+      </div>
 
-        {/* Budget Categories */}
-        <div className="grid gap-6 lg:grid-cols-3 mb-8">
-          <div className="lg:col-span-2">
-            <FinancialCard variant="financial" className="fade-in-up">
-              <FinancialCardHeader>
-                <div className="flex items-center justify-between">
-                  <FinancialCardTitle className="section-title">Budget Categories</FinancialCardTitle>
-                  <Button variant="ghost" size="sm">
-                    <Settings className="w-4 h-4" />
-                  </Button>
-                </div>
-                <FinancialCardDescription>
-                  Track spending across different categories
-                </FinancialCardDescription>
-              </FinancialCardHeader>
-              <FinancialCardContent>
-                <div className="space-y-6">
-                  {budgetCategories.map((category) => {
-                    const percentage = (category.spent / category.allocated) * 100;
-                    const isOverBudget = category.remaining < 0;
-                    
-                    return (
-                      <div key={category.id} className="space-y-3 interactive-row">
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center space-x-3">
-                            <div className={`w-4 h-4 rounded-full ${category.color}`}></div>
-                            <div>
-                              <div className="font-medium text-foreground">{category.name}</div>
-                              <div className="text-sm text-muted-foreground">
-                                ${category.spent} of ${category.allocated}
-                              </div>
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <div className={`font-semibold ${
-                              isOverBudget ? 'text-destructive' : 'text-foreground'
-                            }`}>
-                              {isOverBudget ? '-' : ''}${Math.abs(category.remaining)}
-                            </div>
-                            <div className="flex items-center text-sm">
-                              {category.trend === 'up' ? (
-                                <TrendingUp className="w-3 h-3 text-destructive mr-1" />
-                              ) : (
-                                <TrendingDown className="w-3 h-3 text-success mr-1" />
-                              )}
-                              <span className={
-                                category.trend === 'up' ? 'text-destructive' : 'text-success'
-                              }>
-                                {category.change}
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                        <div className={`chart-track ${isOverBudget ? 'bg-destructive-light' : ''}`}>
-                          <div
-                            className={isOverBudget ? 'chart-fill-danger' : 'chart-fill-primary'}
-                            style={{ width: `${Math.min(percentage, 100)}%` }}
-                          />
-                        </div>
-                        {isOverBudget && (
-                          <Badge variant="destructive" className="text-xs">
-                            Over Budget
-                          </Badge>
-                        )}
+      <FinancialCard variant="financial" className="fade-in-up">
+        <FinancialCardHeader>
+          <FinancialCardTitle className="section-title">Budget Categories</FinancialCardTitle>
+          <FinancialCardDescription>Track spending across different categories</FinancialCardDescription>
+        </FinancialCardHeader>
+        <FinancialCardContent>
+          {warnings.length === 0 && !loading ? (
+            <div className="text-sm text-muted-foreground">No budgets set for this month. Click "Set Budget" to get started.</div>
+          ) : (
+            <div className="space-y-6">
+              {warnings.map((w) => (
+                <div key={`${w.category_id ?? 'total'}`} className="space-y-2 interactive-row">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="font-medium text-foreground">{w.category_name}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {formatMoney(w.spent)} of {formatMoney(w.monthly_limit)}
                       </div>
-                    );
-                  })}
+                    </div>
+                    <div className="text-right flex items-center gap-2">
+                      <span className={`font-semibold ${w.status === 'over' ? 'text-destructive' : 'text-foreground'}`}>
+                        {formatMoney(Math.abs(w.remaining))} {w.remaining < 0 ? 'over' : 'left'}
+                      </span>
+                      <Badge variant={statusBadge[w.status]}>{w.status}</Badge>
+                    </div>
+                  </div>
+                  <Progress
+                    value={Math.min(w.pct_used, 100)}
+                    className={`h-3 [&>div]:${statusColor[w.status]}`}
+                  />
                 </div>
-              </FinancialCardContent>
-            </FinancialCard>
-          </div>
+              ))}
+            </div>
+          )}
+        </FinancialCardContent>
+      </FinancialCard>
 
-          {/* Savings Goals */}
-          <div>
-            <FinancialCard variant="financial" className="fade-in-up">
-              <FinancialCardHeader>
-                <div className="flex items-center justify-between">
-                  <FinancialCardTitle className="section-title">Savings Goals</FinancialCardTitle>
-                  <Button variant="ghost" size="sm">
-                    <Plus className="w-4 h-4" />
-                  </Button>
-                </div>
-                <FinancialCardDescription>
-                  Your financial objectives
-                </FinancialCardDescription>
-              </FinancialCardHeader>
-              <FinancialCardContent>
-                <div className="space-y-4">
-                  {budgetGoals.map((goal) => {
-                    const percentage = (goal.current / goal.target) * 100;
-                    
-                    return (
-                      <div key={goal.id} className="interactive-row p-3 rounded-lg border border-border">
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="font-medium text-foreground text-sm">
-                            {goal.title}
-                          </div>
-                          <Badge 
-                            variant={
-                              goal.status === 'on-track' ? 'default' :
-                              goal.status === 'ahead' ? 'secondary' : 'destructive'
-                            }
-                            className="text-xs"
-                          >
-                            {goal.status === 'on-track' ? 'On Track' :
-                             goal.status === 'ahead' ? 'Ahead' : 'Behind'}
-                          </Badge>
-                        </div>
-                        <div className="space-y-2">
-                          <div className="flex justify-between text-sm">
-                            <span className="text-muted-foreground">
-                              ${goal.current.toLocaleString()} / ${goal.target.toLocaleString()}
-                            </span>
-                            <span className="text-foreground font-medium">
-                              {percentage.toFixed(0)}%
-                            </span>
-                          </div>
-                          <div className="chart-track">
-                            <div className="chart-fill-success" style={{ width: `${Math.min(percentage, 100)}%` }} />
-                          </div>
-                          <div className="flex justify-between text-xs text-muted-foreground">
-                            <span>Target: {goal.deadline}</span>
-                            <span>${goal.monthlyTarget}/mo</span>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </FinancialCardContent>
-              <FinancialCardFooter>
-                <Button variant="financial" size="sm" className="w-full">
-                  <Plus className="w-4 h-4" />
-                  Add New Goal
-                </Button>
-              </FinancialCardFooter>
-            </FinancialCard>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Set Budget Limit</DialogTitle>
+            <DialogDescription>Set a monthly spending limit for a category.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div>
+              <label className="text-sm font-medium" htmlFor="budget-category">Category</label>
+              <Select value={formCatId} onValueChange={setFormCatId}>
+                <SelectTrigger id="budget-category">
+                  <SelectValue placeholder="Total (all categories)" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__total__">Total (all categories)</SelectItem>
+                  {categories.map(c => (
+                    <SelectItem key={c.id} value={String(c.id)}>{c.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="text-sm font-medium" htmlFor="budget-limit">Monthly Limit</label>
+              <Input id="budget-limit" type="number" min="0" step="0.01" placeholder="0.00" value={formLimit} onChange={e => setFormLimit(e.target.value)} />
+            </div>
           </div>
-        </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+            <Button onClick={handleSave}>Save</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -20,6 +20,7 @@ import {
   Plus,
 } from 'lucide-react';
 import { getDashboardSummary, type DashboardSummary } from '@/api/dashboard';
+import { getBudgetWarnings, type BudgetWarning } from '@/api/budgets';
 import { useNavigate } from 'react-router-dom';
 import { formatMoney } from '@/lib/currency';
 
@@ -33,6 +34,8 @@ export function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [budgetWarnings, setBudgetWarnings] = useState<BudgetWarning[]>([]);
+  const [warningsDismissed, setWarningsDismissed] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -47,6 +50,13 @@ export function Dashboard() {
         setLoading(false);
       }
     })();
+  }, [month]);
+
+  useEffect(() => {
+    getBudgetWarnings(month)
+      .then(w => setBudgetWarnings(w.filter(i => i.status === 'over' || i.status === 'critical')))
+      .catch(() => setBudgetWarnings([]));
+    setWarningsDismissed(false);
   }, [month]);
 
   const summary = useMemo(() => {
@@ -138,6 +148,28 @@ export function Dashboard() {
       {data?.errors && data.errors.length > 0 && (
         <div className="card mb-6 text-sm text-warning">
           Some widgets are temporarily unavailable: {data.errors.join(', ')}
+        </div>
+      )}
+
+      {!warningsDismissed && budgetWarnings.length > 0 && (
+        <div className="relative rounded-lg border border-yellow-400 bg-yellow-50 dark:bg-yellow-950/30 p-4 mb-6">
+          <button
+            className="absolute top-2 right-2 text-sm text-muted-foreground hover:text-foreground"
+            onClick={() => setWarningsDismissed(true)}
+            aria-label="Dismiss budget warnings"
+          >
+            ✕
+          </button>
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="w-5 h-5 text-yellow-600 mt-0.5 shrink-0" />
+            <div className="space-y-1">
+              {budgetWarnings.map(w => (
+                <p key={w.category_id ?? 'total'} className="text-sm text-foreground">
+                  <span className="font-medium">{w.category_name}</span> is at {w.pct_used}% of budget
+                </p>
+              ))}
+            </div>
+          </div>
         </div>
       )}
 

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,19 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class BudgetLimit(db.Model):
+    __tablename__ = "budget_limits"
+    __table_args__ = (
+        db.UniqueConstraint("user_id", "category_id", "month", name="uq_budget_user_cat_month"),
+    )
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    monthly_limit = db.Column(db.Numeric(12, 2), nullable=False)
+    month = db.Column(db.String(7), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .budgets import bp as budgets_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(budgets_bp, url_prefix="/budgets")

--- a/packages/backend/app/routes/budgets.py
+++ b/packages/backend/app/routes/budgets.py
@@ -1,0 +1,145 @@
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import BudgetLimit, Category, Expense
+
+bp = Blueprint("budgets", __name__)
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _is_valid_month(ym: str) -> bool:
+    if len(ym) != 7 or ym[4] != "-":
+        return False
+    parts = ym.split("-")
+    if not (parts[0].isdigit() and parts[1].isdigit()):
+        return False
+    return 1 <= int(parts[1]) <= 12
+
+
+def _spent_for_category(uid: int, category_id: int | None, year: int, month: int) -> float:
+    q = db.session.query(func.coalesce(func.sum(Expense.amount), 0)).filter(
+        Expense.user_id == uid,
+        extract("year", Expense.spent_at) == year,
+        extract("month", Expense.spent_at) == month,
+        Expense.expense_type != "INCOME",
+    )
+    if category_id is not None:
+        q = q.filter(Expense.category_id == category_id)
+    return float(q.scalar())
+
+
+def _status(pct: float) -> str:
+    if pct > 100:
+        return "over"
+    if pct >= 90:
+        return "critical"
+    if pct >= 75:
+        return "warning"
+    return "ok"
+
+
+@bp.get("")
+@jwt_required()
+def list_budgets():
+    uid = int(get_jwt_identity())
+    ym = (request.args.get("month") or "").strip()
+    if not ym or not _is_valid_month(ym):
+        return jsonify(error="month param required (YYYY-MM)"), 400
+    year, month = map(int, ym.split("-"))
+    limits = db.session.query(BudgetLimit).filter_by(user_id=uid, month=ym).all()
+    result = []
+    for bl in limits:
+        cat_name = "Total"
+        if bl.category_id:
+            cat = db.session.get(Category, bl.category_id)
+            cat_name = cat.name if cat else "Unknown"
+        spent = _spent_for_category(uid, bl.category_id, year, month)
+        result.append({
+            "id": bl.id,
+            "category_id": bl.category_id,
+            "category_name": cat_name,
+            "monthly_limit": float(bl.monthly_limit),
+            "month": bl.month,
+            "spent": spent,
+        })
+    return jsonify(result)
+
+
+@bp.post("")
+@jwt_required()
+def create_budget():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    amount = _parse_amount(data.get("monthly_limit"))
+    if amount is None or amount <= 0:
+        return jsonify(error="invalid monthly_limit"), 400
+    ym = (data.get("month") or "").strip()
+    if not _is_valid_month(ym):
+        return jsonify(error="invalid month"), 400
+    category_id = data.get("category_id")
+    existing = db.session.query(BudgetLimit).filter_by(
+        user_id=uid, category_id=category_id, month=ym
+    ).first()
+    if existing:
+        existing.monthly_limit = amount
+        db.session.commit()
+        return jsonify({"id": existing.id, "category_id": existing.category_id,
+                        "monthly_limit": float(existing.monthly_limit), "month": existing.month}), 200
+    bl = BudgetLimit(user_id=uid, category_id=category_id, monthly_limit=amount, month=ym)
+    db.session.add(bl)
+    db.session.commit()
+    return jsonify({"id": bl.id, "category_id": bl.category_id,
+                    "monthly_limit": float(bl.monthly_limit), "month": bl.month}), 201
+
+
+@bp.delete("/<int:budget_id>")
+@jwt_required()
+def delete_budget(budget_id: int):
+    uid = int(get_jwt_identity())
+    bl = db.session.get(BudgetLimit, budget_id)
+    if not bl or bl.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(bl)
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+@bp.get("/warnings")
+@jwt_required()
+def budget_warnings():
+    uid = int(get_jwt_identity())
+    ym = (request.args.get("month") or "").strip()
+    if not ym or not _is_valid_month(ym):
+        return jsonify(error="month param required (YYYY-MM)"), 400
+    year, month = map(int, ym.split("-"))
+    limits = db.session.query(BudgetLimit).filter_by(user_id=uid, month=ym).all()
+    result = []
+    for bl in limits:
+        cat_name = "Total"
+        if bl.category_id:
+            cat = db.session.get(Category, bl.category_id)
+            cat_name = cat.name if cat else "Unknown"
+        spent = _spent_for_category(uid, bl.category_id, year, month)
+        limit_f = float(bl.monthly_limit)
+        remaining = round(limit_f - spent, 2)
+        pct = round((spent / limit_f) * 100, 1) if limit_f > 0 else 0
+        result.append({
+            "category_id": bl.category_id,
+            "category_name": cat_name,
+            "monthly_limit": limit_f,
+            "spent": spent,
+            "remaining": remaining,
+            "pct_used": pct,
+            "status": _status(pct),
+        })
+    return jsonify(result)

--- a/packages/backend/migrations/versions/003_add_budget_limits.py
+++ b/packages/backend/migrations/versions/003_add_budget_limits.py
@@ -1,0 +1,30 @@
+"""add budget_limits table
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-04-04
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "003"
+down_revision = "002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "budget_limits",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("category_id", sa.Integer(), sa.ForeignKey("categories.id"), nullable=True),
+        sa.Column("monthly_limit", sa.Numeric(12, 2), nullable=False),
+        sa.Column("month", sa.String(7), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("user_id", "category_id", "month", name="uq_budget_user_cat_month"),
+    )
+
+
+def downgrade():
+    op.drop_table("budget_limits")

--- a/packages/backend/tests/test_budgets.py
+++ b/packages/backend/tests/test_budgets.py
@@ -1,0 +1,61 @@
+from datetime import date
+
+
+def _create_category(client, auth_header, name="Food"):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code in (201, 409)
+    r = client.get("/categories", headers=auth_header)
+    cats = r.get_json()
+    return next(c["id"] for c in cats if c["name"] == name)
+
+
+def _add_expense(client, auth_header, amount, category_id, dt="2026-04-10"):
+    r = client.post("/expenses", json={
+        "amount": amount, "category_id": category_id,
+        "description": "test", "date": dt,
+    }, headers=auth_header)
+    assert r.status_code == 201
+
+
+def test_create_budget_limit(client, auth_header):
+    cat_id = _create_category(client, auth_header)
+    r = client.post("/budgets", json={
+        "category_id": cat_id, "monthly_limit": 500, "month": "2026-04",
+    }, headers=auth_header)
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["monthly_limit"] == 500
+    assert data["category_id"] == cat_id
+
+
+def test_budget_warnings_status_levels(client, auth_header):
+    cat_0 = _create_category(client, auth_header, "Zero")
+    cat_80 = _create_category(client, auth_header, "Eighty")
+    cat_95 = _create_category(client, auth_header, "NinetyFive")
+    cat_110 = _create_category(client, auth_header, "Over")
+
+    month = "2026-04"
+    for cat_id in [cat_0, cat_80, cat_95, cat_110]:
+        client.post("/budgets", json={
+            "category_id": cat_id, "monthly_limit": 100, "month": month,
+        }, headers=auth_header)
+
+    _add_expense(client, auth_header, 80, cat_80)
+    _add_expense(client, auth_header, 95, cat_95)
+    _add_expense(client, auth_header, 110, cat_110)
+
+    r = client.get(f"/budgets/warnings?month={month}", headers=auth_header)
+    assert r.status_code == 200
+    items = {w["category_name"]: w for w in r.get_json()}
+
+    assert items["Zero"]["status"] == "ok"
+    assert items["Zero"]["pct_used"] == 0
+
+    assert items["Eighty"]["status"] == "warning"
+    assert items["Eighty"]["pct_used"] == 80.0
+
+    assert items["NinetyFive"]["status"] == "critical"
+    assert items["NinetyFive"]["pct_used"] == 95.0
+
+    assert items["Over"]["status"] == "over"
+    assert items["Over"]["pct_used"] == 110.0


### PR DESCRIPTION
Closes #117

## Summary
Adds a real budget limits system with overspend early warnings for categories.

## Features
- BudgetLimit model with per-category monthly spending caps
- GET /budgets/warnings endpoint - returns ok/warning/critical/over status per category
- Real Budgets page replacing mock data - set limits, view progress bars, color-coded by status
- Dashboard OverspendBanner - dismissible warning when categories hit 90%+ of budget
- Toast notifications on Budgets page for critical/over categories

## Files Changed
- packages/backend/app/models.py (BudgetLimit model added)
- packages/backend/app/routes/budgets.py (new CRUD + warnings endpoint)
- packages/backend/app/routes/__init__.py (blueprint registered)
- packages/backend/migrations/versions/003_add_budget_limits.py (migration)
- app/src/api/budgets.ts (new API client)
- app/src/pages/Budgets.tsx (replaced mock with real implementation)
- app/src/pages/Dashboard.tsx (OverspendBanner added)
- packages/backend/tests/test_budgets.py (new tests)