### PR TITLE
fix: Multi-account financial overview dashboard

### DIFF
--- a/packages/backend/app/api/__init__.py
+++ b/packages/backend/app/api/__init__.py
@@ -1,0 +1,21 @@
+from flask import Blueprint
+
+from app.api.auth import auth_bp
+from app.api.transactions import transactions_bp
+from app.api.categories import categories_bp
+from app.api.dashboard import dashboard_bp
+from app.api.bills import bills_bp
+from app.api.reminders import reminders_bp
+from app.api.observability import observability_bp
+from app.api.accounts import accounts_bp # Import the new accounts blueprint
+
+api_bp = Blueprint("api", __name__, url_prefix="/api")
+
+api_bp.register_blueprint(auth_bp)
+api_bp.register_blueprint(transactions_bp)
+api_bp.register_blueprint(categories_bp)
+api_bp.register_blueprint(dashboard_bp)
+api_bp.register_blueprint(bills_bp)
+api_bp.register_blueprint(reminders_bp)
+api_bp.register_blueprint(observability_bp)
+api_bp.register_blueprint(accounts_bp) # Register the new accounts blueprint

--- a/packages/backend/app/api/accounts.py
+++ b/packages/backend/app/api/accounts.py
@@ -1,0 +1,316 @@
+from flask import Blueprint, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from marshmallow import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from app.extensions import db
+from app.models import Account, User
+from app.schemas import AccountSchema
+from app.utils.api import json_abort, json_response
+
+accounts_bp = Blueprint("accounts", __name__, url_prefix="/accounts")
+
+
+@accounts_bp.route("/", methods=["GET"])
+@jwt_required()
+def list_accounts():
+    """
+    List all financial accounts for the authenticated user.
+    ---
+    get:
+      summary: List user accounts
+      security:
+        - jwt: []
+      responses:
+        200:
+          description: A list of financial accounts.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountSchema'
+        401:
+          description: Unauthorized.
+    """
+    user_id = get_jwt_identity()
+    accounts = Account.query.filter_by(user_id=user_id).order_by(Account.name).all()
+    return AccountSchema(many=True).dump(accounts)
+
+
+@accounts_bp.route("/", methods=["POST"])
+@jwt_required()
+def create_account():
+    """
+    Create a new financial account for the authenticated user.
+    ---
+    post:
+      summary: Create an account
+      security:
+        - jwt: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Name of the account
+                  example: My Savings
+                currency:
+                  type: string
+                  description: ISO 4217 currency code (e.g., 'USD', 'INR')
+                  example: USD
+      responses:
+        201:
+          description: Account created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSchema'
+        400:
+          description: Invalid input or missing required fields.
+        401:
+          description: Unauthorized.
+        409:
+          description: An account with this name already exists for the user.
+    """
+    user_id = get_jwt_identity()
+    user = User.query.get(user_id)
+    if not user:
+        json_abort(404, "User not found")
+
+    try:
+        data = AccountSchema(partial=True).load(request.json)  # Use partial to allow 'name' and 'currency' only
+    except ValidationError as err:
+        json_abort(400, err.messages)
+
+    name = data.get("name")
+    currency = data.get("currency")
+
+    if not name or not currency:
+        json_abort(400, "Account name and currency are required.")
+
+    # Check if this is the first account for the user, if so, make it primary
+    is_primary = Account.query.filter_by(user_id=user_id).count() == 0
+
+    new_account = Account(
+        name=name,
+        user_id=user_id,
+        currency=currency,
+        is_primary=is_primary
+    )
+
+    try:
+        db.session.add(new_account)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        json_abort(409, "An account with this name already exists, or primary account constraint violated.")
+    except Exception as e:
+        db.session.rollback()
+        json_abort(500, f"Failed to create account: {str(e)}")
+
+    return json_response(AccountSchema().dump(new_account), 201)
+
+
+@accounts_bp.route("/<int:account_id>", methods=["GET"])
+@jwt_required()
+def get_account(account_id):
+    """
+    Get a specific financial account by ID for the authenticated user.
+    ---
+    get:
+      summary: Get account by ID
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: account_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the account to retrieve
+      responses:
+        200:
+          description: Account details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSchema'
+        401:
+          description: Unauthorized.
+        404:
+          description: Account not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+    if not account:
+        json_abort(404, "Account not found or not owned by user.")
+    return AccountSchema().dump(account)
+
+
+@accounts_bp.route("/<int:account_id>", methods=["PATCH"])
+@jwt_required()
+def update_account(account_id):
+    """
+    Update a specific financial account by ID for the authenticated user.
+    Allows changing name, currency, and setting as primary.
+    ---
+    patch:
+      summary: Update an account
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: account_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the account to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: New name for the account
+                  example: My Checking
+                currency:
+                  type: string
+                  description: New ISO 4217 currency code
+                  example: EUR
+                is_primary:
+                  type: boolean
+                  description: Set this account as the user's primary account
+                  example: true
+      responses:
+        200:
+          description: Account updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSchema'
+        400:
+          description: Invalid input.
+        401:
+          description: Unauthorized.
+        404:
+          description: Account not found or not owned by the user.
+        409:
+          description: An account with this name already exists, or primary account constraint violated.
+    """
+    user_id = get_jwt_identity()
+    account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+    if not account:
+        json_abort(404, "Account not found or not owned by user.")
+
+    try:
+        data = AccountSchema(partial=True).load(request.json)
+    except ValidationError as err:
+        json_abort(400, err.messages)
+
+    new_name = data.get("name")
+    new_currency = data.get("currency")
+    set_primary = data.get("is_primary")
+
+    if new_name:
+        account.name = new_name
+    if new_currency:
+        account.currency = new_currency
+    
+    if set_primary is not None:
+        if set_primary and not account.is_primary: # if we want to make it primary and it's not already
+            # Unset current primary account for this user
+            current_primary = Account.query.filter_by(user_id=user_id, is_primary=True).first()
+            if current_primary and current_primary.id != account.id:
+                current_primary.is_primary = False
+                db.session.add(current_primary)
+            account.is_primary = True
+        elif not set_primary and account.is_primary: # if we want to unset it, but it's currently primary
+            # A user must always have one primary account.
+            # If this is the only account, it cannot be unset as primary.
+            if Account.query.filter_by(user_id=user_id).count() == 1:
+                json_abort(400, "Cannot unset the only primary account. A user must always have one primary account.")
+            # If there are other accounts, we could randomly pick another one to become primary,
+            # or require the client to specify a new primary, or fail and let the client explicitly
+            # set a new one. Let's fail for now to enforce explicit primary setting.
+            json_abort(400, "Cannot unset a primary account. Please set another account as primary first.")
+
+    try:
+        db.session.add(account)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        json_abort(409, "An account with this name already exists for the user, or primary account constraint violated.")
+    except Exception as e:
+        db.session.rollback()
+        json_abort(500, f"Failed to update account: {str(e)}")
+
+    return AccountSchema().dump(account)
+
+
+@accounts_bp.route("/<int:account_id>", methods=["DELETE"])
+@jwt_required()
+def delete_account(account_id):
+    """
+    Delete a financial account by ID for the authenticated user.
+    ---
+    delete:
+      summary: Delete an account
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: account_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the account to delete
+      responses:
+        200:
+          description: Account deleted successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Account deleted
+        400:
+          description: Cannot delete primary account if it's the only one.
+        401:
+          description: Unauthorized.
+        404:
+          description: Account not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+    if not account:
+        json_abort(404, "Account not found or not owned by user.")
+    
+    # Prevent deleting the last primary account
+    if account.is_primary:
+        remaining_accounts = Account.query.filter_by(user_id=user_id).count()
+        if remaining_accounts == 1:
+            json_abort(400, "Cannot delete the only primary account. A user must always have one primary account.")
+        # If there are other accounts, we need to make another one primary before deleting this one.
+        # This design choice prefers explicit action from the client.
+        json_abort(400, "Cannot delete a primary account. Please set another account as primary first.")
+
+
+    try:
+        db.session.delete(account)
+        db.session.commit()
+    except Exception as e:
+        db.session.rollback()
+        json_abort(500, f"Failed to delete account: {str(e)}")
+
+    return json_response({"message": "Account deleted"})
+

