### PR TITLE
feat: add PII export and delete workflow (GDPR-ready)

### DIFF
--- a/app/src/api/privacy.ts
+++ b/app/src/api/privacy.ts
@@ -1,0 +1,39 @@
+import { api } from './client';
+
+export type ExportSummary = {
+  profile: number;
+  expenses: number;
+  categories: number;
+  bills: number;
+  reminders: number;
+  recurring_expenses: number;
+};
+
+export type ExportResult = {
+  json_data: string;
+  csv_data: string;
+  summary: ExportSummary;
+};
+
+export type DeleteResult = {
+  message: string;
+  deleted: Record<string, number>;
+};
+
+export type AuditEntry = {
+  id: number;
+  action: string;
+  created_at: string;
+};
+
+export async function exportData(): Promise<ExportResult> {
+  return api<ExportResult>('/privacy/export');
+}
+
+export async function deleteAllData(): Promise<DeleteResult> {
+  return api<DeleteResult>('/privacy/delete', { method: 'POST', body: { confirm: true } });
+}
+
+export async function getAuditLog(): Promise<AuditEntry[]> {
+  return api<AuditEntry[]>('/privacy/audit-log');
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .privacy import bp as privacy_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(privacy_bp, url_prefix="/privacy")

--- a/packages/backend/app/routes/privacy.py
+++ b/packages/backend/app/routes/privacy.py
@@ -1,0 +1,55 @@
+"""PII export & deletion endpoints (GDPR-ready)."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.privacy import delete_user_data, export_user_data, get_audit_log
+import logging
+
+bp = Blueprint("privacy", __name__)
+logger = logging.getLogger("finmind.privacy")
+
+
+@bp.get("/export")
+@jwt_required()
+def export_data():
+    """Export all PII for the authenticated user as JSON + CSV."""
+    uid = int(get_jwt_identity())
+    try:
+        result = export_user_data(uid)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 404
+    logger.info("PII export requested user=%s", uid)
+    return jsonify(
+        json_data=result["json_export"],
+        csv_data=result["csv_export"],
+        summary=result["summary"],
+    )
+
+
+@bp.post("/delete")
+@jwt_required()
+def delete_data():
+    """Permanently delete all data for the authenticated user.
+
+    Requires ``{"confirm": true}`` in the request body.
+    """
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    if not data.get("confirm"):
+        return jsonify(error="confirmation required: send {\"confirm\": true}"), 400
+    try:
+        counts = delete_user_data(uid)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 404
+    logger.info("PII deletion completed user=%s counts=%s", uid, counts)
+    return jsonify(message="all data permanently deleted", deleted=counts)
+
+
+@bp.get("/audit-log")
+@jwt_required()
+def audit_log():
+    """Return privacy-related audit log entries."""
+    uid = int(get_jwt_identity())
+    entries = get_audit_log(uid)
+    return jsonify(entries)

--- a/packages/backend/app/services/privacy.py
+++ b/packages/backend/app/services/privacy.py
@@ -1,0 +1,196 @@
+"""PII export & deletion service (GDPR-ready)."""
+
+import csv
+import io
+import json
+from datetime import datetime
+
+from ..extensions import db
+from ..models import (
+    AuditLog,
+    Bill,
+    Category,
+    Expense,
+    RecurringExpense,
+    Reminder,
+    User,
+    UserSubscription,
+)
+
+
+def export_user_data(user_id: int) -> dict:
+    """Collect all PII for *user_id* into an export package.
+
+    Returns a dict with ``json_export`` (str) and ``csv_export`` (str).
+    """
+    user = db.session.get(User, user_id)
+    if not user:
+        raise ValueError("user not found")
+
+    profile = {
+        "id": user.id,
+        "email": user.email,
+        "preferred_currency": user.preferred_currency,
+        "role": user.role,
+        "created_at": user.created_at.isoformat(),
+    }
+
+    expenses = [
+        {
+            "id": e.id,
+            "amount": float(e.amount),
+            "currency": e.currency,
+            "category_id": e.category_id,
+            "expense_type": e.expense_type,
+            "notes": e.notes,
+            "spent_at": e.spent_at.isoformat(),
+        }
+        for e in db.session.query(Expense).filter_by(user_id=user_id).all()
+    ]
+
+    categories = [
+        {"id": c.id, "name": c.name}
+        for c in db.session.query(Category).filter_by(user_id=user_id).all()
+    ]
+
+    bills = [
+        {
+            "id": b.id,
+            "name": b.name,
+            "amount": float(b.amount),
+            "currency": b.currency,
+            "next_due_date": b.next_due_date.isoformat(),
+            "cadence": b.cadence.value if b.cadence else None,
+        }
+        for b in db.session.query(Bill).filter_by(user_id=user_id).all()
+    ]
+
+    reminders = [
+        {
+            "id": r.id,
+            "message": r.message,
+            "send_at": r.send_at.isoformat(),
+            "sent": r.sent,
+            "channel": r.channel,
+        }
+        for r in db.session.query(Reminder).filter_by(user_id=user_id).all()
+    ]
+
+    recurring = [
+        {
+            "id": r.id,
+            "amount": float(r.amount),
+            "notes": r.notes,
+            "cadence": r.cadence.value if r.cadence else None,
+            "start_date": r.start_date.isoformat(),
+        }
+        for r in db.session.query(RecurringExpense).filter_by(user_id=user_id).all()
+    ]
+
+    package = {
+        "export_date": datetime.utcnow().isoformat(),
+        "user_id": user_id,
+        "profile": profile,
+        "expenses": expenses,
+        "categories": categories,
+        "bills": bills,
+        "reminders": reminders,
+        "recurring_expenses": recurring,
+    }
+
+    json_export = json.dumps(package, indent=2, default=str)
+
+    # CSV export of expenses (most common data export request)
+    csv_buffer = io.StringIO()
+    writer = csv.DictWriter(
+        csv_buffer,
+        fieldnames=["id", "amount", "currency", "category_id", "expense_type", "notes", "spent_at"],
+    )
+    writer.writeheader()
+    for e in expenses:
+        writer.writerow(e)
+    csv_export = csv_buffer.getvalue()
+
+    _log_audit(user_id, "pii_export")
+
+    return {
+        "json_export": json_export,
+        "csv_export": csv_export,
+        "summary": {
+            "profile": 1,
+            "expenses": len(expenses),
+            "categories": len(categories),
+            "bills": len(bills),
+            "reminders": len(reminders),
+            "recurring_expenses": len(recurring),
+        },
+    }
+
+
+def delete_user_data(user_id: int) -> dict:
+    """Permanently delete all user data (irreversible).
+
+    Preserves a minimal audit log entry for compliance.
+    Returns counts of deleted records.
+    """
+    user = db.session.get(User, user_id)
+    if not user:
+        raise ValueError("user not found")
+
+    counts = {}
+
+    # Delete in dependency order (children first)
+    counts["reminders"] = (
+        db.session.query(Reminder).filter_by(user_id=user_id).delete()
+    )
+    counts["recurring_expenses"] = (
+        db.session.query(RecurringExpense).filter_by(user_id=user_id).delete()
+    )
+    counts["expenses"] = (
+        db.session.query(Expense).filter_by(user_id=user_id).delete()
+    )
+    counts["bills"] = (
+        db.session.query(Bill).filter_by(user_id=user_id).delete()
+    )
+    counts["categories"] = (
+        db.session.query(Category).filter_by(user_id=user_id).delete()
+    )
+    counts["subscriptions"] = (
+        db.session.query(UserSubscription).filter_by(user_id=user_id).delete()
+    )
+
+    # Log deletion BEFORE removing user (audit log references user_id)
+    _log_audit(user_id, "pii_deletion_complete")
+
+    # Delete the user account itself
+    db.session.delete(user)
+    counts["user"] = 1
+
+    db.session.commit()
+
+    return counts
+
+
+def get_audit_log(user_id: int) -> list:
+    """Return privacy-related audit log entries for *user_id*."""
+    entries = (
+        db.session.query(AuditLog)
+        .filter_by(user_id=user_id)
+        .filter(AuditLog.action.in_(["pii_export", "pii_deletion_requested", "pii_deletion_complete"]))
+        .order_by(AuditLog.created_at.desc())
+        .all()
+    )
+    return [
+        {
+            "id": e.id,
+            "action": e.action,
+            "created_at": e.created_at.isoformat(),
+        }
+        for e in entries
+    ]
+
+
+def _log_audit(user_id: int, action: str) -> None:
+    entry = AuditLog(user_id=user_id, action=action)
+    db.session.add(entry)
+    db.session.flush()

--- a/packages/backend/tests/test_privacy.py
+++ b/packages/backend/tests/test_privacy.py
@@ -1,0 +1,97 @@
+"""Tests for PII export & deletion endpoints."""
+
+import json
+
+
+def _seed_expense(client, auth_header, amount=50, desc="Test expense"):
+    r = client.post("/expenses", json={"amount": amount, "description": desc, "expense_type": "EXPENSE"}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def _seed_category(client, auth_header, name="TestCat"):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+# 1. Auth required for export
+def test_export_requires_auth(client):
+    r = client.get("/privacy/export")
+    assert r.status_code in (401, 422)
+
+
+# 2. Auth required for delete
+def test_delete_requires_auth(client):
+    r = client.post("/privacy/delete", json={"confirm": True})
+    assert r.status_code in (401, 422)
+
+
+# 3. Export returns user data
+def test_export_returns_data(client, auth_header):
+    _seed_expense(client, auth_header, 100, "Groceries")
+    _seed_category(client, auth_header, "Food")
+
+    r = client.get("/privacy/export", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "json_data" in data
+    assert "csv_data" in data
+    assert "summary" in data
+    assert data["summary"]["expenses"] >= 1
+    assert data["summary"]["categories"] >= 1
+    assert data["summary"]["profile"] == 1
+
+    parsed = json.loads(data["json_data"])
+    assert parsed["profile"]["email"] == "test@example.com"
+    assert len(parsed["expenses"]) >= 1
+
+
+# 4. Export CSV contains expenses
+def test_export_csv_format(client, auth_header):
+    _seed_expense(client, auth_header, 75, "Coffee")
+    r = client.get("/privacy/export", headers=auth_header)
+    assert r.status_code == 200
+    csv_data = r.get_json()["csv_data"]
+    assert "amount" in csv_data
+    assert "75" in csv_data
+
+
+# 5. Delete requires confirmation
+def test_delete_requires_confirmation(client, auth_header):
+    r = client.post("/privacy/delete", json={}, headers=auth_header)
+    assert r.status_code == 400
+    assert "confirm" in r.get_json()["error"].lower()
+
+
+# 6. Delete removes all data
+def test_delete_removes_all_data(client, auth_header):
+    _seed_expense(client, auth_header, 200, "Dinner")
+    _seed_category(client, auth_header, "Dining")
+
+    r = client.post("/privacy/delete", json={"confirm": True}, headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["message"] == "all data permanently deleted"
+    assert "deleted" in data
+    assert data["deleted"]["user"] == 1
+    assert data["deleted"]["expenses"] >= 1
+
+
+# 7. Audit log tracks export
+def test_audit_log_tracks_export(client, auth_header):
+    client.get("/privacy/export", headers=auth_header)
+    r = client.get("/privacy/audit-log", headers=auth_header)
+    assert r.status_code == 200
+    entries = r.get_json()
+    actions = [e["action"] for e in entries]
+    assert "pii_export" in actions
+
+
+# 8. Empty export for fresh user
+def test_empty_export(client, auth_header):
+    r = client.get("/privacy/export", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["summary"]["expenses"] == 0
+    assert data["summary"]["bills"] == 0


### PR DESCRIPTION
## Summary
/claim #76

## What this PR does
- Export: GET /privacy/export collects all user PII into JSON + CSV
- Delete: POST /privacy/delete with confirmation, cascading deletion
- Audit trail: GET /privacy/audit-log tracks events
- 8 test cases

Fixes #76