### PR TITLE
feat: Background job retry & monitoring system

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
+- Admin Jobs (requires ADMIN role):
+  - `GET /admin/jobs` — list jobs with pagination (`?page=1&per_page=20&status=pending&job_type=send_reminder`)
+  - `GET /admin/jobs/<id>` — job detail with full execution history
+  - `POST /admin/jobs/<id>/retry` — manually retry a permanently failed job
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
 
 ## MVP UI/UX Plan
@@ -179,8 +183,15 @@ finmind/
 ## Contribution Policy
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.
 
+## Background Job Framework
+- All async work (reminder delivery, etc.) is wrapped in the `BackgroundJob` model with automatic retry and exponential backoff (5s, 25s, 125s).
+- Each execution attempt is logged in `job_execution_logs` with timestamps and error tracebacks for full observability.
+- New job types are added by decorating a handler with `@register_handler("job_type")` in `services/`.
+- Admin endpoints (`/admin/jobs`) provide monitoring, filtering, and manual retry for failed jobs.
+
 ## Notes on Free-Tier Reminders
 - Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
+- Reminder sends are wrapped in the background job framework (`send_reminder` job type) with automatic retry on delivery failure.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).
 
 ## Security & Scalability

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -49,6 +49,9 @@ def create_app(settings: Settings | None = None) -> Flask:
     CORS(app, resources={r"*": {"origins": "*"}}, supports_credentials=True)
 
     # Redis (already global)
+    # Register background job handlers (import triggers @register_handler)
+    from .services import reminder_jobs  # noqa: F401
+
     # Blueprint routes
     register_routes(app)
 

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,30 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS background_jobs (
+  id SERIAL PRIMARY KEY,
+  job_type VARCHAR(100) NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  payload JSON,
+  result JSON,
+  retry_count INT NOT NULL DEFAULT 0,
+  max_retries INT NOT NULL DEFAULT 3,
+  last_error TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  next_retry_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_background_jobs_status ON background_jobs(status, next_retry_at);
+CREATE INDEX IF NOT EXISTS idx_background_jobs_type ON background_jobs(job_type);
+
+CREATE TABLE IF NOT EXISTS job_execution_logs (
+  id SERIAL PRIMARY KEY,
+  job_id INT NOT NULL REFERENCES background_jobs(id) ON DELETE CASCADE,
+  attempt INT NOT NULL,
+  status VARCHAR(20) NOT NULL,
+  error TEXT,
+  started_at TIMESTAMP NOT NULL,
+  finished_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_job_execution_logs_job ON job_execution_logs(job_id, attempt);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -100,6 +100,75 @@ class Reminder(db.Model):
     channel = db.Column(db.String(20), default="email", nullable=False)
 
 
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class BackgroundJob(db.Model):
+    __tablename__ = "background_jobs"
+    id = db.Column(db.Integer, primary_key=True)
+    job_type = db.Column(db.String(100), nullable=False)
+    status = db.Column(
+        db.String(20), default=JobStatus.PENDING.value, nullable=False
+    )
+    payload = db.Column(db.JSON, nullable=True)
+    result = db.Column(db.JSON, nullable=True)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    max_retries = db.Column(db.Integer, default=3, nullable=False)
+    last_error = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "job_type": self.job_type,
+            "status": self.status,
+            "payload": self.payload,
+            "result": self.result,
+            "retry_count": self.retry_count,
+            "max_retries": self.max_retries,
+            "last_error": self.last_error,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "next_retry_at": (
+                self.next_retry_at.isoformat() if self.next_retry_at else None
+            ),
+        }
+
+
+class JobExecutionLog(db.Model):
+    __tablename__ = "job_execution_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    job_id = db.Column(
+        db.Integer, db.ForeignKey("background_jobs.id"), nullable=False
+    )
+    attempt = db.Column(db.Integer, nullable=False)
+    status = db.Column(db.String(20), nullable=False)
+    error = db.Column(db.Text, nullable=True)
+    started_at = db.Column(db.DateTime, nullable=False)
+    finished_at = db.Column(db.DateTime, nullable=True)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "job_id": self.job_id,
+            "attempt": self.attempt,
+            "status": self.status,
+            "error": self.error,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": (
+                self.finished_at.isoformat() if self.finished_at else None
+            ),
+        }
+
+
 class AdImpression(db.Model):
     __tablename__ = "ad_impressions"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .admin_jobs import bp as admin_jobs_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(admin_jobs_bp, url_prefix="/admin/jobs")