--- a/packages/backend/app/api/auth.py
+++ b/packages/backend/app/api/auth.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, request
+from flask_jwt_extended import (
+    create_access_token,
+    create_refresh_token,
+    jwt_required,
+    get_jwt_identity,
+    get_jwt,
+    current_user,
+)
+from marshmallow import ValidationError
+from sqlalchemy.exc import IntegrityError
+from datetime import timedelta
+
+from app.extensions import db, jwt
+from app.models import User, Account # Import Account
+from app.schemas import RegisterSchema, LoginSchema, UserSchema, UpdateUserSchema, AccountSchema # Import AccountSchema
+from app.utils.api import json_abort, json_response
+from app.utils.auth import hash_password, verify_password, add_token_to_blocklist    if existing_user:
+        json_abort(409, "User with this email already exists.")
+
+    hashed_password = hash_password(data["password"])
+    new_user = User(email=data["email"], password_hash=hashed_password)
+    db.session.add(new_user)
+    db.session.flush() # Flush to get new_user.id before committing
+
+    # Create a default primary account for the new user
+    default_account = Account(
+        name="Main Account",
+        user_id=new_user.id,
+        currency=new_user.preferred_currency, # Use user's preferred currency
+        is_primary=True
+    )
+    db.session.add(default_account)
+    db.session.commit()
+
+    return json_response(UserSchema().dump(new_user), 201)    """
+    user_id = get_jwt_identity()
+    user = User.query.get(user_id)
+    if not user:
+        json_abort(404, "User not found")
+
+    try:
+        data = UpdateUserSchema().load(request.json, partial=True)
+    except ValidationError as err:
+        json_abort(400, err.messages)
+
+    if "preferred_currency" in data:
+        user.preferred_currency = data["preferred_currency"].upper()
+
+    db.session.commit()
+    # The UserSchema now includes accounts, which need to be dumped.
+    # We must ensure the user object has its relationships loaded.
+    db.session.refresh(user)
+    return UserSchema().dump(user)

--- a/packages/backend/app/api/bills.py
+++ b/packages/backend/app/api/bills.py
@@ -1,0 +1,388 @@
+from flask import Blueprint, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from marshmallow import ValidationError
+from datetime import date, timedelta
+import calendar # Import calendar for month-end calculations
+
+from app.extensions import db
+from app.models import Bill, User, Account
+from app.schemas import BillSchema
+from app.utils.api import json_abort, json_response
+
+bills_bp = Blueprint("bills", __name__, url_prefix="/bills")
+
+
+@bills_bp.route("/", methods=["POST"])
+@jwt_required()
+def create_bill():
+    """
+    Create a new bill.
+    ---
+    post:
+      summary: Create a bill
+      security:
+        - jwt: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Name of the bill
+                  example: Internet
+                amount:
+                  type: number
+                  format: float
+                  description: Amount of the bill
+                  example: 59.99
+                account_id:
+                  type: integer
+                  description: The ID of the account this bill belongs to.
+                  example: 1
+                currency:
+                  type: string
+                  description: ISO 4217 currency code (e.g., 'USD', 'INR')
+                  example: USD
+                next_due_date:
+                  type: string
+                  format: date
+                  description: Next due date in YYYY-MM-DD format
+                  example: 2024-03-20
+                cadence:
+                  type: string
+                  enum: [DAILY, WEEKLY, MONTHLY, YEARLY]
+                  description: How often the bill recurs
+                  example: MONTHLY
+                channel_email:
+                  type: boolean
+                  description: Whether to send email reminders
+                  example: true
+                channel_whatsapp:
+                  type: boolean
+                  description: Whether to send WhatsApp reminders
+                  example: false
+                autopay_enabled:
+                  type: boolean
+                  description: Whether autopay is enabled
+                  example: false
+      responses:
+        201:
+          description: Bill created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillSchema'
+        400:
+          description: Invalid input or account_id missing/invalid.
+        401:
+          description: Unauthorized.
+        404:
+          description: Account not found or not owned by user.
+    """
+    user_id = get_jwt_identity()
+    user = User.query.get_or_404(user_id)
+
+    try:
+        data = BillSchema().load(request.json)
+    except ValidationError as err:
+        json_abort(400, err.messages)
+
+    account_id = data.get("account_id")
+    if not account_id:
+        json_abort(400, "Account ID is required for a bill.")
+    
+    account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+    if not account:
+        json_abort(404, "Account not found or not owned by user.")
+
+    # If currency is not provided, default to the account's currency
+    if "currency" not in data or not data["currency"]:
+        data["currency"] = account.currency
+
+    new_bill = Bill(user_id=user_id, **data)
+    db.session.add(new_bill)
+    db.session.commit()
+    return json_response(BillSchema().dump(new_bill), 201)
+
+
+@bills_bp.route("/", methods=["GET"])
+@jwt_required()
+def list_bills():
+    """
+    List all bills for the authenticated user.
+    ---
+    get:
+      summary: List user bills
+      security:
+        - jwt: []
+      parameters:
+        - in: query
+          name: account_id
+          schema:
+            type: integer
+          description: Optional. ID of the financial account to filter bills by.
+                       If not provided, bills from all user accounts are returned.
+      responses:
+        200:
+          description: A list of bills.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BillSchema'
+        401:
+          description: Unauthorized.
+    """
+    user_id = get_jwt_identity()
+    query = Bill.query.filter_by(user_id=user_id)
+
+    account_id = request.args.get("account_id", type=int)
+    if account_id:
+        account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+        if not account:
+            json_abort(404, "Account not found or not owned by user.")
+        query = query.filter_by(account_id=account_id)
+
+    bills = query.order_by(Bill.next_due_date).all()
+    return BillSchema(many=True).dump(bills)
+
+
+@bills_bp.route("/<int:bill_id>", methods=["GET"])
+@jwt_required()
+def get_bill(bill_id):
+    """
+    Get a specific bill by ID for the authenticated user.
+    ---
+    get:
+      summary: Get bill by ID
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: bill_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the bill to retrieve
+      responses:
+        200:
+          description: Bill details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillSchema'
+        401:
+          description: Unauthorized.
+        404:
+          description: Bill not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    bill = Bill.query.filter_by(id=bill_id, user_id=user_id).first()
+    if not bill:
+        json_abort(404, "Bill not found or not owned by user.")
+    return BillSchema().dump(bill)
+
+
+@bills_bp.route("/<int:bill_id>", methods=["PATCH"])
+@jwt_required()
+def update_bill(bill_id):
+    """
+    Update a specific bill by ID for the authenticated user.
+    ---
+    patch:
+      summary: Update a bill
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: bill_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the bill to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: Name of the bill
+                  example: Updated Internet Bill
+                amount:
+                  type: number
+                  format: float
+                  description: New amount
+                  example: 65.00
+                account_id:
+                  type: integer
+                  description: The ID of the account this bill belongs to.
+                  example: 1
+                currency:
+                  type: string
+                  description: ISO 4217 currency code (e.g., 'USD', 'INR')
+                  example: EUR
+                next_due_date:
+                  type: string
+                  format: date
+                  description: New next due date in YYYY-MM-DD format
+                  example: 2024-04-20
+                cadence:
+                  type: string
+                  enum: [DAILY, WEEKLY, MONTHLY, YEARLY]
+                  description: New cadence
+                  example: MONTHLY
+                channel_email:
+                  type: boolean
+                  description: Whether to send email reminders
+                  example: false
+                channel_whatsapp:
+                  type: boolean
+                  description: Whether to send WhatsApp reminders
+                  example: true
+                autopay_enabled:
+                  type: boolean
+                  description: Whether autopay is enabled
+                  example: true
+      responses:
+        200:
+          description: Bill updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BillSchema'
+        400:
+          description: Invalid input or account_id not owned by user.
+        401:
+          description: Unauthorized.
+        404:
+          description: Bill not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    bill = Bill.query.filter_by(id=bill_id, user_id=user_id).first()
+    if not bill:
+        json_abort(404, "Bill not found or not owned by user.")
+
+    try:
+        data = BillSchema(partial=True).load(request.json)
+    except ValidationError as err:
+        json_abort(400, err.messages)
+
+    if "account_id" in data:
+        account = Account.query.filter_by(id=data["account_id"], user_id=user_id).first()
+        if not account:
+            json_abort(400, "Account not found or not owned by user.")
+
+    for key, value in data.items():
+        setattr(bill, key, value)
+
+    db.session.commit()
+    return BillSchema().dump(bill)
+
+
+@bills_bp.route("/<int:bill_id>", methods=["DELETE"])
+@jwt_required()
+def delete_bill(bill_id):
+    """
+    Delete a bill by ID for the authenticated user.
+    ---
+    delete:
+      summary: Delete a bill
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: bill_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the bill to delete
+      responses:
+        200:
+          description: Bill deleted successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Bill deleted
+        401:
+          description: Unauthorized.
+        404:
+          description: Bill not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    bill = Bill.query.filter_by(id=bill_id, user_id=user_id).first()
+    if not bill:
+        json_abort(404, "Bill not found or not owned by user.")
+
+    db.session.delete(bill)
+    db.session.commit()
+    return json_response({"message": "Bill deleted"})
+
+
+@bills_bp.route("/<int:bill_id>/pay", methods=["POST"])
+@jwt_required()
+def mark_bill_paid(bill_id):
+    """
+    Marks a bill as paid and updates its next due date based on its cadence.
+    ---
+    post:
+      summary: Mark bill as paid
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: bill_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the bill to mark as paid
+      responses:
+        200:
+          description: Bill marked as paid and next due date updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: updated
+        401:
+          description: Unauthorized.
+        404:
+          description: Bill not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    bill = Bill.query.filter_by(id=bill_id, user_id=user_id).first()
+    if not bill:
+        json_abort(404, "Bill not found or not owned by user.")
+
+    # Update next_due_date based on cadence
+    current_date = bill.next_due_date
+    if bill.cadence == "DAILY":
+        bill.next_due_date = current_date + timedelta(days=1)
+    elif bill.cadence == "WEEKLY":
+        bill.next_due_date = current_date + timedelta(weeks=1)
+    elif bill.cadence == "MONTHLY":
+        # Advance by one month, handle month end correctly
+        next_month = current_date.month % 12 + 1
+        next_year = current_date.year + (current_date.month // 12)
+        day = min(current_date.day, calendar.monthrange(next_year, next_month)[1])
+        bill.next_due_date = date(next_year, next_month, day)
+    elif bill.cadence == "YEARLY":
+        bill.next_due_date = date(current_date.year + 1, current_date.month, current_date.day)
+    else:
+        json_abort(400, "Unknown bill cadence.")
+
+    db.session.commit()
+    return json_response({"message": "updated"})

--- a/packages/backend/app/api/dashboard.py
+++ b/packages/backend/app/api/dashboard.py
@@ -1,0 +1,215 @@
+from flask import Blueprint, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from datetime import datetime
+from sqlalchemy import func
+from sqlalchemy.orm import joinedload
+from app.extensions import db
+from app.models import Transaction, Bill, Category, User, Account
+from app.schemas import DashboardSummarySchema, TransactionSchema, BillSchema, CategoryBreakdownSchema
+from app.utils.api import json_abort
+
+dashboard_bp = Blueprint("dashboard", __name__, url_prefix="/dashboard")
+
+
+@dashboard_bp.route("/summary", methods=["GET"])
+@jwt_required()
+def dashboard_summary():
+    """
+    Provides a financial overview for the authenticated user for a given month,
+    optionally filtered by account.
+    ---
+    get:
+      summary: Get dashboard summary
+      security:
+        - jwt: []
+      parameters:
+        - in: query
+          name: month
+          schema:
+            type: string
+            format: YYYY-MM
+          description: Month for which to retrieve the summary (e.g., "2023-10"). Defaults to current month.
+        - in: query
+          name: account_id
+          schema:
+            type: integer
+          description: Optional. ID of the financial account to filter the summary by.
+                       If not provided, the summary will be for the user's primary account.
+      responses:
+        200:
+          description: A summary of financial data.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DashboardSummarySchema'
+        400:
+          description: Invalid month format or account_id.
+        401:
+          description: Unauthorized.
+        404:
+          description: Account not found or not owned by user.
+    """
+    user_id = get_jwt_identity()
+    user = User.query.get_or_404(user_id)
+
+    # Determine the target account
+    account_id = request.args.get("account_id", type=int)
+    target_account = None
+
+    if account_id:
+        target_account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+        if not target_account:
+            json_abort(404, "Account not found or not owned by user.")
+    else:
+        # If no account_id is provided, use the user's primary account
+        target_account = Account.query.filter_by(user_id=user_id, is_primary=True).first()
+        if not target_account:
+            json_abort(400, "No account_id provided and user has no primary account. Please specify an account or create a primary one.")
+
+    # Validate month parameter
+    month_str = request.args.get("month")
+    if month_str:
+        try:
+            year, month = map(int, month_str.split("-"))
+            start_date = datetime(year, month, 1).date()
+            # Calculate end_date for the month
+            if month == 12:
+                end_date = datetime(year + 1, 1, 1).date()
+            else:
+                end_date = datetime(year, month + 1, 1).date()
+            period = {"month": month_str}
+        except ValueError:
+            json_abort(400, "Invalid month format. Use YYYY-MM.")
+    else:
+        # Default to current month
+        now = datetime.now()
+        start_date = datetime(now.year, now.month, 1).date()
+        if now.month == 12:
+            end_date = datetime(now.year + 1, 1, 1).date()
+        else:
+            end_date = datetime(now.year, now.month + 1, 1).date()
+        period = {"month": now.strftime("%Y-%m")}
+
+    # Base query filters for transactions and bills
+    base_transaction_filter = [
+        Transaction.user_id == user_id,
+        Transaction.account_id == target_account.id,
+        Transaction.date >= start_date,
+        Transaction.date < end_date,
+    ]
+
+    base_bill_filter = [
+        Bill.user_id == user_id,
+        Bill.account_id == target_account.id,
+        Bill.next_due_date >= datetime.now().date(),
+    ]
+
+    # Get transactions for the period
+    transactions_query = Transaction.query.filter(*base_transaction_filter)
+    transactions = transactions_query.order_by(Transaction.date.desc()).all()
+    transactions_data = TransactionSchema(many=True).dump(transactions)
+
+    # Calculate monthly income and expenses
+    income = db.session.query(func.sum(Transaction.amount)).filter(
+        *base_transaction_filter,
+        Transaction.type == "INCOME",
+    ).scalar() or 0.0
+
+    expenses = db.session.query(func.sum(Transaction.amount)).filter(
+        *base_transaction_filter,
+        Transaction.type == "EXPENSE",
+    ).scalar() or 0.0
+
+    net_flow = income - expenses
+
+    # Upcoming bills (for the current month onwards)
+    upcoming_bills_query = Bill.query.filter(*base_bill_filter)
+    upcoming_bills = upcoming_bills_query.order_by(Bill.next_due_date.asc()).all()
+    upcoming_bills_data = BillSchema(many=True).dump(upcoming_bills)
+
+    upcoming_bills_total = sum(b.amount for b in upcoming_bills)
+    upcoming_bills_count = len(upcoming_bills)
+
+    # Category breakdown for expenses
+    category_breakdown_query = (
+        db.session.query(
+            Category.id,
+            Category.name,
+            func.sum(Transaction.amount).label("total_amount"),
+        )
+        .join(Transaction, Transaction.category_id == Category.id)
+        .filter(
+            *base_transaction_filter,
+            Transaction.type == "EXPENSE",
+        )
+        .group_by(Category.id, Category.name)
+    ).all()
+
+    total_expenses_for_breakdown = (
+        db.session.query(func.sum(Transaction.amount))
+        .filter(
+            *base_transaction_filter,
+            Transaction.type == "EXPENSE",
+        )
+        .scalar()
+        or 0.0
+    )
+
+    category_breakdown_data = []
+    for cat_id, cat_name, total_amount in category_breakdown_query:
+        share_pct = (
+            (total_amount / total_expenses_for_breakdown * 100)
+            if total_expenses_for_breakdown > 0
+            else 0.0
+        )
+        category_breakdown_data.append(
+            {
+                "category_id": cat_id,
+                "category_name": cat_name,
+                "amount": total_amount,
+                "share_pct": round(share_pct, 2),
+            }
+        )
+
+    # Handle uncategorized expenses
+    uncategorized_expenses = (
+        db.session.query(func.sum(Transaction.amount))
+        .filter(
+            *base_transaction_filter,
+            Transaction.type == "EXPENSE",
+            Transaction.category_id.is_(None),
+        )
+        .scalar()
+        or 0.0
+    )
+
+    if uncategorized_expenses > 0:
+        share_pct = (
+            (uncategorized_expenses / total_expenses_for_breakdown * 100)
+            if total_expenses_for_breakdown > 0
+            else 0.0
+        )
+        category_breakdown_data.append(
+            {
+                "category_id": None,
+                "category_name": "Uncategorized",
+                "amount": uncategorized_expenses,
+                "share_pct": round(share_pct, 2),
+            }
+        )
+
+    response_data = {
+        "period": period,
+        "summary": {
+            "net_flow": round(net_flow, 2),
+            "monthly_income": round(income, 2),
+            "monthly_expenses": round(expenses, 2),
+            "upcoming_bills_total": round(upcoming_bills_total, 2),
+            "upcoming_bills_count": upcoming_bills_count,
+        },
+        "recent_transactions": transactions_data,
+        "upcoming_bills": upcoming_bills_data,
+        "category_breakdown": category_breakdown_data,
+    }
+
+    return DashboardSummarySchema().dump(response_data)

--- a/packages/backend/app/api/transactions.py
+++ b/packages/backend/app/api/transactions.py
@@ -1,0 +1,376 @@
+from flask import Blueprint, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from marshmallow import ValidationError
+from datetime import date
+
+from app.extensions import db
+from app.models import Transaction, Category, User, Account # Import Account
+from app.schemas import TransactionSchema
+from app.utils.api import json_abort, json_response
+
+transactions_bp = Blueprint("transactions", __name__, url_prefix="/transactions")
+
+
+@transactions_bp.route("/", methods=["POST"])
+@jwt_required()
+def create_transaction():
+    """
+    Create a new transaction.
+    ---
+    post:
+      summary: Create a transaction
+      security:
+        - jwt: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  description: Description of the transaction
+                  example: Groceries
+                amount:
+                  type: number
+                  format: float
+                  description: Amount of the transaction
+                  example: 50.75
+                date:
+                  type: string
+                  format: date
+                  description: Date of the transaction in YYYY-MM-DD format
+                  example: 2023-10-26
+                type:
+                  type: string
+                  enum: [INCOME, EXPENSE]
+                  description: Type of transaction
+                  example: EXPENSE
+                category_id:
+                  type: integer
+                  description: Optional ID of the category
+                  example: 1
+                account_id:
+                  type: integer
+                  description: The ID of the account this transaction belongs to.
+                  example: 1
+                currency:
+                  type: string
+                  description: ISO 4217 currency code (e.g., 'USD', 'INR')
+                  example: USD
+      responses:
+        201:
+          description: Transaction created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionSchema'
+        400:
+          description: Invalid input or account_id missing/invalid.
+        401:
+          description: Unauthorized.
+        404:
+          description: Category or Account not found or not owned by user.
+    """
+    user_id = get_jwt_identity()
+    user = User.query.get_or_404(user_id)
+
+    try:
+        data = TransactionSchema().load(request.json)
+    except ValidationError as err:
+        json_abort(400, err.messages)
+
+    category_id = data.get("category_id")
+    if category_id:
+        category = Category.query.filter_by(id=category_id, user_id=user_id).first()
+        if not category:
+            json_abort(404, "Category not found or not owned by user.")
+
+    account_id = data.get("account_id")
+    if not account_id:
+        json_abort(400, "Account ID is required for a transaction.")
+    
+    account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+    if not account:
+        json_abort(404, "Account not found or not owned by user.")
+
+    # If currency is not provided, default to the account's currency
+    if "currency" not in data or not data["currency"]:
+        data["currency"] = account.currency
+
+    new_transaction = Transaction(user_id=user_id, **data)
+    db.session.add(new_transaction)
+    db.session.commit()
+    return json_response(TransactionSchema().dump(new_transaction), 201)
+
+
+@transactions_bp.route("/", methods=["GET"])
+@jwt_required()
+def list_transactions():
+    """
+    List all transactions for the authenticated user.
+    ---
+    get:
+      summary: List user transactions
+      security:
+        - jwt: []
+      parameters:
+        - in: query
+          name: start_date
+          schema:
+            type: string
+            format: date
+          description: Filter transactions from this date (YYYY-MM-DD).
+        - in: query
+          name: end_date
+          schema:
+            type: string
+            format: date
+          description: Filter transactions up to this date (YYYY-MM-DD).
+        - in: query
+          name: type
+          schema:
+            type: string
+            enum: [INCOME, EXPENSE]
+          description: Filter by transaction type.
+        - in: query
+          name: category_id
+          schema:
+            type: integer
+          description: Filter by category ID.
+        - in: query
+          name: account_id
+          schema:
+            type: integer
+          description: Optional. ID of the financial account to filter transactions by.
+                       If not provided, transactions from all user accounts are returned.
+      responses:
+        200:
+          description: A list of transactions.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TransactionSchema'
+        400:
+          description: Invalid date format or account_id.
+        401:
+          description: Unauthorized.
+    """
+    user_id = get_jwt_identity()
+    query = Transaction.query.filter_by(user_id=user_id)
+
+    start_date_str = request.args.get("start_date")
+    end_date_str = request.args.get("end_date")
+    transaction_type = request.args.get("type")
+    category_id = request.args.get("category_id", type=int)
+    account_id = request.args.get("account_id", type=int)
+
+    try:
+        if start_date_str:
+            start_date = date.fromisoformat(start_date_str)
+            query = query.filter(Transaction.date >= start_date)
+        if end_date_str:
+            end_date = date.fromisoformat(end_date_str)
+            query = query.filter(Transaction.date <= end_date)
+    except ValueError:
+        json_abort(400, "Invalid date format. Use YYYY-MM-DD.")
+
+    if transaction_type:
+        if transaction_type not in ["INCOME", "EXPENSE"]:
+            json_abort(400, "Invalid transaction type. Must be 'INCOME' or 'EXPENSE'.")
+        query = query.filter_by(type=transaction_type)
+
+    if category_id:
+        category = Category.query.filter_by(id=category_id, user_id=user_id).first()
+        if not category:
+            json_abort(404, "Category not found or not owned by user.")
+        query = query.filter_by(category_id=category_id)
+    
+    if account_id:
+        account = Account.query.filter_by(id=account_id, user_id=user_id).first()
+        if not account:
+            json_abort(404, "Account not found or not owned by user.")
+        query = query.filter_by(account_id=account_id)
+
+    transactions = query.order_by(Transaction.date.desc()).all()
+    return TransactionSchema(many=True).dump(transactions)
+
+
+@transactions_bp.route("/<int:transaction_id>", methods=["GET"])
+@jwt_required()
+def get_transaction(transaction_id):
+    """
+    Get a specific transaction by ID for the authenticated user.
+    ---
+    get:
+      summary: Get transaction by ID
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: transaction_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the transaction to retrieve
+      responses:
+        200:
+          description: Transaction details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionSchema'
+        401:
+          description: Unauthorized.
+        404:
+          description: Transaction not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    transaction = Transaction.query.filter_by(id=transaction_id, user_id=user_id).first()
+    if not transaction:
+        json_abort(404, "Transaction not found or not owned by user.")
+    return TransactionSchema().dump(transaction)
+
+
+@transactions_bp.route("/<int:transaction_id>", methods=["PATCH"])
+@jwt_required()
+def update_transaction(transaction_id):
+    """
+    Update a specific transaction by ID for the authenticated user.
+    ---
+    patch:
+      summary: Update a transaction
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: transaction_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the transaction to update
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                description:
+                  type: string
+                  description: New description
+                  example: Updated Groceries
+                amount:
+                  type: number
+                  format: float
+                  description: New amount
+                  example: 60.00
+                date:
+                  type: string
+                  format: date
+                  description: New date in YYYY-MM-DD format
+                  example: 2023-11-01
+                type:
+                  type: string
+                  enum: [INCOME, EXPENSE]
+                  description: New type
+                  example: EXPENSE
+                category_id:
+                  type: integer
+                  description: New optional ID of the category
+                  example: 2
+                account_id:
+                  type: integer
+                  description: The ID of the account this transaction belongs to.
+                  example: 1
+                currency:
+                  type: string
+                  description: New ISO 4217 currency code (e.g., 'USD', 'INR')
+                  example: EUR
+      responses:
+        200:
+          description: Transaction updated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransactionSchema'
+        400:
+          description: Invalid input or category/account not found/owned by user.
+        401:
+          description: Unauthorized.
+        404:
+          description: Transaction not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    transaction = Transaction.query.filter_by(id=transaction_id, user_id=user_id).first()
+    if not transaction:
+        json_abort(404, "Transaction not found or not owned by user.")
+
+    try:
+        data = TransactionSchema(partial=True).load(request.json)
+    except ValidationError as err:
+        json_abort(400, err.messages)
+
+    if "category_id" in data and data["category_id"] is not None:
+        category = Category.query.filter_by(
+            id=data["category_id"], user_id=user_id
+        ).first()
+        if not category:
+            json_abort(404, "Category not found or not owned by user.")
+    
+    if "account_id" in data and data["account_id"] is not None:
+        account = Account.query.filter_by(id=data["account_id"], user_id=user_id).first()
+        if not account:
+            json_abort(404, "Account not found or not owned by user.")
+
+    for key, value in data.items():
+        setattr(transaction, key, value)
+
+    db.session.commit()
+    return TransactionSchema().dump(transaction)
+
+
+@transactions_bp.route("/<int:transaction_id>", methods=["DELETE"])
+@jwt_required()
+def delete_transaction(transaction_id):
+    """
+    Delete a transaction by ID for the authenticated user.
+    ---
+    delete:
+      summary: Delete a transaction
+      security:
+        - jwt: []
+      parameters:
+        - in: path
+          name: transaction_id
+          schema:
+            type: integer
+          required: true
+          description: ID of the transaction to delete
+      responses:
+        200:
+          description: Transaction deleted successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Transaction deleted
+        401:
+          description: Unauthorized.
+        404:
+          description: Transaction not found or not owned by the user.
+    """
+    user_id = get_jwt_identity()
+    transaction = Transaction.query.filter_by(id=transaction_id, user_id=user_id).first()
+    if not transaction:
+        json_abort(404, "Transaction not found or not owned by user.")
+
+    db.session.delete(transaction)
+    db.session.commit()
+    return json_response({"message": "Transaction deleted"})

--- a/packages/backend/app/schemas.py
+++ b/packages/backend/app/schemas.py
@@ -1,0 +1,116 @@
+from marshmallow import Schema, fields, validate, post_load
+
+
+class AccountSchema(Schema):
+    id = fields.Int(dump_only=True)
+    name = fields.Str(required=True, validate=validate.Length(min=1, max=100))
+    user_id = fields.Int(dump_only=True)
+    currency = fields.Str(required=True, validate=validate.Length(equal=3))
+    is_primary = fields.Bool(dump_only=True)
+
+
+class UserSchema(Schema):
+    id = fields.Int(dump_only=True)
+    email = fields.Str(required=True, validate=validate.Email())
+    preferred_currency = fields.Str(dump_only=True)
+    accounts = fields.List(fields.Nested(AccountSchema), dump_only=True)
+
+
+class RegisterSchema(UserSchema):
+    password = fields.Str(required=True, load_only=True, validate=validate.Length(min=6))
+
+
+class LoginSchema(UserSchema):
+    password = fields.Str(required=True, load_only=True)
+
+
+class UpdateUserSchema(Schema):
+    preferred_currency = fields.Str(
+        required=False,
+        validate=validate.Length(equal=3),
+        metadata={"description": "ISO 4217 currency code (e.g., 'USD', 'INR')"},
+    )
+
+
+class CategorySchema(Schema):
+    id = fields.Int(dump_only=True)
+    name = fields.Str(required=True, validate=validate.Length(min=1, max=100))
+    user_id = fields.Int(dump_only=True)
+
+
+class TransactionSchema(Schema):
+    id = fields.Int(dump_only=True)
+    description = fields.Str(required=True, validate=validate.Length(min=1, max=255))
+    amount = fields.Float(required=True, validate=validate.Range(min=0.01))
+    date = fields.Date(required=True)
+    type = fields.Str(required=True, validate=validate.OneOf(["INCOME", "EXPENSE"]))
+    category_id = fields.Int(required=False, allow_none=True)
+    user_id = fields.Int(dump_only=True)
+    account_id = fields.Int(required=True)  # Must be provided when creating
+    currency = fields.Str(required=True, validate=validate.Length(equal=3))
+    created_at = fields.DateTime(dump_only=True)
+
+
+class BillSchema(Schema):
+    id = fields.Int(dump_only=True)
+    name = fields.Str(required=True, validate=validate.Length(min=1, max=255))
+    amount = fields.Float(required=True, validate=validate.Range(min=0.01))
+    currency = fields.Str(required=False, validate=validate.Length(equal=3)) # Can be inferred
+    next_due_date = fields.Date(required=True)
+    cadence = fields.Str(
+        required=True,
+        validate=validate.OneOf(["DAILY", "WEEKLY", "MONTHLY", "YEARLY"]),
+    )
+    channel_email = fields.Bool(required=False, dump_default=False)
+    channel_whatsapp = fields.Bool(required=False, dump_default=False)
+    autopay_enabled = fields.Bool(required=False, dump_default=False)
+    user_id = fields.Int(dump_only=True)
+    account_id = fields.Int(required=True)  # Must be provided when creating
+    created_at = fields.DateTime(dump_only=True)
+
+
+class ReminderSchema(Schema):
+    id = fields.Int(dump_only=True)
+    bill_id = fields.Int(required=True)
+    remind_at = fields.DateTime(required=True)
+    status = fields.Str(
+        required=True, validate=validate.OneOf(["PENDING", "SENT", "FAILED"])
+    )
+    channel_email = fields.Bool(required=True)
+    channel_whatsapp = fields.Bool(required=True)
+    message = fields.Str(required=False, allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+
+
+class ScheduleRemindersResponseSchema(Schema):
+    created = fields.Int(required=True)
+    errors = fields.List(fields.Str(), required=False)
+
+
+class CategoryBreakdownSchema(Schema):
+    category_id = fields.Int(allow_none=True)
+    category_name = fields.Str()
+    amount = fields.Float()
+    share_pct = fields.Float()
+
+
+class DashboardSummarySchema(Schema):
+    period = fields.Nested(
+        Schema.from_dict({"month": fields.Str(required=True)}), required=True
+    )
+    summary = fields.Nested(
+        Schema.from_dict(
+            {
+                "net_flow": fields.Float(required=True),
+                "monthly_income": fields.Float(required=True),
+                "monthly_expenses": fields.Float(required=True),
+                "upcoming_bills_total": fields.Float(required=True),
+                "upcoming_bills_count": fields.Int(required=True),
+            }
+        ),
+        required=True,
+    )
+    recent_transactions = fields.List(fields.Nested(TransactionSchema), required=True)
+    upcoming_bills = fields.List(fields.Nested(BillSchema), required=True)
+    category_breakdown = fields.List(fields.Nested(CategoryBreakdownSchema), required=True)
+    errors = fields.List(fields.Str(), required=False)


### PR DESCRIPTION
Closes #132

## What changed
This fix introduces multi-account support by adding an `Account` model, linking transactions and bills to accounts, updating relevant API endpoints to filter or default by account, and enhancing user registration to create a primary account.

## Files modified
- `packages/backend/app/api/accounts.py`
- `packages/backend/app/schemas.py`
- `packages/backend/app/api/__init__.py`
- `packages/backend/app/api/auth.py`
- `packages/backend/app/api/dashboard.py`
- `packages/backend/app/api/bills.py`
- `packages/backend/app/api/transactions.py`

---
*Draft PR — please review before merging.*