### PR TITLE
feat: add savings goal milestone tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FinMind — AI-Powered Budget & Bill Tracking
 
-FinMind helps users control spending, track bills, and get smart financial insights. Built for free-tier friendly deployment with scalable architecture.
+FinMind helps users control spending, track bills, track savings goals with milestone progress, and get smart financial insights. Built for free-tier friendly deployment with scalable architecture.
 
 ## System Architecture
 
@@ -74,6 +74,7 @@ OpenAPI: `backend/app/openapi.yaml`
   - Upcoming bills list with due dates and pay status.
   - AI budget suggestion card.
 - Expenses page: add expense (amount, category, notes, date), list & filter.
+- Budgets page: monitor savings goals, milestone progress bars, monthly contribution targets, and local goal persistence.
 - Bills page: create bill (name, amount, cadence, due date, channel), toggle WhatsApp/email.
 - Settings: profile, categories, reminders default channel, export (premium).
 

--- a/app/src/__tests__/Budgets.integration.test.tsx
+++ b/app/src/__tests__/Budgets.integration.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Budgets } from '@/pages/Budgets';
+
+describe('Budgets savings goals', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('renders responsive savings goal progress with visible percentages', () => {
+    render(<Budgets />);
+
+    expect(screen.getByRole('heading', { name: /savings goals/i })).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: /emergency fund progress/i })).toHaveAttribute('aria-valuenow', '73');
+    expect(screen.getByLabelText(/emergency fund progress percentage/i)).toHaveTextContent('73%');
+    expect(screen.getAllByText(/next milestone 75%/i).length).toBeGreaterThan(0);
+  });
+
+  it('adds a new savings goal and persists it locally', async () => {
+    const user = userEvent.setup();
+    render(<Budgets />);
+
+    await user.type(screen.getByLabelText(/goal name/i), 'House Deposit');
+    await user.type(screen.getByLabelText(/target amount/i), '50000');
+    const savedSoFarInput = screen.getByLabelText(/saved so far/i);
+    await user.clear(savedSoFarInput);
+    await user.type(savedSoFarInput, '12000');
+    await user.clear(screen.getByLabelText(/target date/i));
+    await user.type(screen.getByLabelText(/target date/i), '2027-12-31');
+    await user.click(screen.getByRole('button', { name: /add new goal/i }));
+
+    expect(screen.getByText('House Deposit')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: /house deposit progress/i })).toHaveAttribute('aria-valuenow', '24');
+
+    const stored = window.localStorage.getItem('finmind.savings-goals');
+    expect(stored).toContain('House Deposit');
+  });
+});

