### PR TITLE
feat(import): bulk import validation & preview improvements

### DIFF
--- a/packages/backend/app/services/bulk_import.py
+++ b/packages/backend/app/services/bulk_import.py
@@ -1,0 +1,63 @@
+"""Bulk import validation & preview (issue #115)."""
+import csv, io, logging
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+logger = logging.getLogger("finmind.import")
+
+REQUIRED_COLS = {"amount", "spent_at"}
+OPTIONAL_COLS = {"notes", "currency", "category", "expense_type"}
+ALL_COLS = REQUIRED_COLS | OPTIONAL_COLS
+
+
+def parse_csv(raw: str) -> dict:
+    reader = csv.DictReader(io.StringIO(raw.strip()))
+    headers = {h.strip().lower() for h in (reader.fieldnames or [])}
+    missing = REQUIRED_COLS - headers
+    unknown = headers - ALL_COLS
+
+    errors, warnings, preview = [], [], []
+
+    if missing:
+        errors.append(f"Missing required columns: {', '.join(sorted(missing))}")
+        return {"valid": False, "errors": errors, "warnings": [], "preview": [], "row_count": 0}
+
+    if unknown:
+        warnings.append(f"Unknown columns will be ignored: {', '.join(sorted(unknown))}")
+
+    for i, row in enumerate(reader, start=2):
+        row_errors = []
+        # Validate amount
+        try:
+            amt = Decimal(str(row.get("amount","")).strip())
+            if amt <= 0: row_errors.append(f"Row {i}: amount must be > 0")
+        except InvalidOperation:
+            row_errors.append(f"Row {i}: invalid amount '{row.get('amount')}'")
+            amt = None
+
+        # Validate date
+        raw_date = str(row.get("spent_at","")).strip()
+        parsed_date = None
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%d-%m-%Y"):
+            try: parsed_date = date.fromisoformat(raw_date) if fmt == "%Y-%m-%d" else date.strptime(raw_date, fmt); break
+            except ValueError: continue
+        if not parsed_date:
+            row_errors.append(f"Row {i}: invalid date '{raw_date}' (use YYYY-MM-DD)")
+
+        errors.extend(row_errors)
+        if not row_errors:
+            preview.append({
+                "row": i, "amount": float(amt) if amt else None,
+                "spent_at": parsed_date.isoformat() if parsed_date else None,
+                "notes": row.get("notes","").strip(),
+                "currency": (row.get("currency","INR") or "INR").strip().upper(),
+                "expense_type": (row.get("expense_type","EXPENSE") or "EXPENSE").strip().upper(),
+            })
+
+    return {
+        "valid": len(errors) == 0,
+        "errors": errors, "warnings": warnings,
+        "preview": preview[:10],  # first 10 for preview
+        "row_count": len(preview),
+        "total_rows_parsed": i - 1 if preview or errors else 0,
+    }

--- a/packages/backend/tests/test_bulk_import.py
+++ b/packages/backend/tests/test_bulk_import.py
@@ -1,0 +1,36 @@
+"""Tests for bulk import validation (issue #115)."""
+
+def test_valid_csv():
+    from app.services.bulk_import import parse_csv
+    csv = "amount,spent_at,notes\n100,2026-04-01,Groceries\n50,2026-04-02,Coffee"
+    result = parse_csv(csv)
+    assert result["valid"] is True
+    assert result["row_count"] == 2
+    assert result["preview"][0]["amount"] == 100.0
+
+def test_missing_required_column():
+    from app.services.bulk_import import parse_csv
+    csv = "notes,spent_at\ntest,2026-04-01"
+    result = parse_csv(csv)
+    assert result["valid"] is False
+    assert any("amount" in e for e in result["errors"])
+
+def test_invalid_amount():
+    from app.services.bulk_import import parse_csv
+    csv = "amount,spent_at\nabc,2026-04-01"
+    result = parse_csv(csv)
+    assert result["valid"] is False
+    assert any("amount" in e for e in result["errors"])
+
+def test_invalid_date():
+    from app.services.bulk_import import parse_csv
+    csv = "amount,spent_at\n100,not-a-date"
+    result = parse_csv(csv)
+    assert result["valid"] is False
+    assert any("date" in e for e in result["errors"])
+
+def test_unknown_columns_warn():
+    from app.services.bulk_import import parse_csv
+    csv = "amount,spent_at,mystery_col\n100,2026-04-01,x"
+    result = parse_csv(csv)
+    assert any("mystery_col" in w for w in result["warnings"])


### PR DESCRIPTION
Closes #115

## What
CSV import validator with row-level error reporting and a 10-row preview before committing data.

## Validation
- Required: `amount` (positive decimal), `spent_at` (YYYY-MM-DD, MM/DD/YYYY, or DD-MM-YYYY)
- Optional: `notes`, `currency`, `category`, `expense_type`
- Unknown columns: warned but not rejected
- Row-level errors with line numbers

## Testing
`pytest packages/backend/tests/test_bulk_import.py -v` — 5 tests.