### PR TITLE
feat(reminders): reliability tracking & delivery metrics

### DIFF
--- a/packages/backend/app/routes/reminder_reliability.py
+++ b/packages/backend/app/routes/reminder_reliability.py
@@ -1,0 +1,22 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+from ..services.reminder_reliability import record_acknowledged, get_metrics, get_status
+
+bp = Blueprint("reminder_metrics", __name__)
+
+@bp.get("/metrics")
+@jwt_required()
+def metrics():
+    return jsonify(get_metrics())
+
+@bp.post("/<int:reminder_id>/ack")
+@jwt_required()
+def ack(reminder_id):
+    record_acknowledged(reminder_id)
+    return jsonify({"acknowledged": True})
+
+@bp.get("/<int:reminder_id>/status")
+@jwt_required()
+def status(reminder_id):
+    s = get_status(reminder_id)
+    return jsonify(s) if s else (jsonify(error="not found"), 404)

--- a/packages/backend/app/services/reminder_reliability.py
+++ b/packages/backend/app/services/reminder_reliability.py
@@ -1,0 +1,66 @@
+"""
+Reminder reliability tracking & delivery metrics (issue #123).
+Tracks whether reminders were delivered, acknowledged, and measures success rates.
+"""
+import json, logging
+from datetime import datetime, timezone
+from ..extensions import redis_client
+
+logger = logging.getLogger("finmind.reminders")
+
+PREFIX = "reminder:track:"
+STATS_KEY = "reminder:stats"
+TTL = 60 * 60 * 24 * 30  # 30 days
+
+
+def _utcnow(): return datetime.now(timezone.utc).isoformat()
+def _key(reminder_id: int): return f"{PREFIX}{reminder_id}"
+
+
+def record_sent(reminder_id: int, channel: str, user_id: int):
+    rec = {"reminder_id": reminder_id, "user_id": user_id, "channel": channel,
+           "sent_at": _utcnow(), "status": "sent", "ack_at": None}
+    redis_client.setex(_key(reminder_id), TTL, json.dumps(rec))
+    _incr_stat("sent")
+    logger.info("Reminder %d sent via %s to user %d", reminder_id, channel, user_id)
+
+
+def record_delivered(reminder_id: int):
+    raw = redis_client.get(_key(reminder_id))
+    if not raw: return
+    rec = json.loads(raw); rec["status"] = "delivered"; rec["delivered_at"] = _utcnow()
+    redis_client.setex(_key(reminder_id), TTL, json.dumps(rec))
+    _incr_stat("delivered")
+
+
+def record_acknowledged(reminder_id: int):
+    raw = redis_client.get(_key(reminder_id))
+    if not raw: return
+    rec = json.loads(raw); rec["status"] = "acknowledged"; rec["ack_at"] = _utcnow()
+    redis_client.setex(_key(reminder_id), TTL, json.dumps(rec))
+    _incr_stat("acknowledged")
+
+
+def get_status(reminder_id: int) -> dict | None:
+    raw = redis_client.get(_key(reminder_id))
+    return json.loads(raw) if raw else None
+
+
+def get_metrics() -> dict:
+    raw = redis_client.hgetall(STATS_KEY)
+    stats = {k.decode() if isinstance(k, bytes) else k:
+             int(v) for k, v in raw.items()}
+    sent = stats.get("sent", 0)
+    delivered = stats.get("delivered", 0)
+    acked = stats.get("acknowledged", 0)
+    return {
+        "total_sent": sent,
+        "total_delivered": delivered,
+        "total_acknowledged": acked,
+        "delivery_rate_pct": round(delivered / sent * 100, 1) if sent else 0,
+        "acknowledgment_rate_pct": round(acked / sent * 100, 1) if sent else 0,
+    }
+
+
+def _incr_stat(field: str):
+    redis_client.hincrby(STATS_KEY, field, 1)

--- a/packages/backend/tests/test_reminder_reliability.py
+++ b/packages/backend/tests/test_reminder_reliability.py
@@ -1,0 +1,48 @@
+"""Tests for reminder reliability tracking (issue #123)."""
+import json, pytest
+from unittest.mock import MagicMock, patch
+
+@pytest.fixture
+def mock_redis():
+    store, hashes = {}, {}
+    r = MagicMock()
+    def setex(k, t, v): store[k] = v
+    def get(k): v = store.get(k); return v.encode() if isinstance(v,str) else v
+    def hincrby(k, f, n): hashes.setdefault(k, {})[f] = hashes.get(k, {}).get(f, 0) + n
+    def hgetall(k): return {f: str(v).encode() for f,v in hashes.get(k,{}).items()}
+    r.setex.side_effect=setex; r.get.side_effect=get
+    r.hincrby.side_effect=hincrby; r.hgetall.side_effect=hgetall
+    return r, store, hashes
+
+def test_record_and_get_status(mock_redis):
+    r,_,_ = mock_redis
+    with patch("app.services.reminder_reliability.redis_client", r):
+        from app.services.reminder_reliability import record_sent, get_status
+        record_sent(1, "email", 42)
+        s = get_status(1)
+        assert s["status"] == "sent"
+        assert s["channel"] == "email"
+
+def test_delivery_flow(mock_redis):
+    r,_,_ = mock_redis
+    with patch("app.services.reminder_reliability.redis_client", r):
+        from app.services.reminder_reliability import record_sent, record_delivered, record_acknowledged, get_status
+        record_sent(2, "push", 1); record_delivered(2); record_acknowledged(2)
+        assert get_status(2)["status"] == "acknowledged"
+
+def test_metrics_rates(mock_redis):
+    r,_,_ = mock_redis
+    with patch("app.services.reminder_reliability.redis_client", r):
+        from app.services.reminder_reliability import record_sent, record_delivered, get_metrics
+        record_sent(3, "sms", 1); record_sent(4, "sms", 1)
+        record_delivered(3)
+        m = get_metrics()
+        assert m["total_sent"] == 2
+        assert m["delivery_rate_pct"] == 50.0
+
+def test_metrics_empty(mock_redis):
+    r,_,_ = mock_redis
+    with patch("app.services.reminder_reliability.redis_client", r):
+        from app.services.reminder_reliability import get_metrics
+        m = get_metrics()
+        assert m["delivery_rate_pct"] == 0


### PR DESCRIPTION
Closes #123

## What
Redis-backed reminder lifecycle tracking with delivery rate and acknowledgment rate metrics.

## Status Lifecycle
`sent` → `delivered` → `acknowledged`

## API
| Method | Path | Description |
|--------|------|-------------|
| GET | `/reminder-metrics/metrics` | Delivery + ack rates |
| POST | `/reminder-metrics/:id/ack` | Mark reminder acknowledged |
| GET | `/reminder-metrics/:id/status` | Single reminder status |

## Metrics Response
```json
{"total_sent": 150, "total_delivered": 142, "total_acknowledged": 98,
 "delivery_rate_pct": 94.7, "acknowledgment_rate_pct": 65.3}
```

## Testing
`pytest packages/backend/tests/test_reminder_reliability.py -v` — 4 tests.