### PR TITLE
feat(backup): AES-256-GCM encrypted backup & secure export options

### DIFF
--- a/packages/backend/app/routes/backup.py
+++ b/packages/backend/app/routes/backup.py
@@ -1,0 +1,26 @@
+from flask import Blueprint, jsonify, request, send_file
+from flask_jwt_extended import jwt_required, get_jwt_identity
+import io
+from ..services.backup import create_encrypted_backup, create_plaintext_backup
+
+bp = Blueprint("backup", __name__)
+
+@bp.post("/encrypted")
+@jwt_required()
+def encrypted_backup():
+    uid = int(get_jwt_identity())
+    d = request.get_json() or {}
+    password = d.get("password")
+    if not password or len(password) < 8:
+        return jsonify(error="password required (min 8 chars)"), 400
+    payload = create_encrypted_backup(uid, password)
+    return send_file(io.BytesIO(payload), mimetype="application/octet-stream",
+                     as_attachment=True, download_name=f"finmind-backup-{uid}.enc")
+
+@bp.get("/plaintext")
+@jwt_required()
+def plaintext_backup():
+    uid = int(get_jwt_identity())
+    data = create_plaintext_backup(uid)
+    return send_file(io.BytesIO(data), mimetype="application/zip",
+                     as_attachment=True, download_name=f"finmind-backup-{uid}.zip")

--- a/packages/backend/app/services/backup.py
+++ b/packages/backend/app/services/backup.py
@@ -1,0 +1,76 @@
+"""
+Secure backup & encrypted export options (issue #126).
+AES-256-GCM encryption via cryptography library.
+"""
+import io, json, logging, os, zipfile
+from datetime import datetime, timezone
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives import hashes
+import base64, secrets
+from ..extensions import db
+from ..models import Expense, Category, Bill, User
+
+logger = logging.getLogger("finmind.backup")
+
+
+def _derive_key(password: str, salt: bytes) -> bytes:
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=salt, iterations=480000)
+    return kdf.derive(password.encode())
+
+
+def _utcnow():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _collect_user_data(user_id: int) -> dict:
+    user = db.session.get(User, user_id)
+    expenses = db.session.query(Expense).filter_by(user_id=user_id).all()
+    categories = db.session.query(Category).filter_by(user_id=user_id).all()
+    bills = db.session.query(Bill).filter_by(user_id=user_id).all()
+    return {
+        "version": 1, "exported_at": _utcnow(), "user_id": user_id,
+        "email": user.email if user else None,
+        "expenses": [{"id": e.id, "amount": float(e.amount), "currency": e.currency,
+                      "type": e.expense_type, "notes": e.notes,
+                      "spent_at": e.spent_at.isoformat()} for e in expenses],
+        "categories": [{"id": c.id, "name": c.name} for c in categories],
+        "bills": [{"id": b.id, "name": b.name, "amount": float(b.amount)} for b in bills],
+    }
+
+
+def create_encrypted_backup(user_id: int, password: str) -> bytes:
+    """
+    Creates AES-256-GCM encrypted backup ZIP.
+    Returns raw bytes: [4-byte salt_len][salt][nonce][ciphertext]
+    """
+    data = json.dumps(_collect_user_data(user_id)).encode()
+    salt = secrets.token_bytes(16)
+    key = _derive_key(password, salt)
+    aesgcm = AESGCM(key)
+    nonce = secrets.token_bytes(12)
+    ciphertext = aesgcm.encrypt(nonce, data, None)
+    # Format: salt(16) + nonce(12) + ciphertext
+    payload = salt + nonce + ciphertext
+    logger.info("Encrypted backup created for user %d (%d bytes)", user_id, len(payload))
+    return payload
+
+
+def decrypt_backup(payload: bytes, password: str) -> dict:
+    """Decrypt a backup payload and return the data dict."""
+    salt = payload[:16]
+    nonce = payload[16:28]
+    ciphertext = payload[28:]
+    key = _derive_key(password, salt)
+    aesgcm = AESGCM(key)
+    plaintext = aesgcm.decrypt(nonce, ciphertext, None)
+    return json.loads(plaintext)
+
+
+def create_plaintext_backup(user_id: int) -> bytes:
+    """Unencrypted ZIP backup (for users who prefer it)."""
+    data = _collect_user_data(user_id)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("backup.json", json.dumps(data, indent=2))
+    return buf.getvalue()

--- a/packages/backend/tests/test_backup.py
+++ b/packages/backend/tests/test_backup.py
@@ -1,0 +1,56 @@
+"""Tests for encrypted backup (issue #126)."""
+import pytest
+
+def _app():
+    from app import create_app
+    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"})
+
+def _seed(db):
+    from werkzeug.security import generate_password_hash
+    from app.models import User
+    u = User(email="backup@test.com", password_hash=generate_password_hash("pw"))
+    db.session.add(u); db.session.commit()
+    return u
+
+def test_encrypt_decrypt_roundtrip():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all(); u = _seed(db)
+        from app.services.backup import create_encrypted_backup, decrypt_backup
+        payload = create_encrypted_backup(u.id, "securepass123")
+        assert isinstance(payload, bytes)
+        assert len(payload) > 28
+        data = decrypt_backup(payload, "securepass123")
+        assert data["user_id"] == u.id
+        assert data["email"] == "backup@test.com"
+
+def test_wrong_password_fails():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all(); u = _seed(db)
+        from app.services.backup import create_encrypted_backup, decrypt_backup
+        payload = create_encrypted_backup(u.id, "correctpass")
+        with pytest.raises(Exception):  # cryptography raises InvalidTag
+            decrypt_backup(payload, "wrongpass")
+
+def test_plaintext_backup_is_zip():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all(); u = _seed(db)
+        from app.services.backup import create_plaintext_backup
+        import zipfile, io
+        data = create_plaintext_backup(u.id)
+        assert zipfile.is_zipfile(io.BytesIO(data))
+
+def test_different_passwords_produce_different_ciphertext():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db
+        db.create_all(); u = _seed(db)
+        from app.services.backup import create_encrypted_backup
+        p1 = create_encrypted_backup(u.id, "pass1111")
+        p2 = create_encrypted_backup(u.id, "pass2222")
+        assert p1 != p2  # different salts + different keys


### PR DESCRIPTION
Closes #126

## What
Two backup modes: AES-256-GCM encrypted binary export and plaintext ZIP export.

## Encryption
- **Algorithm**: AES-256-GCM (authenticated encryption — detects tampering)
- **Key derivation**: PBKDF2-SHA256, 480,000 iterations (OWASP 2024 recommendation)
- **Format**: `salt(16B) + nonce(12B) + ciphertext`
- Random salt per backup — same password never produces same ciphertext

## API
| Method | Path | Description |
|--------|------|-------------|
| POST | `/backup/encrypted` | `{"password": "..."}` → `.enc` download |
| GET | `/backup/plaintext` | Unencrypted ZIP download |

## Testing
`pytest packages/backend/tests/test_backup.py -v`
4 tests: roundtrip, wrong password fails, ZIP valid, unique ciphertext per backup.