### PR TITLE
feat(transactions): smart payee & merchant alias management

### DIFF
--- a/packages/backend/app/services/payee_alias.py
+++ b/packages/backend/app/services/payee_alias.py
@@ -1,0 +1,51 @@
+"""Smart payee & merchant alias management (issue #114)."""
+import json, logging, re
+from ..extensions import redis_client
+
+logger = logging.getLogger("finmind.payee")
+PREFIX = "payee:aliases:"
+TTL = 60 * 60 * 24 * 365
+
+
+def _key(user_id): return f"{PREFIX}{user_id}"
+
+
+def set_alias(user_id: int, raw: str, alias: str, category_id: int = None):
+    store = _load(user_id)
+    store[raw.strip().lower()] = {"alias": alias.strip(), "category_id": category_id}
+    _save(user_id, store)
+
+
+def get_alias(user_id: int, raw: str) -> dict | None:
+    store = _load(user_id)
+    return store.get(raw.strip().lower())
+
+
+def resolve(user_id: int, raw: str) -> str:
+    """Return alias display name or cleaned raw name."""
+    entry = get_alias(user_id, raw)
+    if entry: return entry["alias"]
+    # Auto-clean: strip transaction codes, uppercase, extra spaces
+    cleaned = re.sub(r'\s+', ' ', re.sub(r'[*#\d]{4,}', '', raw)).strip().title()
+    return cleaned or raw
+
+
+def list_aliases(user_id: int) -> list:
+    store = _load(user_id)
+    return [{"raw": k, **v} for k, v in store.items()]
+
+
+def delete_alias(user_id: int, raw: str) -> bool:
+    store = _load(user_id)
+    key = raw.strip().lower()
+    if key not in store: return False
+    del store[key]; _save(user_id, store); return True
+
+
+def _load(user_id): 
+    raw = redis_client.get(_key(user_id))
+    return json.loads(raw) if raw else {}
+
+
+def _save(user_id, store):
+    redis_client.setex(_key(user_id), TTL, json.dumps(store))

--- a/packages/backend/tests/test_payee_alias.py
+++ b/packages/backend/tests/test_payee_alias.py
@@ -1,0 +1,44 @@
+"""Tests for payee alias management (issue #114)."""
+import pytest
+from unittest.mock import MagicMock, patch
+import json
+
+@pytest.fixture
+def mock_redis():
+    store = {}
+    r = MagicMock()
+    def setex(k,t,v): store[k]=v
+    def get(k): v=store.get(k); return v.encode() if isinstance(v,str) else v
+    r.setex.side_effect=setex; r.get.side_effect=get
+    return r, store
+
+def test_set_and_get_alias(mock_redis):
+    r,_ = mock_redis
+    with patch("app.services.payee_alias.redis_client", r):
+        from app.services.payee_alias import set_alias, get_alias
+        set_alias(1, "AMZN MKTP US*AB1234", "Amazon")
+        result = get_alias(1, "AMZN MKTP US*AB1234")
+        assert result["alias"] == "Amazon"
+
+def test_resolve_with_alias(mock_redis):
+    r,_ = mock_redis
+    with patch("app.services.payee_alias.redis_client", r):
+        from app.services.payee_alias import set_alias, resolve
+        set_alias(1, "STARBUCKS #4521", "Starbucks")
+        assert resolve(1, "STARBUCKS #4521") == "Starbucks"
+
+def test_resolve_auto_clean(mock_redis):
+    r,_ = mock_redis
+    with patch("app.services.payee_alias.redis_client", r):
+        from app.services.payee_alias import resolve
+        cleaned = resolve(1, "WALMART STORE 4521  ")
+        assert "4521" not in cleaned  # numeric code stripped
+        assert cleaned == cleaned.strip()
+
+def test_delete_alias(mock_redis):
+    r,_ = mock_redis
+    with patch("app.services.payee_alias.redis_client", r):
+        from app.services.payee_alias import set_alias, delete_alias, get_alias
+        set_alias(1, "Netflix", "Netflix Sub")
+        assert delete_alias(1, "Netflix") is True
+        assert get_alias(1, "Netflix") is None


### PR DESCRIPTION
Closes #114

## What
Per-user merchant alias system that maps messy bank transaction names to clean display names.

## Features
- **Manual aliases**: `AMZN MKTP US*AB1234` → `Amazon` with optional category auto-assign
- **Auto-clean fallback**: strips transaction codes, normalizes whitespace, title-cases
- **Full CRUD**: set, get, list, delete

## Testing
`pytest packages/backend/tests/test_payee_alias.py -v` — 4 tests.