### PR TITLE
feat(sync): offline-first sync with conflict resolution

### DIFF
--- a/packages/backend/app/services/offline_sync.py
+++ b/packages/backend/app/services/offline_sync.py
@@ -1,0 +1,37 @@
+"""Offline-first sync with conflict resolution (issue #98)."""
+import json, logging, time, uuid
+from ..extensions import db, redis_client
+
+logger = logging.getLogger("finmind.sync")
+QUEUE_KEY = "sync:queue:{user_id}"
+CONFLICT_KEY = "sync:conflicts:{user_id}"
+
+def queue_operation(user_id: int, op: dict) -> str:
+    """Queue an offline operation for sync."""
+    op_id = str(uuid.uuid4())
+    op.update({"id": op_id, "user_id": user_id, "queued_at": time.time(), "status": "pending"})
+    redis_client.rpush(QUEUE_KEY.format(user_id=user_id), json.dumps(op))
+    return op_id
+
+def get_pending_ops(user_id: int) -> list:
+    raw = redis_client.lrange(QUEUE_KEY.format(user_id=user_id), 0, -1)
+    return [json.loads(r) for r in raw]
+
+def resolve_conflict(local: dict, server: dict, strategy: str = "last_write_wins") -> dict:
+    """Resolve sync conflict between local and server versions."""
+    if strategy == "last_write_wins":
+        return local if local.get("updated_at", 0) >= server.get("updated_at", 0) else server
+    elif strategy == "server_wins":
+        return server
+    elif strategy == "client_wins":
+        return local
+    elif strategy == "merge":
+        merged = {**server, **{k: v for k, v in local.items() if v is not None}}
+        return merged
+    return server
+
+def get_sync_status(user_id: int) -> dict:
+    pending = redis_client.llen(QUEUE_KEY.format(user_id=user_id))
+    conflicts = redis_client.llen(CONFLICT_KEY.format(user_id=user_id))
+    return {"pending_ops": pending, "conflicts": conflicts,
+            "in_sync": pending == 0 and conflicts == 0}

--- a/packages/backend/tests/test_offline_sync.py
+++ b/packages/backend/tests/test_offline_sync.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, patch
+
+def _mock_redis():
+    lists = {}
+    r = MagicMock()
+    def rpush(k,v): lists.setdefault(k,[]).append(v)
+    def lrange(k,s,e): return lists.get(k,[])
+    def llen(k): return len(lists.get(k,[]))
+    r.rpush.side_effect=rpush; r.lrange.side_effect=lrange; r.llen.side_effect=llen
+    return r
+
+def test_queue_and_get():
+    with patch("app.services.offline_sync.redis_client", _mock_redis()):
+        from app.services.offline_sync import queue_operation, get_pending_ops
+        queue_operation(1, {"type": "create_expense", "amount": 50})
+        ops = get_pending_ops(1)
+        assert len(ops) == 1 and ops[0]["type"] == "create_expense"
+
+def test_conflict_last_write_wins():
+    from app.services.offline_sync import resolve_conflict
+    local = {"id": 1, "amount": 100, "updated_at": 2000}
+    server = {"id": 1, "amount": 80, "updated_at": 1000}
+    assert resolve_conflict(local, server, "last_write_wins")["amount"] == 100
+
+def test_sync_status():
+    with patch("app.services.offline_sync.redis_client", _mock_redis()):
+        from app.services.offline_sync import get_sync_status
+        status = get_sync_status(999)
+        assert status["in_sync"] == True


### PR DESCRIPTION
Closes #98. Redis op queue, 4 conflict strategies (last_write_wins/server_wins/client_wins/merge), sync status. 3 tests.