--- a/packages/backend/app/routes/admin_jobs.py
+++ b/packages/backend/app/routes/admin_jobs.py
@@ -1,0 +1,94 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import BackgroundJob, JobExecutionLog, JobStatus, User, Role
+from ..services.jobs import retry_failed_job
+import logging
+
+bp = Blueprint("admin_jobs", __name__)
+logger = logging.getLogger("finmind.admin.jobs")
+
+
+def _require_admin():
+    """Return the user if they have ADMIN role, otherwise abort with 403."""
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user or user.role != Role.ADMIN.value:
+        return None
+    return user
+
+
+@bp.get("")
+@jwt_required()
+def list_jobs():
+    user = _require_admin()
+    if user is None:
+        return jsonify(error="admin access required"), 403
+
+    page = request.args.get("page", 1, type=int)
+    per_page = request.args.get("per_page", 20, type=int)
+    per_page = min(per_page, 100)
+    status_filter = request.args.get("status")
+    job_type_filter = request.args.get("job_type")
+
+    query = db.session.query(BackgroundJob)
+    if status_filter:
+        query = query.filter(BackgroundJob.status == status_filter)
+    if job_type_filter:
+        query = query.filter(BackgroundJob.job_type == job_type_filter)
+
+    query = query.order_by(BackgroundJob.created_at.desc())
+    total = query.count()
+    jobs = query.offset((page - 1) * per_page).limit(per_page).all()
+
+    logger.info("Admin list jobs user=%s page=%s total=%s", user.id, page, total)
+    return jsonify(
+        jobs=[j.to_dict() for j in jobs],
+        total=total,
+        page=page,
+        per_page=per_page,
+    )
+
+
+@bp.get("/<int:job_id>")
+@jwt_required()
+def get_job(job_id: int):
+    user = _require_admin()
+    if user is None:
+        return jsonify(error="admin access required"), 403
+
+    job = db.session.get(BackgroundJob, job_id)
+    if not job:
+        return jsonify(error="not found"), 404
+
+    logs = (
+        db.session.query(JobExecutionLog)
+        .filter_by(job_id=job_id)
+        .order_by(JobExecutionLog.attempt)
+        .all()
+    )
+
+    logger.info("Admin get job id=%s user=%s", job_id, user.id)
+    return jsonify(
+        job=job.to_dict(),
+        execution_history=[log.to_dict() for log in logs],
+    )
+
+
+@bp.post("/<int:job_id>/retry")
+@jwt_required()
+def retry_job(job_id: int):
+    user = _require_admin()
+    if user is None:
+        return jsonify(error="admin access required"), 403
+
+    job = db.session.get(BackgroundJob, job_id)
+    if not job:
+        return jsonify(error="not found"), 404
+
+    if job.status != JobStatus.FAILED.value:
+        return jsonify(error="only failed jobs can be retried"), 400
+
+    result = retry_failed_job(job_id)
+    logger.info("Admin retry job id=%s user=%s", job_id, user.id)
+    return jsonify(job=result.to_dict())

