### PR TITLE
feat(digest): smart weekly financial summary digest #121

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import WeeklyDigest from "./pages/WeeklyDigest";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="weekly-digest"
+              element={
+                <ProtectedRoute>
+                  <WeeklyDigest />
                 </ProtectedRoute>
               }
             />

--- a/app/src/__tests__/WeeklyDigest.integration.test.tsx
+++ b/app/src/__tests__/WeeklyDigest.integration.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import WeeklyDigest from '@/pages/WeeklyDigest';
+
+const getWeeklyDigestMock = jest.fn();
+jest.mock('@/api/digest', () => ({
+  getWeeklyDigest: (...args: unknown[]) => getWeeklyDigestMock(...args),
+}));
+
+// Recharts uses ResizeObserver
+beforeAll(() => {
+  (globalThis as any).ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
+});
+
+describe('WeeklyDigest integration', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders digest data from backend', async () => {
+    getWeeklyDigestMock.mockResolvedValue({
+      total_spent: 420.5,
+      last_week_total: 350,
+      pct_change: 20.1,
+      top_categories: [
+        { name: 'Food', amount: 200 },
+        { name: 'Transport', amount: 120 },
+      ],
+      biggest_expense: { description: 'Groceries', amount: 95.0, date: '2026-04-02' },
+      savings_rate: 35.2,
+      insight: 'Keep it up!',
+      week_start: '2026-03-29',
+      week_end: '2026-04-04',
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/weekly-digest']}>
+        <Routes>
+          <Route path="/weekly-digest" element={<WeeklyDigest />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(getWeeklyDigestMock).toHaveBeenCalled());
+    expect(screen.getByText(/weekly digest/i)).toBeInTheDocument();
+    expect(screen.getByText('$420.50')).toBeInTheDocument();
+    expect(screen.getByText('+20.1%')).toBeInTheDocument();
+    expect(screen.getByText('35.2%')).toBeInTheDocument();
+    expect(screen.getByText(/groceries/i)).toBeInTheDocument();
+    expect(screen.getByText(/keep it up/i)).toBeInTheDocument();
+  });
+
+  it('shows error on failure', async () => {
+    getWeeklyDigestMock.mockRejectedValue(new Error('Network error'));
+
+    render(
+      <MemoryRouter initialEntries={['/weekly-digest']}>
+        <Routes>
+          <Route path="/weekly-digest" element={<WeeklyDigest />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText(/network error/i)).toBeInTheDocument());
+  });
+});

