### PR TITLE
feat: goal-based savings tracking with milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,27 @@ finmind/
 ## Contribution Policy
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.
 
+## Savings Goals
+FinMind supports goal-based savings tracking with milestones.
+
+### API Endpoints
+- `GET /savings-goals` - List all savings goals
+- `POST /savings-goals` - Create a new savings goal
+- `GET /savings-goals/:id` - Get goal details with milestones
+- `PUT /savings-goals/:id` - Update a goal
+- `DELETE /savings-goals/:id` - Delete a goal
+- `POST /savings-goals/:id/contribute` - Add money to a goal (auto-checks milestones)
+- `POST /savings-goals/:id/milestones` - Add a milestone
+- `PUT /savings-goals/:id/milestones/:mid` - Update milestone
+- `DELETE /savings-goals/:id/milestones/:mid` - Delete milestone
+
+### Model
+```
+SavingsGoal: name, description, target_amount, current_amount, currency,
+             start_date, target_date, status (active/completed/cancelled)
+SavingsMilestone: name, target_amount, achieved, achieved_at
+```
+
 ## Notes on Free-Tier Reminders
 - Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,32 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Savings Goals (Goal-based savings tracking)
+CREATE TABLE IF NOT EXISTS savings_goals (
+  id SERIAL PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  name VARCHAR(200) NOT NULL,
+  description TEXT DEFAULT '',
+  target_amount NUMERIC(14,2) NOT NULL,
+  current_amount NUMERIC(14,2) DEFAULT 0,
+  currency VARCHAR(10) DEFAULT 'INR',
+  start_date DATE,
+  target_date DATE,
+  status VARCHAR(20) NOT NULL DEFAULT 'active',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_goals_user ON savings_goals(user_id);
+
+-- Savings Milestones
+CREATE TABLE IF NOT EXISTS savings_milestones (
+  id SERIAL PRIMARY KEY,
+  savings_goal_id INTEGER NOT NULL REFERENCES savings_goals(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  target_amount NUMERIC(14,2) NOT NULL,
+  achieved BOOLEAN DEFAULT FALSE,
+  achieved_at DATE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_milestones_goal ON savings_milestones(savings_goal_id);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,51 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SavingsGoalStatus(Enum):
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+
+
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, default="")
+    target_amount = db.Column(db.Numeric(14, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(14, 2), default=0)
+    currency = db.Column(db.String(10), default="INR")
+    start_date = db.Column(db.Date, nullable=True)
+    target_date = db.Column(db.Date, nullable=True)
+    status = db.Column(SAEnum(SavingsGoalStatus), default=SavingsGoalStatus.ACTIVE, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    milestones = db.relationship(
+        "SavingsMilestone",
+        backref="goal",
+        cascade="all, delete-orphan",
+        lazy=True,
+    )
+
+    @property
+    def progress_pct(self) -> float:
+        if self.target_amount and self.target_amount > 0:
+            return round(float(self.current_amount) / float(self.target_amount) * 100, 2)
+        return 0.0
+
+
+class SavingsMilestone(db.Model):
+    __tablename__ = "savings_milestones"
+
+    id = db.Column(db.Integer, primary_key=True)
+    savings_goal_id = db.Column(db.Integer, db.ForeignKey("savings_goals.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    target_amount = db.Column(db.Numeric(14, 2), nullable=False)
+    achieved = db.Column(db.Boolean, default=False)
+    achieved_at = db.Column(db.Date, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -587,3 +587,148 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+  /savings-goals:
+    get:
+      summary: List savings goals
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: List of savings goals
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SavingsGoal'
+    post:
+      summary: Create savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, target_amount]
+              properties:
+                name: { type: string }
+                description: { type: string }
+                target_amount: { type: number }
+                current_amount: { type: number }
+                currency: { type: string }
+                start_date: { type: string, format: date }
+                target_date: { type: string, format: date }
+      responses:
+        '201': { description: Created }
+        '401': { description: Unauthorized }
+  /savings-goals/{id}:
+    get:
+      summary: Get savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ name: id, in: path, required: true, schema: { type: integer } }]
+      responses:
+        '200': { description: Savings goal details }
+        '404': { description: Not found }
+    put:
+      summary: Update savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ name: id, in: path, required: true, schema: { type: integer } }]
+      responses:
+        '200': { description: Updated }
+        '404': { description: Not found }
+    delete:
+      summary: Delete savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ name: id, in: path, required: true, schema: { type: integer } }]
+      responses:
+        '200': { description: Deleted }
+        '404': { description: Not found }
+  /savings-goals/{id}/contribute:
+    post:
+      summary: Contribute to savings goal
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ name: id, in: path, required: true, schema: { type: integer } }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [amount]
+              properties:
+                amount: { type: number }
+      responses:
+        '200': { description: Contribution recorded }
+        '400': { description: Invalid amount }
+  /savings-goals/{id}/milestones:
+    post:
+      summary: Add milestone
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ name: id, in: path, required: true, schema: { type: integer } }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, target_amount]
+              properties:
+                name: { type: string }
+                target_amount: { type: number }
+      responses:
+        '201': { description: Milestone created }
+  /savings-goals/{id}/milestones/{mid}:
+    put:
+      summary: Update milestone
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+        - { name: mid, in: path, required: true, schema: { type: integer } }
+      responses:
+        '200': { description: Updated }
+    delete:
+      summary: Delete milestone
+      tags: [Savings]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+        - { name: mid, in: path, required: true, schema: { type: integer } }
+      responses:
+        '200': { description: Deleted }
+components:
+  schemas:
+    SavingsGoal:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        description: { type: string }
+        target_amount: { type: number }
+        current_amount: { type: number }
+        currency: { type: string }
+        start_date: { type: string, format: date }
+        target_date: { type: string, format: date }
+        status: { type: string, enum: [active, completed, cancelled] }
+        progress_pct: { type: number }
+        milestones: { type: array, items: { $ref: '#/components/schemas/SavingsMilestone' } }
+        created_at: { type: string, format: date-time }
+    SavingsMilestone:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        target_amount: { type: number }
+        achieved: { type: boolean }
+        achieved_at: { type: string, format: date }
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings import bp as savings_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_bp, url_prefix="/savings-goals")