--- a/app/src/lib/savingsGoals.ts
+++ b/app/src/lib/savingsGoals.ts
@@ -1,0 +1,152 @@
+export type SavingsGoalStatus = 'ahead' | 'on-track' | 'behind' | 'completed';
+
+export type SavingsGoal = {
+  id: string;
+  title: string;
+  target: number;
+  current: number;
+  targetDate: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type SavingsGoalMilestone = {
+  label: string;
+  targetAmount: number;
+  reached: boolean;
+  progress: number;
+};
+
+const STORAGE_KEY = 'finmind.savings-goals';
+const DEFAULT_MILESTONE_STEPS = [0.25, 0.5, 0.75, 1] as const;
+
+const DEFAULT_GOALS: SavingsGoal[] = [
+  {
+    id: 'emergency-fund',
+    title: 'Emergency Fund',
+    target: 10000,
+    current: 7250,
+    targetDate: '2026-12-31',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'vacation-fund',
+    title: 'Vacation Fund',
+    target: 3000,
+    current: 1850,
+    targetDate: '2026-06-30',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+  {
+    id: 'new-car',
+    title: 'New Car',
+    target: 25000,
+    current: 15600,
+    targetDate: '2027-03-31',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  },
+];
+
+function clampCurrency(value: number) {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.round(value * 100) / 100);
+}
+
+function monthDiff(from: Date, to: Date) {
+  const yearDiff = to.getFullYear() - from.getFullYear();
+  const monthDiff = to.getMonth() - from.getMonth();
+  const raw = yearDiff * 12 + monthDiff;
+  return Math.max(1, raw + (to.getDate() >= from.getDate() ? 1 : 0));
+}
+
+export function getGoalProgress(goal: SavingsGoal) {
+  if (goal.target <= 0) return 0;
+  return Math.max(0, Math.min(100, (goal.current / goal.target) * 100));
+}
+
+export function getGoalRemaining(goal: SavingsGoal) {
+  return clampCurrency(goal.target - goal.current);
+}
+
+export function getRequiredMonthlyContribution(goal: SavingsGoal, asOf = new Date()) {
+  const remaining = getGoalRemaining(goal);
+  if (remaining <= 0) return 0;
+  const targetDate = new Date(goal.targetDate);
+  const monthsRemaining = monthDiff(asOf, targetDate);
+  return clampCurrency(remaining / monthsRemaining);
+}
+
+export function getProjectedMonthlyContribution(goal: SavingsGoal, asOf = new Date()) {
+  const monthsElapsed = monthDiff(new Date(goal.createdAt), asOf);
+  if (monthsElapsed <= 0) {
+    return clampCurrency(goal.current);
+  }
+  return clampCurrency(goal.current / monthsElapsed);
+}
+
+export function getGoalStatus(goal: SavingsGoal, asOf = new Date()): SavingsGoalStatus {
+  if (goal.current >= goal.target) return 'completed';
+  const required = getRequiredMonthlyContribution(goal, asOf);
+  const actual = getProjectedMonthlyContribution(goal, asOf);
+  if (actual >= required * 1.1) return 'ahead';
+  if (actual >= required * 0.9) return 'on-track';
+  return 'behind';
+}
+
+export function getGoalMilestones(goal: SavingsGoal): SavingsGoalMilestone[] {
+  return DEFAULT_MILESTONE_STEPS.map((step) => {
+    const targetAmount = clampCurrency(goal.target * step);
+    return {
+      label: `${Math.round(step * 100)}%`,
+      targetAmount,
+      reached: goal.current >= targetAmount,
+      progress: Math.max(0, Math.min(100, (goal.current / targetAmount) * 100)),
+    };
+  });
+}
+
+export function loadSavingsGoals(): SavingsGoal[] {
+  if (typeof window === 'undefined') {
+    return DEFAULT_GOALS;
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return DEFAULT_GOALS;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as SavingsGoal[];
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return DEFAULT_GOALS;
+    }
+    return parsed.map((goal) => ({
+      ...goal,
+      target: clampCurrency(Number(goal.target)),
+      current: clampCurrency(Number(goal.current)),
+    }));
+  } catch {
+    return DEFAULT_GOALS;
+  }
+}
+
+export function saveSavingsGoals(goals: SavingsGoal[]) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(goals));
+}
+
+export function createSavingsGoal(input: Pick<SavingsGoal, 'title' | 'target' | 'current' | 'targetDate'>): SavingsGoal {
+  const now = new Date().toISOString();
+  return {
+    id: `${input.title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-${Date.now()}`,
+    title: input.title.trim(),
+    target: clampCurrency(input.target),
+    current: clampCurrency(input.current),
+    targetDate: input.targetDate,
+    createdAt: now,
+    updatedAt: now,
+  };
+}