--- a/app/src/api/digest.ts
+++ b/app/src/api/digest.ts
@@ -1,0 +1,17 @@
+import { api } from './client';
+
+export type WeeklyDigest = {
+  total_spent: number;
+  last_week_total: number;
+  pct_change: number;
+  top_categories: Array<{ name: string; amount: number }>;
+  biggest_expense: { description: string; amount: number; date: string } | null;
+  savings_rate: number;
+  insight: string;
+  week_start: string;
+  week_end: string;
+};
+
+export async function getWeeklyDigest(): Promise<WeeklyDigest> {
+  return api<WeeklyDigest>('/digest/weekly');
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Weekly Digest', href: '/weekly-digest' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/WeeklyDigest.tsx
+++ b/app/src/pages/WeeklyDigest.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { getWeeklyDigest, type WeeklyDigest as DigestData } from '@/api/digest';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+export default function WeeklyDigest() {
+  const [data, setData] = useState<DigestData | null>(null);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getWeeklyDigest()
+      .then(setData)
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <div className="p-6 text-center text-muted-foreground">Loading digest…</div>;
+  if (error) return <div className="p-6 text-center text-destructive">{error}</div>;
+  if (!data) return null;
+
+  const changeColor = data.pct_change > 0 ? 'text-destructive' : 'text-green-600';
+  const changeSign = data.pct_change > 0 ? '+' : '';
+
+  return (
+    <div className="container-financial py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Weekly Digest</h1>
+      <p className="text-sm text-muted-foreground">{data.week_start} — {data.week_end}</p>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2"><CardTitle className="text-sm">Total Spent</CardTitle></CardHeader>
+          <CardContent><p className="text-2xl font-bold">${data.total_spent.toFixed(2)}</p></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2"><CardTitle className="text-sm">vs Last Week</CardTitle></CardHeader>
+          <CardContent><p className={`text-2xl font-bold ${changeColor}`}>{changeSign}{data.pct_change}%</p></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2"><CardTitle className="text-sm">Savings Rate</CardTitle></CardHeader>
+          <CardContent><p className="text-2xl font-bold">{data.savings_rate}%</p></CardContent>
+        </Card>
+        {data.biggest_expense && (
+          <Card>
+            <CardHeader className="pb-2"><CardTitle className="text-sm">Biggest Expense</CardTitle></CardHeader>
+            <CardContent>
+              <p className="text-lg font-bold">${data.biggest_expense.amount.toFixed(2)}</p>
+              <p className="text-xs text-muted-foreground">{data.biggest_expense.description}</p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {data.top_categories.length > 0 && (
+        <Card>
+          <CardHeader><CardTitle>Top Spending Categories</CardTitle></CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={250}>
+              <BarChart data={data.top_categories}>
+                <XAxis dataKey="name" />
+                <YAxis />
+                <Tooltip />
+                <Bar dataKey="amount" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-center text-lg italic text-muted-foreground">💡 {data.insight}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,103 @@
+from datetime import date, timedelta
+from decimal import Decimal
+
+from flask import Blueprint, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Expense, Category
+
+bp = Blueprint("digest", __name__)
+
+INSIGHTS = [
+    "You're making great progress — keep it up!",
+    "Small savings add up over time. Stay consistent!",
+    "Tracking spending is the first step to financial freedom.",
+    "Every dollar saved is a dollar earned.",
+    "Awareness is power — you're already ahead of most people.",
+]
+
+
+@bp.get("/weekly")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    today = date.today()
+    week_start = today - timedelta(days=6)
+    prev_week_start = week_start - timedelta(days=7)
+    prev_week_end = week_start - timedelta(days=1)
+
+    # This week expenses
+    this_week = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(Expense.user_id == uid, Expense.spent_at >= week_start, Expense.spent_at <= today)
+        .scalar()
+    )
+    this_week_total = float(this_week or 0)
+
+    # Last week expenses
+    last_week = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(Expense.user_id == uid, Expense.spent_at >= prev_week_start, Expense.spent_at <= prev_week_end)
+        .scalar()
+    )
+    last_week_total = float(last_week or 0)
+
+    pct_change = 0.0
+    if last_week_total > 0:
+        pct_change = round(((this_week_total - last_week_total) / last_week_total) * 100, 1)
+
+    # Top 3 categories
+    cat_rows = (
+        db.session.query(Category.name, func.sum(Expense.amount).label("total"))
+        .join(Category, Expense.category_id == Category.id)
+        .filter(Expense.user_id == uid, Expense.spent_at >= week_start, Expense.spent_at <= today)
+        .group_by(Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .limit(3)
+        .all()
+    )
+    top_categories = [{"name": r[0], "amount": float(r[1])} for r in cat_rows]
+
+    # Biggest single expense
+    biggest = (
+        db.session.query(Expense)
+        .filter(Expense.user_id == uid, Expense.spent_at >= week_start, Expense.spent_at <= today)
+        .order_by(Expense.amount.desc())
+        .first()
+    )
+    biggest_expense = None
+    if biggest:
+        biggest_expense = {"description": biggest.notes or "", "amount": float(biggest.amount), "date": biggest.spent_at.isoformat()}
+
+    # This week income
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(Expense.user_id == uid, Expense.expense_type == "INCOME", Expense.spent_at >= week_start, Expense.spent_at <= today)
+        .scalar()
+    )
+    income_total = float(income or 0)
+    expenses_only = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(Expense.user_id == uid, Expense.expense_type == "EXPENSE", Expense.spent_at >= week_start, Expense.spent_at <= today)
+        .scalar()
+    )
+    expenses_total = float(expenses_only or 0)
+    savings_rate = 0.0
+    if income_total > 0:
+        savings_rate = round(((income_total - expenses_total) / income_total) * 100, 1)
+
+    insight = INSIGHTS[today.toordinal() % len(INSIGHTS)]
+
+    return jsonify(
+        total_spent=this_week_total,
+        last_week_total=last_week_total,
+        pct_change=pct_change,
+        top_categories=top_categories,
+        biggest_expense=biggest_expense,
+        savings_rate=savings_rate,
+        insight=insight,
+        week_start=week_start.isoformat(),
+        week_end=today.isoformat(),
+    )


### PR DESCRIPTION
Implements #121. See issue for acceptance criteria.

## Changes
- **Backend**: `GET /api/digest/weekly` endpoint — queries expenses for last 7 days, computes totals by category, returns JSON with total spent, week-over-week % change, top 3 categories, biggest expense, savings rate, and motivational insight
- **Frontend**: `WeeklyDigest.tsx` page with summary cards, bar chart (recharts) for top categories, and insight display
- **Routing**: Added `/weekly-digest` route to App.tsx, added "Weekly Digest" link to Navbar
- **Tests**: Integration test in `WeeklyDigest.integration.test.tsx`