--- a/packages/backend/app/routes/savings.py
+++ b/packages/backend/app/routes/savings.py
@@ -1,0 +1,245 @@
+from datetime import date
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import SavingsGoal, SavingsMilestone, SavingsGoalStatus, User
+from ..services.cache import cache_delete_patterns
+from decimal import Decimal
+
+bp = Blueprint("savings", __name__)
+
+
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    goals = (
+        db.session.query(SavingsGoal)
+        .filter_by(user_id=uid)
+        .order_by(SavingsGoal.created_at.desc())
+        .all()
+    )
+    return jsonify(
+        [
+            {
+                "id": g.id,
+                "name": g.name,
+                "description": g.description,
+                "target_amount": float(g.target_amount),
+                "current_amount": float(g.current_amount),
+                "currency": g.currency,
+                "start_date": g.start_date.isoformat() if g.start_date else None,
+                "target_date": g.target_date.isoformat() if g.target_date else None,
+                "status": g.status.value,
+                "milestones": [
+                    {
+                        "id": m.id,
+                        "name": m.name,
+                        "target_amount": float(m.target_amount),
+                        "achieved": m.achieved,
+                        "achieved_at": m.achieved_at.isoformat() if m.achieved_at else None,
+                    }
+                    for m in g.milestones
+                ],
+                "progress_pct": round(float(g.current_amount) / float(g.target_amount) * 100, 2)
+                if g.target_amount and g.target_amount > 0
+                else 0,
+                "created_at": g.created_at.isoformat(),
+            }
+            for g in goals
+        ]
+    )
+
+
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+
+    goal = SavingsGoal(
+        user_id=uid,
+        name=data["name"],
+        description=data.get("description", ""),
+        target_amount=Decimal(str(data["target_amount"])),
+        current_amount=Decimal(str(data.get("current_amount", 0))),
+        currency=data.get("currency") or (user.preferred_currency if user and user.preferred_currency else "INR"),
+        start_date=date.fromisoformat(data["start_date"]) if data.get("start_date") else date.today(),
+        target_date=date.fromisoformat(data["target_date"]) if data.get("target_date") else None,
+    )
+    db.session.add(goal)
+    db.session.commit()
+    cache_delete_patterns([f"user:{uid}:*"])
+    return jsonify(id=goal.id), 201
+
+
+@bp.get("/<int:goal_id>")
+@jwt_required()
+def get_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    return jsonify(
+        {
+            "id": goal.id,
+            "name": goal.name,
+            "description": goal.description,
+            "target_amount": float(goal.target_amount),
+            "current_amount": float(goal.current_amount),
+            "currency": goal.currency,
+            "start_date": goal.start_date.isoformat() if goal.start_date else None,
+            "target_date": goal.target_date.isoformat() if goal.target_date else None,
+            "status": goal.status.value,
+            "milestones": [
+                {
+                    "id": m.id,
+                    "name": m.name,
+                    "target_amount": float(m.target_amount),
+                    "achieved": m.achieved,
+                    "achieved_at": m.achieved_at.isoformat() if m.achieved_at else None,
+                }
+                for m in goal.milestones
+            ],
+            "progress_pct": round(float(goal.current_amount) / float(goal.target_amount) * 100, 2)
+            if goal.target_amount and goal.target_amount > 0
+            else 0,
+            "created_at": goal.created_at.isoformat(),
+            "updated_at": goal.updated_at.isoformat(),
+        }
+    )
+
+
+@bp.put("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    if "name" in data:
+        goal.name = data["name"]
+    if "description" in data:
+        goal.description = data["description"]
+    if "target_amount" in data:
+        goal.target_amount = Decimal(str(data["target_amount"]))
+    if "current_amount" in data:
+        goal.current_amount = Decimal(str(data["current_amount"]))
+    if "target_date" in data:
+        goal.target_date = date.fromisoformat(data["target_date"]) if data["target_date"] else None
+    if "status" in data:
+        goal.status = SavingsGoalStatus(data["status"])
+
+    db.session.commit()
+    cache_delete_patterns([f"user:{uid}:*"])
+    return jsonify(message="updated")
+
+
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    db.session.delete(goal)
+    db.session.commit()
+    cache_delete_patterns([f"user:{uid}:*"])
+    return jsonify(message="deleted")
+
+
+@bp.post("/<int:goal_id>/contribute")
+@jwt_required()
+def contribute(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    amount = Decimal(str(data.get("amount", 0)))
+    if amount <= 0:
+        return jsonify(error="amount must be positive"), 400
+
+    goal.current_amount += amount
+
+    # Auto-check milestones
+    for milestone in goal.milestones:
+        if not milestone.achieved and goal.current_amount >= milestone.target_amount:
+            milestone.achieved = True
+            milestone.achieved_at = date.today()
+
+    db.session.commit()
+    cache_delete_patterns([f"user:{uid}:*"])
+    return jsonify(
+        id=goal.id,
+        current_amount=float(goal.current_amount),
+        progress_pct=round(float(goal.current_amount) / float(goal.target_amount) * 100, 2)
+        if goal.target_amount and goal.target_amount > 0
+        else 0,
+    )
+
+
+# --- Milestone endpoints ---
+
+@bp.post("/<int:goal_id>/milestones")
+@jwt_required()
+def add_milestone(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    milestone = SavingsMilestone(
+        savings_goal_id=goal_id,
+        name=data["name"],
+        target_amount=Decimal(str(data["target_amount"])),
+    )
+    db.session.add(milestone)
+    db.session.commit()
+    return jsonify(id=milestone.id), 201
+
+
+@bp.put("/<int:goal_id>/milestones/<int:milestone_id>")
+@jwt_required()
+def update_milestone(goal_id: int, milestone_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    milestone = db.session.get(SavingsMilestone, milestone_id)
+    if not milestone or milestone.savings_goal_id != goal_id:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    if "name" in data:
+        milestone.name = data["name"]
+    if "target_amount" in data:
+        milestone.target_amount = Decimal(str(data["target_amount"]))
+
+    db.session.commit()
+    return jsonify(message="updated")
+
+
+@bp.delete("/<int:goal_id>/milestones/<int:milestone_id>")
+@jwt_required()
+def delete_milestone(goal_id: int, milestone_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    milestone = db.session.get(SavingsMilestone, milestone_id)
+    if not milestone or milestone.savings_goal_id != goal_id:
+        return jsonify(error="not found"), 404
+
+    db.session.delete(milestone)
+    db.session.commit()
+    return jsonify(message="deleted")

--- a/packages/backend/tests/test_savings.py
+++ b/packages/backend/tests/test_savings.py
@@ -1,0 +1,194 @@
+import pytest
+
+
+@pytest.fixture
+def sample_goal(client, auth_header):
+    r = client.post(
+        "/savings-goals",
+        json={
+            "name": "Emergency Fund",
+            "description": "6 months expenses",
+            "target_amount": 50000,
+            "currency": "INR",
+            "target_date": "2026-12-31",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+class TestSavingsGoals:
+    def test_create_goal(self, client, auth_header):
+        r = client.post(
+            "/savings-goals",
+            json={
+                "name": "Vacation Fund",
+                "description": "Japan trip 2026",
+                "target_amount": 2000,
+                "currency": "USD",
+                "target_date": "2026-06-01",
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        assert "id" in r.get_json()
+
+    def test_create_goal_default_currency(self, client, auth_header):
+        r = client.post(
+            "/savings-goals",
+            json={
+                "name": "Test Goal",
+                "target_amount": 1000,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    def test_list_goals(self, client, auth_header, sample_goal):
+        r = client.get("/savings-goals", headers=auth_header)
+        assert r.status_code == 200
+        goals = r.get_json()
+        assert isinstance(goals, list)
+        assert len(goals) >= 1
+        assert goals[0]["name"] == "Emergency Fund"
+
+    def test_get_goal(self, client, auth_header, sample_goal):
+        r = client.get(f"/savings-goals/{sample_goal}", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["name"] == "Emergency Fund"
+        assert data["target_amount"] == 50000.0
+        assert data["current_amount"] == 0.0
+        assert data["progress_pct"] == 0.0
+
+    def test_get_goal_not_found(self, client, auth_header):
+        r = client.get("/savings-goals/99999", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_update_goal(self, client, auth_header, sample_goal):
+        r = client.put(
+            f"/savings-goals/{sample_goal}",
+            json={"name": "Updated Goal Name", "target_amount": 60000},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        r2 = client.get(f"/savings-goals/{sample_goal}", headers=auth_header)
+        data = r2.get_json()
+        assert data["name"] == "Updated Goal Name"
+        assert data["target_amount"] == 60000.0
+
+    def test_delete_goal(self, client, auth_header, sample_goal):
+        r = client.delete(f"/savings-goals/{sample_goal}", headers=auth_header)
+        assert r.status_code == 200
+        r2 = client.get(f"/savings-goals/{sample_goal}", headers=auth_header)
+        assert r2.status_code == 404
+
+    def test_contribute(self, client, auth_header, sample_goal):
+        r = client.post(
+            f"/savings-goals/{sample_goal}/contribute",
+            json={"amount": 5000},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["current_amount"] == 5000.0
+        assert data["progress_pct"] == 10.0
+
+    def test_contribute_negative_fails(self, client, auth_header, sample_goal):
+        r = client.post(
+            f"/savings-goals/{sample_goal}/contribute",
+            json={"amount": -100},
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+
+    def test_contribute_multiple_and_milestone_auto(self, client, auth_header, auth_header2):
+        # Create a goal with milestones
+        r = client.post(
+            "/savings-goals",
+            json={
+                "name": "Car Fund",
+                "target_amount": 10000,
+                "currency": "USD",
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        goal_id = r.get_json()["id"]
+
+        # Add a milestone at 50%
+        r = client.post(
+            f"/savings-goals/{goal_id}/milestones",
+            json={"name": "50% reached", "target_amount": 5000},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        milestone_id = r.get_json()["id"]
+
+        # Contribute 3000 - milestone not yet reached
+        r = client.post(
+            f"/savings-goals/{goal_id}/contribute",
+            json={"amount": 3000},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        assert r.get_json()["progress_pct"] == 30.0
+
+        # Contribute 2500 more - now 5500 total, milestone reached
+        r = client.post(
+            f"/savings-goals/{goal_id}/contribute",
+            json={"amount": 2500},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        assert r.get_json()["current_amount"] == 5500.0
+
+        # Check milestone was auto-achieved
+        r = client.get(f"/savings-goals/{goal_id}", headers=auth_header)
+        data = r.get_json()
+        milestones = data["milestones"]
+        assert len(milestones) == 1
+        assert milestones[0]["achieved"] is True
+        assert milestones[0]["achieved_at"] is not None
+
+    def test_milestone_crud(self, client, auth_header, sample_goal):
+        # Create milestone
+        r = client.post(
+            f"/savings-goals/{sample_goal}/milestones",
+            json={"name": "First $1k", "target_amount": 1000},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        mid = r.get_json()["id"]
+
+        # Update milestone
+        r = client.put(
+            f"/savings-goals/{sample_goal}/milestones/{mid}",
+            json={"name": "Updated Milestone", "target_amount": 2000},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+
+        # Delete milestone
+        r = client.delete(f"/savings-goals/{sample_goal}/milestones/{mid}", headers=auth_header)
+        assert r.status_code == 200
+
+    def test_goal_requires_auth(self, client):
+        r = client.get("/savings-goals")
+        assert r.status_code == 401
+
+    def test_cannot_access_other_user_goal(self, client, auth_header, auth_header2, sample_goal):
+        # auth_header2 is a different user - can't access sample_goal
+        r = client.get(f"/savings-goals/{sample_goal}", headers=auth_header2)
+        assert r.status_code == 404
+
+
+@pytest.fixture
+def auth_header2(client):
+    email = "test2@example.com"
+    password = "password123"
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    access = r.get_json()["access_token"]
+    return {"Authorization": f"Bearer {access}"}


### PR DESCRIPTION
## Summary

Implements goal-based savings tracking with milestone support for FinMind.

### Changes
- **New model**: `SavingsGoal` - tracks savings goals with target amounts, dates, status
- **New model**: `SavingsMilestone` - sub-goals within a savings goal that auto-mark as achieved when contribution reaches the milestone amount
- **New API routes**:
  - `GET/POST /savings-goals` - list and create goals
  - `GET/PUT/DELETE /savings-goals/:id` - CRUD operations
  - `POST /savings-goals/:id/contribute` - add money; auto-checks milestones
  - `POST/PUT/DELETE /savings-goals/:id/milestones` - milestone CRUD
- **12 new tests** covering all endpoints including milestone auto-achievement
- **OpenAPI spec** updated with SavingsGoal schema
- **README** updated with feature documentation

### Example usage
```bash
# Create a goal
POST /savings-goals
{ "name": "Emergency Fund", "target_amount": 50000, "target_date": "2026-12-31" }

# Add milestone
POST /savings-goals/1/milestones
{ "name": "50% reached", "target_amount": 25000 }

# Contribute (milestone auto-achieved when target reached)
POST /savings-goals/1/contribute
{ "amount": 25000 }
```

Closes #133
[Bounty] algora bounty - $250