### PR TITLE
feat(accounts): multi-account financial overview dashboard

### DIFF
--- a/packages/backend/app/routes/multi_account.py
+++ b/packages/backend/app/routes/multi_account.py
@@ -1,0 +1,29 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.multi_account import create_account, get_overview, update_balance
+
+bp = Blueprint("accounts", __name__)
+
+@bp.get("/overview")
+@jwt_required()
+def overview():
+    return jsonify(get_overview(int(get_jwt_identity())))
+
+@bp.post("")
+@jwt_required()
+def create():
+    uid = int(get_jwt_identity())
+    d = request.get_json() or {}
+    if not d.get("name"):
+        return jsonify(error="name required"), 400
+    acct = create_account(uid, d["name"], d.get("account_type","checking"),
+                          d.get("currency","INR"), float(d.get("balance",0)),
+                          d.get("institution"))
+    return jsonify({"id": acct.id, "name": acct.name}), 201
+
+@bp.patch("/<int:account_id>/balance")
+@jwt_required()
+def patch_balance(account_id):
+    d = request.get_json() or {}
+    acct = update_balance(account_id, float(d.get("balance", 0)))
+    return jsonify({"id": acct.id, "balance": float(acct.balance)})

--- a/packages/backend/app/services/multi_account.py
+++ b/packages/backend/app/services/multi_account.py
@@ -1,0 +1,83 @@
+"""
+Multi-account financial overview dashboard (issue #132 — $200 bounty).
+Allows users to create named financial accounts (checking, savings, credit)
+and view a unified overview across all of them.
+"""
+import logging
+from datetime import date
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Expense
+
+logger = logging.getLogger("finmind.accounts")
+
+
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    account_type = db.Column(db.String(50), default="checking", nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    balance = db.Column(db.Numeric(14, 2), default=0, nullable=False)
+    institution = db.Column(db.String(200), nullable=True)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=date.today, nullable=False)
+
+
+VALID_TYPES = {"checking", "savings", "credit", "investment", "cash", "loan"}
+
+
+def create_account(user_id: int, name: str, account_type: str = "checking",
+                   currency: str = "INR", balance: float = 0,
+                   institution: str = None) -> FinancialAccount:
+    if account_type not in VALID_TYPES:
+        raise ValueError(f"Invalid account_type. Must be one of: {VALID_TYPES}")
+    acct = FinancialAccount(user_id=user_id, name=name, account_type=account_type,
+                            currency=currency, balance=balance, institution=institution)
+    db.session.add(acct)
+    db.session.commit()
+    return acct
+
+
+def update_balance(account_id: int, new_balance: float) -> FinancialAccount:
+    acct = db.session.get(FinancialAccount, account_id)
+    if not acct:
+        raise ValueError(f"Account {account_id} not found")
+    acct.balance = new_balance
+    db.session.commit()
+    return acct
+
+
+def get_overview(user_id: int) -> dict:
+    """Unified overview across all active accounts."""
+    accounts = (db.session.query(FinancialAccount)
+                .filter_by(user_id=user_id, is_active=True)
+                .order_by(FinancialAccount.id).all())
+
+    total_assets = sum(float(a.balance) for a in accounts
+                       if a.account_type not in ("credit", "loan"))
+    total_liabilities = sum(float(a.balance) for a in accounts
+                            if a.account_type in ("credit", "loan"))
+    net_worth = total_assets - total_liabilities
+
+    by_type = {}
+    for a in accounts:
+        by_type.setdefault(a.account_type, []).append(_acct_dict(a))
+
+    return {
+        "net_worth": round(net_worth, 2),
+        "total_assets": round(total_assets, 2),
+        "total_liabilities": round(total_liabilities, 2),
+        "account_count": len(accounts),
+        "by_type": by_type,
+        "accounts": [_acct_dict(a) for a in accounts],
+    }
+
+
+def _acct_dict(a: FinancialAccount) -> dict:
+    return {
+        "id": a.id, "name": a.name, "type": a.account_type,
+        "balance": float(a.balance), "currency": a.currency,
+        "institution": a.institution, "is_active": a.is_active,
+    }

--- a/packages/backend/tests/test_multi_account.py
+++ b/packages/backend/tests/test_multi_account.py
@@ -1,0 +1,53 @@
+"""Tests for multi-account dashboard (issue #132)."""
+def _app():
+    from app import create_app
+    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"})
+
+def test_create_and_overview():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        from app.services.multi_account import FinancialAccount
+        db.create_all()
+        from app.services.multi_account import create_account, get_overview
+        create_account(1, "Chase Checking", "checking", balance=2000)
+        create_account(1, "Savings", "savings", balance=5000)
+        create_account(1, "Credit Card", "credit", balance=500)
+        ov = get_overview(1)
+        assert ov["net_worth"] == 6500.0  # 7000 assets - 500 liabilities
+        assert ov["total_assets"] == 7000.0
+        assert ov["total_liabilities"] == 500.0
+        assert ov["account_count"] == 3
+
+def test_overview_empty():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        from app.services.multi_account import FinancialAccount
+        db.create_all()
+        from app.services.multi_account import get_overview
+        ov = get_overview(999)
+        assert ov["net_worth"] == 0
+        assert ov["accounts"] == []
+
+def test_update_balance():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        from app.services.multi_account import FinancialAccount
+        db.create_all()
+        from app.services.multi_account import create_account, update_balance
+        a = create_account(1, "Main", balance=100)
+        updated = update_balance(a.id, 999.99)
+        assert float(updated.balance) == 999.99
+
+def test_invalid_account_type():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        from app.services.multi_account import FinancialAccount
+        db.create_all()
+        from app.services.multi_account import create_account
+        import pytest
+        with pytest.raises(ValueError):
+            create_account(1, "Bad", account_type="invalid_type")


### PR DESCRIPTION
Closes #132

## What
Multi-account financial tracking with a unified net worth dashboard.

## Model
`FinancialAccount`: name, type (checking/savings/credit/investment/cash/loan), balance, currency, institution, is_active

## API
| Method | Path | Description |
|--------|------|-------------|
| GET | `/accounts/overview` | Net worth + all accounts grouped by type |
| POST | `/accounts` | Create a new financial account |
| PATCH | `/accounts/:id/balance` | Update account balance |

## Overview Response
```json
{"net_worth": 6500.0, "total_assets": 7000.0, "total_liabilities": 500.0,
 "by_type": {"checking": [...], "credit": [...]}, "accounts": [...]}
```

## Testing
`pytest packages/backend/tests/test_multi_account.py -v` — 4 tests.