### PR TITLE
feat(insights): spending trend heatmap visualization data

### DIFF
--- a/packages/backend/app/services/heatmap.py
+++ b/packages/backend/app/services/heatmap.py
@@ -1,0 +1,63 @@
+"""
+Spending trend heatmap visualization data (issue #116).
+Returns day-of-week × week-of-month spend matrix for frontend rendering.
+"""
+import logging
+from datetime import date, timedelta
+from sqlalchemy import func, extract
+from ..extensions import db
+from ..models import Expense
+
+logger = logging.getLogger("finmind.heatmap")
+
+DAYS = ["Mon","Tue","Wed","Thu","Fri","Sat","Sun"]
+
+
+def get_heatmap(user_id: int, year: int, month: int) -> dict:
+    """
+    Returns spend matrix: rows=week(1-5), cols=day(Mon-Sun).
+    Also returns daily totals array and max value for color scaling.
+    """
+    rows = (
+        db.session.query(Expense.spent_at, func.sum(Expense.amount).label("total"))
+        .filter(
+            Expense.user_id == user_id,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.spent_at).all()
+    )
+
+    daily = {r.spent_at: float(r.total or 0) for r in rows}
+
+    # Build 5×7 matrix
+    matrix = [[0.0] * 7 for _ in range(5)]
+    daily_list = []
+
+    first = date(year, month, 1)
+    last_day = (date(year, month % 12 + 1, 1) - timedelta(days=1)).day if month < 12 else 31
+
+    for day_num in range(1, last_day + 1):
+        try:
+            d = date(year, month, day_num)
+        except ValueError:
+            break
+        amt = daily.get(d, 0.0)
+        dow = d.weekday()          # 0=Mon
+        week_idx = min((d.day - 1 + first.weekday()) // 7, 4)
+        matrix[week_idx][dow] = round(amt, 2)
+        daily_list.append({"date": d.isoformat(), "amount": round(amt, 2), "day": DAYS[dow]})
+
+    all_vals = [v for row in matrix for v in row]
+    max_val = max(all_vals) if all_vals else 0
+
+    return {
+        "period": f"{year}-{month:02d}",
+        "matrix": matrix,
+        "days": DAYS,
+        "weeks": [f"Week {i+1}" for i in range(5)],
+        "daily": daily_list,
+        "max_value": round(max_val, 2),
+        "total": round(sum(all_vals), 2),
+    }

--- a/packages/backend/tests/test_heatmap.py
+++ b/packages/backend/tests/test_heatmap.py
@@ -1,0 +1,40 @@
+"""Tests for spending heatmap (issue #116)."""
+
+def _app():
+    from app import create_app
+    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:"})
+
+def test_heatmap_structure():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db; db.create_all()
+        from app.services.heatmap import get_heatmap
+        result = get_heatmap(999, 2026, 4)
+        assert "matrix" in result
+        assert len(result["matrix"]) == 5
+        assert len(result["matrix"][0]) == 7
+        assert len(result["days"]) == 7
+
+def test_heatmap_zero_state():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db; db.create_all()
+        from app.services.heatmap import get_heatmap
+        result = get_heatmap(999, 2026, 4)
+        assert result["total"] == 0
+        assert result["max_value"] == 0
+
+def test_days_label():
+    from app.services.heatmap import DAYS
+    assert DAYS[0] == "Mon"
+    assert DAYS[6] == "Sun"
+    assert len(DAYS) == 7
+
+def test_daily_list_has_correct_month():
+    app = _app()
+    with app.app_context():
+        from app.extensions import db; db.create_all()
+        from app.services.heatmap import get_heatmap
+        result = get_heatmap(999, 2026, 4)
+        for d in result["daily"]:
+            assert d["date"].startswith("2026-04")


### PR DESCRIPTION
Closes #116

## What
Returns a 5×7 (week × day-of-week) spend matrix for rendering a calendar heatmap — plug directly into any heatmap chart library.

## Response
```json
{"period": "2026-04", "matrix": [[0,45,0,120,0,200,80], ...],
 "days": ["Mon","Tue",...,"Sun"], "max_value": 200,
 "daily": [{"date": "2026-04-01", "amount": 45, "day": "Wed"},...]}
```
Use `max_value` to normalize cell colors (0 → white, max → darkest).

## Testing
`pytest packages/backend/tests/test_heatmap.py -v` — 4 tests.