### PR TITLE
feat: smart weekly financial digest with AI insights

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import { Dashboard } from "./pages/Dashboard";
 import { Budgets } from "./pages/Budgets";
 import { Bills } from "./pages/Bills";
 import { Analytics } from "./pages/Analytics";
+import { Digest } from "./pages/Digest";
 import Reminders from "./pages/Reminders";
 import Expenses from "./pages/Expenses";
 import { SignIn } from "./pages/SignIn";
@@ -72,6 +73,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Analytics />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="digest"
+              element={
+                <ProtectedRoute>
+                  <Digest />
                 </ProtectedRoute>
               }
             />

--- a/app/src/__tests__/Digest.integration.test.tsx
+++ b/app/src/__tests__/Digest.integration.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Digest } from '@/pages/Digest';
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: React.PropsWithChildren & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+jest.mock('@/components/ui/input', () => ({
+  Input: ({ ...props }: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+jest.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: React.PropsWithChildren & React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+jest.mock('@/components/ui/financial-card', () => ({
+  FinancialCard: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardHeader: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardTitle: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+  FinancialCardDescription: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+const toastMock = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+const getWeeklyDigestMock = jest.fn();
+jest.mock('@/api/digest', () => ({
+  getWeeklyDigest: (...args: unknown[]) => getWeeklyDigestMock(...args),
+}));
+
+describe('Digest integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getWeeklyDigestMock.mockResolvedValue({
+      week: '2026-W15',
+      total_income: 5000,
+      total_expenses: 3200,
+      net_flow: 1800,
+      tips: ['Cut coffee spending by 15%.', 'Set a mid-week checkpoint.'],
+      analytics: {
+        week_over_week_change_pct: -8.5,
+        current_week_expenses: 3200,
+        previous_week_expenses: 3496.5,
+        top_categories: [{ category_id: 'food', amount: 1200 }],
+      },
+      persona: 'Balanced coach',
+      method: 'heuristic',
+      warnings: [],
+    });
+  });
+
+  it('loads and renders weekly digest data', async () => {
+    render(<Digest />);
+    await waitFor(() => expect(getWeeklyDigestMock).toHaveBeenCalled());
+    expect(screen.getByText(/weekly digest/i)).toBeInTheDocument();
+    expect(screen.getByText(/total income/i)).toBeInTheDocument();
+    expect(screen.getByText(/total expenses/i)).toBeInTheDocument();
+    expect(screen.getByText(/net flow/i)).toBeInTheDocument();
+    expect(screen.getByText(/cut coffee spending/i)).toBeInTheDocument();
+  });
+
+  it('calls API with week/persona/key when Load Digest is clicked', async () => {
+    render(<Digest />);
+    await waitFor(() => expect(getWeeklyDigestMock).toHaveBeenCalledTimes(1));
+
+    await userEvent.clear(screen.getByLabelText(/digest week/i));
+    await userEvent.type(screen.getByLabelText(/digest week/i), '2026-W10');
+    await userEvent.selectOptions(screen.getByLabelText(/digest persona/i), 'Debt-focused planner');
+    await userEvent.type(screen.getByLabelText(/gemini api key/i), 'test-key');
+    await userEvent.click(screen.getByRole('button', { name: /load digest/i }));
+
+    await waitFor(() =>
+      expect(getWeeklyDigestMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          week: '2026-W10',
+          persona: 'Debt-focused planner',
+          geminiApiKey: 'test-key',
+        }),
+      ),
+    );
+  });
+
+  it('displays error message on API failure', async () => {
+    getWeeklyDigestMock.mockRejectedValueOnce(new Error('Network error'));
+    render(<Digest />);
+    await waitFor(() => expect(screen.getByText(/network error/i)).toBeInTheDocument());
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Failed to load digest' }),
+    );
+  });
+});

