### PR TITLE
feat(accounts): multi-account financial overview dashboard #132

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Accounts from "./pages/Accounts";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="accounts"
+              element={
+                <ProtectedRoute>
+                  <Accounts />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/accounts.ts
+++ b/app/src/api/accounts.ts
@@ -1,0 +1,14 @@
+import { api } from './client';
+
+export type FinancialAccount = {
+  id: number;
+  name: string;
+  account_type: 'checking' | 'savings' | 'credit';
+  balance: number;
+  last_transaction: string | null;
+};
+
+export const getAccounts = () => api<FinancialAccount[]>('/accounts');
+
+export const createAccount = (data: { name: string; account_type: string; balance: number }) =>
+  api<FinancialAccount>('/accounts', { method: 'POST', body: data });

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Accounts', href: '/accounts' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { getAccounts, createAccount, type FinancialAccount } from '@/api/accounts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+export default function Accounts() {
+  const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState('');
+  const [type, setType] = useState('checking');
+  const [balance, setBalance] = useState('');
+
+  const load = () => { getAccounts().then(setAccounts).finally(() => setLoading(false)); };
+  useEffect(() => { load(); }, []);
+
+  const assets = accounts.filter((a) => a.account_type !== 'credit').reduce((s, a) => s + a.balance, 0);
+  const liabilities = accounts.filter((a) => a.account_type === 'credit').reduce((s, a) => s + a.balance, 0);
+  const netWorth = assets - liabilities;
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name) return;
+    await createAccount({ name, account_type: type, balance: parseFloat(balance || '0') });
+    setName(''); setBalance('');
+    load();
+  };
+
+  if (loading) return <div className="p-6 text-center text-muted-foreground">Loading…</div>;
+
+  return (
+    <div className="container-financial py-8 space-y-6">
+      <h1 className="text-2xl font-bold">Accounts Overview</h1>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Total Assets</CardTitle></CardHeader><CardContent><p className="text-2xl font-bold text-green-600">${assets.toFixed(2)}</p></CardContent></Card>
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Total Liabilities</CardTitle></CardHeader><CardContent><p className="text-2xl font-bold text-destructive">${liabilities.toFixed(2)}</p></CardContent></Card>
+        <Card><CardHeader className="pb-2"><CardTitle className="text-sm">Net Worth</CardTitle></CardHeader><CardContent><p className="text-2xl font-bold">${netWorth.toFixed(2)}</p></CardContent></Card>
+      </div>
+
+      <Card>
+        <CardHeader><CardTitle>Add Account</CardTitle></CardHeader>
+        <CardContent>
+          <form onSubmit={handleCreate} className="flex flex-wrap gap-3">
+            <Input placeholder="Account name" value={name} onChange={(e) => setName(e.target.value)} className="w-48" required />
+            <select value={type} onChange={(e) => setType(e.target.value)} className="rounded-md border px-3 py-2 text-sm" aria-label="Account type">
+              <option value="checking">Checking</option>
+              <option value="savings">Savings</option>
+              <option value="credit">Credit</option>
+            </select>
+            <Input type="number" placeholder="Balance" value={balance} onChange={(e) => setBalance(e.target.value)} className="w-36" step="0.01" />
+            <Button type="submit">Add</Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {accounts.length === 0 && <p className="text-center text-muted-foreground">No accounts yet.</p>}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {accounts.map((a) => (
+          <Card key={a.id}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">{a.name}</CardTitle>
+              <span className="text-xs uppercase text-muted-foreground">{a.account_type}</span>
+            </CardHeader>
+            <CardContent>
+              <p className={`text-xl font-bold ${a.account_type === 'credit' ? 'text-destructive' : ''}`}>${a.balance.toFixed(2)}</p>
+              {a.last_transaction && <p className="text-xs text-muted-foreground mt-1">Last: {a.last_transaction}</p>}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,14 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    account_type = db.Column(db.String(20), nullable=False)  # checking, savings, credit
+    balance = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    last_transaction = db.Column(db.String(200), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,50 @@
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import FinancialAccount
+
+bp = Blueprint("accounts", __name__)
+
+VALID_TYPES = {"checking", "savings", "credit"}
+
+
+def _acct_to_dict(a: FinancialAccount) -> dict:
+    return {
+        "id": a.id,
+        "name": a.name,
+        "account_type": a.account_type,
+        "balance": float(a.balance),
+        "last_transaction": a.last_transaction,
+    }
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    accts = db.session.query(FinancialAccount).filter_by(user_id=uid).order_by(FinancialAccount.created_at.desc()).all()
+    return jsonify([_acct_to_dict(a) for a in accts])
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    acct_type = (data.get("account_type") or "").lower()
+    if acct_type not in VALID_TYPES:
+        return jsonify(error="account_type must be checking, savings, or credit"), 400
+    try:
+        balance = Decimal(str(data.get("balance", 0))).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return jsonify(error="invalid balance"), 400
+    a = FinancialAccount(user_id=uid, name=name, account_type=acct_type, balance=balance)
+    db.session.add(a)
+    db.session.commit()
+    return jsonify(_acct_to_dict(a)), 201


### PR DESCRIPTION
Implements #132. See issue for acceptance criteria.

## Changes
- **Backend**: `GET/POST /api/accounts` endpoints in `accounts.py`, with `FinancialAccount` model in `models.py`
- **Frontend**: `Accounts.tsx` page — account grid (name, type, balance, last transaction), summary row (total assets, total liabilities, net worth), add account form
- **Routing**: Added `/accounts` route to App.tsx, added "Accounts" link to Navbar