### PR TITLE
feat(savings): goal-based savings tracking with milestones #133

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import SavingsGoals from "./pages/SavingsGoals";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="savings-goals"
+              element={
+                <ProtectedRoute>
+                  <SavingsGoals />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/savingsGoals.ts
+++ b/app/src/api/savingsGoals.ts
@@ -1,0 +1,22 @@
+import { api } from './client';
+
+export type SavingsGoal = {
+  id: number;
+  name: string;
+  target_amount: number;
+  saved_amount: number;
+  target_date: string | null;
+  progress_pct: number;
+  milestones: number[];
+};
+
+export const getSavingsGoals = () => api<SavingsGoal[]>('/savings-goals');
+
+export const createSavingsGoal = (data: { name: string; target_amount: number; target_date?: string }) =>
+  api<SavingsGoal>('/savings-goals', { method: 'POST', body: data });
+
+export const updateSavingsGoal = (id: number, data: Partial<{ name: string; target_amount: number; saved_amount: number; target_date: string | null }>) =>
+  api<SavingsGoal>(`/savings-goals/${id}`, { method: 'PUT' as any, body: data });
+
+export const deleteSavingsGoal = (id: number) =>
+  api<{ message: string }>(`/savings-goals/${id}`, { method: 'DELETE' });

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Savings Goals', href: '/savings-goals' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/SavingsGoals.tsx
+++ b/app/src/pages/SavingsGoals.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from 'react';
+import { getSavingsGoals, createSavingsGoal, updateSavingsGoal, deleteSavingsGoal, type SavingsGoal } from '@/api/savingsGoals';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Progress } from '@/components/ui/progress';
+import { Trash2 } from 'lucide-react';
+
+const MILESTONE_LABELS: Record<number, string> = { 25: '🥉 25%', 50: '🥈 50%', 75: '🥇 75%', 100: '🏆 100%' };
+
+export default function SavingsGoals() {
+  const [goals, setGoals] = useState<SavingsGoal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState('');
+  const [target, setTarget] = useState('');
+  const [targetDate, setTargetDate] = useState('');
+  const [addAmount, setAddAmount] = useState<Record<number, string>>({});
+
+  const load = () => {
+    getSavingsGoals().then(setGoals).finally(() => setLoading(false));
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !target) return;
+    await createSavingsGoal({ name, target_amount: parseFloat(target), target_date: targetDate || undefined });
+    setName(''); setTarget(''); setTargetDate('');
+    load();
+  };
+
+  const handleAddSaved = async (goal: SavingsGoal) => {
+    const amt = parseFloat(addAmount[goal.id] || '0');
+    if (!amt || amt <= 0) return;
+    await updateSavingsGoal(goal.id, { saved_amount: goal.saved_amount + amt });
+    setAddAmount((p) => ({ ...p, [goal.id]: '' }));
+    load();
+  };
+
+  const handleDelete = async (id: number) => {
+    await deleteSavingsGoal(id);
+    load();
+  };
+
+  if (loading) return <div className="p-6 text-center text-muted-foreground">Loading…</div>;
+
+  return (
+    <div className="container-financial py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Savings Goals</h1>
+
+      <Card>
+        <CardHeader><CardTitle>Create Goal</CardTitle></CardHeader>
+        <CardContent>
+          <form onSubmit={handleCreate} className="flex flex-wrap gap-3">
+            <Input placeholder="Goal name" value={name} onChange={(e) => setName(e.target.value)} className="w-48" required />
+            <Input type="number" placeholder="Target amount" value={target} onChange={(e) => setTarget(e.target.value)} className="w-36" min="0.01" step="0.01" required />
+            <Input type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} className="w-40" />
+            <Button type="submit">Add Goal</Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {goals.length === 0 && <p className="text-center text-muted-foreground">No goals yet. Create one above!</p>}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {goals.map((g) => (
+          <Card key={g.id}>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <CardTitle className="text-base">{g.name}</CardTitle>
+              <Button variant="ghost" size="icon" onClick={() => handleDelete(g.id)} aria-label={`Delete ${g.name}`}>
+                <Trash2 className="h-4 w-4 text-destructive" />
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="flex justify-between text-sm">
+                <span>${g.saved_amount.toFixed(2)} / ${g.target_amount.toFixed(2)}</span>
+                <span className="font-semibold">{g.progress_pct}%</span>
+              </div>
+              <Progress value={g.progress_pct} className="h-3" />
+              {g.target_date && <p className="text-xs text-muted-foreground">Target: {g.target_date}</p>}
+              <div className="flex flex-wrap gap-1">
+                {[25, 50, 75, 100].map((m) => (
+                  <span key={m} className={`text-xs px-2 py-0.5 rounded-full ${g.milestones.includes(m) ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'}`}>
+                    {MILESTONE_LABELS[m]}
+                  </span>
+                ))}
+              </div>
+              <div className="flex gap-2">
+                <Input type="number" placeholder="Add savings" value={addAmount[g.id] || ''} onChange={(e) => setAddAmount((p) => ({ ...p, [g.id]: e.target.value }))} className="w-32" min="0.01" step="0.01" />
+                <Button size="sm" onClick={() => handleAddSaved(g)}>Add</Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,14 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    target_amount = db.Column(db.Numeric(12, 2), nullable=False)
+    saved_amount = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    target_date = db.Column(db.Date, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings_goals import bp as savings_goals_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_goals_bp, url_prefix="/savings-goals")

--- a/packages/backend/app/routes/savings_goals.py
+++ b/packages/backend/app/routes/savings_goals.py
@@ -1,0 +1,104 @@
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import SavingsGoal
+
+bp = Blueprint("savings_goals", __name__)
+
+
+def _goal_to_dict(g: SavingsGoal) -> dict:
+    target = float(g.target_amount)
+    saved = float(g.saved_amount)
+    pct = round((saved / target) * 100, 1) if target > 0 else 0
+    milestones = [m for m in [25, 50, 75, 100] if pct >= m]
+    return {
+        "id": g.id,
+        "name": g.name,
+        "target_amount": target,
+        "saved_amount": saved,
+        "target_date": g.target_date.isoformat() if g.target_date else None,
+        "progress_pct": pct,
+        "milestones": milestones,
+    }
+
+
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    goals = db.session.query(SavingsGoal).filter_by(user_id=uid).order_by(SavingsGoal.created_at.desc()).all()
+    return jsonify([_goal_to_dict(g) for g in goals])
+
+
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    try:
+        target = Decimal(str(data.get("target_amount", 0))).quantize(Decimal("0.01"))
+        if target <= 0:
+            raise ValueError
+    except (InvalidOperation, ValueError, TypeError):
+        return jsonify(error="invalid target_amount"), 400
+    target_date = None
+    if data.get("target_date"):
+        try:
+            target_date = date.fromisoformat(data["target_date"])
+        except ValueError:
+            return jsonify(error="invalid target_date"), 400
+    g = SavingsGoal(user_id=uid, name=name, target_amount=target, target_date=target_date)
+    db.session.add(g)
+    db.session.commit()
+    return jsonify(_goal_to_dict(g)), 201
+
+
+@bp.put("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    g = db.session.get(SavingsGoal, goal_id)
+    if not g or g.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        g.name = (data["name"] or "").strip() or g.name
+    if "target_amount" in data:
+        try:
+            g.target_amount = Decimal(str(data["target_amount"])).quantize(Decimal("0.01"))
+        except (InvalidOperation, ValueError, TypeError):
+            return jsonify(error="invalid target_amount"), 400
+    if "saved_amount" in data:
+        try:
+            g.saved_amount = Decimal(str(data["saved_amount"])).quantize(Decimal("0.01"))
+        except (InvalidOperation, ValueError, TypeError):
+            return jsonify(error="invalid saved_amount"), 400
+    if "target_date" in data:
+        if data["target_date"]:
+            try:
+                g.target_date = date.fromisoformat(data["target_date"])
+            except ValueError:
+                return jsonify(error="invalid target_date"), 400
+        else:
+            g.target_date = None
+    db.session.commit()
+    return jsonify(_goal_to_dict(g))
+
+
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    g = db.session.get(SavingsGoal, goal_id)
+    if not g or g.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(g)
+    db.session.commit()
+    return jsonify(message="deleted")


### PR DESCRIPTION
Implements #133. See issue for acceptance criteria.

## Changes
- **Backend**: CRUD endpoints `GET/POST/PUT/DELETE /api/savings-goals` in `savings_goals.py`, with `SavingsGoal` model in `models.py`
- **Frontend**: `SavingsGoals.tsx` page — create goals (name, target, date), progress bars, milestone badges at 25%/50%/75%/100%, add savings, delete goals
- **Routing**: Added `/savings-goals` route to App.tsx, added "Savings Goals" link to Navbar