### PR TITLE
fix: Smart payee & merchant alias management

### DIFF
--- a/alembic/versions/xxxx_create_payee_merchant_alias_table.py
+++ b/alembic/versions/xxxx_create_payee_merchant_alias_table.py
@@ -1,0 +1,38 @@
+"""create payee merchant alias table
+
+Revision ID: xxxx
+Revises: <previous_revision_id>
+Create Date: 2024-01-01 12:00:00.000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'xxxx'
+down_revision = '<previous_revision_id>' # Placeholder: replace with actual previous revision ID
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "payee_merchant_aliases",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("raw_name", sa.String(length=255), nullable=False),
+        sa.Column("canonical_name", sa.String(length=255), nullable=False),
+        sa.Column("category_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["category_id"], ["categories.id"], ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", sa.func.lower(sa.column("raw_name")), name="uq_user_raw_name")
+    )
+
+
+def downgrade():
+    op.drop_table("payee_merchant_aliases")
+

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,15 @@
+from app.routes.expenses import expenses_bp
+from app.routes.reminders import reminders_bp
+from app.routes.payee_merchant_aliases import payee_merchant_aliases_bp # NEW IMPORT
+
+
+def create_app(settings: Settings):
+    app = Flask(__name__)
+    app.config.from_object(settings)        app.register_blueprint(expenses_bp, url_prefix="/expenses")
+        app.register_blueprint(reminders_bp, url_prefix="/reminders")
+        app.register_blueprint(payee_merchant_aliases_bp, url_prefix="/payee-merchant-aliases") # NEW REGISTRATION
+
+        # Health check endpoint
+        @app.route("/health", methods=["GET"])
+        def health():
+            return jsonify({"status": "ok"}), HTTPStatus.OK

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,44 @@
+    def __repr__(self):
+        return f"<Category {self.id} (name='{self.name}')>"
+
+
+from sqlalchemy.schema import UniqueConstraint
+class PayeeMerchantAlias(db.Model):
+    __tablename__ = "payee_merchant_aliases"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    raw_name = db.Column(db.String(255), nullable=False)
+    canonical_name = db.Column(db.String(255), nullable=False)
+    category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    user = db.relationship("User", backref="payee_merchant_aliases")
+    category = db.relationship("Category", backref="payee_merchant_aliases")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", db.func.lower(raw_name), name="uq_user_raw_name"),
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "raw_name": self.raw_name,
+            "canonical_name": self.canonical_name,
+            "category_id": self.category_id,
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+    def __repr__(self):
+        return (
+            f"<PayeeMerchantAlias {self.id} (user_id={self.user_id}, "
+            f"raw='{self.raw_name}', canonical='{self.canonical_name}')>"
+        )
+
+
+class Bill(db.Model):
+    __tablename__ = "bills"

--- a/app/routes/payee_merchant_aliases.py
+++ b/app/routes/payee_merchant_aliases.py
@@ -1,0 +1,155 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from app.extensions import db
+from app.models import PayeeMerchantAlias, Category
+from app.schemas import PayeeMerchantAliasSchema
+from http import HTTPStatus
+
+payee_merchant_aliases_bp = Blueprint("payee_merchant_aliases", __name__)
+payee_merchant_alias_schema = PayeeMerchantAliasSchema()
+payee_merchant_aliases_schema = PayeeMerchantAliasSchema(many=True)
+
+
+@payee_merchant_aliases_bp.route("/", methods=["POST"])
+@jwt_required()
+def create_payee_merchant_alias():
+    """Create a new payee/merchant alias mapping.
+
+    Allows mapping a 'raw_name' found in transactions to a user-defined 'canonical_name'.
+    Optionally associates a category for automatic categorization.
+    Ensures uniqueness of 'raw_name' per user (case-insensitive).
+    """
+    user_id = get_jwt_identity()
+    data = request.get_json()
+
+    try:
+        alias_data = payee_merchant_alias_schema.load(data)
+    except Exception as e:
+        return jsonify({"message": str(e)}), HTTPStatus.BAD_REQUEST
+
+    raw_name = alias_data["raw_name"]
+    canonical_name = alias_data["canonical_name"]
+    category_id = alias_data.get("category_id")
+
+    # Check for existing alias with the same raw_name for this user (case-insensitive)
+    existing_alias = PayeeMerchantAlias.query.filter(
+        PayeeMerchantAlias.user_id == user_id,
+        db.func.lower(PayeeMerchantAlias.raw_name) == db.func.lower(raw_name),
+    ).first()
+
+    if existing_alias:
+        return (
+            jsonify({"message": f"Alias '{raw_name}' already exists for this user."}),
+            HTTPStatus.CONFLICT,
+        )
+
+    # Validate category_id if provided
+    if category_id:
+        category = Category.query.filter_by(id=category_id, user_id=user_id).first()
+        if not category:
+            return jsonify({"message": "Category not found or does not belong to user"}), HTTPStatus.BAD_REQUEST
+
+
+    new_alias = PayeeMerchantAlias(
+        user_id=user_id,
+        raw_name=raw_name,
+        canonical_name=canonical_name,
+        category_id=category_id,
+    )
+
+    db.session.add(new_alias)
+    db.session.commit()
+
+    return (
+        jsonify(payee_merchant_alias_schema.dump(new_alias)),
+        HTTPStatus.CREATED,
+    )
+
+
+@payee_merchant_aliases_bp.route("/", methods=["GET"])
+@jwt_required()
+def list_payee_merchant_aliases():
+    """List all payee/merchant aliases for the current user."""
+    user_id = get_jwt_identity()
+    aliases = PayeeMerchantAlias.query.filter_by(user_id=user_id).all()
+    return jsonify(payee_merchant_aliases_schema.dump(aliases)), HTTPStatus.OK
+
+
+@payee_merchant_aliases_bp.route("/<int:alias_id>", methods=["GET"])
+@jwt_required()
+def get_payee_merchant_alias(alias_id):
+    """Get a specific payee/merchant alias by ID."""
+    user_id = get_jwt_identity()
+    alias = PayeeMerchantAlias.query.filter_by(
+        id=alias_id, user_id=user_id
+    ).first()
+
+    if not alias:
+        return jsonify({"message": "Alias not found"}), HTTPStatus.NOT_FOUND
+
+    return jsonify(payee_merchant_alias_schema.dump(alias)), HTTPStatus.OK
+
+
+@payee_merchant_aliases_bp.route("/<int:alias_id>", methods=["PATCH"])
+@jwt_required()
+def update_payee_merchant_alias(alias_id):
+    """Update a payee/merchant alias.
+
+    Allows updating the 'canonical_name' and 'category_id' for an existing alias.
+    The 'raw_name' cannot be changed via this endpoint as it's the unique identifier for the alias mapping.
+    """
+    user_id = get_jwt_identity()
+    alias = PayeeMerchantAlias.query.filter_by(
+        id=alias_id, user_id=user_id
+    ).first()
+
+    if not alias:
+        return jsonify({"message": "Alias not found"}), HTTPStatus.NOT_FOUND
+
+    data = request.get_json()
+    try:
+        # Only allow updating canonical_name and category_id.
+        # raw_name is considered immutable after creation for a given alias entry.
+        update_data = {}
+        if "canonical_name" in data:
+            update_data["canonical_name"] = data["canonical_name"]
+        if "category_id" in data:
+            update_data["category_id"] = data["category_id"]
+
+        # Validate incoming data types for allowed fields
+        payee_merchant_alias_schema.load(update_data, partial=True)
+
+    except Exception as e:
+        return jsonify({"message": str(e)}), HTTPStatus.BAD_REQUEST
+
+    if "canonical_name" in update_data:
+        alias.canonical_name = update_data["canonical_name"]
+    if "category_id" in update_data:
+        # Validate category_id if provided
+        if update_data["category_id"] is not None:
+            category = Category.query.filter_by(id=update_data["category_id"], user_id=user_id).first()
+            if not category:
+                return jsonify({"message": "Category not found or does not belong to user"}), HTTPStatus.BAD_REQUEST
+        alias.category_id = update_data["category_id"]
+
+
+    db.session.commit()
+    return jsonify(payee_merchant_alias_schema.dump(alias)), HTTPStatus.OK
+
+
+@payee_merchant_aliases_bp.route("/<int:alias_id>", methods=["DELETE"])
+@jwt_required()
+def delete_payee_merchant_alias(alias_id):
+    """Delete a payee/merchant alias."""
+    user_id = get_jwt_identity()
+    alias = PayeeMerchantAlias.query.filter_by(
+        id=alias_id, user_id=user_id
+    ).first()
+
+    if not alias:
+        return jsonify({"message": "Alias not found"}), HTTPStatus.NOT_FOUND
+
+    db.session.delete(alias)
+    db.session.commit()
+
+    return jsonify({"message": "Alias deleted"}), HTTPStatus.OK

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,19 @@
+from marshmallow import Schema, fields, validate
+
+# Shared schemas
+class UserSchema(Schema):
+    id = fields.Int(dump_only=True)
+    email = fields.Email(required=True)
+    preferred_currency = fields.Str(required=True, validate=validate.OneOf(["INR", "USD", "EUR", "GBP"]))
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)
+
+
+class PayeeMerchantAliasSchema(Schema):
+    id = fields.Int(dump_only=True)
+    user_id = fields.Int(dump_only=True)
+    raw_name = fields.Str(required=True, validate=validate.Length(min=1, max=255))
+    canonical_name = fields.Str(required=True, validate=validate.Length(min=1, max=255))
+    category_id = fields.Int(allow_none=True)
+    created_at = fields.DateTime(dump_only=True)
+    updated_at = fields.DateTime(dump_only=True)

--- a/packages/backend/tests/test_payee_merchant_aliases.py
+++ b/packages/backend/tests/test_payee_merchant_aliases.py
@@ -1,0 +1,198 @@
+import pytest
+from http import HTTPStatus
+from app.models import PayeeMerchantAlias, Category
+from app.extensions import db
+
+
+def test_payee_merchant_alias_crud_flow(client, auth_header):
+    # Initially empty
+    r = client.get("/payee-merchant-aliases", headers=auth_header)
+    assert r.status_code == HTTPStatus.OK
+    assert r.get_json() == []
+
+    # Create a category first for testing category_id linking
+    r = client.post("/categories", json={"name": "Groceries"}, headers=auth_header)
+    assert r.status_code == HTTPStatus.CREATED
+    category_id = r.get_json()["id"]
+
+    # Create alias 1 (with category)
+    alias_data_1 = {
+        "raw_name": "Starbucks Coffee",
+        "canonical_name": "Starbucks",
+        "category_id": category_id,
+    }
+    r = client.post(
+        "/payee-merchant-aliases", json=alias_data_1, headers=auth_header
+    )
+    assert r.status_code == HTTPStatus.CREATED
+    alias_1 = r.get_json()
+    assert alias_1["raw_name"] == alias_data_1["raw_name"]
+    assert alias_1["canonical_name"] == alias_data_1["canonical_name"]
+    assert alias_1["category_id"] == alias_data_1["category_id"]
+
+    # Create alias 2 (without category)
+    alias_data_2 = {
+        "raw_name": "Walmart Supercenter",
+        "canonical_name": "Walmart",
+    }
+    r = client.post(
+        "/payee-merchant-aliases", json=alias_data_2, headers=auth_header
+    )
+    assert r.status_code == HTTPStatus.CREATED
+    alias_2 = r.get_json()
+    assert alias_2["raw_name"] == alias_data_2["raw_name"]
+    assert alias_2["canonical_name"] == alias_data_2["canonical_name"]
+    assert alias_2["category_id"] is None
+
+    # List should have 2 aliases
+    r = client.get("/payee-merchant-aliases", headers=auth_header)
+    assert r.status_code == HTTPStatus.OK
+    items = r.get_json()
+    assert len(items) == 2
+    assert any(item["id"] == alias_1["id"] for item in items)
+    assert any(item["id"] == alias_2["id"] for item in items)
+
+    # Attempt to create duplicate raw_name (case-insensitive)
+    duplicate_data = {
+        "raw_name": "starbucks coffee",  # same as alias_1, but different case
+        "canonical_name": "Different Starbucks",
+    }
+    r = client.post(
+        "/payee-merchant-aliases", json=duplicate_data, headers=auth_header
+    )
+    assert r.status_code == HTTPStatus.CONFLICT
+
+    # Get single alias
+    r = client.get(f"/payee-merchant-aliases/{alias_1['id']}", headers=auth_header)
+    assert r.status_code == HTTPStatus.OK
+    retrieved_alias = r.get_json()
+    assert retrieved_alias["id"] == alias_1["id"]
+    assert retrieved_alias["raw_name"] == alias_1["raw_name"]
+
+    # Update alias 1's canonical_name and category
+    update_data = {"canonical_name": "Starbucks Inc.", "category_id": None}
+    r = client.patch(
+        f"/payee-merchant-aliases/{alias_1['id']}",
+        json=update_data,
+        headers=auth_header,
+    )
+    assert r.status_code == HTTPStatus.OK
+    updated_alias_1 = r.get_json()
+    assert updated_alias_1["canonical_name"] == update_data["canonical_name"]
+    assert updated_alias_1["category_id"] is None
+    assert updated_alias_1["raw_name"] == alias_1["raw_name"]  # raw_name should not change
+
+    # Update alias 2's category to an existing one
+    r = client.post("/categories", json={"name": "Restaurants"}, headers=auth_header)
+    assert r.status_code == HTTPStatus.CREATED
+    new_category_id = r.get_json()["id"]
+
+    update_data_cat = {"category_id": new_category_id}
+    r = client.patch(
+        f"/payee-merchant-aliases/{alias_2['id']}",
+        json=update_data_cat,
+        headers=auth_header,
+    )
+    assert r.status_code == HTTPStatus.OK
+    updated_alias_2 = r.get_json()
+    assert updated_alias_2["category_id"] == new_category_id
+
+    # Attempt to update with a non-existent category
+    update_data_bad_cat = {"category_id": 99999}
+    r = client.patch(
+        f"/payee-merchant-aliases/{alias_2['id']}",
+        json=update_data_bad_cat,
+        headers=auth_header,
+    )
+    assert r.status_code == HTTPStatus.BAD_REQUEST
+
+    # Delete alias 1
+    r = client.delete(f"/payee-merchant-aliases/{alias_1['id']}", headers=auth_header)
+    assert r.status_code == HTTPStatus.OK
+    assert r.get_json()["message"] == "Alias deleted"
+
+    # List should have 1 alias now
+    r = client.get("/payee-merchant-aliases", headers=auth_header)
+    assert r.status_code == HTTPStatus.OK
+    items = r.get_json()
+    assert len(items) == 1
+    assert items[0]["id"] == alias_2["id"]
+
+    # Attempt to get deleted alias
+    r = client.get(f"/payee-merchant-aliases/{alias_1['id']}", headers=auth_header)
+    assert r.status_code == HTTPStatus.NOT_FOUND
+
+    # Delete alias 2
+    r = client.delete(f"/payee-merchant-aliases/{alias_2['id']}", headers=auth_header)
+    assert r.status_code == HTTPStatus.OK
+
+    # List should be empty again
+    r = client.get("/payee-merchant-aliases", headers=auth_header)
+    assert r.status_code == HTTPStatus.OK
+    assert r.get_json() == []
+
+
+def test_payee_merchant_alias_auth_and_ownership(client, auth_header):
+    # Create alias as user 1
+    alias_data = {
+        "raw_name": "User1Alias",
+        "canonical_name": "User1 Canonical",
+    }
+    r = client.post(
+        "/payee-merchant-aliases", json=alias_data, headers=auth_header
+    )
+    assert r.status_code == HTTPStatus.CREATED
+    alias_id_user1 = r.get_json()["id"]
+
+    # Login as a different user
+    email = "test2@example.com"
+    password = "password123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == HTTPStatus.OK
+    auth_header_user2 = {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+    # Attempt to list aliases as user 2 - should be empty
+    r = client.get("/payee-merchant-aliases", headers=auth_header_user2)
+    assert r.status_code == HTTPStatus.OK
+    assert r.get_json() == []
+
+    # Attempt to get user 1's alias as user 2 - should be 404
+    r = client.get(
+        f"/payee-merchant-aliases/{alias_id_user1}", headers=auth_header_user2
+    )
+    assert r.status_code == HTTPStatus.NOT_FOUND
+
+    # Attempt to update user 1's alias as user 2 - should be 404
+    update_data = {"canonical_name": "Malicious Update"}
+    r = client.patch(
+        f"/payee-merchant-aliases/{alias_id_user1}",
+        json=update_data,
+        headers=auth_header_user2,
+    )
+    assert r.status_code == HTTPStatus.NOT_FOUND
+
+    # Attempt to delete user 1's alias as user 2 - should be 404
+    r = client.delete(
+        f"/payee-merchant-aliases/{alias_id_user1}", headers=auth_header_user2
+    )
+    assert r.status_code == HTTPStatus.NOT_FOUND
+
+    # Create an alias for user 2
+    alias_data_user2 = {
+        "raw_name": "User2Alias",
+        "canonical_name": "User2 Canonical",
+    }
+    r = client.post(
+        "/payee-merchant-aliases", json=alias_data_user2, headers=auth_header_user2
+    )
+    assert r.status_code == HTTPStatus.CREATED
+    alias_id_user2 = r.get_json()["id"]
+
+    # Delete user 2's alias (cleanup)
+    r = client.delete(
+        f"/payee-merchant-aliases/{alias_id_user2}", headers=auth_header_user2
+    )
+    assert r.status_code == HTTPStatus.OK
+


### PR DESCRIPTION
Closes #114

## What changed
This fix introduces smart payee and merchant alias management by adding a new `PayeeMerchantAlias` model and corresponding CRUD API endpoints, allowing users to map raw transaction names to canonical merchant names and optionally assign a default category.

## Files modified
- `app/routes/payee_merchant_aliases.py`
- `alembic/versions/xxxx_create_payee_merchant_alias_table.py`
- `packages/backend/tests/test_payee_merchant_aliases.py`
- `app/models.py`
- `app/schemas.py`
- `app/__init__.py`

---
*Automated PR — please review.*