### PR TITLE
perf(db): add composite indexes for high-frequency financial queries

### DIFF
--- a/packages/backend/app/models_indexed.py
+++ b/packages/backend/app/models_indexed.py
@@ -1,0 +1,15 @@
+"""
+SQLAlchemy __table_args__ indexes applied directly to models.
+These mirror 003_perf_indexes.py migration for ORM-level awareness.
+Import this module to patch index definitions onto existing models.
+"""
+from sqlalchemy import Index
+from .models import Expense, RecurringExpense, Bill, Category
+
+# High-frequency query indexes
+Index("ix_expenses_user_spent",     Expense.user_id,          Expense.spent_at)
+Index("ix_expenses_user_category",  Expense.user_id,          Expense.category_id)
+Index("ix_expenses_user_type",      Expense.user_id,          Expense.expense_type)
+Index("ix_recurring_user_active",   RecurringExpense.user_id, RecurringExpense.active)
+Index("ix_bills_user_due",          Bill.user_id,             Bill.due_date)
+Index("ix_categories_user",         Category.user_id)

--- a/packages/backend/migrations/versions/003_add_performance_indexes.py
+++ b/packages/backend/migrations/versions/003_add_performance_indexes.py
@@ -1,0 +1,36 @@
+"""Add database indexes for high-frequency financial queries
+
+Revision ID: 003_perf_indexes
+Revises: 002
+Create Date: 2026-04-05
+"""
+from alembic import op
+
+revision = "003_perf_indexes"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # expenses: user_id + spent_at — most common dashboard query
+    op.create_index("ix_expenses_user_spent", "expenses", ["user_id", "spent_at"])
+    # expenses: user_id + category_id — category breakdown queries
+    op.create_index("ix_expenses_user_category", "expenses", ["user_id", "category_id"])
+    # expenses: user_id + expense_type — income vs expense splits
+    op.create_index("ix_expenses_user_type", "expenses", ["user_id", "expense_type"])
+    # recurring_expenses: user_id + active — active recurring fetch
+    op.create_index("ix_recurring_user_active", "recurring_expenses", ["user_id", "active"])
+    # bills: user_id + due_date — upcoming bills queries
+    op.create_index("ix_bills_user_due", "bills", ["user_id", "due_date"])
+    # categories: user_id — all category lookups are by user
+    op.create_index("ix_categories_user", "categories", ["user_id"])
+
+
+def downgrade():
+    op.drop_index("ix_expenses_user_spent", "expenses")
+    op.drop_index("ix_expenses_user_category", "expenses")
+    op.drop_index("ix_expenses_user_type", "expenses")
+    op.drop_index("ix_recurring_user_active", "recurring_expenses")
+    op.drop_index("ix_bills_user_due", "bills")
+    op.drop_index("ix_categories_user", "categories")

--- a/packages/backend/tests/test_db_indexes.py
+++ b/packages/backend/tests/test_db_indexes.py
@@ -1,0 +1,49 @@
+"""Tests for database performance indexes (issue #128)."""
+import pytest
+from sqlalchemy import inspect, text
+from app import create_app
+from app.extensions import db as _db
+
+
+@pytest.fixture(scope="module")
+def app():
+    app = create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"})
+    with app.app_context():
+        _db.create_all()
+        # Apply indexes (SQLite supports them)
+        import app.models_indexed  # noqa: F401 — registers indexes
+        yield app
+
+
+def test_expense_indexes_defined(app):
+    """Verify index definitions exist on the Expense model."""
+    import app.models_indexed  # noqa: F401
+    from sqlalchemy import Index
+    from app.models import Expense
+    mapper = inspect(Expense)
+    index_names = {i.name for i in mapper.mapper.persist_selectable.indexes}
+    assert "ix_expenses_user_spent" in index_names
+    assert "ix_expenses_user_category" in index_names
+    assert "ix_expenses_user_type" in index_names
+
+
+def test_migration_file_exists():
+    """Verify the Alembic migration file is present."""
+    import os
+    migration = os.path.join(
+        os.path.dirname(__file__),
+        "../migrations/versions/003_add_performance_indexes.py"
+    )
+    assert os.path.exists(migration), "Migration file missing"
+
+
+def test_expense_query_uses_index(app):
+    """Smoke test: query by user_id + spent_at executes without error."""
+    from app.models import Expense
+    from datetime import date
+    with app.app_context():
+        result = _db.session.query(Expense).filter(
+            Expense.user_id == 1,
+            Expense.spent_at >= date(2026, 1, 1)
+        ).all()
+        assert isinstance(result, list)


### PR DESCRIPTION
Closes #128

## What
Adds 6 composite SQLAlchemy indexes targeting the most common query patterns in FinMind's financial data layer.

## Indexes Added
| Index | Table | Columns | Query Pattern |
|-------|-------|---------|---------------|
| `ix_expenses_user_spent` | expenses | user_id, spent_at | Dashboard date-range aggregations |
| `ix_expenses_user_category` | expenses | user_id, category_id | Category breakdown reports |
| `ix_expenses_user_type` | expenses | user_id, expense_type | Income vs expense splits |
| `ix_recurring_user_active` | recurring_expenses | user_id, active | Active recurring expense fetches |
| `ix_bills_user_due` | bills | user_id, due_date | Upcoming bills lookups |
| `ix_categories_user` | categories | user_id | Per-user category list |

## Implementation
- **Alembic migration** `003_add_performance_indexes.py` with `upgrade()` and `downgrade()`
- **`models_indexed.py`** — ORM-level `Index()` definitions for SQLAlchemy awareness
- **Tests** — verify index definitions exist and queries execute without error

## Testing
```
pytest packages/backend/tests/test_db_indexes.py -v
```