--- a/packages/backend/app/services/jobs.py
+++ b/packages/backend/app/services/jobs.py
@@ -1,0 +1,158 @@
+from datetime import datetime, timedelta
+import logging
+import traceback
+
+from ..extensions import db
+from ..models import BackgroundJob, JobExecutionLog, JobStatus
+
+logger = logging.getLogger("finmind.jobs")
+
+# Base delay in seconds for exponential backoff (5^attempt: 5, 25, 125 …)
+BACKOFF_BASE = 5
+
+# Registry of callable handlers keyed by job_type string.
+_handlers: dict[str, callable] = {}
+
+
+def register_handler(job_type: str):
+    """Decorator to register a handler function for a given job_type."""
+
+    def decorator(fn):
+        _handlers[job_type] = fn
+        return fn
+
+    return decorator
+
+
+def get_handler(job_type: str):
+    return _handlers.get(job_type)
+
+
+def create_job(job_type: str, payload: dict | None = None, max_retries: int = 3):
+    """Enqueue a new background job and return it."""
+    job = BackgroundJob(
+        job_type=job_type,
+        payload=payload,
+        max_retries=max_retries,
+        status=JobStatus.PENDING.value,
+    )
+    db.session.add(job)
+    db.session.commit()
+    logger.info("Created job id=%s type=%s", job.id, job_type)
+    return job
+
+
+def execute_job(job: BackgroundJob) -> BackgroundJob:
+    """Execute a single job, handling retries and logging each attempt."""
+    handler = get_handler(job.job_type)
+    if handler is None:
+        job.status = JobStatus.FAILED.value
+        job.last_error = f"No handler registered for job_type={job.job_type}"
+        db.session.commit()
+        logger.error("No handler for job id=%s type=%s", job.id, job.job_type)
+        return job
+
+    job.status = JobStatus.RUNNING.value
+    db.session.commit()
+
+    attempt = job.retry_count + 1
+    started_at = datetime.utcnow()
+    log_entry = JobExecutionLog(
+        job_id=job.id,
+        attempt=attempt,
+        status=JobStatus.RUNNING.value,
+        started_at=started_at,
+    )
+    db.session.add(log_entry)
+    db.session.commit()
+
+    try:
+        result = handler(job.payload)
+        finished_at = datetime.utcnow()
+
+        job.status = JobStatus.COMPLETED.value
+        job.result = result if isinstance(result, dict) else {"ok": True}
+        job.last_error = None
+        job.next_retry_at = None
+        job.updated_at = finished_at
+
+        log_entry.status = JobStatus.COMPLETED.value
+        log_entry.finished_at = finished_at
+
+        db.session.commit()
+        logger.info("Job id=%s completed on attempt %s", job.id, attempt)
+
+    except Exception as exc:
+        finished_at = datetime.utcnow()
+        error_msg = f"{type(exc).__name__}: {exc}"
+        tb = traceback.format_exc()
+
+        job.retry_count = attempt
+        job.last_error = error_msg
+        job.updated_at = finished_at
+
+        log_entry.status = JobStatus.FAILED.value
+        log_entry.error = tb
+        log_entry.finished_at = finished_at
+
+        if attempt >= job.max_retries:
+            job.status = JobStatus.FAILED.value
+            job.next_retry_at = None
+            logger.error(
+                "Job id=%s permanently failed after %s attempts: %s",
+                job.id,
+                attempt,
+                error_msg,
+            )
+        else:
+            job.status = JobStatus.PENDING.value
+            delay = BACKOFF_BASE ** attempt  # 5, 25, 125
+            job.next_retry_at = finished_at + timedelta(seconds=delay)
+            logger.warning(
+                "Job id=%s failed attempt %s, next retry at %s: %s",
+                job.id,
+                attempt,
+                job.next_retry_at.isoformat(),
+                error_msg,
+            )
+
+        db.session.commit()
+
+    return job
+
+
+def run_due_jobs():
+    """Find all pending jobs whose next_retry_at has passed and execute them."""
+    now = datetime.utcnow()
+    jobs = (
+        db.session.query(BackgroundJob)
+        .filter(
+            BackgroundJob.status == JobStatus.PENDING.value,
+            db.or_(
+                BackgroundJob.next_retry_at.is_(None),
+                BackgroundJob.next_retry_at <= now,
+            ),
+        )
+        .order_by(BackgroundJob.created_at)
+        .all()
+    )
+    results = []
+    for job in jobs:
+        execute_job(job)
+        results.append(job)
+    return results
+
+
+def retry_failed_job(job_id: int) -> BackgroundJob | None:
+    """Manually retry a permanently failed job by resetting its state."""
+    job = db.session.get(BackgroundJob, job_id)
+    if job is None:
+        return None
+    if job.status != JobStatus.FAILED.value:
+        return job
+
+    job.status = JobStatus.PENDING.value
+    job.next_retry_at = None
+    db.session.commit()
+    logger.info("Manual retry queued for job id=%s", job.id)
+    return execute_job(job)

