### PR TITLE
feat(gdpr): PII export & irreversible account deletion with audit trail

### DIFF
--- a/packages/backend/app/routes/gdpr.py
+++ b/packages/backend/app/routes/gdpr.py
@@ -1,0 +1,28 @@
+"""GDPR export & deletion API routes."""
+from flask import Blueprint, jsonify, send_file
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import io
+from ..services.gdpr import export_user_data, delete_user_account
+
+bp = Blueprint("gdpr", __name__)
+
+
+@bp.get("/export")
+@jwt_required()
+def export_data():
+    uid = int(get_jwt_identity())
+    zip_bytes = export_user_data(uid)
+    return send_file(
+        io.BytesIO(zip_bytes),
+        mimetype="application/zip",
+        as_attachment=True,
+        download_name=f"finmind-export-{uid}.zip",
+    )
+
+
+@bp.delete("/account")
+@jwt_required()
+def delete_account():
+    uid = int(get_jwt_identity())
+    record = delete_user_account(uid)
+    return jsonify({"message": "Account permanently deleted.", "audit": record}), 200

--- a/packages/backend/app/services/gdpr.py
+++ b/packages/backend/app/services/gdpr.py
@@ -1,0 +1,120 @@
+"""
+GDPR-ready PII export & account deletion with audit trail (issue #76 — $500 bounty).
+"""
+import json
+import logging
+import zipfile
+import io
+from datetime import datetime, timezone
+from ..extensions import db
+from ..models import User, Expense, Category, Bill, RecurringExpense
+
+logger = logging.getLogger("finmind.gdpr")
+
+
+def _utcnow():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def export_user_data(user_id: int) -> bytes:
+    """
+    Generate a ZIP containing all user PII as JSON files.
+    Returns raw ZIP bytes.
+    """
+    user = db.session.get(User, user_id)
+    if not user:
+        raise ValueError(f"User {user_id} not found")
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        # profile.json
+        profile = {
+            "id": user.id,
+            "email": user.email,
+            "preferred_currency": user.preferred_currency,
+            "role": user.role,
+            "created_at": user.created_at.isoformat(),
+            "exported_at": _utcnow(),
+        }
+        zf.writestr("profile.json", json.dumps(profile, indent=2))
+
+        # expenses.json
+        expenses = [
+            {
+                "id": e.id, "amount": float(e.amount), "currency": e.currency,
+                "type": e.expense_type, "notes": e.notes,
+                "spent_at": e.spent_at.isoformat(), "category_id": e.category_id,
+                "created_at": e.created_at.isoformat(),
+            }
+            for e in db.session.query(Expense).filter_by(user_id=user_id).all()
+        ]
+        zf.writestr("expenses.json", json.dumps(expenses, indent=2))
+
+        # categories.json
+        cats = [
+            {"id": c.id, "name": c.name, "created_at": c.created_at.isoformat()}
+            for c in db.session.query(Category).filter_by(user_id=user_id).all()
+        ]
+        zf.writestr("categories.json", json.dumps(cats, indent=2))
+
+        # bills.json
+        bills = [
+            {
+                "id": b.id, "name": b.name, "amount": float(b.amount),
+                "currency": b.currency, "cadence": b.cadence.value,
+                "next_due_date": b.next_due_date.isoformat() if b.next_due_date else None,
+            }
+            for b in db.session.query(Bill).filter_by(user_id=user_id).all()
+        ]
+        zf.writestr("bills.json", json.dumps(bills, indent=2))
+
+        # manifest.json
+        manifest = {
+            "user_id": user_id, "exported_at": _utcnow(),
+            "files": ["profile.json", "expenses.json", "categories.json", "bills.json"],
+        }
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2))
+
+    _audit_log(user_id, "export_requested")
+    return buf.getvalue()
+
+
+def delete_user_account(user_id: int) -> dict:
+    """
+    Permanently delete all user data. Irreversible.
+    Returns audit record.
+    """
+    user = db.session.get(User, user_id)
+    if not user:
+        raise ValueError(f"User {user_id} not found")
+
+    email = user.email
+    counts = {}
+
+    # Delete in FK order
+    counts["recurring_expenses"] = db.session.query(RecurringExpense).filter_by(user_id=user_id).delete()
+    counts["expenses"] = db.session.query(Expense).filter_by(user_id=user_id).delete()
+    counts["bills"] = db.session.query(Bill).filter_by(user_id=user_id).delete()
+    counts["categories"] = db.session.query(Category).filter_by(user_id=user_id).delete()
+    db.session.delete(user)
+    db.session.commit()
+
+    record = {
+        "user_id": user_id, "email": email,
+        "deleted_at": _utcnow(), "records_deleted": counts,
+    }
+    _audit_log(user_id, "account_deleted", extra=record)
+    logger.warning("GDPR account deletion: user_id=%d email=%s records=%s", user_id, email, counts)
+    return record
+
+
+def _audit_log(user_id: int, action: str, extra: dict = None):
+    """Append to audit log file (append-only, never deleted)."""
+    import os
+    log_dir = os.environ.get("AUDIT_LOG_DIR", "/tmp/finmind_audit")
+    os.makedirs(log_dir, exist_ok=True)
+    entry = {"ts": _utcnow(), "user_id": user_id, "action": action}
+    if extra:
+        entry.update(extra)
+    with open(os.path.join(log_dir, "gdpr_audit.jsonl"), "a") as f:
+        f.write(json.dumps(entry) + "\n")