--- a/app/src/api/digest.ts
+++ b/app/src/api/digest.ts
@@ -1,0 +1,31 @@
+import { api } from './client';
+
+export type WeeklyDigest = {
+  week: string;
+  total_income: number;
+  total_expenses: number;
+  net_flow: number;
+  tips?: string[];
+  summary?: string;
+  analytics: {
+    week_over_week_change_pct: number;
+    current_week_expenses: number;
+    previous_week_expenses: number;
+    top_categories: Array<{ category_id: string; amount: number }>;
+  };
+  persona?: string;
+  method: 'gemini' | 'heuristic' | string;
+  warnings?: string[];
+};
+
+export async function getWeeklyDigest(params?: {
+  week?: string;
+  geminiApiKey?: string;
+  persona?: string;
+}): Promise<WeeklyDigest> {
+  const weekQuery = params?.week ? `?week=${encodeURIComponent(params.week)}` : '';
+  const headers: Record<string, string> = {};
+  if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
+  if (params?.persona) headers['X-Insight-Persona'] = params.persona;
+  return api<WeeklyDigest>(`/digest/weekly${weekQuery}`, { headers });
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -13,6 +13,7 @@ const navigation = [
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
+  { name: 'Digest', href: '/digest' },
 ];
 
 export function Navbar() {

--- a/app/src/pages/Digest.tsx
+++ b/app/src/pages/Digest.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardDescription,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { useToast } from '@/hooks/use-toast';
+import { getWeeklyDigest, type WeeklyDigest } from '@/api/digest';
+import { formatMoney } from '@/lib/currency';
+
+function currentISOWeek(): string {
+  const now = new Date();
+  const jan4 = new Date(now.getFullYear(), 0, 4);
+  const dayOfYear = Math.ceil(
+    (now.getTime() - new Date(now.getFullYear(), 0, 1).getTime()) / 86400000 + 1,
+  );
+  const dayOfWeek = now.getDay() || 7;
+  const weekNum = Math.ceil((dayOfYear - dayOfWeek + 10) / 7);
+  const year = weekNum === 1 && now.getMonth() === 11 ? now.getFullYear() + 1 : now.getFullYear();
+  return `${year}-W${String(weekNum).padStart(2, '0')}`;
+}
+
+const PERSONAS = ['Balanced coach', 'Conservative saver', 'Debt-focused planner'];
+
+export function Digest() {
+  const { toast } = useToast();
+  const [week, setWeek] = useState(currentISOWeek);
+  const [persona, setPersona] = useState(PERSONAS[0]);
+  const [geminiKey, setGeminiKey] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<WeeklyDigest | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await getWeeklyDigest({
+        week,
+        persona,
+        geminiApiKey: geminiKey.trim() || undefined,
+      });
+      setData(payload);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to load digest';
+      setError(message);
+      toast({ title: 'Failed to load digest', description: message });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const wowPct = data?.analytics?.week_over_week_change_pct ?? 0;
+  const wowLabel = wowPct > 0 ? `+${wowPct.toFixed(2)}%` : `${wowPct.toFixed(2)}%`;
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header">
+        <div className="relative flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div>
+            <h1 className="page-title">Weekly Digest</h1>
+            <p className="page-subtitle">
+              Smart weekly financial summary with AI-powered tips.
+            </p>
+          </div>
+          <div className="grid gap-2 md:grid-cols-4">
+            <div>
+              <Label htmlFor="digest-week">Week</Label>
+              <Input
+                id="digest-week"
+                aria-label="digest week"
+                type="text"
+                placeholder="YYYY-Wnn"
+                value={week}
+                onChange={(e) => setWeek(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="digest-persona">Persona</Label>
+              <select
+                id="digest-persona"
+                aria-label="digest persona"
+                className="input"
+                value={persona}
+                onChange={(e) => setPersona(e.target.value)}
+              >
+                {PERSONAS.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="md:col-span-2">
+              <Label htmlFor="digest-key">Gemini API Key (optional BYOK)</Label>
+              <Input
+                id="digest-key"
+                aria-label="gemini api key"
+                type="password"
+                value={geminiKey}
+                onChange={(e) => setGeminiKey(e.target.value)}
+                placeholder="AIza..."
+              />
+            </div>
+          </div>
+          <Button onClick={load} disabled={loading}>
+            Load Digest
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="card">Loading digest...</div>
+      ) : error ? (
+        <div className="card text-red-600">{error}</div>
+      ) : data ? (
+        <div className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-4">
+            <FinancialCard variant="financial">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm">Total Income</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>{formatMoney(data.total_income)}</FinancialCardContent>
+            </FinancialCard>
+            <FinancialCard variant="financial">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm">Total Expenses</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>{formatMoney(data.total_expenses)}</FinancialCardContent>
+            </FinancialCard>
+            <FinancialCard variant="financial">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm">Net Flow</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <span className={data.net_flow >= 0 ? 'text-green-600' : 'text-red-600'}>
+                  {formatMoney(data.net_flow)}
+                </span>
+              </FinancialCardContent>
+            </FinancialCard>
+            <FinancialCard variant="financial">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm">Week-over-Week</FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <span className={wowPct <= 0 ? 'text-green-600' : 'text-red-600'}>
+                  {wowLabel}
+                </span>
+              </FinancialCardContent>
+            </FinancialCard>
+          </div>
+
+          {data.analytics.top_categories.length > 0 && (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Top Categories</FinancialCardTitle>
+                <FinancialCardDescription>Highest spending categories this week</FinancialCardDescription>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid gap-3 md:grid-cols-3">
+                  {data.analytics.top_categories.map((cat) => (
+                    <div key={cat.category_id} className="rounded-lg border p-3">
+                      <div className="text-sm text-muted-foreground">
+                        Category {cat.category_id}
+                      </div>
+                      <div className="font-semibold">{formatMoney(cat.amount)}</div>
+                    </div>
+                  ))}
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+
+          <FinancialCard variant="financial">
+            <FinancialCardHeader>
+              <FinancialCardTitle>Tips &amp; Insights</FinancialCardTitle>
+              <FinancialCardDescription>{data.persona}</FinancialCardDescription>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              {data.summary && (
+                <p className="mb-3 text-sm">{data.summary}</p>
+              )}
+              {data.tips?.length ? (
+                <ul className="list-disc pl-5 space-y-1">
+                  {data.tips.map((tip) => (
+                    <li key={tip}>{tip}</li>
+                  ))}
+                </ul>
+              ) : (
+                <div className="text-sm text-muted-foreground">
+                  No tips available for this week.
+                </div>
+              )}
+              {data.warnings?.length ? (
+                <div className="mt-3 text-sm text-amber-700">
+                  Warning: {data.warnings.join(', ')}
+                </div>
+              ) : null}
+            </FinancialCardContent>
+          </FinancialCard>
+
+          <div className="text-xs text-muted-foreground text-right">
+            Method: {data.method} &middot; Week: {data.week}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,54 @@
+import logging
+import re
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.ai import weekly_digest
+from ..services.cache import cache_get, cache_set
+
+bp = Blueprint("digest", __name__)
+logger = logging.getLogger("finmind.digest")
+
+_ISO_WEEK_RE = re.compile(r"^(\d{4})-W(\d{2})$")
+
+
+def _current_iso_week() -> str:
+    today = date.today()
+    year, week, _ = today.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+@bp.get("/weekly")
+@jwt_required()
+def weekly():
+    uid = int(get_jwt_identity())
+    raw = (request.args.get("week") or _current_iso_week()).strip()
+    m = _ISO_WEEK_RE.match(raw)
+    if not m:
+        return jsonify({"error": "Invalid week format. Expected YYYY-Wnn."}), 400
+    year, week_num = int(m.group(1)), int(m.group(2))
+    if week_num < 1 or week_num > 53:
+        return jsonify({"error": "Week number must be between 01 and 53."}), 400
+
+    cache_key = f"user:{uid}:digest_weekly:{year}-W{week_num:02d}"
+    cached = cache_get(cache_key)
+    if cached:
+        logger.info("Weekly digest cache hit user=%s week=%s-W%02d", uid, year, week_num)
+        return jsonify(cached)
+
+    user_gemini_key = (request.headers.get("X-Gemini-Api-Key") or "").strip() or None
+    persona = (request.headers.get("X-Insight-Persona") or "").strip() or None
+
+    result = weekly_digest(
+        uid,
+        year,
+        week_num,
+        gemini_api_key=user_gemini_key,
+        persona=persona,
+    )
+
+    cache_set(cache_key, result, ttl_seconds=3600)
+    logger.info("Weekly digest served user=%s week=%s-W%02d", uid, year, week_num)
+    return jsonify(result)

--- a/packages/backend/app/services/ai.py
+++ b/packages/backend/app/services/ai.py
@@ -185,3 +185,196 @@ def monthly_budget_suggestion(
                 uid, ym, persona_text, warnings=["gemini_unavailable"]
             )
     return _heuristic_budget(uid, ym, persona_text)
+
+
+# ---------------------------------------------------------------------------
+# Weekly digest helpers
+# ---------------------------------------------------------------------------
+
+
+def _weekly_totals(uid: int, year: int, week: int) -> tuple[float, float]:
+    """Get income and expense totals for an ISO week."""
+    from datetime import date as _date
+
+    monday = _date.fromisocalendar(year, week, 1)
+    sunday = _date.fromisocalendar(year, week, 7)
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= monday,
+            Expense.spent_at <= sunday,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= monday,
+            Expense.spent_at <= sunday,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+    return float(income or 0), float(expenses or 0)
+
+
+def _weekly_category_spend(uid: int, year: int, week: int) -> dict[str, float]:
+    """Category breakdown for a week."""
+    from datetime import date as _date
+
+    monday = _date.fromisocalendar(year, week, 1)
+    sunday = _date.fromisocalendar(year, week, 7)
+    rows = (
+        db.session.query(
+            Expense.category_id, func.coalesce(func.sum(Expense.amount), 0)
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= monday,
+            Expense.spent_at <= sunday,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+    return {str(k or "uncat"): float(v) for k, v in rows}
+
+
+def _build_weekly_analytics(uid: int, year: int, week: int) -> dict:
+    """Weekly analytics with week-over-week comparison."""
+    _, current_expenses = _weekly_totals(uid, year, week)
+
+    # Previous week
+    from datetime import date as _date, timedelta
+
+    prev_monday = _date.fromisocalendar(year, week, 1) - timedelta(weeks=1)
+    prev_year, prev_week, _ = prev_monday.isocalendar()
+    _, prev_expenses = _weekly_totals(uid, prev_year, prev_week)
+
+    if prev_expenses > 0:
+        wow = round(((current_expenses - prev_expenses) / prev_expenses) * 100, 2)
+    else:
+        wow = 0.0
+
+    cats = _weekly_category_spend(uid, year, week)
+    top = sorted(cats.items(), key=lambda x: x[1], reverse=True)[:3]
+    return {
+        "week_over_week_change_pct": wow,
+        "current_week_expenses": round(current_expenses, 2),
+        "previous_week_expenses": round(prev_expenses, 2),
+        "top_categories": [
+            {"category_id": k, "amount": round(v, 2)} for k, v in top
+        ],
+    }
+
+
+def _heuristic_weekly_digest(
+    uid: int,
+    year: int,
+    week: int,
+    persona: str,
+    warnings: list[str] | None = None,
+) -> dict:
+    """Heuristic weekly digest without AI."""
+    income, expenses = _weekly_totals(uid, year, week)
+    net = round(income - expenses, 2)
+    analytics = _build_weekly_analytics(uid, year, week)
+    payload = {
+        "week": f"{year}-W{week:02d}",
+        "total_income": round(income, 2),
+        "total_expenses": round(expenses, 2),
+        "net_flow": net,
+        "tips": [
+            "Review your top spending category and look for savings.",
+            "Set a mid-week spending checkpoint to stay on track.",
+        ],
+        "analytics": analytics,
+        "persona": persona,
+        "method": "heuristic",
+    }
+    if warnings:
+        payload["warnings"] = warnings
+    return payload
+
+
+def _gemini_weekly_digest(
+    uid: int,
+    year: int,
+    week: int,
+    api_key: str,
+    model: str,
+    persona: str,
+) -> dict:
+    """AI-powered weekly digest via Gemini."""
+    categories = _weekly_category_spend(uid, year, week)
+    analytics = _build_weekly_analytics(uid, year, week)
+    income, expenses = _weekly_totals(uid, year, week)
+    prompt = (
+        f"{persona}\n"
+        "Use this week data and return strict JSON only with keys: "
+        "tips(list <=3), summary(string).\n"
+        f"week={year}-W{week:02d}\n"
+        f"income={income}\n"
+        f"expenses={expenses}\n"
+        f"category_spend={categories}\n"
+        f"analytics={analytics}"
+    )
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent?key={api_key}"
+    )
+    body = json.dumps(
+        {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {"temperature": 0.2},
+        }
+    ).encode("utf-8")
+    req = request.Request(
+        url=url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=10) as resp:  # nosec B310
+        payload = json.loads(resp.read().decode("utf-8"))
+    text = (
+        payload.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])[0]
+        .get("text", "")
+    )
+    parsed = _extract_json_object(text)
+    parsed["week"] = f"{year}-W{week:02d}"
+    parsed["total_income"] = round(income, 2)
+    parsed["total_expenses"] = round(expenses, 2)
+    parsed["net_flow"] = round(income - expenses, 2)
+    parsed["analytics"] = analytics
+    parsed["persona"] = persona
+    parsed["method"] = "gemini"
+    return parsed
+
+
+def weekly_digest(
+    uid: int,
+    year: int,
+    week: int,
+    gemini_api_key: str | None = None,
+    gemini_model: str | None = None,
+    persona: str | None = None,
+) -> dict:
+    """Main entry point - try Gemini, fallback to heuristic."""
+    key = (gemini_api_key or "").strip() or (_settings.gemini_api_key or "")
+    model = gemini_model or _settings.gemini_model
+    persona_text = (persona or DEFAULT_PERSONA).strip()
+
+    if key:
+        try:
+            return _gemini_weekly_digest(uid, year, week, key, model, persona_text)
+        except Exception:
+            return _heuristic_weekly_digest(
+                uid, year, week, persona_text, warnings=["gemini_unavailable"]
+            )
+    return _heuristic_weekly_digest(uid, year, week, persona_text)

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,114 @@
+from datetime import date, timedelta
+
+
+def _iso_week_str(d):
+    year, week, _ = d.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def test_weekly_digest_returns_expected_fields(client, auth_header):
+    today = date.today()
+    week_str = _iso_week_str(today)
+
+    # Add an expense in the current week
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 75,
+            "description": "Weekly test spend",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get(f"/digest/weekly?week={week_str}", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["week"] == week_str
+    assert "total_income" in payload
+    assert "total_expenses" in payload
+    assert "net_flow" in payload
+    assert "analytics" in payload
+    assert "week_over_week_change_pct" in payload["analytics"]
+    assert "tips" in payload
+    assert payload["method"] == "heuristic"
+
+
+def test_weekly_digest_defaults_to_current_week(client, auth_header):
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    expected = _iso_week_str(date.today())
+    assert payload["week"] == expected
+
+
+def test_weekly_digest_rejects_invalid_week_format(client, auth_header):
+    r = client.get("/digest/weekly?week=2026-13", headers=auth_header)
+    assert r.status_code == 400
+
+    r = client.get("/digest/weekly?week=not-a-week", headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_weekly_digest_requires_auth(client):
+    r = client.get("/digest/weekly")
+    assert r.status_code == 401
+
+
+def test_weekly_digest_gemini_fallback(client, auth_header, monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("gemini down")
+
+    monkeypatch.setattr("app.services.ai._gemini_weekly_digest", _boom)
+
+    r = client.get(
+        "/digest/weekly",
+        headers={
+            **auth_header,
+            "X-Gemini-Api-Key": "user-key",
+        },
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["method"] == "heuristic"
+    assert "warnings" in payload
+    assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_weekly_digest_week_over_week(client, auth_header):
+    today = date.today()
+    last_week = today - timedelta(weeks=1)
+
+    # Expense this week
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "This week",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Expense last week
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 100,
+            "description": "Last week",
+            "date": last_week.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    week_str = _iso_week_str(today)
+    r = client.get(f"/digest/weekly?week={week_str}", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["analytics"]["week_over_week_change_pct"] != 0


### PR DESCRIPTION
## Summary

Implements **Smart weekly financial digest** (#121) — AI-powered weekly spending summary with trends and actionable tips.

### What's included

**Backend (Flask)**
- `GET /digest/weekly?week=YYYY-Wnn` — returns weekly income/expense totals, net flow, category breakdown, week-over-week comparison, and AI-generated tips
- Gemini AI narrative with automatic heuristic fallback when API unavailable
- Redis caching (3600s TTL) for repeat requests
- ISO week validation, JWT auth, persona support via headers

**Frontend (React + TypeScript)**
- New `/digest` page with week picker, persona selector, and optional BYOK Gemini key
- 4 metric cards (Total Income, Total Expenses, Net Flow, Week-over-Week %)
- Top spending categories and actionable tips section
- Error handling with toast notifications

**Tests**
- 6 backend pytest tests (normal response, default week, invalid format 400, no auth 401, Gemini fallback, week-over-week comparison)
- 3 frontend Jest integration tests (render, controls pass-through, error display)

### Files changed
- 5 new files, 4 modified files, 720 insertions
- No existing code modified in `ai.py` — only new functions appended

### How to test
```bash
# Backend
cd packages/backend && python -m pytest tests/test_digest.py -v

# Frontend
cd app && npx jest src/__tests__/Digest.integration.test.tsx
```

### Demo
Weekly digest page accessible at `/digest` after login. Defaults to current ISO week, supports week navigation and multiple coach personas.

/claim #121
Closes #121