--- a/app/src/pages/Budgets.tsx
+++ b/app/src/pages/Budgets.tsx
@@ -1,8 +1,37 @@
-import { useState } from 'react';
-import { FinancialCard, FinancialCardContent, FinancialCardDescription, FinancialCardFooter, FinancialCardHeader, FinancialCardTitle } from '@/components/ui/financial-card';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardDescription,
+  FinancialCardFooter,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, DollarSign, Plus, PieChart, TrendingDown, TrendingUp, Target, AlertCircle, Settings } from 'lucide-react';
+import {
+  AlertCircle,
+  Calendar,
+  DollarSign,
+  PieChart,
+  Plus,
+  Settings,
+  Target,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
+import { formatMoney } from '@/lib/currency';
+import {
+  createSavingsGoal,
+  getGoalMilestones,
+  getGoalProgress,
+  getGoalRemaining,
+  getGoalStatus,
+  getRequiredMonthlyContribution,
+  loadSavingsGoals,
+  saveSavingsGoals,
+  type SavingsGoal,
+} from '@/lib/savingsGoals';
 
 const budgetCategories = [
   {
@@ -13,7 +42,7 @@ const budgetCategories = [
     remaining: 150,
     color: 'bg-primary',
     trend: 'up',
-    change: '+2.3%'
+    change: '+2.3%',
   },
   {
     id: 2,
@@ -23,7 +52,7 @@ const budgetCategories = [
     remaining: 80,
     color: 'bg-success',
     trend: 'down',
-    change: '-5.1%'
+    change: '-5.1%',
   },
   {
     id: 3,
@@ -33,7 +62,7 @@ const budgetCategories = [
     remaining: -45,
     color: 'bg-destructive',
     trend: 'up',
-    change: '+11.3%'
+    change: '+11.3%',
   },
   {
     id: 4,
@@ -43,7 +72,7 @@ const budgetCategories = [
     remaining: 115,
     color: 'bg-accent',
     trend: 'down',
-    change: '-8.2%'
+    change: '-8.2%',
   },
   {
     id: 5,
@@ -53,7 +82,7 @@ const budgetCategories = [
     remaining: 85,
     color: 'bg-warning',
     trend: 'up',
-    change: '+3.1%'
+    change: '+3.1%',
   },
   {
     id: 6,
@@ -63,46 +92,105 @@ const budgetCategories = [
     remaining: 120,
     color: 'bg-secondary',
     trend: 'down',
-    change: '-12.4%'
-  }
+    change: '-12.4%',
+  },
 ];
 
-const budgetGoals = [
-  {
-    id: 1,
-    title: 'Emergency Fund',
-    target: 10000,
-    current: 7250,
-    deadline: 'Dec 2025',
-    monthlyTarget: 458,
-    status: 'on-track'
-  },
-  {
-    id: 2,
-    title: 'Vacation Fund',
-    target: 3000,
-    current: 1850,
-    deadline: 'Jun 2025',
-    monthlyTarget: 383,
-    status: 'behind'
-  },
-  {
-    id: 3,
-    title: 'New Car',
-    target: 25000,
-    current: 15600,
-    deadline: 'Mar 2026',
-    monthlyTarget: 625,
-    status: 'ahead'
+function formatDeadline(date: string) {
+  return new Date(date).toLocaleDateString(undefined, {
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function getGoalProgressBarClass(status: ReturnType<typeof getGoalStatus>) {
+  switch (status) {
+    case 'completed':
+      return 'chart-fill-success';
+    case 'ahead':
+      return 'chart-fill-primary';
+    case 'on-track':
+      return 'chart-fill-success';
+    case 'behind':
+      return 'chart-fill-danger';
+    default:
+      return 'chart-fill-primary';
   }
-];
+}
 
 export function Budgets() {
   const [selectedPeriod] = useState('monthly');
-  
+  const [goals, setGoals] = useState<SavingsGoal[]>(() => loadSavingsGoals());
+  const [goalTitle, setGoalTitle] = useState('');
+  const [goalTarget, setGoalTarget] = useState('');
+  const [goalCurrent, setGoalCurrent] = useState('0');
+  const [goalTargetDate, setGoalTargetDate] = useState(() => new Date().toISOString().slice(0, 10));
+
+  useEffect(() => {
+    saveSavingsGoals(goals);
+  }, [goals]);
+
   const totalAllocated = budgetCategories.reduce((sum, cat) => sum + cat.allocated, 0);
   const totalSpent = budgetCategories.reduce((sum, cat) => sum + cat.spent, 0);
   const totalRemaining = totalAllocated - totalSpent;
+
+  const goalSummary = useMemo(() => {
+    const totalTarget = goals.reduce((sum, goal) => sum + goal.target, 0);
+    const totalSaved = goals.reduce((sum, goal) => sum + goal.current, 0);
+    const totalMonthlyTarget = goals.reduce(
+      (sum, goal) => sum + getRequiredMonthlyContribution(goal),
+      0,
+    );
+
+    return {
+      totalTarget,
+      totalSaved,
+      totalMonthlyTarget,
+      completedGoals: goals.filter((goal) => getGoalStatus(goal) === 'completed').length,
+    };
+  }, [goals]);
+
+  const goalCards = useMemo(
+    () =>
+      goals.map((goal) => {
+        const status = getGoalStatus(goal);
+        const progress = getGoalProgress(goal);
+        const remaining = getGoalRemaining(goal);
+        const monthlyTarget = getRequiredMonthlyContribution(goal);
+        const milestones = getGoalMilestones(goal);
+        const nextMilestone = milestones.find((milestone) => !milestone.reached);
+
+        return {
+          ...goal,
+          status,
+          progress,
+          remaining,
+          monthlyTarget,
+          milestones,
+          nextMilestone,
+        };
+      }),
+    [goals],
+  );
+
+  function onAddGoal() {
+    if (!goalTitle.trim() || !goalTarget || !goalTargetDate) {
+      return;
+    }
+
+    const nextGoal = createSavingsGoal({
+      title: goalTitle,
+      target: Number(goalTarget),
+      current: Number(goalCurrent || 0),
+      targetDate: goalTargetDate,
+    });
+
+    setGoals((currentGoals) => [nextGoal, ...currentGoals]);
+    setGoalTitle('');
+    setGoalTarget('');
+    setGoalCurrent('0');
+    setGoalTargetDate(new Date().toISOString().slice(0, 10));
+  }
 
   return (
     <div className="page-wrap">
@@ -111,7 +199,7 @@ export function Budgets() {
           <div>
             <h1 className="page-title">Budget Management</h1>
             <p className="page-subtitle">
-              Track your spending and stay on top of your financial goals
+              Track spending, savings goals, and milestone progress from one place
             </p>
           </div>
           <div className="flex gap-3">
@@ -127,209 +215,324 @@ export function Budgets() {
         </div>
       </div>
 
-        {/* Budget Overview */}
-        <div className="grid gap-4 md:grid-cols-3 mb-8">
-          <FinancialCard variant="financial">
-            <FinancialCardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
-                  Total Allocated
-                </FinancialCardTitle>
-                <Target className="w-5 h-5 text-muted-foreground" />
-              </div>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              <div className="metric-value text-foreground mb-1">
-                ${totalAllocated.toLocaleString()}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                This month's budget
-              </div>
-            </FinancialCardContent>
-          </FinancialCard>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4 mb-8">
+        <FinancialCard variant="financial">
+          <FinancialCardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                Total Allocated
+              </FinancialCardTitle>
+              <Target className="w-5 h-5 text-muted-foreground" />
+            </div>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value text-foreground mb-1">{formatMoney(totalAllocated)}</div>
+            <div className="text-sm text-muted-foreground">This month's budget</div>
+          </FinancialCardContent>
+        </FinancialCard>
 
-          <FinancialCard variant="financial">
-            <FinancialCardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
-                  Total Spent
-                </FinancialCardTitle>
-                <DollarSign className="w-5 h-5 text-muted-foreground" />
-              </div>
-            </FinancialCardHeader>
-            <FinancialCardContent>
-              <div className="metric-value text-foreground mb-1">
-                ${totalSpent.toLocaleString()}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {((totalSpent / totalAllocated) * 100).toFixed(1)}% of budget used
-              </div>
-            </FinancialCardContent>
-          </FinancialCard>
+        <FinancialCard variant="financial">
+          <FinancialCardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                Total Spent
+              </FinancialCardTitle>
+              <DollarSign className="w-5 h-5 text-muted-foreground" />
+            </div>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value text-foreground mb-1">{formatMoney(totalSpent)}</div>
+            <div className="text-sm text-muted-foreground">
+              {((totalSpent / totalAllocated) * 100).toFixed(1)}% of budget used
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
 
-          <FinancialCard variant={totalRemaining < 0 ? "destructive" : "success"}>
-            <FinancialCardHeader className="pb-3">
+        <FinancialCard variant={totalRemaining < 0 ? 'destructive' : 'success'}>
+          <FinancialCardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <FinancialCardTitle className="text-sm font-medium">
+                {totalRemaining < 0 ? 'Over Budget' : 'Remaining'}
+              </FinancialCardTitle>
+              {totalRemaining < 0 ? (
+                <AlertCircle className="w-5 h-5" />
+              ) : (
+                <PieChart className="w-5 h-5" />
+              )}
+            </div>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value mb-1">{formatMoney(Math.abs(totalRemaining))}</div>
+            <div className="text-sm opacity-80">
+              {totalRemaining < 0 ? 'Overspent this month' : 'Available to spend'}
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+
+        <FinancialCard variant="financial">
+          <FinancialCardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                Saved Toward Goals
+              </FinancialCardTitle>
+              <Target className="w-5 h-5 text-muted-foreground" />
+            </div>
+          </FinancialCardHeader>
+          <FinancialCardContent>
+            <div className="metric-value text-foreground mb-1">{formatMoney(goalSummary.totalSaved)}</div>
+            <div className="text-sm text-muted-foreground">
+              {goalSummary.completedGoals} completed, {formatMoney(goalSummary.totalMonthlyTarget)}/mo target
+            </div>
+          </FinancialCardContent>
+        </FinancialCard>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3 mb-8">
+        <div className="lg:col-span-2">
+          <FinancialCard variant="financial" className="fade-in-up">
+            <FinancialCardHeader>
               <div className="flex items-center justify-between">
-                <FinancialCardTitle className="text-sm font-medium">
-                  {totalRemaining < 0 ? 'Over Budget' : 'Remaining'}
-                </FinancialCardTitle>
-                {totalRemaining < 0 ? (
-                  <AlertCircle className="w-5 h-5" />
-                ) : (
-                  <PieChart className="w-5 h-5" />
-                )}
+                <FinancialCardTitle className="section-title">Budget Categories</FinancialCardTitle>
+                <Button variant="ghost" size="sm">
+                  <Settings className="w-4 h-4" />
+                </Button>
               </div>
+              <FinancialCardDescription>
+                Track spending across different categories
+              </FinancialCardDescription>
             </FinancialCardHeader>
             <FinancialCardContent>
-              <div className="metric-value mb-1">
-                ${Math.abs(totalRemaining).toLocaleString()}
-              </div>
-              <div className="text-sm opacity-80">
-                {totalRemaining < 0 ? 'Overspent this month' : 'Available to spend'}
+              <div className="space-y-6">
+                {budgetCategories.map((category) => {
+                  const percentage = (category.spent / category.allocated) * 100;
+                  const isOverBudget = category.remaining < 0;
+
+                  return (
+                    <div key={category.id} className="space-y-3 interactive-row">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center space-x-3">
+                          <div className={`w-4 h-4 rounded-full ${category.color}`}></div>
+                          <div>
+                            <div className="font-medium text-foreground">{category.name}</div>
+                            <div className="text-sm text-muted-foreground">
+                              {formatMoney(category.spent)} of {formatMoney(category.allocated)}
+                            </div>
+                          </div>
+                        </div>
+                        <div className="text-right">
+                          <div className={`font-semibold ${isOverBudget ? 'text-destructive' : 'text-foreground'}`}>
+                            {isOverBudget ? '-' : ''}
+                            {formatMoney(Math.abs(category.remaining))}
+                          </div>
+                          <div className="flex items-center text-sm">
+                            {category.trend === 'up' ? (
+                              <TrendingUp className="w-3 h-3 text-destructive mr-1" />
+                            ) : (
+                              <TrendingDown className="w-3 h-3 text-success mr-1" />
+                            )}
+                            <span className={category.trend === 'up' ? 'text-destructive' : 'text-success'}>
+                              {category.change}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                      <div className={`chart-track ${isOverBudget ? 'bg-destructive-light' : ''}`}>
+                        <div
+                          className={isOverBudget ? 'chart-fill-danger' : 'chart-fill-primary'}
+                          style={{ width: `${Math.min(percentage, 100)}%` }}
+                        />
+                      </div>
+                      {isOverBudget && (
+                        <Badge variant="destructive" className="text-xs">
+                          Over Budget
+                        </Badge>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </FinancialCardContent>
           </FinancialCard>
         </div>
 
-        {/* Budget Categories */}
-        <div className="grid gap-6 lg:grid-cols-3 mb-8">
-          <div className="lg:col-span-2">
-            <FinancialCard variant="financial" className="fade-in-up">
-              <FinancialCardHeader>
-                <div className="flex items-center justify-between">
-                  <FinancialCardTitle className="section-title">Budget Categories</FinancialCardTitle>
-                  <Button variant="ghost" size="sm">
-                    <Settings className="w-4 h-4" />
-                  </Button>
-                </div>
-                <FinancialCardDescription>
-                  Track spending across different categories
-                </FinancialCardDescription>
-              </FinancialCardHeader>
-              <FinancialCardContent>
-                <div className="space-y-6">
-                  {budgetCategories.map((category) => {
-                    const percentage = (category.spent / category.allocated) * 100;
-                    const isOverBudget = category.remaining < 0;
-                    
-                    return (
-                      <div key={category.id} className="space-y-3 interactive-row">
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center space-x-3">
-                            <div className={`w-4 h-4 rounded-full ${category.color}`}></div>
-                            <div>
-                              <div className="font-medium text-foreground">{category.name}</div>
-                              <div className="text-sm text-muted-foreground">
-                                ${category.spent} of ${category.allocated}
-                              </div>
-                            </div>
-                          </div>
-                          <div className="text-right">
-                            <div className={`font-semibold ${
-                              isOverBudget ? 'text-destructive' : 'text-foreground'
-                            }`}>
-                              {isOverBudget ? '-' : ''}${Math.abs(category.remaining)}
-                            </div>
-                            <div className="flex items-center text-sm">
-                              {category.trend === 'up' ? (
-                                <TrendingUp className="w-3 h-3 text-destructive mr-1" />
-                              ) : (
-                                <TrendingDown className="w-3 h-3 text-success mr-1" />
-                              )}
-                              <span className={
-                                category.trend === 'up' ? 'text-destructive' : 'text-success'
-                              }>
-                                {category.change}
-                              </span>
-                            </div>
+        <div>
+          <FinancialCard variant="financial" className="fade-in-up">
+            <FinancialCardHeader>
+              <div className="flex items-center justify-between">
+                <FinancialCardTitle className="section-title">Savings Goals</FinancialCardTitle>
+                <Badge variant="secondary">{goals.length} active</Badge>
+              </div>
+              <FinancialCardDescription>
+                Track progress, monthly targets, and milestone completion
+              </FinancialCardDescription>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <div className="space-y-4">
+                {goalCards.length === 0 ? (
+                  <div className="text-sm text-muted-foreground">No savings goals yet. Add your first one below.</div>
+                ) : (
+                  goalCards.map((goal) => (
+                    <div key={goal.id} className="interactive-row p-3 sm:p-4 rounded-lg border border-border space-y-3">
+                      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2">
+                        <div className="min-w-0">
+                          <div className="font-medium text-foreground text-sm">{goal.title}</div>
+                          <div className="text-xs text-muted-foreground mt-1">
+                            {formatMoney(goal.current)} saved of {formatMoney(goal.target)} target
                           </div>
                         </div>
-                        <div className={`chart-track ${isOverBudget ? 'bg-destructive-light' : ''}`}>
-                          <div
-                            className={isOverBudget ? 'chart-fill-danger' : 'chart-fill-primary'}
-                            style={{ width: `${Math.min(percentage, 100)}%` }}
-                          />
-                        </div>
-                        {isOverBudget && (
-                          <Badge variant="destructive" className="text-xs">
-                            Over Budget
-                          </Badge>
-                        )}
+                        <Badge
+                          variant={
+                            goal.status === 'completed'
+                              ? 'secondary'
+                              : goal.status === 'on-track'
+                                ? 'default'
+                                : goal.status === 'ahead'
+                                  ? 'secondary'
+                                  : 'destructive'
+                          }
+                          className="text-xs w-fit"
+                        >
+                          {goal.status === 'on-track'
+                            ? 'On Track'
+                            : goal.status === 'ahead'
+                              ? 'Ahead'
+                              : goal.status === 'completed'
+                                ? 'Completed'
+                                : 'Behind'}
+                        </Badge>
                       </div>
-                    );
-                  })}
-                </div>
-              </FinancialCardContent>
-            </FinancialCard>
-          </div>
 
-          {/* Savings Goals */}
-          <div>
-            <FinancialCard variant="financial" className="fade-in-up">
-              <FinancialCardHeader>
-                <div className="flex items-center justify-between">
-                  <FinancialCardTitle className="section-title">Savings Goals</FinancialCardTitle>
-                  <Button variant="ghost" size="sm">
-                    <Plus className="w-4 h-4" />
-                  </Button>
-                </div>
-                <FinancialCardDescription>
-                  Your financial objectives
-                </FinancialCardDescription>
-              </FinancialCardHeader>
-              <FinancialCardContent>
-                <div className="space-y-4">
-                  {budgetGoals.map((goal) => {
-                    const percentage = (goal.current / goal.target) * 100;
-                    
-                    return (
-                      <div key={goal.id} className="interactive-row p-3 rounded-lg border border-border">
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="font-medium text-foreground text-sm">
-                            {goal.title}
-                          </div>
-                          <Badge 
-                            variant={
-                              goal.status === 'on-track' ? 'default' :
-                              goal.status === 'ahead' ? 'secondary' : 'destructive'
-                            }
-                            className="text-xs"
-                          >
-                            {goal.status === 'on-track' ? 'On Track' :
-                             goal.status === 'ahead' ? 'Ahead' : 'Behind'}
-                          </Badge>
+                      <div className="space-y-3">
+                        <div className="flex items-center justify-between gap-3 text-sm">
+                          <span className="text-muted-foreground">Progress</span>
+                          <span className="text-foreground font-semibold" aria-label={`${goal.title} progress percentage`}>
+                            {goal.progress.toFixed(0)}%
+                          </span>
                         </div>
                         <div className="space-y-2">
-                          <div className="flex justify-between text-sm">
-                            <span className="text-muted-foreground">
-                              ${goal.current.toLocaleString()} / ${goal.target.toLocaleString()}
-                            </span>
-                            <span className="text-foreground font-medium">
-                              {percentage.toFixed(0)}%
-                            </span>
+                          <div
+                            className="chart-track h-3"
+                            role="progressbar"
+                            aria-label={`${goal.title} progress`}
+                            aria-valuemin={0}
+                            aria-valuemax={100}
+                            aria-valuenow={Math.round(goal.progress)}
+                          >
+                            <div
+                              className={getGoalProgressBarClass(goal.status)}
+                              style={{ width: `${Math.min(goal.progress, 100)}%` }}
+                            />
                           </div>
-                          <div className="chart-track">
-                            <div className="chart-fill-success" style={{ width: `${Math.min(percentage, 100)}%` }} />
-                          </div>
-                          <div className="flex justify-between text-xs text-muted-foreground">
-                            <span>Target: {goal.deadline}</span>
-                            <span>${goal.monthlyTarget}/mo</span>
+                          <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+                            <span>0%</span>
+                            <span>{goal.nextMilestone ? `Next milestone ${goal.nextMilestone.label}` : 'Goal complete'}</span>
+                            <span>100%</span>
                           </div>
                         </div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs text-muted-foreground">
+                          <span>Target: {formatDeadline(goal.targetDate)}</span>
+                          <span className="sm:text-right">{formatMoney(goal.monthlyTarget)}/mo needed</span>
+                          <span>Remaining: {formatMoney(goal.remaining)}</span>
+                          <span className="sm:text-right">
+                            {goal.nextMilestone
+                              ? `Next ${goal.nextMilestone.label}: ${formatMoney(goal.nextMilestone.targetAmount)}`
+                              : 'All milestones hit'}
+                          </span>
+                        </div>
                       </div>
-                    );
-                  })}
+
+                      <div className="flex flex-wrap gap-2">
+                        {goal.milestones.map((milestone) => (
+                          <Badge
+                            key={`${goal.id}-${milestone.label}`}
+                            variant={milestone.reached ? 'default' : 'outline'}
+                            className="text-[11px]"
+                          >
+                            {milestone.label}
+                          </Badge>
+                        ))}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </FinancialCardContent>
+            <FinancialCardFooter>
+              <div className="w-full space-y-3">
+                <div>
+                  <div className="text-sm font-medium text-foreground">Add savings goal</div>
+                  <div className="text-xs text-muted-foreground">
+                    Goals are saved in-browser so progress and milestones persist locally.
+                  </div>
                 </div>
-              </FinancialCardContent>
-              <FinancialCardFooter>
-                <Button variant="financial" size="sm" className="w-full">
+                <div className="space-y-3">
+                  <div>
+                    <label htmlFor="goal-title" className="block text-sm mb-1">Goal name</label>
+                    <input
+                      id="goal-title"
+                      className="input w-full"
+                      value={goalTitle}
+                      onChange={(event) => setGoalTitle(event.target.value)}
+                      placeholder="Emergency fund"
+                    />
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label htmlFor="goal-target" className="block text-sm mb-1">Target amount</label>
+                      <input
+                        id="goal-target"
+                        className="input w-full"
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={goalTarget}
+                        onChange={(event) => setGoalTarget(event.target.value)}
+                        placeholder="10000"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="goal-current" className="block text-sm mb-1">Saved so far</label>
+                      <input
+                        id="goal-current"
+                        className="input w-full"
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        value={goalCurrent}
+                        onChange={(event) => setGoalCurrent(event.target.value)}
+                        placeholder="0"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <label htmlFor="goal-target-date" className="block text-sm mb-1">Target date</label>
+                    <input
+                      id="goal-target-date"
+                      className="input w-full"
+                      type="date"
+                      value={goalTargetDate}
+                      onChange={(event) => setGoalTargetDate(event.target.value)}
+                    />
+                  </div>
+                </div>
+                <Button
+                  variant="financial"
+                  size="sm"
+                  className="w-full"
+                  onClick={onAddGoal}
+                  disabled={!goalTitle.trim() || !goalTarget || !goalTargetDate}
+                >
                   <Plus className="w-4 h-4" />
                   Add New Goal
                 </Button>
-              </FinancialCardFooter>
-            </FinancialCard>
-          </div>
+                <div className="text-xs text-muted-foreground">
+                  Total target across goals: {formatMoney(goalSummary.totalTarget)}
+                </div>
+              </div>
+            </FinancialCardFooter>
+          </FinancialCard>
         </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Hey @rohitdash08, I’ve been using FinMind and wanted to contribute this savings goals flow.

I kept the implementation inside the existing `Budgets` page so it stays consistent with the current frontend structure and doesn’t add API or state-management bloat. I also moved the goal math into a dedicated helper module so milestone status, monthly contribution targets, and percentage progress all come from one place instead of being spread across the UI.

What’s included:
- savings goals with clear progress bars and visible percentages
- milestone tracking at 25%, 50%, 75%, and 100%
- monthly contribution targets and remaining amount per goal
- responsive goal cards with local persistence for saved progress
- integration tests covering progress display and goal creation
- README update for the new Budgets behavior

Validation run locally:
- `npm run lint`
- `npm test`
- `npm run build`

Closes #133.

Cheers,
George