### PR TITLE
feat(reminders): smart reminder timing optimization

### DIFF
--- a/packages/backend/app/services/reminder_timing.py
+++ b/packages/backend/app/services/reminder_timing.py
@@ -1,0 +1,45 @@
+"""Smart reminder timing optimization (issue #111)."""
+import json, logging
+from datetime import datetime, timezone, time
+from ..extensions import redis_client
+
+logger = logging.getLogger("finmind.reminder_timing")
+PREFIX = "remindertiming:"
+TTL = 60 * 60 * 24 * 90
+
+
+def _key(user_id): return f"{PREFIX}{user_id}"
+def _utcnow(): return datetime.now(timezone.utc)
+
+
+def record_engagement(user_id: int, hour: int, day_of_week: int):
+    """Record that a user was active at this hour/day."""
+    store = _load(user_id)
+    slot = f"{day_of_week}:{hour}"
+    store[slot] = store.get(slot, 0) + 1
+    _save(user_id, store)
+
+
+def get_optimal_time(user_id: int) -> dict:
+    """Return the best hour + day to send reminders based on engagement history."""
+    store = _load(user_id)
+    if not store:
+        return {"hour": 9, "day_of_week": None, "confidence": "low",
+                "reason": "No engagement data — defaulting to 9AM"}
+    best_slot = max(store, key=store.get)
+    day, hour = map(int, best_slot.split(":"))
+    total = sum(store.values())
+    best_count = store[best_slot]
+    confidence = "high" if best_count / total > 0.3 else "medium" if best_count / total > 0.1 else "low"
+    days = ["Monday","Tuesday","Wednesday","Thursday","Friday","Saturday","Sunday"]
+    return {"hour": hour, "day_of_week": day, "day_name": days[day],
+            "confidence": confidence, "engagement_count": best_count,
+            "reason": f"Most active at {hour:02d}:00 on {days[day]} ({best_count}/{total} sessions)"}
+
+
+def _load(user_id):
+    raw = redis_client.get(_key(user_id))
+    return json.loads(raw) if raw else {}
+
+def _save(user_id, store):
+    redis_client.setex(_key(user_id), TTL, json.dumps(store))

--- a/packages/backend/tests/test_reminder_timing.py
+++ b/packages/backend/tests/test_reminder_timing.py
@@ -1,0 +1,39 @@
+"""Tests for smart reminder timing (issue #111)."""
+import json, pytest
+from unittest.mock import MagicMock, patch
+
+@pytest.fixture
+def mock_redis():
+    store = {}
+    r = MagicMock()
+    def setex(k,t,v): store[k]=v
+    def get(k): v=store.get(k); return v.encode() if isinstance(v,str) else v
+    r.setex.side_effect=setex; r.get.side_effect=get
+    return r, store
+
+def test_default_when_no_data(mock_redis):
+    r,_ = mock_redis
+    with patch("app.services.reminder_timing.redis_client", r):
+        from app.services.reminder_timing import get_optimal_time
+        result = get_optimal_time(1)
+        assert result["hour"] == 9
+        assert result["confidence"] == "low"
+
+def test_record_and_optimize(mock_redis):
+    r,_ = mock_redis
+    with patch("app.services.reminder_timing.redis_client", r):
+        from app.services.reminder_timing import record_engagement, get_optimal_time
+        for _ in range(10): record_engagement(1, 9, 0)   # Monday 9AM x10
+        for _ in range(2): record_engagement(1, 14, 2)   # Wednesday 2PM x2
+        result = get_optimal_time(1)
+        assert result["hour"] == 9
+        assert result["day_of_week"] == 0
+
+def test_high_confidence_threshold(mock_redis):
+    r,_ = mock_redis
+    with patch("app.services.reminder_timing.redis_client", r):
+        from app.services.reminder_timing import record_engagement, get_optimal_time
+        for _ in range(8): record_engagement(2, 18, 4)
+        for _ in range(2): record_engagement(2, 10, 1)
+        result = get_optimal_time(2)
+        assert result["confidence"] == "high"


### PR DESCRIPTION
Closes #111. Tracks user engagement by hour/day. Finds optimal send time. Confidence levels. Defaults to 9AM. 3 tests.