### PR TITLE
feat(notifications): priority & grouping system with deduplication

### DIFF
--- a/packages/backend/app/services/notifications.py
+++ b/packages/backend/app/services/notifications.py
@@ -1,0 +1,80 @@
+"""
+Notification priority & grouping system (issue #122).
+Priority levels: CRITICAL > HIGH > MEDIUM > LOW
+Grouping: batch similar notifications, deduplicate within windows.
+"""
+import json, logging
+from datetime import datetime, timezone
+from enum import IntEnum
+from ..extensions import redis_client
+
+logger = logging.getLogger("finmind.notifications")
+
+QUEUE_PREFIX = "notif:queue:"
+GROUP_PREFIX = "notif:group:"
+TTL = 60 * 60 * 24 * 7
+
+
+class Priority(IntEnum):
+    LOW = 0; MEDIUM = 1; HIGH = 2; CRITICAL = 3
+
+
+PRIORITY_TTL = {Priority.CRITICAL: 60, Priority.HIGH: 300,
+                Priority.MEDIUM: 3600, Priority.LOW: 86400}
+
+
+def _utcnow(): return datetime.now(timezone.utc).isoformat()
+def _qkey(user_id: int): return f"{QUEUE_PREFIX}{user_id}"
+def _gkey(user_id: int, group: str): return f"{GROUP_PREFIX}{user_id}:{group}"
+
+
+def push(user_id: int, title: str, body: str,
+         priority: Priority = Priority.MEDIUM,
+         group: str = None, dedup_key: str = None) -> bool:
+    """
+    Push a notification. Returns False if deduped.
+    group: group name for batching (e.g. 'bills', 'budget_warning')
+    dedup_key: suppress if identical key seen recently
+    """
+    if dedup_key:
+        dk = f"notif:dedup:{user_id}:{dedup_key}"
+        if redis_client.get(dk):
+            logger.debug("Notification deduped: %s", dedup_key)
+            return False
+        redis_client.setex(dk, PRIORITY_TTL[priority], "1")
+
+    notif = {"title": title, "body": body, "priority": int(priority),
+             "priority_name": priority.name, "group": group,
+             "created_at": _utcnow(), "read": False}
+
+    # Push to sorted set with priority score
+    score = int(priority) * 1e12 + datetime.now(timezone.utc).timestamp()
+    redis_client.zadd(_qkey(user_id), {json.dumps(notif): score})
+    redis_client.expire(_qkey(user_id), TTL)
+
+    if group:
+        redis_client.rpush(_gkey(user_id, group), json.dumps(notif))
+        redis_client.expire(_gkey(user_id, group), TTL)
+
+    logger.info("Notification pushed user=%d priority=%s title=%s", user_id, priority.name, title)
+    return True
+
+
+def get_notifications(user_id: int, limit: int = 20) -> list:
+    """Return notifications sorted by priority (highest first)."""
+    raw = redis_client.zrevrange(_qkey(user_id), 0, limit - 1)
+    return [json.loads(r) for r in raw]
+
+
+def get_group(user_id: int, group: str) -> list:
+    """Return all notifications in a group."""
+    raw = redis_client.lrange(_gkey(user_id, group), 0, -1)
+    return [json.loads(r) for r in raw]
+
+
+def clear_group(user_id: int, group: str):
+    redis_client.delete(_gkey(user_id, group))
+
+
+def unread_count(user_id: int) -> int:
+    return redis_client.zcard(_qkey(user_id))

--- a/packages/backend/tests/test_notifications.py
+++ b/packages/backend/tests/test_notifications.py
@@ -1,0 +1,57 @@
+"""Tests for notification priority & grouping (issue #122)."""
+import json, pytest
+from unittest.mock import MagicMock, patch
+
+@pytest.fixture
+def mock_redis():
+    store, zsets, lists = {}, {}, {}
+    r = MagicMock()
+    def zadd(k, mapping):
+        for v, s in mapping.items(): zsets.setdefault(k,[]).append((s,v))
+        zsets[k].sort(reverse=True)
+    def zrevrange(k, s, e):
+        items = [v for _,v in zsets.get(k,[])]
+        return items[s:e+1] if e >= 0 else items[s:]
+    def zcard(k): return len(zsets.get(k,[]))
+    def rpush(k,v): lists.setdefault(k,[]).append(v)
+    def lrange(k,s,e): items=lists.get(k,[]); return items[s:e+1] if e>=0 else items[s:]
+    def delete(k): lists.pop(k,None); zsets.pop(k,None)
+    def get(k): return store.get(k)
+    def setex(k,t,v): store[k]=v
+    def expire(k,t): pass
+    r.zadd.side_effect=zadd; r.zrevrange.side_effect=zrevrange; r.zcard.side_effect=zcard
+    r.rpush.side_effect=rpush; r.lrange.side_effect=lrange; r.delete.side_effect=delete
+    r.get.side_effect=get; r.setex.side_effect=setex; r.expire.side_effect=expire
+    return r
+
+def test_push_and_get(mock_redis):
+    with patch("app.services.notifications.redis_client", mock_redis):
+        from app.services.notifications import push, get_notifications, Priority
+        push(1, "Bill due", "Pay rent", Priority.HIGH)
+        notifs = get_notifications(1)
+        assert len(notifs) == 1
+        assert notifs[0]["title"] == "Bill due"
+
+def test_priority_ordering(mock_redis):
+    with patch("app.services.notifications.redis_client", mock_redis):
+        from app.services.notifications import push, get_notifications, Priority
+        push(1, "Low", "low msg", Priority.LOW)
+        push(1, "Critical", "critical msg", Priority.CRITICAL)
+        push(1, "Medium", "med msg", Priority.MEDIUM)
+        notifs = get_notifications(1)
+        assert notifs[0]["priority_name"] == "CRITICAL"
+
+def test_dedup_suppresses(mock_redis):
+    with patch("app.services.notifications.redis_client", mock_redis):
+        from app.services.notifications import push, unread_count, Priority
+        push(1, "Dup", "body", Priority.MEDIUM, dedup_key="dup-001")
+        result = push(1, "Dup", "body", Priority.MEDIUM, dedup_key="dup-001")
+        assert result is False
+
+def test_group_batching(mock_redis):
+    with patch("app.services.notifications.redis_client", mock_redis):
+        from app.services.notifications import push, get_group, Priority
+        push(1, "Bill 1", "b1", Priority.MEDIUM, group="bills")
+        push(1, "Bill 2", "b2", Priority.MEDIUM, group="bills")
+        group = get_group(1, "bills")
+        assert len(group) == 2


### PR DESCRIPTION
Closes #122

## Priority Levels
`CRITICAL > HIGH > MEDIUM > LOW` — notifications sorted by priority first, then recency.

## Features
- **Priority queue**: Redis sorted set, score = `priority * 1e12 + timestamp`
- **Group batching**: push to named groups (e.g. `'bills'`, `'budget'`) for summary views
- **Deduplication**: suppress repeat notifications within TTL window via dedup_key
- **TTL by priority**: CRITICAL=60s, HIGH=5min, MEDIUM=1hr, LOW=24hr

## Testing
`pytest packages/backend/tests/test_notifications.py -v` — 4 tests.