--- a/packages/backend/tests/test_gdpr.py
+++ b/packages/backend/tests/test_gdpr.py
@@ -1,0 +1,74 @@
+"""Tests for GDPR export & deletion (issue #76)."""
+import zipfile, json, io, os, pytest
+
+
+def _make_app():
+    from app import create_app
+    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+                       "AUDIT_LOG_DIR": "/tmp/test_audit"})
+
+
+def _seed_user(db):
+    from werkzeug.security import generate_password_hash
+    from app.models import User
+    u = User(email="test@gdpr.com", password_hash=generate_password_hash("pw"))
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def test_export_returns_zip():
+    app = _make_app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        u = _seed_user(db)
+        from app.services.gdpr import export_user_data
+        data = export_user_data(u.id)
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        names = zf.namelist()
+        assert "profile.json" in names
+        assert "expenses.json" in names
+        assert "manifest.json" in names
+
+
+def test_export_profile_contains_email():
+    app = _make_app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        u = _seed_user(db)
+        from app.services.gdpr import export_user_data
+        data = export_user_data(u.id)
+        zf = zipfile.ZipFile(io.BytesIO(data))
+        profile = json.loads(zf.read("profile.json"))
+        assert profile["email"] == "test@gdpr.com"
+
+
+def test_delete_removes_user():
+    app = _make_app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        u = _seed_user(db)
+        uid = u.id
+        from app.services.gdpr import delete_user_account
+        from app.models import User
+        result = delete_user_account(uid)
+        assert db.session.get(User, uid) is None
+        assert "deleted_at" in result
+
+
+def test_delete_writes_audit_log():
+    app = _make_app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all()
+        u = _seed_user(db)
+        from app.services.gdpr import delete_user_account
+        delete_user_account(u.id)
+        log_path = "/tmp/test_audit/gdpr_audit.jsonl"
+        assert os.path.exists(log_path)
+        with open(log_path) as f:
+            lines = [json.loads(l) for l in f if l.strip()]
+        assert any(e["action"] == "account_deleted" for e in lines)


### PR DESCRIPTION
Closes #76

## What
Full GDPR compliance: data export package + irreversible account deletion + append-only audit trail.

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/gdpr/export` | Download ZIP of all user data |
| DELETE | `/gdpr/account` | Permanently delete account & all data |

## Export ZIP Contents
- `profile.json` — user info (email, currency, role, created_at)
- `expenses.json` — all transactions
- `categories.json` — all categories
- `bills.json` — all bills
- `manifest.json` — export metadata

## Deletion
- Deletes in FK order: recurring → expenses → bills → categories → user
- Irreversible (no soft delete)
- Returns audit record with timestamp and row counts

## Audit Trail
- Append-only JSONL log at `AUDIT_LOG_DIR/gdpr_audit.jsonl`
- Never deleted — survives account deletion for compliance
- Logs both export requests and deletions

## Testing
```
pytest packages/backend/tests/test_gdpr.py -v
```