### PR TITLE
feat(dashboard): customizable widgets & visibility

### DIFF
--- a/packages/backend/app/services/dashboard_widgets.py
+++ b/packages/backend/app/services/dashboard_widgets.py
@@ -1,0 +1,51 @@
+"""Customizable dashboard widgets & visibility (issue #103)."""
+import json, logging
+from ..extensions import redis_client
+
+logger = logging.getLogger("finmind.widgets")
+KEY = "dashboard:widgets:"
+TTL = 60 * 60 * 24 * 365
+
+DEFAULT_WIDGETS = [
+    {"id": "net_flow", "label": "Net Flow", "visible": True, "position": 0},
+    {"id": "monthly_summary", "label": "Monthly Summary", "visible": True, "position": 1},
+    {"id": "category_breakdown", "label": "Category Breakdown", "visible": True, "position": 2},
+    {"id": "upcoming_bills", "label": "Upcoming Bills", "visible": True, "position": 3},
+    {"id": "recent_transactions", "label": "Recent Transactions", "visible": True, "position": 4},
+    {"id": "savings_goals", "label": "Savings Goals", "visible": False, "position": 5},
+    {"id": "spending_heatmap", "label": "Spending Heatmap", "visible": False, "position": 6},
+    {"id": "weekly_digest", "label": "Weekly Digest", "visible": False, "position": 7},
+]
+
+
+def get_widgets(user_id: int) -> list:
+    raw = redis_client.get(f"{KEY}{user_id}")
+    return json.loads(raw) if raw else DEFAULT_WIDGETS[:]
+
+
+def update_widget(user_id: int, widget_id: str, visible: bool = None, position: int = None) -> bool:
+    widgets = get_widgets(user_id)
+    for w in widgets:
+        if w["id"] == widget_id:
+            if visible is not None: w["visible"] = visible
+            if position is not None: w["position"] = position
+            redis_client.setex(f"{KEY}{user_id}", TTL, json.dumps(widgets))
+            return True
+    return False
+
+
+def reorder_widgets(user_id: int, order: list[str]) -> list:
+    """Reorder widgets by providing list of widget IDs in desired order."""
+    widgets = {w["id"]: w for w in get_widgets(user_id)}
+    result = []
+    for i, wid in enumerate(order):
+        if wid in widgets:
+            widgets[wid]["position"] = i
+            result.append(widgets[wid])
+    # Append any not in order list
+    positioned = {w["id"] for w in result}
+    for w in widgets.values():
+        if w["id"] not in positioned:
+            result.append(w)
+    redis_client.setex(f"{KEY}{user_id}", TTL, json.dumps(result))
+    return result

--- a/packages/backend/tests/test_dashboard_widgets.py
+++ b/packages/backend/tests/test_dashboard_widgets.py
@@ -1,0 +1,42 @@
+"""Tests for dashboard widgets (issue #103)."""
+import json
+from unittest.mock import MagicMock, patch
+
+def _mock_redis():
+    store = {}
+    r = MagicMock()
+    def get(k): v=store.get(k); return v.encode() if isinstance(v,str) else v
+    def setex(k,t,v): store[k]=v
+    r.get.side_effect=get; r.setex.side_effect=setex
+    return r, store
+
+def test_default_widgets():
+    r,_ = _mock_redis()
+    with patch("app.services.dashboard_widgets.redis_client", r):
+        from app.services.dashboard_widgets import get_widgets, DEFAULT_WIDGETS
+        widgets = get_widgets(1)
+        assert len(widgets) == len(DEFAULT_WIDGETS)
+        assert widgets[0]["id"] == "net_flow"
+
+def test_toggle_visibility():
+    r,_ = _mock_redis()
+    with patch("app.services.dashboard_widgets.redis_client", r):
+        from app.services.dashboard_widgets import update_widget, get_widgets
+        update_widget(1, "savings_goals", visible=True)
+        widgets = get_widgets(1)
+        sg = next(w for w in widgets if w["id"] == "savings_goals")
+        assert sg["visible"] is True
+
+def test_reorder_widgets():
+    r,_ = _mock_redis()
+    with patch("app.services.dashboard_widgets.redis_client", r):
+        from app.services.dashboard_widgets import reorder_widgets
+        result = reorder_widgets(1, ["upcoming_bills", "net_flow"])
+        assert result[0]["id"] == "upcoming_bills"
+        assert result[1]["id"] == "net_flow"
+
+def test_update_unknown_widget():
+    r,_ = _mock_redis()
+    with patch("app.services.dashboard_widgets.redis_client", r):
+        from app.services.dashboard_widgets import update_widget
+        assert update_widget(1, "nonexistent_widget") is False


### PR DESCRIPTION
Closes #103. 8 default widgets. Toggle visibility, reorder by drag-drop order list. Redis-backed. 4 tests.