--- a/packages/backend/app/services/reminder_jobs.py
+++ b/packages/backend/app/services/reminder_jobs.py
@@ -1,0 +1,37 @@
+"""Wraps reminder delivery in the background job framework."""
+import logging
+
+from ..extensions import db
+from ..models import Reminder
+from .jobs import register_handler
+from .reminders import send_reminder
+
+logger = logging.getLogger("finmind.reminder_jobs")
+
+
+@register_handler("send_reminder")
+def handle_send_reminder(payload: dict | None) -> dict:
+    """Execute a single reminder send via the job framework.
+
+    Expected payload: {"reminder_id": <int>}
+    """
+    if not payload or "reminder_id" not in payload:
+        raise ValueError("payload must contain 'reminder_id'")
+
+    reminder_id = payload["reminder_id"]
+    reminder = db.session.get(Reminder, reminder_id)
+    if reminder is None:
+        raise ValueError(f"Reminder id={reminder_id} not found")
+
+    if reminder.sent:
+        logger.info("Reminder id=%s already sent, skipping", reminder_id)
+        return {"skipped": True, "reason": "already_sent"}
+
+    success = send_reminder(reminder)
+    if not success:
+        raise RuntimeError(f"Failed to deliver reminder id={reminder_id}")
+
+    reminder.sent = True
+    db.session.commit()
+    logger.info("Reminder id=%s sent successfully via job", reminder_id)
+    return {"sent": True, "reminder_id": reminder_id}

