### PR TITLE
feat: rule-based auto-tagging and categorization for transactions (closes #107)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Rules from "./pages/Rules";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -88,6 +89,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Account />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="rules"
+              element={
+                <ProtectedRoute>
+                  <Rules />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/rules.ts
+++ b/app/src/api/rules.ts
@@ -1,0 +1,79 @@
+import { api } from './client';
+
+export type RuleCondition = {
+  field: 'description' | 'amount' | 'expense_type';
+  operator: 'contains' | 'not_contains' | 'regex' | 'equals' | 'gt' | 'lt' | 'between';
+  value: string | number | [number, number];
+};
+
+export type RuleActions = {
+  set_category_id?: number | null;
+  add_tags?: string[];
+  set_expense_type?: 'EXPENSE' | 'INCOME' | null;
+};
+
+export type AutoTagRule = {
+  id: number;
+  name: string;
+  priority: number;
+  conditions: RuleCondition[];
+  actions: RuleActions;
+  active: boolean;
+  created_at: string;
+};
+
+export type RuleCreate = {
+  name: string;
+  priority?: number;
+  conditions: RuleCondition[];
+  actions: RuleActions;
+  active?: boolean;
+};
+
+export type RuleUpdate = Partial<RuleCreate>;
+
+export type DryRunResult = {
+  matched_rule_ids: number[];
+  changes: {
+    set_category_id: number | null;
+    add_tags: string[];
+    set_expense_type: string | null;
+  };
+};
+
+export type ApplyAllResult = {
+  updated: number;
+  skipped: number;
+};
+
+export async function listRules(): Promise<AutoTagRule[]> {
+  return api<AutoTagRule[]>('/rules');
+}
+
+export async function getRule(id: number): Promise<AutoTagRule> {
+  return api<AutoTagRule>(`/rules/${id}`);
+}
+
+export async function createRule(payload: RuleCreate): Promise<AutoTagRule> {
+  return api<AutoTagRule>('/rules', { method: 'POST', body: payload });
+}
+
+export async function updateRule(id: number, payload: RuleUpdate): Promise<AutoTagRule> {
+  return api<AutoTagRule>(`/rules/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function deleteRule(id: number): Promise<{ message: string }> {
+  return api<{ message: string }>(`/rules/${id}`, { method: 'DELETE' });
+}
+
+export async function testRule(transaction: {
+  description?: string;
+  amount?: number;
+  expense_type?: string;
+}): Promise<DryRunResult> {
+  return api<DryRunResult>('/rules/test', { method: 'POST', body: { transaction } });
+}
+
+export async function applyAllRules(force?: boolean): Promise<ApplyAllResult> {
+  return api<ApplyAllResult>('/rules/apply-all', { method: 'POST', body: { force: !!force } });
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Rules', href: '/rules' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/Rules.tsx
+++ b/app/src/pages/Rules.tsx
@@ -1,0 +1,713 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type {
+  AutoTagRule,
+  RuleCondition,
+  RuleActions,
+  DryRunResult,
+} from '../api/rules';
+import {
+  listRules,
+  createRule,
+  updateRule,
+  deleteRule,
+  testRule,
+  applyAllRules,
+} from '../api/rules';
+import { listCategories } from '../api/categories';
+import type { Category } from '../api/categories';
+import { getToken } from '../lib/auth';
+import { useToast } from '@/hooks/use-toast';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dailog';
+
+// ── types ──────────────────────────────────────────────────────────────────────
+
+type ConditionField = RuleCondition['field'];
+type ConditionOperator = RuleCondition['operator'];
+
+const FIELDS: { value: ConditionField; label: string }[] = [
+  { value: 'description', label: 'Description' },
+  { value: 'amount', label: 'Amount' },
+  { value: 'expense_type', label: 'Expense type' },
+];
+
+const OPERATORS: Record<ConditionField, { value: ConditionOperator; label: string }[]> = {
+  description: [
+    { value: 'contains', label: 'contains' },
+    { value: 'not_contains', label: 'does not contain' },
+    { value: 'equals', label: 'equals' },
+    { value: 'regex', label: 'matches regex' },
+  ],
+  amount: [
+    { value: 'gt', label: 'greater than' },
+    { value: 'lt', label: 'less than' },
+    { value: 'equals', label: 'equals' },
+    { value: 'between', label: 'between' },
+  ],
+  expense_type: [
+    { value: 'equals', label: 'equals' },
+  ],
+};
+
+interface DraftCondition {
+  field: ConditionField;
+  operator: ConditionOperator;
+  value: string;
+  valueTo: string; // for "between"
+}
+
+interface DraftRule {
+  name: string;
+  priority: string;
+  conditions: DraftCondition[];
+  actions: {
+    set_category_id: string;
+    add_tags: string; // comma-separated
+    set_expense_type: string;
+  };
+  active: boolean;
+}
+
+const emptyCondition = (): DraftCondition => ({
+  field: 'description',
+  operator: 'contains',
+  value: '',
+  valueTo: '',
+});
+
+const emptyDraft = (): DraftRule => ({
+  name: '',
+  priority: '0',
+  conditions: [emptyCondition()],
+  actions: { set_category_id: '', add_tags: '', set_expense_type: '' },
+  active: true,
+});
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+function draftToPayload(draft: DraftRule): { conditions: RuleCondition[]; actions: RuleActions } {
+  const conditions: RuleCondition[] = draft.conditions
+    .filter((c) => c.value.trim() !== '')
+    .map((c) => {
+      const value: RuleCondition['value'] =
+        c.operator === 'between'
+          ? [parseFloat(c.value) || 0, parseFloat(c.valueTo) || 0]
+          : c.field === 'amount' && c.operator !== 'regex'
+          ? parseFloat(c.value) || 0
+          : c.value.trim();
+      return { field: c.field, operator: c.operator, value } as RuleCondition;
+    });
+
+  const actions: RuleActions = {};
+  if (draft.actions.set_category_id) {
+    actions.set_category_id = parseInt(draft.actions.set_category_id, 10);
+  }
+  const tags = draft.actions.add_tags
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (tags.length > 0) actions.add_tags = tags;
+  if (draft.actions.set_expense_type) {
+    actions.set_expense_type = draft.actions.set_expense_type as 'EXPENSE' | 'INCOME';
+  }
+  return { conditions, actions };
+}
+
+function ruleToDraft(rule: AutoTagRule): DraftRule {
+  return {
+    name: rule.name,
+    priority: String(rule.priority),
+    active: rule.active,
+    conditions:
+      rule.conditions.length > 0
+        ? rule.conditions.map((c) => ({
+            field: c.field,
+            operator: c.operator,
+            value: Array.isArray(c.value) ? String(c.value[0]) : String(c.value),
+            valueTo: Array.isArray(c.value) ? String(c.value[1]) : '',
+          }))
+        : [emptyCondition()],
+    actions: {
+      set_category_id: rule.actions.set_category_id != null ? String(rule.actions.set_category_id) : '',
+      add_tags: (rule.actions.add_tags || []).join(', '),
+      set_expense_type: rule.actions.set_expense_type || '',
+    },
+  };
+}
+
+function getErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+// ── RuleForm ──────────────────────────────────────────────────────────────────
+
+function RuleForm({
+  draft,
+  onChange,
+  categories,
+}: {
+  draft: DraftRule;
+  onChange: (d: DraftRule) => void;
+  categories: Category[];
+}) {
+  function setField<K extends keyof DraftRule>(k: K, v: DraftRule[K]) {
+    onChange({ ...draft, [k]: v });
+  }
+
+  function updateCondition(i: number, partial: Partial<DraftCondition>) {
+    const updated = draft.conditions.map((c, idx) =>
+      idx === i ? { ...c, ...partial } : c,
+    );
+    onChange({ ...draft, conditions: updated });
+  }
+
+  function addCondition() {
+    onChange({ ...draft, conditions: [...draft.conditions, emptyCondition()] });
+  }
+
+  function removeCondition(i: number) {
+    onChange({ ...draft, conditions: draft.conditions.filter((_, idx) => idx !== i) });
+  }
+
+  function updateAction<K extends keyof DraftRule['actions']>(k: K, v: string) {
+    onChange({ ...draft, actions: { ...draft.actions, [k]: v } });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1">
+          <Label>Rule name</Label>
+          <Input
+            value={draft.name}
+            onChange={(e) => setField('name', e.target.value)}
+            placeholder="e.g., Coffee purchases"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>Priority (lower = higher priority)</Label>
+          <Input
+            type="number"
+            value={draft.priority}
+            onChange={(e) => setField('priority', e.target.value)}
+            placeholder="0"
+          />
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <Label>Conditions (ALL must match)</Label>
+          <Button variant="outline" size="sm" onClick={addCondition}>
+            + Add condition
+          </Button>
+        </div>
+        <div className="space-y-2">
+          {draft.conditions.map((cond, i) => (
+            <div
+              key={i}
+              className="flex flex-wrap items-center gap-2 rounded-lg border border-border/60 bg-muted/30 p-2"
+            >
+              <select
+                className="rounded border border-border bg-background px-2 py-1 text-sm"
+                value={cond.field}
+                onChange={(e) =>
+                  updateCondition(i, {
+                    field: e.target.value as ConditionField,
+                    operator: OPERATORS[e.target.value as ConditionField][0].value,
+                  })
+                }
+              >
+                {FIELDS.map((f) => (
+                  <option key={f.value} value={f.value}>
+                    {f.label}
+                  </option>
+                ))}
+              </select>
+
+              <select
+                className="rounded border border-border bg-background px-2 py-1 text-sm"
+                value={cond.operator}
+                onChange={(e) =>
+                  updateCondition(i, { operator: e.target.value as ConditionOperator })
+                }
+              >
+                {OPERATORS[cond.field].map((op) => (
+                  <option key={op.value} value={op.value}>
+                    {op.label}
+                  </option>
+                ))}
+              </select>
+
+              {cond.field === 'expense_type' ? (
+                <select
+                  className="rounded border border-border bg-background px-2 py-1 text-sm"
+                  value={cond.value}
+                  onChange={(e) => updateCondition(i, { value: e.target.value })}
+                >
+                  <option value="">—</option>
+                  <option value="EXPENSE">EXPENSE</option>
+                  <option value="INCOME">INCOME</option>
+                </select>
+              ) : cond.operator === 'between' ? (
+                <>
+                  <Input
+                    type="number"
+                    className="w-24 text-sm"
+                    placeholder="min"
+                    value={cond.value}
+                    onChange={(e) => updateCondition(i, { value: e.target.value })}
+                  />
+                  <span className="text-sm text-muted-foreground">and</span>
+                  <Input
+                    type="number"
+                    className="w-24 text-sm"
+                    placeholder="max"
+                    value={cond.valueTo}
+                    onChange={(e) => updateCondition(i, { valueTo: e.target.value })}
+                  />
+                </>
+              ) : (
+                <Input
+                  className="w-44 text-sm"
+                  type={['gt', 'lt', 'equals'].includes(cond.operator) && cond.field === 'amount' ? 'number' : 'text'}
+                  value={cond.value}
+                  onChange={(e) => updateCondition(i, { value: e.target.value })}
+                  placeholder={cond.field === 'description' ? 'e.g., starbucks' : 'value'}
+                />
+              )}
+
+              {draft.conditions.length > 1 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => removeCondition(i)}
+                  className="ml-auto text-destructive"
+                >
+                  Remove
+                </Button>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <Label className="mb-2 block">Actions (applied when all conditions match)</Label>
+        <div className="space-y-2 rounded-lg border border-border/60 bg-muted/30 p-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label className="text-xs">Set category</Label>
+              <select
+                className="w-full rounded border border-border bg-background px-2 py-1 text-sm"
+                value={draft.actions.set_category_id}
+                onChange={(e) => updateAction('set_category_id', e.target.value)}
+              >
+                <option value="">— no change —</option>
+                {categories.map((c) => (
+                  <option key={c.id} value={String(c.id)}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <Label className="text-xs">Set expense type</Label>
+              <select
+                className="w-full rounded border border-border bg-background px-2 py-1 text-sm"
+                value={draft.actions.set_expense_type}
+                onChange={(e) => updateAction('set_expense_type', e.target.value)}
+              >
+                <option value="">— no change —</option>
+                <option value="EXPENSE">EXPENSE</option>
+                <option value="INCOME">INCOME</option>
+              </select>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs">Add tags (comma-separated)</Label>
+            <Input
+              value={draft.actions.add_tags}
+              onChange={(e) => updateAction('add_tags', e.target.value)}
+              placeholder="e.g., food, dining, coffee"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          id="rule-active"
+          type="checkbox"
+          checked={draft.active}
+          onChange={(e) => setField('active', e.target.checked)}
+          className="h-4 w-4 rounded border-border"
+        />
+        <Label htmlFor="rule-active" className="text-sm">
+          Active (rule fires automatically on new transactions)
+        </Label>
+      </div>
+    </div>
+  );
+}
+
+// ── DryRun panel ───────────────────────────────────────────────────────────────
+
+function DryRunPanel({ categories }: { categories: Category[] }) {
+  const { toast } = useToast();
+  const [desc, setDesc] = useState('');
+  const [amount, setAmount] = useState('');
+  const [result, setResult] = useState<DryRunResult | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function run() {
+    if (!desc && !amount) return;
+    setLoading(true);
+    try {
+      const res = await testRule({
+        description: desc || undefined,
+        amount: amount ? parseFloat(amount) : undefined,
+      });
+      setResult(res);
+    } catch (err) {
+      toast({ title: 'Dry-run failed', description: getErrorMessage(err, 'Unknown error') });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="card space-y-3 fade-in-up">
+      <h3 className="font-semibold text-foreground">Dry-run tester</h3>
+      <p className="text-sm text-muted-foreground">
+        Enter a transaction and see which rules would match without saving anything.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        <Input
+          className="flex-1 min-w-40"
+          placeholder="Description (e.g., Starbucks)"
+          value={desc}
+          onChange={(e) => setDesc(e.target.value)}
+        />
+        <Input
+          className="w-32"
+          type="number"
+          placeholder="Amount"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+        />
+        <Button onClick={run} disabled={loading || (!desc && !amount)}>
+          Test
+        </Button>
+      </div>
+
+      {result && (
+        <div className="rounded-lg border border-border/60 bg-muted/40 p-3 text-sm space-y-1">
+          <div>
+            <span className="font-medium">Matched rules:</span>{' '}
+            {result.matched_rule_ids.length > 0
+              ? result.matched_rule_ids.join(', ')
+              : 'none'}
+          </div>
+          <div>
+            <span className="font-medium">Category:</span>{' '}
+            {result.changes.set_category_id != null
+              ? categories.find((c) => c.id === result.changes.set_category_id)?.name ??
+                `ID ${result.changes.set_category_id}`
+              : 'unchanged'}
+          </div>
+          <div>
+            <span className="font-medium">Tags:</span>{' '}
+            {result.changes.add_tags.length > 0
+              ? result.changes.add_tags.join(', ')
+              : 'none'}
+          </div>
+          <div>
+            <span className="font-medium">Expense type:</span>{' '}
+            {result.changes.set_expense_type ?? 'unchanged'}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── main page ─────────────────────────────────────────────────────────────────
+
+export default function Rules() {
+  const { toast } = useToast();
+  const nav = useNavigate();
+  const [rules, setRules] = useState<AutoTagRule[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+  const [draft, setDraft] = useState<DraftRule>(emptyDraft());
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState<DraftRule>(emptyDraft());
+
+  useEffect(() => {
+    if (!getToken()) {
+      nav('/signin', { replace: true });
+      return;
+    }
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function refresh() {
+    setLoading(true);
+    try {
+      const [r, cats] = await Promise.all([listRules(), listCategories()]);
+      setRules(r);
+      setCategories(cats);
+    } catch (err) {
+      toast({ title: 'Failed to load rules', description: getErrorMessage(err, 'Please try again.') });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function onCreate() {
+    const { conditions, actions } = draftToPayload(draft);
+    if (!Object.keys(actions).length) {
+      toast({ title: 'At least one action required', description: 'Set a category, tags, or expense type.' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const rule = await createRule({
+        name: draft.name.trim(),
+        priority: parseInt(draft.priority, 10) || 0,
+        conditions,
+        actions,
+        active: draft.active,
+      });
+      setRules((prev) => [...prev, rule].sort((a, b) => a.priority - b.priority));
+      setDraft(emptyDraft());
+      setShowCreate(false);
+      toast({ title: 'Rule created' });
+    } catch (err) {
+      toast({ title: 'Failed to create rule', description: getErrorMessage(err, 'Please try again.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onUpdate(id: number) {
+    const { conditions, actions } = draftToPayload(editDraft);
+    setSaving(true);
+    try {
+      const updated = await updateRule(id, {
+        name: editDraft.name.trim(),
+        priority: parseInt(editDraft.priority, 10) || 0,
+        conditions,
+        actions,
+        active: editDraft.active,
+      });
+      setRules((prev) => prev.map((r) => (r.id === id ? updated : r)));
+      setEditingId(null);
+      toast({ title: 'Rule updated' });
+    } catch (err) {
+      toast({ title: 'Failed to update rule', description: getErrorMessage(err, 'Please try again.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onDelete(id: number) {
+    setSaving(true);
+    try {
+      await deleteRule(id);
+      setRules((prev) => prev.filter((r) => r.id !== id));
+      toast({ title: 'Rule deleted' });
+    } catch (err) {
+      toast({ title: 'Failed to delete rule', description: getErrorMessage(err, 'Please try again.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onApplyAll() {
+    setSaving(true);
+    try {
+      const result = await applyAllRules();
+      toast({
+        title: 'Rules applied',
+        description: `${result.updated} expense${result.updated !== 1 ? 's' : ''} updated, ${result.skipped} skipped.`,
+      });
+    } catch (err) {
+      toast({ title: 'Apply failed', description: getErrorMessage(err, 'Please try again.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header">
+        <div className="relative">
+          <h2 className="page-title text-2xl md:text-3xl">Auto-tagging rules</h2>
+          <p className="page-subtitle">
+            Define rules to automatically categorize and tag transactions when they are created or
+            updated.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => void onApplyAll()} disabled={saving}>
+            Apply to existing
+          </Button>
+          <Button onClick={() => { setShowCreate(true); setDraft(emptyDraft()); }} disabled={showCreate}>
+            New rule
+          </Button>
+        </div>
+      </div>
+
+      {showCreate && (
+        <div className="card card-interactive space-y-4 fade-in-up">
+          <h3 className="font-semibold text-foreground">New rule</h3>
+          <RuleForm draft={draft} onChange={setDraft} categories={categories} />
+          <div className="flex gap-2">
+            <Button onClick={() => void onCreate()} disabled={saving || !draft.name.trim()}>
+              Create rule
+            </Button>
+            <Button variant="outline" onClick={() => setShowCreate(false)}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <DryRunPanel categories={categories} />
+
+      {loading ? (
+        <div className="card">Loading...</div>
+      ) : rules.length === 0 ? (
+        <div className="card text-sm text-muted-foreground">
+          No rules yet. Create your first rule above.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {rules.map((rule) => (
+            <div key={rule.id} className="card card-interactive fade-in-up">
+              {editingId === rule.id ? (
+                <div className="space-y-4">
+                  <RuleForm draft={editDraft} onChange={setEditDraft} categories={categories} />
+                  <div className="flex gap-2">
+                    <Button
+                      onClick={() => void onUpdate(rule.id)}
+                      disabled={saving || !editDraft.name.trim()}
+                    >
+                      Save
+                    </Button>
+                    <Button variant="outline" onClick={() => setEditingId(null)}>
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-foreground">{rule.name}</span>
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        p{rule.priority}
+                      </span>
+                      {!rule.active && (
+                        <span className="rounded-full bg-destructive/15 px-2 py-0.5 text-xs text-destructive">
+                          inactive
+                        </span>
+                      )}
+                    </div>
+                    <div className="text-xs text-muted-foreground space-y-0.5">
+                      {rule.conditions.length > 0 ? (
+                        rule.conditions.map((c, i) => (
+                          <div key={i}>
+                            <span className="font-mono">{c.field}</span>{' '}
+                            <span className="italic">{c.operator}</span>{' '}
+                            <span className="font-mono">
+                              {Array.isArray(c.value) ? c.value.join(' – ') : String(c.value)}
+                            </span>
+                          </div>
+                        ))
+                      ) : (
+                        <div className="italic">matches everything</div>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs mt-1">
+                      {rule.actions.set_category_id != null && (
+                        <span className="rounded bg-primary/10 px-2 py-0.5 text-primary">
+                          category:{' '}
+                          {categories.find((c) => c.id === rule.actions.set_category_id)?.name ??
+                            `#${rule.actions.set_category_id}`}
+                        </span>
+                      )}
+                      {(rule.actions.add_tags || []).map((tag) => (
+                        <span key={tag} className="rounded bg-secondary/60 px-2 py-0.5 text-secondary-foreground">
+                          #{tag}
+                        </span>
+                      ))}
+                      {rule.actions.set_expense_type && (
+                        <span className="rounded bg-accent/20 px-2 py-0.5 text-accent-foreground">
+                          type: {rule.actions.set_expense_type}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex shrink-0 gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        setEditingId(rule.id);
+                        setEditDraft(ruleToDraft(rule));
+                      }}
+                    >
+                      Edit
+                    </Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="outline" size="sm">
+                          Delete
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Delete rule?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This will permanently delete the rule &quot;{rule.name}&quot;. Transactions
+                            already tagged will not be affected.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction onClick={() => void onDelete(rule.id)}>
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,54 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+# ── Auto-tagging / rule engine ────────────────────────────────────────────────
+
+# Many-to-many: expenses ↔ tags
+expense_tags = db.Table(
+    "expense_tags",
+    db.Column("expense_id", db.Integer, db.ForeignKey("expenses.id"), primary_key=True),
+    db.Column("tag_id", db.Integer, db.ForeignKey("tags.id"), primary_key=True),
+)
+
+
+class Tag(db.Model):
+    """User-defined label that can be attached to any expense."""
+
+    __tablename__ = "tags"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (db.UniqueConstraint("user_id", "name", name="uq_tag_user_name"),)
+
+
+# Back-populate tags onto Expense (done after Tag is defined to avoid forward-ref issues)
+Expense.tags = db.relationship("Tag", secondary=expense_tags, lazy="select")
+
+
+class AutoTagRule(db.Model):
+    """A user-defined rule that auto-categorises or auto-tags transactions.
+
+    ``conditions`` (JSON text) — list of condition objects:
+        [{"field": "description|amount|expense_type",
+          "operator": "contains|not_contains|regex|equals|gt|lt|between",
+          "value": "<string or number or [min,max]>"}]
+
+    ``actions`` (JSON text) — object describing what to apply when ALL conditions match:
+        {"set_category_id": <int|null>,
+         "add_tags": ["<tag-name>", ...],
+         "set_expense_type": "<EXPENSE|INCOME|null>"}
+    """
+
+    __tablename__ = "auto_tag_rules"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    priority = db.Column(db.Integer, default=0, nullable=False)
+    conditions = db.Column(db.Text, nullable=False, default="[]")
+    actions = db.Column(db.Text, nullable=False, default="{}")
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .rules import bp as rules_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(rules_bp, url_prefix="/rules")

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -5,9 +5,10 @@ from decimal import Decimal, InvalidOperation
 from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
-from ..models import Expense, RecurringCadence, RecurringExpense, User
+from ..models import AutoTagRule, Category, Expense, RecurringCadence, RecurringExpense, Tag, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
+from ..services.rule_engine import apply_rules, parse_conditions
 import logging
 
 bp = Blueprint("expenses", __name__)
@@ -75,6 +76,8 @@ def create_expense():
         spent_at=date.fromisoformat(raw_date) if raw_date else date.today(),
     )
     db.session.add(e)
+    db.session.flush()  # get the id before applying rules
+    _apply_rules_to_expense(uid, e)
     db.session.commit()
     logger.info("Created expense id=%s user=%s amount=%s", e.id, uid, e.amount)
     # Invalidate caches
@@ -229,6 +232,7 @@ def update_expense(expense_id: int):
     if "date" in data or "spent_at" in data:
         raw_date = data.get("date") or data.get("spent_at")
         e.spent_at = date.fromisoformat(raw_date)
+    _apply_rules_to_expense(uid, e)
     db.session.commit()
     _invalidate_expense_cache(uid, e.spent_at.isoformat())
     return jsonify(_expense_to_dict(e))
@@ -312,6 +316,7 @@ def import_commit():
 
 
 def _expense_to_dict(e: Expense) -> dict:
+    tags = [t.name for t in (e.tags or [])]
     return {
         "id": e.id,
         "amount": float(e.amount),
@@ -320,7 +325,50 @@ def _expense_to_dict(e: Expense) -> dict:
         "expense_type": e.expense_type,
         "description": e.notes or "",
         "date": e.spent_at.isoformat(),
+        "tags": tags,
     }
+
+
+def _apply_rules_to_expense(uid: int, expense: Expense) -> None:
+    """Fetch active rules for the user and apply them to the expense in-place."""
+    rules = (
+        db.session.query(AutoTagRule)
+        .filter_by(user_id=uid, active=True)
+        .order_by(AutoTagRule.priority.asc(), AutoTagRule.created_at.asc())
+        .all()
+    )
+    if not rules:
+        return
+
+    rule_dicts = [
+        {"id": r.id, "conditions": r.conditions, "actions": r.actions}
+        for r in rules
+    ]
+    exp_dict = {
+        "description": expense.notes or "",
+        "amount": float(expense.amount),
+        "expense_type": expense.expense_type,
+        "category_id": expense.category_id,
+    }
+    result = apply_rules(exp_dict, rule_dicts)
+
+    if result["set_category_id"] is not None and expense.category_id is None:
+        cat = db.session.get(Category, result["set_category_id"])
+        if cat and cat.user_id == uid:
+            expense.category_id = result["set_category_id"]
+
+    if result["set_expense_type"]:
+        expense.expense_type = result["set_expense_type"]
+
+    for tag_name in result["add_tags"]:
+        tag = db.session.query(Tag).filter_by(user_id=uid, name=tag_name).first()
+        if not tag:
+            tag = Tag(user_id=uid, name=tag_name)
+            db.session.add(tag)
+            db.session.flush()
+        current_tag_ids = {t.id for t in expense.tags}
+        if tag.id not in current_tag_ids:
+            expense.tags.append(tag)
 
 
 def _recurring_to_dict(r: RecurringExpense) -> dict:

--- a/packages/backend/app/routes/rules.py
+++ b/packages/backend/app/routes/rules.py
@@ -1,0 +1,327 @@
+"""Routes for AutoTagRule CRUD and rule engine endpoints."""
+
+import json
+import logging
+from datetime import datetime
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import AutoTagRule, Category, Expense, Tag, expense_tags
+from ..services.rule_engine import apply_rules, parse_actions, parse_conditions
+
+bp = Blueprint("rules", __name__)
+logger = logging.getLogger("finmind.rules")
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _rule_to_dict(rule: AutoTagRule) -> dict:
+    return {
+        "id": rule.id,
+        "name": rule.name,
+        "priority": rule.priority,
+        "conditions": parse_conditions(rule.conditions),
+        "actions": parse_actions(rule.actions),
+        "active": rule.active,
+        "created_at": rule.created_at.isoformat(),
+    }
+
+
+def _validate_conditions(conditions: list) -> str | None:
+    """Return an error message if conditions are invalid, else None."""
+    valid_fields = {"description", "amount", "expense_type"}
+    valid_operators = {"contains", "not_contains", "regex", "equals", "gt", "lt", "between"}
+    for i, cond in enumerate(conditions):
+        if not isinstance(cond, dict):
+            return f"condition[{i}] must be an object"
+        if cond.get("field") not in valid_fields:
+            return f"condition[{i}].field must be one of {sorted(valid_fields)}"
+        if cond.get("operator") not in valid_operators:
+            return f"condition[{i}].operator must be one of {sorted(valid_operators)}"
+        if "value" not in cond:
+            return f"condition[{i}].value is required"
+        if cond["operator"] == "between":
+            v = cond["value"]
+            if not isinstance(v, (list, tuple)) or len(v) != 2:
+                return f"condition[{i}].value must be a 2-element array for 'between'"
+    return None
+
+
+def _validate_actions(actions: dict) -> str | None:
+    """Return an error message if actions are invalid, else None."""
+    if not isinstance(actions, dict):
+        return "actions must be an object"
+    if not any(k in actions for k in ("set_category_id", "add_tags", "set_expense_type")):
+        return "actions must include at least one of: set_category_id, add_tags, set_expense_type"
+    tags = actions.get("add_tags")
+    if tags is not None and not isinstance(tags, list):
+        return "actions.add_tags must be an array"
+    exp_type = actions.get("set_expense_type")
+    if exp_type is not None and str(exp_type).upper() not in ("EXPENSE", "INCOME"):
+        return "actions.set_expense_type must be 'EXPENSE' or 'INCOME'"
+    return None
+
+
+def _get_or_create_tag(uid: int, name: str) -> Tag:
+    tag = db.session.query(Tag).filter_by(user_id=uid, name=name).first()
+    if not tag:
+        tag = Tag(user_id=uid, name=name)
+        db.session.add(tag)
+        db.session.flush()  # get the id without committing
+    return tag
+
+
+# ── CRUD ───────────────────────────────────────────────────────────────────────
+
+
+@bp.get("")
+@jwt_required()
+def list_rules():
+    uid = int(get_jwt_identity())
+    rules = (
+        db.session.query(AutoTagRule)
+        .filter_by(user_id=uid)
+        .order_by(AutoTagRule.priority.asc(), AutoTagRule.created_at.asc())
+        .all()
+    )
+    return jsonify([_rule_to_dict(r) for r in rules])
+
+
+@bp.post("")
+@jwt_required()
+def create_rule():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+
+    conditions = data.get("conditions", [])
+    if not isinstance(conditions, list):
+        return jsonify(error="conditions must be an array"), 400
+    err = _validate_conditions(conditions)
+    if err:
+        return jsonify(error=err), 400
+
+    actions = data.get("actions", {})
+    err = _validate_actions(actions)
+    if err:
+        return jsonify(error=err), 400
+
+    try:
+        priority = int(data.get("priority", 0))
+    except (ValueError, TypeError):
+        return jsonify(error="priority must be an integer"), 400
+
+    rule = AutoTagRule(
+        user_id=uid,
+        name=name,
+        priority=priority,
+        conditions=json.dumps(conditions),
+        actions=json.dumps(actions),
+        active=bool(data.get("active", True)),
+    )
+    db.session.add(rule)
+    db.session.commit()
+    logger.info("Created rule id=%s user=%s name=%s", rule.id, uid, name)
+    return jsonify(_rule_to_dict(rule)), 201
+
+
+@bp.get("/<int:rule_id>")
+@jwt_required()
+def get_rule(rule_id: int):
+    uid = int(get_jwt_identity())
+    rule = db.session.get(AutoTagRule, rule_id)
+    if not rule or rule.user_id != uid:
+        return jsonify(error="not found"), 404
+    return jsonify(_rule_to_dict(rule))
+
+
+@bp.patch("/<int:rule_id>")
+@jwt_required()
+def update_rule(rule_id: int):
+    uid = int(get_jwt_identity())
+    rule = db.session.get(AutoTagRule, rule_id)
+    if not rule or rule.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+
+    if "name" in data:
+        name = (data["name"] or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        rule.name = name
+
+    if "priority" in data:
+        try:
+            rule.priority = int(data["priority"])
+        except (ValueError, TypeError):
+            return jsonify(error="priority must be an integer"), 400
+
+    if "conditions" in data:
+        conditions = data["conditions"]
+        if not isinstance(conditions, list):
+            return jsonify(error="conditions must be an array"), 400
+        err = _validate_conditions(conditions)
+        if err:
+            return jsonify(error=err), 400
+        rule.conditions = json.dumps(conditions)
+
+    if "actions" in data:
+        actions = data["actions"]
+        err = _validate_actions(actions)
+        if err:
+            return jsonify(error=err), 400
+        rule.actions = json.dumps(actions)
+
+    if "active" in data:
+        rule.active = bool(data["active"])
+
+    db.session.commit()
+    logger.info("Updated rule id=%s user=%s", rule.id, uid)
+    return jsonify(_rule_to_dict(rule))
+
+
+@bp.delete("/<int:rule_id>")
+@jwt_required()
+def delete_rule(rule_id: int):
+    uid = int(get_jwt_identity())
+    rule = db.session.get(AutoTagRule, rule_id)
+    if not rule or rule.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(rule)
+    db.session.commit()
+    logger.info("Deleted rule id=%s user=%s", rule.id, uid)
+    return jsonify(message="deleted")
+
+
+# ── dry-run / batch apply ──────────────────────────────────────────────────────
+
+
+@bp.post("/test")
+@jwt_required()
+def test_rule():
+    """Dry-run: evaluate all active rules against a provided transaction dict.
+
+    Request body:
+        {
+            "transaction": {
+                "description": "Starbucks Coffee",
+                "amount": 5.50,
+                "expense_type": "EXPENSE"
+            }
+        }
+
+    Response:
+        {
+            "matched_rule_ids": [1, 3],
+            "changes": {
+                "set_category_id": 2,
+                "add_tags": ["coffee", "food"],
+                "set_expense_type": null
+            }
+        }
+    """
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    transaction = data.get("transaction")
+    if not isinstance(transaction, dict):
+        return jsonify(error="transaction object required"), 400
+
+    rules = (
+        db.session.query(AutoTagRule)
+        .filter_by(user_id=uid, active=True)
+        .order_by(AutoTagRule.priority.asc(), AutoTagRule.created_at.asc())
+        .all()
+    )
+    rule_dicts = [
+        {"id": r.id, "conditions": r.conditions, "actions": r.actions} for r in rules
+    ]
+    result = apply_rules(transaction, rule_dicts)
+    return jsonify(
+        matched_rule_ids=result["matched_rule_ids"],
+        changes={
+            "set_category_id": result["set_category_id"],
+            "add_tags": result["add_tags"],
+            "set_expense_type": result["set_expense_type"],
+        },
+    )
+
+
+@bp.post("/apply-all")
+@jwt_required()
+def apply_rules_to_all():
+    """Batch-apply all active rules to uncategorised existing expenses.
+
+    Only expenses without a category are targeted by default.
+    Pass ``{"force": true}`` to re-apply to all expenses.
+
+    Response:
+        {"updated": <int>, "skipped": <int>}
+    """
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    force = bool(data.get("force", False))
+
+    rules = (
+        db.session.query(AutoTagRule)
+        .filter_by(user_id=uid, active=True)
+        .order_by(AutoTagRule.priority.asc(), AutoTagRule.created_at.asc())
+        .all()
+    )
+    if not rules:
+        return jsonify(updated=0, skipped=0)
+
+    rule_dicts = [
+        {"id": r.id, "conditions": r.conditions, "actions": r.actions} for r in rules
+    ]
+
+    query = db.session.query(Expense).filter_by(user_id=uid)
+    if not force:
+        query = query.filter(Expense.category_id.is_(None))
+
+    expenses = query.all()
+    updated = 0
+    skipped = 0
+
+    for expense in expenses:
+        exp_dict = {
+            "description": expense.notes or "",
+            "amount": float(expense.amount),
+            "expense_type": expense.expense_type,
+            "category_id": expense.category_id,
+        }
+        result = apply_rules(exp_dict, rule_dicts)
+
+        changed = False
+        if result["set_category_id"] is not None:
+            # Validate the category belongs to the user
+            cat = db.session.get(Category, result["set_category_id"])
+            if cat and cat.user_id == uid:
+                expense.category_id = result["set_category_id"]
+                changed = True
+
+        if result["set_expense_type"]:
+            expense.expense_type = result["set_expense_type"]
+            changed = True
+
+        for tag_name in result["add_tags"]:
+            tag = _get_or_create_tag(uid, tag_name)
+            # Avoid duplicates on the association
+            current_tag_ids = {t.id for t in expense.tags}
+            if tag.id not in current_tag_ids:
+                expense.tags.append(tag)
+                changed = True
+
+        if changed:
+            updated += 1
+        else:
+            skipped += 1
+
+    db.session.commit()
+    logger.info("apply-all rules user=%s updated=%s skipped=%s", uid, updated, skipped)
+    return jsonify(updated=updated, skipped=skipped)

--- a/packages/backend/app/services/rule_engine.py
+++ b/packages/backend/app/services/rule_engine.py
@@ -1,0 +1,195 @@
+"""Rule engine: evaluate AutoTagRule conditions against an expense and compute actions.
+
+This module contains only pure functions — no database access, no Flask context.
+That makes it straightforward to unit-test and keeps route handlers thin.
+
+Condition schema
+----------------
+Each condition is a dict::
+
+    {
+        "field":    "description" | "amount" | "expense_type",
+        "operator": "contains" | "not_contains" | "regex" | "equals"
+                  | "gt" | "lt" | "between",
+        "value":    <str, number, or [min, max] for "between">
+    }
+
+ALL conditions in a rule must match for the rule to fire (AND semantics).
+
+Action schema
+-------------
+::
+
+    {
+        "set_category_id":  <int | null>,       # optional
+        "add_tags":         ["<tag>", ...],     # optional
+        "set_expense_type": "<EXPENSE|INCOME>"  # optional
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+logger = logging.getLogger("finmind.rule_engine")
+
+# ── condition evaluation ───────────────────────────────────────────────────────
+
+
+def _get_field_value(expense: dict, field: str) -> Any:
+    """Extract the field value from an expense dict (uses canonical key names)."""
+    if field == "description":
+        return str(expense.get("description") or expense.get("notes") or "")
+    if field == "amount":
+        try:
+            return Decimal(str(expense.get("amount", 0)))
+        except (InvalidOperation, ValueError):
+            return Decimal(0)
+    if field == "expense_type":
+        return str(expense.get("expense_type") or "EXPENSE").upper()
+    return None
+
+
+def _evaluate_condition(condition: dict, expense: dict) -> bool:
+    """Return True if a single condition matches the expense."""
+    field = condition.get("field", "")
+    operator = condition.get("operator", "")
+    value = condition.get("value")
+    actual = _get_field_value(expense, field)
+
+    if actual is None:
+        return False
+
+    try:
+        if field == "amount":
+            # Numeric operators
+            if operator == "gt":
+                return actual > Decimal(str(value))
+            if operator == "lt":
+                return actual < Decimal(str(value))
+            if operator == "equals":
+                return actual == Decimal(str(value))
+            if operator == "between":
+                if not isinstance(value, (list, tuple)) or len(value) != 2:
+                    return False
+                lo, hi = Decimal(str(value[0])), Decimal(str(value[1]))
+                return lo <= actual <= hi
+            # String-style operators on amounts (edge case)
+            if operator in ("contains", "not_contains", "regex"):
+                str_actual = str(actual)
+                str_value = str(value)
+                if operator == "contains":
+                    return str_value.lower() in str_actual.lower()
+                if operator == "not_contains":
+                    return str_value.lower() not in str_actual.lower()
+                if operator == "regex":
+                    return bool(re.search(str_value, str_actual, re.IGNORECASE))
+        else:
+            # String field operators
+            str_actual = str(actual)
+            str_value = str(value) if value is not None else ""
+            if operator == "contains":
+                return str_value.lower() in str_actual.lower()
+            if operator == "not_contains":
+                return str_value.lower() not in str_actual.lower()
+            if operator == "equals":
+                return str_actual.lower() == str_value.lower()
+            if operator == "regex":
+                return bool(re.search(str_value, str_actual, re.IGNORECASE))
+            # Numeric operators on string fields fall through → False
+    except (InvalidOperation, ValueError, re.error) as exc:
+        logger.debug("Condition eval error field=%s op=%s: %s", field, operator, exc)
+        return False
+
+    logger.debug("Unknown operator %s for field %s", operator, field)
+    return False
+
+
+def _evaluate_rule(conditions: list[dict], expense: dict) -> bool:
+    """Return True only if ALL conditions match (AND semantics)."""
+    if not conditions:
+        # An empty condition list matches everything.
+        return True
+    return all(_evaluate_condition(c, expense) for c in conditions)
+
+
+# ── public API ─────────────────────────────────────────────────────────────────
+
+
+def parse_conditions(raw: str | list) -> list[dict]:
+    """Parse conditions from a JSON string or list."""
+    if isinstance(raw, list):
+        return raw
+    try:
+        return json.loads(raw) if raw else []
+    except (json.JSONDecodeError, TypeError):
+        return []
+
+
+def parse_actions(raw: str | dict) -> dict:
+    """Parse actions from a JSON string or dict."""
+    if isinstance(raw, dict):
+        return raw
+    try:
+        return json.loads(raw) if raw else {}
+    except (json.JSONDecodeError, TypeError):
+        return {}
+
+
+def apply_rules(expense: dict, rules: list[dict]) -> dict:
+    """Evaluate rules against an expense and return a merged dict of changes.
+
+    Parameters
+    ----------
+    expense:
+        Dict with keys: ``description`` (or ``notes``), ``amount``,
+        ``expense_type``, ``category_id``.
+    rules:
+        List of rule dicts sorted by priority (ascending = applied first).
+        Each rule dict should have: ``conditions`` (str or list),
+        ``actions`` (str or dict).
+
+    Returns
+    -------
+    dict
+        ``{"set_category_id": <int|None>, "add_tags": [<str>...],
+           "set_expense_type": <str|None>, "matched_rule_ids": [<int>...]}``
+    """
+    result: dict[str, Any] = {
+        "set_category_id": None,
+        "add_tags": [],
+        "set_expense_type": None,
+        "matched_rule_ids": [],
+    }
+    category_set = False
+
+    for rule in rules:
+        conditions = parse_conditions(rule.get("conditions", []))
+        if not _evaluate_rule(conditions, expense):
+            continue
+
+        actions = parse_actions(rule.get("actions", {}))
+        rule_id = rule.get("id")
+        if rule_id is not None:
+            result["matched_rule_ids"].append(rule_id)
+
+        # set_category_id: first matching rule wins
+        if not category_set and "set_category_id" in actions:
+            result["set_category_id"] = actions["set_category_id"]
+            category_set = True
+
+        # add_tags: accumulate across all matching rules (deduplication later)
+        for tag in actions.get("add_tags") or []:
+            tag_str = str(tag).strip()
+            if tag_str and tag_str not in result["add_tags"]:
+                result["add_tags"].append(tag_str)
+
+        # set_expense_type: first matching rule wins
+        if result["set_expense_type"] is None and actions.get("set_expense_type"):
+            result["set_expense_type"] = str(actions["set_expense_type"]).upper()
+
+    return result

--- a/packages/backend/tests/test_rules.py
+++ b/packages/backend/tests/test_rules.py
@@ -1,0 +1,639 @@
+"""Tests for rule-based auto-tagging and categorization (issue #107).
+
+Structure
+---------
+- Unit tests: ``rule_engine`` service with no Flask context required.
+- Integration tests: full API round-trips using the Flask test client.
+"""
+
+import pytest
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from app.services.rule_engine import (
+    _evaluate_condition,
+    _evaluate_rule,
+    apply_rules,
+    parse_actions,
+    parse_conditions,
+)
+
+
+# ── unit tests: condition evaluation ──────────────────────────────────────────
+
+
+class TestEvaluateCondition:
+    def test_description_contains_match(self):
+        cond = {"field": "description", "operator": "contains", "value": "coffee"}
+        assert _evaluate_condition(cond, {"description": "Starbucks Coffee Shop"}) is True
+
+    def test_description_contains_case_insensitive(self):
+        cond = {"field": "description", "operator": "contains", "value": "COFFEE"}
+        assert _evaluate_condition(cond, {"description": "starbucks coffee"}) is True
+
+    def test_description_contains_no_match(self):
+        cond = {"field": "description", "operator": "contains", "value": "grocery"}
+        assert _evaluate_condition(cond, {"description": "Starbucks Coffee"}) is False
+
+    def test_description_not_contains(self):
+        cond = {"field": "description", "operator": "not_contains", "value": "coffee"}
+        assert _evaluate_condition(cond, {"description": "Grocery Store"}) is True
+        assert _evaluate_condition(cond, {"description": "Coffee Shop"}) is False
+
+    def test_description_equals(self):
+        cond = {"field": "description", "operator": "equals", "value": "netflix"}
+        assert _evaluate_condition(cond, {"description": "Netflix"}) is True
+        assert _evaluate_condition(cond, {"description": "Netflix Plus"}) is False
+
+    def test_description_regex_match(self):
+        cond = {"field": "description", "operator": "regex", "value": r"^uber\s*(eats)?"}
+        assert _evaluate_condition(cond, {"description": "Uber Eats"}) is True
+        assert _evaluate_condition(cond, {"description": "Uber"}) is True
+        assert _evaluate_condition(cond, {"description": "Lyft"}) is False
+
+    def test_description_regex_invalid(self):
+        # Invalid regex should not crash; returns False
+        cond = {"field": "description", "operator": "regex", "value": "[unclosed"}
+        assert _evaluate_condition(cond, {"description": "test"}) is False
+
+    def test_amount_gt(self):
+        cond = {"field": "amount", "operator": "gt", "value": 100}
+        assert _evaluate_condition(cond, {"amount": 150.0}) is True
+        assert _evaluate_condition(cond, {"amount": 50.0}) is False
+        assert _evaluate_condition(cond, {"amount": 100.0}) is False
+
+    def test_amount_lt(self):
+        cond = {"field": "amount", "operator": "lt", "value": 50}
+        assert _evaluate_condition(cond, {"amount": 20.0}) is True
+        assert _evaluate_condition(cond, {"amount": 100.0}) is False
+
+    def test_amount_equals(self):
+        cond = {"field": "amount", "operator": "equals", "value": "9.99"}
+        assert _evaluate_condition(cond, {"amount": Decimal("9.99")}) is True
+        assert _evaluate_condition(cond, {"amount": 10.0}) is False
+
+    def test_amount_between(self):
+        cond = {"field": "amount", "operator": "between", "value": [10, 50]}
+        assert _evaluate_condition(cond, {"amount": 25.0}) is True
+        assert _evaluate_condition(cond, {"amount": 10.0}) is True  # inclusive
+        assert _evaluate_condition(cond, {"amount": 50.0}) is True  # inclusive
+        assert _evaluate_condition(cond, {"amount": 5.0}) is False
+        assert _evaluate_condition(cond, {"amount": 51.0}) is False
+
+    def test_amount_between_invalid_value(self):
+        cond = {"field": "amount", "operator": "between", "value": 100}  # wrong type
+        assert _evaluate_condition(cond, {"amount": 50.0}) is False
+
+    def test_expense_type_equals(self):
+        cond = {"field": "expense_type", "operator": "equals", "value": "INCOME"}
+        assert _evaluate_condition(cond, {"expense_type": "INCOME"}) is True
+        assert _evaluate_condition(cond, {"expense_type": "EXPENSE"}) is False
+
+    def test_unknown_field_returns_false(self):
+        cond = {"field": "merchant", "operator": "contains", "value": "Amazon"}
+        assert _evaluate_condition(cond, {"description": "Amazon"}) is False
+
+    def test_unknown_operator_returns_false(self):
+        cond = {"field": "description", "operator": "startswith", "value": "Amazon"}
+        assert _evaluate_condition(cond, {"description": "Amazon Prime"}) is False
+
+
+class TestEvaluateRule:
+    def test_empty_conditions_matches_everything(self):
+        assert _evaluate_rule([], {"description": "anything", "amount": 10}) is True
+
+    def test_and_semantics_all_must_match(self):
+        conditions = [
+            {"field": "description", "operator": "contains", "value": "coffee"},
+            {"field": "amount", "operator": "lt", "value": 10},
+        ]
+        assert _evaluate_rule(conditions, {"description": "coffee shop", "amount": 5.0}) is True
+        assert _evaluate_rule(conditions, {"description": "coffee shop", "amount": 50.0}) is False
+        assert _evaluate_rule(conditions, {"description": "lunch", "amount": 5.0}) is False
+
+
+class TestApplyRules:
+    def test_no_rules_returns_empty_result(self):
+        result = apply_rules({"description": "Coffee", "amount": 5.0}, [])
+        assert result["set_category_id"] is None
+        assert result["add_tags"] == []
+        assert result["set_expense_type"] is None
+        assert result["matched_rule_ids"] == []
+
+    def test_matching_rule_sets_category(self):
+        rules = [
+            {
+                "id": 1,
+                "conditions": '[{"field":"description","operator":"contains","value":"coffee"}]',
+                "actions": '{"set_category_id":5}',
+            }
+        ]
+        result = apply_rules({"description": "Starbucks Coffee", "amount": 4.5}, rules)
+        assert result["set_category_id"] == 5
+        assert 1 in result["matched_rule_ids"]
+
+    def test_non_matching_rule_ignored(self):
+        rules = [
+            {
+                "id": 1,
+                "conditions": '[{"field":"description","operator":"contains","value":"grocery"}]',
+                "actions": '{"set_category_id":5}',
+            }
+        ]
+        result = apply_rules({"description": "Starbucks Coffee", "amount": 4.5}, rules)
+        assert result["set_category_id"] is None
+        assert result["matched_rule_ids"] == []
+
+    def test_first_matching_rule_wins_for_category(self):
+        rules = [
+            {
+                "id": 1,
+                "conditions": '[{"field":"description","operator":"contains","value":"coffee"}]',
+                "actions": '{"set_category_id":5}',
+            },
+            {
+                "id": 2,
+                "conditions": '[{"field":"amount","operator":"lt","value":10}]',
+                "actions": '{"set_category_id":99}',
+            },
+        ]
+        result = apply_rules({"description": "Starbucks Coffee", "amount": 4.5}, rules)
+        assert result["set_category_id"] == 5  # first match wins
+        assert 1 in result["matched_rule_ids"]
+        assert 2 in result["matched_rule_ids"]
+
+    def test_tags_accumulate_across_rules(self):
+        rules = [
+            {
+                "id": 1,
+                "conditions": '[{"field":"description","operator":"contains","value":"coffee"}]',
+                "actions": '{"add_tags":["caffeine","food"]}',
+            },
+            {
+                "id": 2,
+                "conditions": '[{"field":"amount","operator":"lt","value":10}]',
+                "actions": '{"add_tags":["small-spend","food"]}',  # "food" is a duplicate
+            },
+        ]
+        result = apply_rules({"description": "Starbucks Coffee", "amount": 4.5}, rules)
+        assert set(result["add_tags"]) == {"caffeine", "food", "small-spend"}
+        assert result["add_tags"].count("food") == 1  # deduplication
+
+    def test_set_expense_type_first_match_wins(self):
+        rules = [
+            {
+                "id": 1,
+                "conditions": '[{"field":"description","operator":"contains","value":"salary"}]',
+                "actions": '{"set_expense_type":"INCOME"}',
+            },
+            {
+                "id": 2,
+                "conditions": '[{"field":"amount","operator":"gt","value":1000}]',
+                "actions": '{"set_expense_type":"EXPENSE"}',
+            },
+        ]
+        result = apply_rules({"description": "Monthly Salary", "amount": 5000.0}, rules)
+        assert result["set_expense_type"] == "INCOME"
+
+    def test_parse_conditions_from_list(self):
+        conditions = [{"field": "description", "operator": "contains", "value": "test"}]
+        assert parse_conditions(conditions) == conditions
+
+    def test_parse_conditions_from_json_string(self):
+        raw = '[{"field":"description","operator":"contains","value":"test"}]'
+        parsed = parse_conditions(raw)
+        assert parsed[0]["field"] == "description"
+
+    def test_parse_conditions_invalid_json(self):
+        assert parse_conditions("not json") == []
+
+    def test_parse_actions_from_dict(self):
+        actions = {"set_category_id": 5}
+        assert parse_actions(actions) == actions
+
+    def test_parse_actions_from_json_string(self):
+        assert parse_actions('{"set_category_id":5}') == {"set_category_id": 5}
+
+
+# ── integration tests: Rules API ───────────────────────────────────────────────
+
+# Patch redis for all integration tests so they run without a live Redis server.
+@pytest.fixture(autouse=True)
+def _mock_redis(monkeypatch):
+    """Replace the module-level redis_client with a minimal in-memory mock."""
+    try:
+        import fakeredis
+
+        fake = fakeredis.FakeRedis(decode_responses=True)
+    except ImportError:
+        # Fall back to a MagicMock that silently no-ops all Redis calls.
+        fake = MagicMock()
+        fake.get.return_value = None
+        fake.scan.return_value = (0, [])
+        fake.setex.return_value = True
+        fake.set.return_value = True
+        fake.delete.return_value = 0
+        fake.flushdb.return_value = True
+
+    monkeypatch.setattr("app.extensions.redis_client", fake)
+    # Patch the already-imported reference in auth and cache modules
+    monkeypatch.setattr("app.routes.auth.redis_client", fake)
+    monkeypatch.setattr("app.services.cache.redis_client", fake)
+    return fake
+
+
+def _create_category(client, auth_header, name="Food"):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code in (201, 409)
+    r = client.get("/categories", headers=auth_header)
+    assert r.status_code == 200
+    return next(c["id"] for c in r.get_json() if c["name"] == name)
+
+
+class TestRulesCRUD:
+    def test_list_empty(self, client, auth_header):
+        r = client.get("/rules", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json() == []
+
+    def test_create_and_get(self, client, auth_header):
+        payload = {
+            "name": "Coffee rule",
+            "priority": 1,
+            "conditions": [
+                {"field": "description", "operator": "contains", "value": "coffee"}
+            ],
+            "actions": {"add_tags": ["caffeine"]},
+        }
+        r = client.post("/rules", json=payload, headers=auth_header)
+        assert r.status_code == 201
+        data = r.get_json()
+        rule_id = data["id"]
+        assert data["name"] == "Coffee rule"
+        assert data["priority"] == 1
+        assert data["conditions"][0]["value"] == "coffee"
+        assert data["actions"]["add_tags"] == ["caffeine"]
+        assert data["active"] is True
+
+        # GET by id
+        r = client.get(f"/rules/{rule_id}", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["id"] == rule_id
+
+    def test_create_missing_name(self, client, auth_header):
+        r = client.post(
+            "/rules",
+            json={"conditions": [], "actions": {"add_tags": ["x"]}},
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+
+    def test_create_invalid_conditions_field(self, client, auth_header):
+        r = client.post(
+            "/rules",
+            json={
+                "name": "Bad rule",
+                "conditions": [
+                    {"field": "merchant", "operator": "contains", "value": "x"}
+                ],
+                "actions": {"add_tags": ["x"]},
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+        assert "field" in r.get_json()["error"]
+
+    def test_create_invalid_actions_no_action_key(self, client, auth_header):
+        r = client.post(
+            "/rules",
+            json={
+                "name": "Empty actions",
+                "conditions": [],
+                "actions": {},
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 400
+
+    def test_update_rule(self, client, auth_header):
+        r = client.post(
+            "/rules",
+            json={
+                "name": "Old name",
+                "conditions": [],
+                "actions": {"add_tags": ["a"]},
+            },
+            headers=auth_header,
+        )
+        rule_id = r.get_json()["id"]
+
+        r = client.patch(
+            f"/rules/{rule_id}",
+            json={"name": "New name", "priority": 5, "active": False},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        updated = r.get_json()
+        assert updated["name"] == "New name"
+        assert updated["priority"] == 5
+        assert updated["active"] is False
+
+    def test_delete_rule(self, client, auth_header):
+        r = client.post(
+            "/rules",
+            json={"name": "To delete", "conditions": [], "actions": {"add_tags": ["x"]}},
+            headers=auth_header,
+        )
+        rule_id = r.get_json()["id"]
+        r = client.delete(f"/rules/{rule_id}", headers=auth_header)
+        assert r.status_code == 200
+        r = client.get(f"/rules/{rule_id}", headers=auth_header)
+        assert r.status_code == 404
+
+    def test_cannot_access_other_users_rule(self, client, auth_header):
+        # Create with user 1
+        r = client.post(
+            "/rules",
+            json={"name": "Mine", "conditions": [], "actions": {"add_tags": ["x"]}},
+            headers=auth_header,
+        )
+        rule_id = r.get_json()["id"]
+
+        # Register user 2
+        client.post("/auth/register", json={"email": "user2@example.com", "password": "pass1234"})
+        r2 = client.post(
+            "/auth/login", json={"email": "user2@example.com", "password": "pass1234"}
+        )
+        token2 = r2.get_json()["access_token"]
+        headers2 = {"Authorization": f"Bearer {token2}"}
+
+        r = client.get(f"/rules/{rule_id}", headers=headers2)
+        assert r.status_code == 404
+
+    def test_list_sorted_by_priority(self, client, auth_header):
+        for priority in (3, 1, 2):
+            client.post(
+                "/rules",
+                json={
+                    "name": f"Rule p{priority}",
+                    "priority": priority,
+                    "conditions": [],
+                    "actions": {"add_tags": ["x"]},
+                },
+                headers=auth_header,
+            )
+        r = client.get("/rules", headers=auth_header)
+        priorities = [rule["priority"] for rule in r.get_json()]
+        assert priorities == sorted(priorities)
+
+
+class TestRuleDryRun:
+    def test_test_endpoint_matches(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Dining")
+        client.post(
+            "/rules",
+            json={
+                "name": "Coffee",
+                "conditions": [
+                    {"field": "description", "operator": "contains", "value": "starbucks"}
+                ],
+                "actions": {"set_category_id": cat_id, "add_tags": ["coffee"]},
+            },
+            headers=auth_header,
+        )
+        r = client.post(
+            "/rules/test",
+            json={"transaction": {"description": "Starbucks Pumpkin Latte", "amount": 6.5}},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        result = r.get_json()
+        assert len(result["matched_rule_ids"]) == 1
+        assert result["changes"]["set_category_id"] == cat_id
+        assert "coffee" in result["changes"]["add_tags"]
+
+    def test_test_endpoint_no_match(self, client, auth_header):
+        client.post(
+            "/rules",
+            json={
+                "name": "Coffee",
+                "conditions": [
+                    {"field": "description", "operator": "contains", "value": "coffee"}
+                ],
+                "actions": {"add_tags": ["caffeine"]},
+            },
+            headers=auth_header,
+        )
+        r = client.post(
+            "/rules/test",
+            json={"transaction": {"description": "Grocery Run", "amount": 40.0}},
+            headers=auth_header,
+        )
+        assert r.status_code == 200
+        result = r.get_json()
+        assert result["matched_rule_ids"] == []
+        assert result["changes"]["add_tags"] == []
+
+    def test_test_endpoint_requires_transaction(self, client, auth_header):
+        r = client.post("/rules/test", json={}, headers=auth_header)
+        assert r.status_code == 400
+
+
+class TestAutoTaggingOnExpenseCreate:
+    def test_rule_applied_on_create(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Cafes")
+        # Create a rule
+        client.post(
+            "/rules",
+            json={
+                "name": "Tag coffee purchases",
+                "conditions": [
+                    {"field": "description", "operator": "contains", "value": "coffee"}
+                ],
+                "actions": {"set_category_id": cat_id, "add_tags": ["beverage"]},
+            },
+            headers=auth_header,
+        )
+        # Create a matching expense
+        r = client.post(
+            "/expenses",
+            json={"amount": 4.5, "description": "Morning Coffee", "date": "2026-01-10"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        expense = r.get_json()
+        assert expense["category_id"] == cat_id
+        assert "beverage" in expense["tags"]
+
+    def test_rule_not_applied_to_non_matching_expense(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Cafes")
+        client.post(
+            "/rules",
+            json={
+                "name": "Tag coffee purchases",
+                "conditions": [
+                    {"field": "description", "operator": "contains", "value": "coffee"}
+                ],
+                "actions": {"set_category_id": cat_id, "add_tags": ["beverage"]},
+            },
+            headers=auth_header,
+        )
+        r = client.post(
+            "/expenses",
+            json={"amount": 50.0, "description": "Grocery shopping", "date": "2026-01-10"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        expense = r.get_json()
+        assert expense["category_id"] is None
+        assert "beverage" not in expense["tags"]
+
+    def test_inactive_rule_not_applied(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Cafes")
+        r = client.post(
+            "/rules",
+            json={
+                "name": "Inactive",
+                "conditions": [
+                    {"field": "description", "operator": "contains", "value": "coffee"}
+                ],
+                "actions": {"set_category_id": cat_id},
+                "active": False,
+            },
+            headers=auth_header,
+        )
+        rule_id = r.get_json()["id"]
+        assert r.get_json()["active"] is False
+
+        r = client.post(
+            "/expenses",
+            json={"amount": 4.5, "description": "Morning Coffee", "date": "2026-01-10"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        assert r.get_json()["category_id"] is None
+
+    def test_amount_range_rule(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Small Spend")
+        client.post(
+            "/rules",
+            json={
+                "name": "Small purchases",
+                "conditions": [
+                    {"field": "amount", "operator": "between", "value": [1, 15]}
+                ],
+                "actions": {"set_category_id": cat_id, "add_tags": ["small"]},
+            },
+            headers=auth_header,
+        )
+        r = client.post(
+            "/expenses",
+            json={"amount": 8.99, "description": "Parking meter", "date": "2026-01-10"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        expense = r.get_json()
+        assert expense["category_id"] == cat_id
+        assert "small" in expense["tags"]
+
+    def test_regex_rule(self, client, auth_header):
+        client.post(
+            "/rules",
+            json={
+                "name": "Streaming services",
+                "conditions": [
+                    {"field": "description", "operator": "regex", "value": r"netflix|spotify|hulu"}
+                ],
+                "actions": {"add_tags": ["streaming"]},
+            },
+            headers=auth_header,
+        )
+        r = client.post(
+            "/expenses",
+            json={"amount": 15.99, "description": "Netflix Monthly", "date": "2026-01-10"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+        assert "streaming" in r.get_json()["tags"]
+
+
+class TestApplyAllRules:
+    def test_apply_all_uncategorised(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Dining")
+
+        # Create expenses WITHOUT a matching rule active yet
+        for desc in ("Burger King", "McDonalds", "Tech store"):
+            client.post(
+                "/expenses",
+                json={"amount": 10.0, "description": desc, "date": "2026-01-05"},
+                headers=auth_header,
+            )
+
+        # Now create a rule
+        client.post(
+            "/rules",
+            json={
+                "name": "Fast food",
+                "conditions": [
+                    {
+                        "field": "description",
+                        "operator": "regex",
+                        "value": r"burger king|mcdonalds",
+                    }
+                ],
+                "actions": {"set_category_id": cat_id, "add_tags": ["fast-food"]},
+            },
+            headers=auth_header,
+        )
+
+        r = client.post("/rules/apply-all", json={}, headers=auth_header)
+        assert r.status_code == 200
+        result = r.get_json()
+        # Only the 2 fast-food entries should be updated
+        assert result["updated"] == 2
+        assert result["skipped"] == 1  # "Tech store" stays uncategorised
+
+    def test_apply_all_force_flag(self, client, auth_header):
+        cat_id = _create_category(client, auth_header, "Misc")
+
+        # Create an expense that already has a category
+        existing_cat = _create_category(client, auth_header, "Other")
+        client.post(
+            "/expenses",
+            json={
+                "amount": 10.0,
+                "description": "Coffee shop",
+                "date": "2026-01-05",
+                "category_id": existing_cat,
+            },
+            headers=auth_header,
+        )
+
+        client.post(
+            "/rules",
+            json={
+                "name": "All coffee",
+                "conditions": [
+                    {"field": "description", "operator": "contains", "value": "coffee"}
+                ],
+                "actions": {"set_category_id": cat_id},
+            },
+            headers=auth_header,
+        )
+
+        # Without force: apply-all only targets expenses with no category.
+        # The expense above already has a category, so 0 expenses are processed.
+        r = client.post("/rules/apply-all", json={}, headers=auth_header)
+        assert r.status_code == 200
+        result = r.get_json()
+        assert result["updated"] == 0
+        assert result["skipped"] == 0  # no uncategorised expenses exist
+
+        # With force=True: the already-categorised expense is evaluated.
+        # The rule matches, but set_category_id only applies when category_id is None,
+        # so the expense is counted as skipped (no change applied).
+        r = client.post("/rules/apply-all", json={"force": True}, headers=auth_header)
+        assert r.status_code == 200
+        result = r.get_json()
+        assert "updated" in result
+        assert "skipped" in result


### PR DESCRIPTION
## Summary

Implements the rule-based auto-tagging and categorization feature requested in #107. Users can define named rules with conditions and actions that fire automatically whenever a transaction is created or updated.

- **Rule model** with conditions (field/operator/value triples) and actions (set category, add tags, set expense type), stored per-user with priority ordering
- **Rule engine service** as a pure function — testable without Flask context, supports 7 operators across 3 fields
- **Full REST API** at `/rules` with CRUD + dry-run tester + batch apply to existing transactions
- **Tag model** with many-to-many expense association, so tags are first-class entities not just strings
- **Rules management page** in the frontend with a condition builder UI, inline dry-run tester, and full CRUD
- **47 tests** (28 unit + 19 integration), all passing

## API Reference

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/rules` | List all rules for the authenticated user (sorted by priority) |
| POST | `/rules` | Create a rule |
| GET | `/rules/:id` | Get a single rule |
| PATCH | `/rules/:id` | Update a rule |
| DELETE | `/rules/:id` | Delete a rule |
| POST | `/rules/test` | Dry-run: evaluate all active rules against a sample transaction |
| POST | `/rules/apply-all` | Batch-apply rules to existing uncategorised expenses (pass `force: true` for all) |

### Condition schema

```json
{
  "field": "description | amount | expense_type",
  "operator": "contains | not_contains | regex | equals | gt | lt | between",
  "value": "<string, number, or [min, max] for between>"
}
```

All conditions in a rule use AND semantics — all must match for the rule to fire.

### Action schema

```json
{
  "set_category_id": 5,
  "add_tags": ["food", "dining"],
  "set_expense_type": "INCOME"
}
```

At least one action key is required. For categories, the first matching rule wins. Tags accumulate across all matching rules (deduplicated). `set_expense_type` also uses first-match-wins.

### Example: create a rule

```bash
curl -X POST /rules \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Tag streaming services",
    "priority": 10,
    "conditions": [
      {"field": "description", "operator": "regex", "value": "netflix|spotify|hulu|disney"}
    ],
    "actions": {"add_tags": ["streaming", "subscription"]}
  }'
```

### Example: dry-run

```bash
curl -X POST /rules/test \
  -H "Authorization: Bearer <token>" \
  -d '{"transaction": {"description": "Netflix Monthly", "amount": 15.99}}'
# → {"matched_rule_ids": [3], "changes": {"set_category_id": null, "add_tags": ["streaming","subscription"], "set_expense_type": null}}
```

## Test plan

- [ ] `cd packages/backend && pytest tests/test_rules.py -v` — 47 tests should pass
- [ ] Start the full stack with `docker-compose up` and navigate to `/rules`
- [ ] Create a rule matching "coffee" in description, set a category and add tag "caffeine"
- [ ] Create an expense with description "Starbucks Coffee" — verify it gets the category and tag automatically
- [ ] Use the dry-run tester on the Rules page to preview matches without saving
- [ ] Click "Apply to existing" to backfill rules onto uncategorised expenses
- [ ] Create a rule with `amount between [1, 15]` and verify amount-based matching works
- [ ] Create a rule with a regex pattern and verify it matches correctly
- [ ] Toggle a rule inactive and verify it no longer fires on new expenses

## Implementation notes

- Conditions/actions stored as JSON text columns for SQLite + PostgreSQL compatibility
- The rule engine (`services/rule_engine.py`) has zero Flask dependencies — it takes plain dicts in, returns a plain dict out
- Existing expenses gain a `tags` array field in all API responses (empty array by default, no breaking change)
- The `expense_tags` join table and `tags` table are created via `db.create_all()` in tests and via the existing `init-db` CLI command for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)