--- a/packages/backend/tests/test_jobs.py
+++ b/packages/backend/tests/test_jobs.py
@@ -1,0 +1,344 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+from app.extensions import db
+from app.models import (
+    BackgroundJob,
+    JobExecutionLog,
+    JobStatus,
+    Reminder,
+    User,
+    Role,
+)
+from app.services.jobs import (
+    create_job,
+    execute_job,
+    register_handler,
+    retry_failed_job,
+    run_due_jobs,
+    BACKOFF_BASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_admin(app_fixture, client):
+    """Register a user and promote to ADMIN, return auth header."""
+    email = "admin@example.com"
+    password = "admin1234"
+    with patch("app.routes.auth.redis_client", MagicMock()):
+        client.post("/auth/register", json={"email": email, "password": password})
+        with app_fixture.app_context():
+            user = db.session.query(User).filter_by(email=email).first()
+            user.role = Role.ADMIN.value
+            db.session.commit()
+        r = client.post("/auth/login", json={"email": email, "password": password})
+    access = r.get_json()["access_token"]
+    return {"Authorization": f"Bearer {access}"}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — job execution engine
+# ---------------------------------------------------------------------------
+
+class TestJobExecution:
+    def test_create_job(self, app_fixture):
+        with app_fixture.app_context():
+            job = create_job("test_type", payload={"key": "value"})
+            assert job.id is not None
+            assert job.status == JobStatus.PENDING.value
+            assert job.payload == {"key": "value"}
+            assert job.retry_count == 0
+            assert job.max_retries == 3
+
+    def test_execute_job_success(self, app_fixture):
+        @register_handler("success_job")
+        def _handler(payload):
+            return {"result": "ok"}
+
+        with app_fixture.app_context():
+            job = create_job("success_job", payload={})
+            result = execute_job(job)
+            assert result.status == JobStatus.COMPLETED.value
+            assert result.result == {"result": "ok"}
+            assert result.last_error is None
+
+            logs = db.session.query(JobExecutionLog).filter_by(job_id=job.id).all()
+            assert len(logs) == 1
+            assert logs[0].status == JobStatus.COMPLETED.value
+            assert logs[0].attempt == 1
+
+    def test_execute_job_failure_with_retry(self, app_fixture):
+        call_count = 0
+
+        @register_handler("fail_once_job")
+        def _handler(payload):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                raise RuntimeError("temporary failure")
+            return {"done": True}
+
+        with app_fixture.app_context():
+            job = create_job("fail_once_job", payload={})
+
+            # First attempt fails
+            execute_job(job)
+            assert job.status == JobStatus.PENDING.value
+            assert job.retry_count == 1
+            assert job.next_retry_at is not None
+            assert "temporary failure" in job.last_error
+
+            logs = db.session.query(JobExecutionLog).filter_by(job_id=job.id).all()
+            assert len(logs) == 1
+            assert logs[0].status == JobStatus.FAILED.value
+
+            # Second attempt succeeds
+            job.next_retry_at = None  # allow immediate retry
+            db.session.commit()
+            execute_job(job)
+            assert job.status == JobStatus.COMPLETED.value
+            assert job.retry_count == 1  # stays at 1 from failure
+
+    def test_execute_job_permanent_failure(self, app_fixture):
+        @register_handler("always_fail_job")
+        def _handler(payload):
+            raise RuntimeError("permanent problem")
+
+        with app_fixture.app_context():
+            job = create_job("always_fail_job", payload={}, max_retries=2)
+
+            # First attempt
+            execute_job(job)
+            assert job.status == JobStatus.PENDING.value
+            assert job.retry_count == 1
+
+            # Second attempt — should be permanently failed
+            job.next_retry_at = None
+            db.session.commit()
+            execute_job(job)
+            assert job.status == JobStatus.FAILED.value
+            assert job.retry_count == 2
+            assert job.next_retry_at is None
+
+    def test_exponential_backoff_schedule(self, app_fixture):
+        @register_handler("backoff_test")
+        def _handler(payload):
+            raise RuntimeError("fail")
+
+        with app_fixture.app_context():
+            job = create_job("backoff_test", payload={}, max_retries=5)
+
+            execute_job(job)
+            # After attempt 1: delay = 5^1 = 5s
+            assert job.next_retry_at is not None
+            delay1 = (job.next_retry_at - job.updated_at).total_seconds()
+            assert abs(delay1 - BACKOFF_BASE ** 1) < 2
+
+    def test_no_handler_marks_failed(self, app_fixture):
+        with app_fixture.app_context():
+            job = create_job("nonexistent_handler", payload={})
+            execute_job(job)
+            assert job.status == JobStatus.FAILED.value
+            assert "No handler" in job.last_error
+
+    def test_run_due_jobs(self, app_fixture):
+        @register_handler("due_job")
+        def _handler(payload):
+            return {"ok": True}
+
+        with app_fixture.app_context():
+            # Job with no next_retry_at (first attempt)
+            j1 = create_job("due_job", payload={})
+
+            # Job with future retry — should NOT be picked up
+            j2 = create_job("due_job", payload={})
+            j2.next_retry_at = datetime.utcnow() + timedelta(hours=1)
+            db.session.commit()
+
+            results = run_due_jobs()
+            ids = [j.id for j in results]
+            assert j1.id in ids
+            assert j2.id not in ids
+
+    def test_retry_failed_job(self, app_fixture):
+        @register_handler("retry_target")
+        def _handler(payload):
+            return {"retried": True}
+
+        with app_fixture.app_context():
+            job = create_job("retry_target", payload={})
+            job.status = JobStatus.FAILED.value
+            job.retry_count = 3
+            db.session.commit()
+
+            result = retry_failed_job(job.id)
+            assert result.status == JobStatus.COMPLETED.value
+
+
+# ---------------------------------------------------------------------------
+# API tests — admin endpoints
+# ---------------------------------------------------------------------------
+
+class TestAdminJobsAPI:
+    def test_list_jobs_requires_admin(self, app_fixture, client):
+        """Non-admin user should receive 403."""
+        email = "regular@example.com"
+        password = "regular1234"
+        with patch("app.routes.auth.redis_client", MagicMock()):
+            client.post("/auth/register", json={"email": email, "password": password})
+            r = client.post("/auth/login", json={"email": email, "password": password})
+        token = r.get_json()["access_token"]
+        header = {"Authorization": f"Bearer {token}"}
+        r = client.get("/admin/jobs", headers=header)
+        assert r.status_code == 403
+
+    def test_list_jobs_as_admin(self, app_fixture, client):
+        admin_header = _make_admin(app_fixture, client)
+        with app_fixture.app_context():
+            create_job("test_list", payload={"n": 1})
+            create_job("test_list", payload={"n": 2})
+
+        r = client.get("/admin/jobs", headers=admin_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["total"] >= 2
+        assert len(data["jobs"]) >= 2
+
+    def test_list_jobs_filter_by_status(self, app_fixture, client):
+        admin_header = _make_admin(app_fixture, client)
+        with app_fixture.app_context():
+            j = create_job("filter_test", payload={})
+            j.status = JobStatus.COMPLETED.value
+            db.session.commit()
+
+        r = client.get("/admin/jobs?status=completed", headers=admin_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        statuses = [j["status"] for j in data["jobs"]]
+        assert all(s == "completed" for s in statuses)
+
+    def test_list_jobs_pagination(self, app_fixture, client):
+        admin_header = _make_admin(app_fixture, client)
+        with app_fixture.app_context():
+            for i in range(5):
+                create_job("page_test", payload={"i": i})
+
+        r = client.get("/admin/jobs?page=1&per_page=2", headers=admin_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert len(data["jobs"]) == 2
+        assert data["per_page"] == 2
+
+    def test_get_job_detail(self, app_fixture, client):
+        admin_header = _make_admin(app_fixture, client)
+
+        @register_handler("detail_test")
+        def _handler(payload):
+            return {"ok": True}
+
+        with app_fixture.app_context():
+            job = create_job("detail_test", payload={"x": 1})
+            execute_job(job)
+            job_id = job.id
+
+        r = client.get(f"/admin/jobs/{job_id}", headers=admin_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["job"]["id"] == job_id
+        assert data["job"]["status"] == "completed"
+        assert len(data["execution_history"]) == 1
+
+    def test_get_job_not_found(self, app_fixture, client):
+        admin_header = _make_admin(app_fixture, client)
+        r = client.get("/admin/jobs/99999", headers=admin_header)
+        assert r.status_code == 404
+
+    def test_retry_job_endpoint(self, app_fixture, client):
+        admin_header = _make_admin(app_fixture, client)
+
+        @register_handler("retry_api_test")
+        def _handler(payload):
+            return {"retried": True}
+
+        with app_fixture.app_context():
+            job = create_job("retry_api_test", payload={})
+            job.status = JobStatus.FAILED.value
+            job.retry_count = 3
+            db.session.commit()
+            job_id = job.id
+
+        r = client.post(f"/admin/jobs/{job_id}/retry", headers=admin_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["job"]["status"] == "completed"
+
+    def test_retry_non_failed_job_rejected(self, app_fixture, client):
+        admin_header = _make_admin(app_fixture, client)
+        with app_fixture.app_context():
+            job = create_job("nonfailed_test", payload={})
+            job_id = job.id
+
+        r = client.post(f"/admin/jobs/{job_id}/retry", headers=admin_header)
+        assert r.status_code == 400
+        assert "only failed" in r.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# Integration test — reminder job handler
+# ---------------------------------------------------------------------------
+
+class TestReminderJobIntegration:
+    def test_send_reminder_via_job_framework(self, app_fixture):
+        with app_fixture.app_context():
+            from app.models import Reminder
+            from app.services.jobs import create_job, execute_job
+
+            r = Reminder(
+                user_id=1,
+                message="Test reminder",
+                send_at=datetime.utcnow(),
+                channel="email",
+            )
+            db.session.add(r)
+            db.session.commit()
+            reminder_id = r.id
+
+            job = create_job(
+                "send_reminder", payload={"reminder_id": reminder_id}
+            )
+            with patch("app.services.reminder_jobs.send_reminder", return_value=True):
+                execute_job(job)
+
+            assert job.status == JobStatus.COMPLETED.value
+            updated = db.session.get(Reminder, reminder_id)
+            assert updated.sent is True
+
+    def test_send_reminder_failure_triggers_retry(self, app_fixture):
+        with app_fixture.app_context():
+            from app.models import Reminder
+            from app.services.jobs import create_job, execute_job
+
+            r = Reminder(
+                user_id=1,
+                message="Retry test reminder",
+                send_at=datetime.utcnow(),
+                channel="email",
+            )
+            db.session.add(r)
+            db.session.commit()
+            reminder_id = r.id
+
+            job = create_job(
+                "send_reminder", payload={"reminder_id": reminder_id}
+            )
+            with patch(
+                "app.services.reminder_jobs.send_reminder", return_value=False
+            ):
+                execute_job(job)
+
+            assert job.status == JobStatus.PENDING.value
+            assert job.retry_count == 1
+            assert job.next_retry_at is not None


### PR DESCRIPTION
## Summary

Implements a complete background job retry and monitoring system for FinMind, closing #130.

- **BackgroundJob model** with status tracking (pending/running/completed/failed), JSON payload, retry count, max retries, exponential backoff scheduling, and error capture
- **JobExecutionLog model** for per-attempt audit trail with timestamps and full error tracebacks
- **Job executor engine** with automatic retry on failure using exponential backoff (5s, 25s, 125s base^attempt), permanent failure after max retries, and a `run_due_jobs()` scheduler entry point
- **Pluggable handler registry** — new job types added via `@register_handler("type")` decorator
- **Admin API endpoints** (JWT-protected, ADMIN role required):
  - `GET /admin/jobs` — paginated listing with status and job_type filters
  - `GET /admin/jobs/<id>` — job detail with full execution history
  - `POST /admin/jobs/<id>/retry` — manual retry for permanently failed jobs
- **Reminder integration** — `send_reminder` job type wraps existing reminder delivery with automatic retry on failure
- **PostgreSQL schema migration** for `background_jobs` and `job_execution_logs` tables with appropriate indexes
- **18 pytest tests** covering the execution engine, admin API, and reminder integration

## Acceptance Criteria

- [x] BackgroundJob model with all required fields (id, job_type, status, payload, retry_count, max_retries, last_error, created_at, updated_at, next_retry_at)
- [x] Exponential backoff retry (5s, 25s, 125s)
- [x] Permanent failure after max retries exceeded
- [x] Per-attempt execution logging with timestamps and errors
- [x] Admin endpoints with JWT auth and ADMIN role check
- [x] Pagination and filtering on job list endpoint
- [x] Manual retry endpoint for failed jobs
- [x] Reminder sends wrapped in job framework
- [x] Database schema migration included
- [x] pytest test coverage (18 tests, all passing)
- [x] README updated with new endpoints and documentation

## Test plan

- [x] Run `pytest tests/test_jobs.py` — all 18 tests pass
- [ ] Verify existing test suite still passes with Docker Compose (`sh scripts/test-backend.sh`)
- [ ] Manual smoke test: create a job via the service layer, verify retry behavior
- [ ] Verify admin endpoints return 403 for non-admin users
