### PR TITLE
feat: Multi-account financial overview dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ flowchart LR
 ## PostgreSQL Schema (DDL)
 See `backend/app/db/schema.sql`. Key tables:
 - users, categories, expenses, bills, reminders
+- accounts (multi-account support: checking, savings, credit, investment)
 - ad_impressions, subscription_plans, user_subscriptions
 - refresh_tokens (optional if rotating), audit_logs
 
@@ -62,7 +63,9 @@ See `backend/app/db/schema.sql`. Key tables:
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
-- Expenses: CRUD `/expenses`
+- Accounts: CRUD `/accounts`, `/accounts/{id}/summary`
+- Dashboard: `/dashboard/summary` (supports `?account_id=` filter), `/dashboard/overview` (aggregated multi-account view)
+- Expenses: CRUD `/expenses` (supports optional `account_id` on create/update/filter)
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
@@ -100,6 +103,7 @@ finmind/
       routes/
         __init__.py
         auth.py
+        accounts.py
         expenses.py
         bills.py
         reminders.py

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -116,5 +116,36 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             "Schema compatibility patch failed for users.preferred_currency"
         )
         conn.rollback()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS accounts (
+                id SERIAL PRIMARY KEY,
+                user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                name VARCHAR(100) NOT NULL,
+                account_type VARCHAR(20) NOT NULL DEFAULT 'CHECKING',
+                balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+                currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+                is_default BOOLEAN NOT NULL DEFAULT FALSE,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE expenses
+            ADD COLUMN IF NOT EXISTS account_id INT
+            REFERENCES accounts(id) ON DELETE SET NULL
+            """
+        )
+        conn.commit()
+    except Exception:
+        app.logger.exception(
+            "Schema compatibility patch failed for accounts"
+        )
+        conn.rollback()
     finally:
         conn.close()

--- a/packages/backend/app/db/migrations/001_add_accounts.sql
+++ b/packages/backend/app/db/migrations/001_add_accounts.sql
@@ -1,0 +1,26 @@
+-- Migration: Add multi-account support
+-- This migration is idempotent and safe to run on existing databases.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS accounts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(100) NOT NULL,
+  account_type VARCHAR(20) NOT NULL DEFAULT 'CHECKING',
+  balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  is_default BOOLEAN NOT NULL DEFAULT FALSE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_accounts_user ON accounts(user_id) WHERE is_active = TRUE;
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS account_id INT REFERENCES accounts(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_expenses_account ON expenses(account_id);
+
+COMMIT;

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,22 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Multi-account support
+CREATE TABLE IF NOT EXISTS accounts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(100) NOT NULL,
+  account_type VARCHAR(20) NOT NULL DEFAULT 'CHECKING',
+  balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  is_default BOOLEAN NOT NULL DEFAULT FALSE,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_accounts_user ON accounts(user_id) WHERE is_active = TRUE;
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS account_id INT REFERENCES accounts(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS idx_expenses_account ON expenses(account_id);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -9,6 +9,14 @@ class Role(str, Enum):
     ADMIN = "ADMIN"
 
 
+
+
+class AccountType(str, Enum):
+    CHECKING = "CHECKING"
+    SAVINGS = "SAVINGS"
+    CREDIT = "CREDIT"
+    INVESTMENT = "INVESTMENT"
+
 class User(db.Model):
     __tablename__ = "users"
     id = db.Column(db.Integer, primary_key=True)
@@ -17,6 +25,22 @@ class User(db.Model):
     preferred_currency = db.Column(db.String(10), default="INR", nullable=False)
     role = db.Column(db.String(20), default=Role.USER.value, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+
+
+class Account(db.Model):
+    __tablename__ = "accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    account_type = db.Column(db.String(20), nullable=False, default=AccountType.CHECKING.value)
+    balance = db.Column(db.Numeric(14, 2), nullable=False, default=0)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    is_default = db.Column(db.Boolean, default=False, nullable=False)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
 
 
 class Category(db.Model):
@@ -32,6 +56,7 @@ class Expense(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    account_id = db.Column(db.Integer, db.ForeignKey("accounts.id"), nullable=True)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
     expense_type = db.Column(db.String(20), default="EXPENSE", nullable=False)
@@ -55,6 +80,7 @@ class RecurringExpense(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    account_id = db.Column(db.Integer, db.ForeignKey("accounts.id"), nullable=True)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
     expense_type = db.Column(db.String(20), default="EXPENSE", nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,291 @@
+import logging
+from datetime import datetime
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import extract, func
+
+from ..extensions import db
+from ..models import Account, AccountType, Expense, Category
+from ..services.cache import (
+    cache_delete_patterns,
+    cache_get,
+    cache_set,
+    accounts_key,
+    account_summary_key,
+    dashboard_overview_key,
+)
+
+bp = Blueprint("accounts", __name__)
+logger = logging.getLogger("finmind.accounts")
+
+VALID_ACCOUNT_TYPES = {t.value for t in AccountType}
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    cached = cache_get(accounts_key(uid))
+    if cached is not None:
+        return jsonify(cached)
+    items = (
+        db.session.query(Account)
+        .filter_by(user_id=uid, is_active=True)
+        .order_by(Account.is_default.desc(), Account.name)
+        .all()
+    )
+    data = [_account_to_dict(a) for a in items]
+    cache_set(accounts_key(uid), data, ttl_seconds=300)
+    logger.info("List accounts user=%s count=%s", uid, len(data))
+    return jsonify(data)
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    account_type = (data.get("account_type") or "CHECKING").upper()
+    if account_type not in VALID_ACCOUNT_TYPES:
+        return jsonify(error="invalid account_type"), 400
+    balance = _parse_balance(data.get("balance", 0))
+    if balance is None:
+        return jsonify(error="invalid balance"), 400
+    currency = (data.get("currency") or "INR").strip().upper()[:10]
+    is_default = bool(data.get("is_default", False))
+
+    # If marked default, clear existing default
+    if is_default:
+        _clear_default(uid)
+
+    # If user has no accounts yet, make it default
+    existing_count = (
+        db.session.query(func.count(Account.id))
+        .filter_by(user_id=uid, is_active=True)
+        .scalar()
+    )
+    if existing_count == 0:
+        is_default = True
+
+    account = Account(
+        user_id=uid,
+        name=name,
+        account_type=account_type,
+        balance=balance,
+        currency=currency,
+        is_default=is_default,
+    )
+    db.session.add(account)
+    db.session.commit()
+    _invalidate_account_cache(uid)
+    logger.info("Created account id=%s user=%s type=%s", account.id, uid, account_type)
+    return jsonify(_account_to_dict(account)), 201
+
+
+@bp.get("/<int:account_id>")
+@jwt_required()
+def get_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, account_id)
+    if not account or account.user_id != uid or not account.is_active:
+        return jsonify(error="not found"), 404
+    return jsonify(_account_to_dict(account))
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, account_id)
+    if not account or account.user_id != uid or not account.is_active:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = (data["name"] or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        account.name = name
+    if "account_type" in data:
+        account_type = (data["account_type"] or "").upper()
+        if account_type not in VALID_ACCOUNT_TYPES:
+            return jsonify(error="invalid account_type"), 400
+        account.account_type = account_type
+    if "balance" in data:
+        balance = _parse_balance(data["balance"])
+        if balance is None:
+            return jsonify(error="invalid balance"), 400
+        account.balance = balance
+    if "currency" in data:
+        account.currency = (data["currency"] or "INR").strip().upper()[:10]
+    if "is_default" in data and data["is_default"]:
+        _clear_default(uid)
+        account.is_default = True
+    account.updated_at = datetime.utcnow()
+    db.session.commit()
+    _invalidate_account_cache(uid)
+    logger.info("Updated account id=%s user=%s", account.id, uid)
+    return jsonify(_account_to_dict(account))
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def delete_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, account_id)
+    if not account or account.user_id != uid or not account.is_active:
+        return jsonify(error="not found"), 404
+    # Soft delete
+    account.is_active = False
+    account.updated_at = datetime.utcnow()
+    # If this was the default, promote another account
+    if account.is_default:
+        account.is_default = False
+        next_default = (
+            db.session.query(Account)
+            .filter(
+                Account.user_id == uid,
+                Account.is_active.is_(True),
+                Account.id != account_id,
+            )
+            .order_by(Account.created_at)
+            .first()
+        )
+        if next_default:
+            next_default.is_default = True
+    db.session.commit()
+    _invalidate_account_cache(uid)
+    logger.info("Soft-deleted account id=%s user=%s", account.id, uid)
+    return jsonify(message="deleted")
+
+
+@bp.get("/<int:account_id>/summary")
+@jwt_required()
+def account_summary(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, account_id)
+    if not account or account.user_id != uid or not account.is_active:
+        return jsonify(error="not found"), 404
+
+    from datetime import date as date_cls
+
+    ym = (request.args.get("month") or date_cls.today().strftime("%Y-%m")).strip()
+
+    key = account_summary_key(uid, account_id, ym)
+    cached = cache_get(key)
+    if cached is not None:
+        return jsonify(cached)
+
+    year, month = map(int, ym.split("-"))
+
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.account_id == account_id,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.account_id == account_id,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+
+    category_rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(Category.name, "Uncategorized").label("category_name"),
+            func.coalesce(func.sum(Expense.amount), 0).label("total_amount"),
+        )
+        .outerjoin(
+            Category,
+            (Category.id == Expense.category_id) & (Category.user_id == uid),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.account_id == account_id,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id, Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .all()
+    )
+
+    total_exp = float(expenses or 0)
+    payload = {
+        "account": _account_to_dict(account),
+        "period": {"month": ym},
+        "summary": {
+            "monthly_income": float(income or 0),
+            "monthly_expenses": total_exp,
+            "net_flow": round(float(income or 0) - total_exp, 2),
+        },
+        "category_breakdown": [
+            {
+                "category_id": r.category_id,
+                "category_name": r.category_name,
+                "amount": float(r.total_amount or 0),
+                "share_pct": (
+                    round((float(r.total_amount or 0) / total_exp) * 100, 2)
+                    if total_exp > 0
+                    else 0
+                ),
+            }
+            for r in category_rows
+        ],
+    }
+    cache_set(key, payload, ttl_seconds=300)
+    return jsonify(payload)
+
+
+def _account_to_dict(a: Account) -> dict:
+    return {
+        "id": a.id,
+        "name": a.name,
+        "account_type": a.account_type,
+        "balance": float(a.balance),
+        "currency": a.currency,
+        "is_default": a.is_default,
+        "created_at": a.created_at.isoformat() if a.created_at else None,
+        "updated_at": a.updated_at.isoformat() if a.updated_at else None,
+    }
+
+
+def _parse_balance(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _clear_default(uid: int):
+    db.session.query(Account).filter_by(user_id=uid, is_default=True).update(
+        {"is_default": False}
+    )
+
+
+def _invalidate_account_cache(uid: int):
+    cache_delete_patterns(
+        [
+            accounts_key(uid),
+            f"user:{uid}:account_summary:*",
+            f"user:{uid}:dashboard_overview:*",
+            f"user:{uid}:dashboard_summary:*",
+        ]
+    )

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -4,8 +4,13 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..extensions import db
-from ..models import Bill, Expense, Category
-from ..services.cache import cache_get, cache_set, dashboard_summary_key
+from ..models import Account, Bill, Expense, Category
+from ..services.cache import (
+    cache_get,
+    cache_set,
+    dashboard_summary_key,
+    dashboard_overview_key,
+)
 
 bp = Blueprint("dashboard", __name__)
 
@@ -17,7 +22,20 @@ def dashboard_summary():
     ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
     if not _is_valid_month(ym):
         return jsonify(error="invalid month, expected YYYY-MM"), 400
-    key = dashboard_summary_key(uid, ym)
+
+    account_id = request.args.get("account_id")
+    if account_id is not None:
+        try:
+            account_id = int(account_id)
+        except ValueError:
+            return jsonify(error="invalid account_id"), 400
+        # Verify ownership
+        account = db.session.get(Account, account_id)
+        if not account or account.user_id != uid or not account.is_active:
+            return jsonify(error="account not found"), 404
+
+    cache_suffix = f":{account_id}" if account_id else ""
+    key = dashboard_summary_key(uid, ym) + cache_suffix
     cached = cache_get(key)
     if cached:
         return jsonify(cached)
@@ -36,31 +54,35 @@ def dashboard_summary():
         "category_breakdown": [],
         "errors": [],
     }
+    if account_id:
+        payload["account_id"] = account_id
 
     year, month = map(int, ym.split("-"))
     today = date.today()
 
     try:
-        income = (
-            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
-            .filter(
-                Expense.user_id == uid,
-                extract("year", Expense.spent_at) == year,
-                extract("month", Expense.spent_at) == month,
-                Expense.expense_type == "INCOME",
-            )
-            .scalar()
+        income_q = db.session.query(
+            func.coalesce(func.sum(Expense.amount), 0)
+        ).filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
         )
-        expenses = (
-            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
-            .filter(
-                Expense.user_id == uid,
-                extract("year", Expense.spent_at) == year,
-                extract("month", Expense.spent_at) == month,
-                Expense.expense_type != "INCOME",
-            )
-            .scalar()
+        expenses_q = db.session.query(
+            func.coalesce(func.sum(Expense.amount), 0)
+        ).filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
         )
+        if account_id:
+            income_q = income_q.filter(Expense.account_id == account_id)
+            expenses_q = expenses_q.filter(Expense.account_id == account_id)
+
+        income = income_q.scalar()
+        expenses = expenses_q.scalar()
         payload["summary"]["monthly_income"] = float(income or 0)
         payload["summary"]["monthly_expenses"] = float(expenses or 0)
         payload["summary"]["net_flow"] = round(
@@ -72,10 +94,14 @@ def dashboard_summary():
         payload["errors"].append("summary_unavailable")
 
     try:
-        rows = (
+        recent_q = (
             db.session.query(Expense)
             .filter(Expense.user_id == uid)
-            .order_by(Expense.spent_at.desc(), Expense.id.desc())
+        )
+        if account_id:
+            recent_q = recent_q.filter(Expense.account_id == account_id)
+        rows = (
+            recent_q.order_by(Expense.spent_at.desc(), Expense.id.desc())
             .limit(10)
             .all()
         )
@@ -88,6 +114,7 @@ def dashboard_summary():
                 "type": e.expense_type,
                 "category_id": e.category_id,
                 "currency": e.currency,
+                "account_id": e.account_id,
             }
             for e in rows
         ]
@@ -127,7 +154,7 @@ def dashboard_summary():
         payload["errors"].append("upcoming_bills_unavailable")
 
     try:
-        category_rows = (
+        cat_q = (
             db.session.query(
                 Expense.category_id,
                 func.coalesce(Category.name, "Uncategorized").label("category_name"),
@@ -143,7 +170,12 @@ def dashboard_summary():
                 extract("month", Expense.spent_at) == month,
                 Expense.expense_type != "INCOME",
             )
-            .group_by(Expense.category_id, Category.name)
+        )
+        if account_id:
+            cat_q = cat_q.filter(Expense.account_id == account_id)
+
+        category_rows = (
+            cat_q.group_by(Expense.category_id, Category.name)
             .order_by(func.sum(Expense.amount).desc())
             .all()
         )
@@ -163,6 +195,109 @@ def dashboard_summary():
         ]
     except Exception:
         payload["errors"].append("category_breakdown_unavailable")
+
+    cache_set(key, payload, ttl_seconds=300)
+    return jsonify(payload)
+
+
+@bp.get("/overview")
+@jwt_required()
+def dashboard_overview():
+    """Aggregated view across all accounts."""
+    uid = int(get_jwt_identity())
+    ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
+    if not _is_valid_month(ym):
+        return jsonify(error="invalid month, expected YYYY-MM"), 400
+
+    key = dashboard_overview_key(uid, ym)
+    cached = cache_get(key)
+    if cached:
+        return jsonify(cached)
+
+    year, month = map(int, ym.split("-"))
+
+    # All active accounts
+    accounts = (
+        db.session.query(Account)
+        .filter_by(user_id=uid, is_active=True)
+        .order_by(Account.is_default.desc(), Account.name)
+        .all()
+    )
+
+    total_balance = sum(float(a.balance) for a in accounts)
+
+    # Per-account monthly summaries
+    account_summaries = []
+    for acct in accounts:
+        income = (
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                Expense.account_id == acct.id,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type == "INCOME",
+            )
+            .scalar()
+        )
+        expenses = (
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                Expense.account_id == acct.id,
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type != "INCOME",
+            )
+            .scalar()
+        )
+        account_summaries.append(
+            {
+                "id": acct.id,
+                "name": acct.name,
+                "account_type": acct.account_type,
+                "balance": float(acct.balance),
+                "currency": acct.currency,
+                "is_default": acct.is_default,
+                "monthly_income": float(income or 0),
+                "monthly_expenses": float(expenses or 0),
+                "net_flow": round(float(income or 0) - float(expenses or 0), 2),
+            }
+        )
+
+    # Aggregated totals (all expenses including unassigned)
+    agg_income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    agg_expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+
+    payload = {
+        "period": {"month": ym},
+        "total_balance": total_balance,
+        "accounts_count": len(accounts),
+        "aggregate": {
+            "monthly_income": float(agg_income or 0),
+            "monthly_expenses": float(agg_expenses or 0),
+            "net_flow": round(float(agg_income or 0) - float(agg_expenses or 0), 2),
+        },
+        "accounts": account_summaries,
+    }
 
     cache_set(key, payload, ttl_seconds=300)
     return jsonify(payload)

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -29,6 +29,7 @@ def list_expenses():
     except ValueError:
         return jsonify(error="invalid pagination"), 400
 
+    account_id = request.args.get("account_id")
     try:
         if from_date:
             q = q.filter(Expense.spent_at >= date.fromisoformat(from_date))
@@ -36,6 +37,8 @@ def list_expenses():
             q = q.filter(Expense.spent_at <= date.fromisoformat(to_date))
         if category_id:
             q = q.filter(Expense.category_id == int(category_id))
+        if account_id:
+            q = q.filter(Expense.account_id == int(account_id))
     except ValueError:
         return jsonify(error="invalid filter values"), 400
     if search:
@@ -71,6 +74,7 @@ def create_expense():
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
         category_id=data.get("category_id"),
+        account_id=data.get("account_id"),
         notes=description,
         spent_at=date.fromisoformat(raw_date) if raw_date else date.today(),
     )
@@ -221,6 +225,8 @@ def update_expense(expense_id: int):
         e.expense_type = str(data.get("expense_type") or "EXPENSE").upper()
     if "category_id" in data:
         e.category_id = data.get("category_id")
+    if "account_id" in data:
+        e.account_id = data.get("account_id")
     if "description" in data or "notes" in data:
         description = (data.get("description") or data.get("notes") or "").strip()
         if not description:
@@ -299,6 +305,7 @@ def import_commit():
             currency=t.get("currency") or (user.preferred_currency if user else "INR"),
             expense_type=str(t.get("expense_type") or "EXPENSE").upper(),
             category_id=t.get("category_id"),
+            account_id=t.get("account_id"),
             notes=t["description"],
             spent_at=date.fromisoformat(t["date"]),
         )
@@ -320,6 +327,7 @@ def _expense_to_dict(e: Expense) -> dict:
         "expense_type": e.expense_type,
         "description": e.notes or "",
         "date": e.spent_at.isoformat(),
+        "account_id": e.account_id,
     }
 
 

--- a/packages/backend/app/services/cache.py
+++ b/packages/backend/app/services/cache.py
@@ -45,3 +45,15 @@ def cache_delete_patterns(patterns: Iterable[str]):
                 redis_client.delete(*keys)
             if cursor == 0:
                 break
+
+
+def accounts_key(user_id: int) -> str:
+    return f"user:{user_id}:accounts"
+
+
+def account_summary_key(user_id: int, account_id: int, ym: str) -> str:
+    return f"user:{user_id}:account_summary:{account_id}:{ym}"
+
+
+def dashboard_overview_key(user_id: int, ym: str) -> str:
+    return f"user:{user_id}:dashboard_overview:{ym}"

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,175 @@
+def test_accounts_crud(client, auth_header):
+    # List empty
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+    # Create first account (auto-default)
+    r = client.post(
+        "/accounts",
+        json={"name": "Checking", "account_type": "CHECKING", "balance": 1000.50},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    acct = r.get_json()
+    assert acct["name"] == "Checking"
+    assert acct["account_type"] == "CHECKING"
+    assert acct["balance"] == 1000.50
+    assert acct["is_default"] is True
+    acct_id = acct["id"]
+
+    # Create second account
+    r = client.post(
+        "/accounts",
+        json={"name": "Savings", "account_type": "SAVINGS", "balance": 5000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    savings = r.get_json()
+    assert savings["is_default"] is False
+
+    # List returns both
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 2
+
+    # Get single account
+    r = client.get(f"/accounts/{acct_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["name"] == "Checking"
+
+    # Update account
+    r = client.patch(
+        f"/accounts/{acct_id}",
+        json={"name": "Main Checking", "balance": 1200},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["name"] == "Main Checking"
+    assert r.get_json()["balance"] == 1200.0
+
+    # Soft delete
+    r = client.delete(f"/accounts/{acct_id}", headers=auth_header)
+    assert r.status_code == 200
+
+    # List returns only savings (now promoted to default)
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert len(items) == 1
+    assert items[0]["name"] == "Savings"
+    assert items[0]["is_default"] is True
+
+    # Deleted account returns 404
+    r = client.get(f"/accounts/{acct_id}", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_account_validation(client, auth_header):
+    r = client.post("/accounts", json={"account_type": "CHECKING"}, headers=auth_header)
+    assert r.status_code == 400
+    assert "name" in r.get_json()["error"]
+
+    r = client.post("/accounts", json={"name": "Bad", "account_type": "INVALID"}, headers=auth_header)
+    assert r.status_code == 400
+    assert "account_type" in r.get_json()["error"]
+
+    r = client.post("/accounts", json={"name": "Bad", "balance": "not-a-number"}, headers=auth_header)
+    assert r.status_code == 400
+    assert "balance" in r.get_json()["error"]
+
+
+def test_set_default_account(client, auth_header):
+    r = client.post("/accounts", json={"name": "A1", "account_type": "CHECKING"}, headers=auth_header)
+    assert r.status_code == 201
+    a1_id = r.get_json()["id"]
+
+    r = client.post("/accounts", json={"name": "A2", "account_type": "SAVINGS", "is_default": True}, headers=auth_header)
+    assert r.status_code == 201
+    assert r.get_json()["is_default"] is True
+
+    r = client.get(f"/accounts/{a1_id}", headers=auth_header)
+    assert r.get_json()["is_default"] is False
+
+
+def test_account_summary(client, auth_header):
+    r = client.post("/accounts", json={"name": "Test", "account_type": "CHECKING", "balance": 500}, headers=auth_header)
+    acct_id = r.get_json()["id"]
+
+    r = client.post("/expenses", json={"amount": 50.0, "description": "Groceries", "date": "2026-04-10", "account_id": acct_id}, headers=auth_header)
+    assert r.status_code == 201
+    assert r.get_json()["account_id"] == acct_id
+
+    r = client.get(f"/accounts/{acct_id}/summary?month=2026-04", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["account"]["id"] == acct_id
+    assert data["summary"]["monthly_expenses"] == 50.0
+    assert data["summary"]["net_flow"] == -50.0
+
+
+def test_dashboard_overview(client, auth_header):
+    r = client.post("/accounts", json={"name": "Checking", "balance": 1000}, headers=auth_header)
+    checking_id = r.get_json()["id"]
+
+    r = client.post("/accounts", json={"name": "Savings", "account_type": "SAVINGS", "balance": 5000}, headers=auth_header)
+    savings_id = r.get_json()["id"]
+
+    client.post("/expenses", json={"amount": 100, "description": "Expense 1", "date": "2026-04-05", "account_id": checking_id}, headers=auth_header)
+    client.post("/expenses", json={"amount": 200, "description": "Expense 2", "date": "2026-04-06", "account_id": savings_id}, headers=auth_header)
+
+    r = client.get("/dashboard/overview?month=2026-04", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_balance"] == 6000.0
+    assert data["accounts_count"] == 2
+    assert data["aggregate"]["monthly_expenses"] == 300.0
+    assert data["aggregate"]["net_flow"] == -300.0
+    assert len(data["accounts"]) == 2
+
+
+def test_dashboard_summary_with_account_filter(client, auth_header):
+    r = client.post("/accounts", json={"name": "Filtered", "balance": 100}, headers=auth_header)
+    acct_id = r.get_json()["id"]
+
+    client.post("/expenses", json={"amount": 30, "description": "Linked", "date": "2026-04-01", "account_id": acct_id}, headers=auth_header)
+    client.post("/expenses", json={"amount": 70, "description": "Unlinked", "date": "2026-04-01"}, headers=auth_header)
+
+    r = client.get("/dashboard/summary?month=2026-04", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["summary"]["monthly_expenses"] == 100.0
+
+    r = client.get(f"/dashboard/summary?month=2026-04&account_id={acct_id}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["summary"]["monthly_expenses"] == 30.0
+    assert data["account_id"] == acct_id
+
+
+def test_expenses_filter_by_account(client, auth_header):
+    r = client.post("/accounts", json={"name": "Filter Test"}, headers=auth_header)
+    acct_id = r.get_json()["id"]
+
+    client.post("/expenses", json={"amount": 10, "description": "With account", "date": "2026-04-01", "account_id": acct_id}, headers=auth_header)
+    client.post("/expenses", json={"amount": 20, "description": "No account", "date": "2026-04-01"}, headers=auth_header)
+
+    r = client.get(f"/expenses?account_id={acct_id}", headers=auth_header)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert len(items) == 1
+    assert items[0]["account_id"] == acct_id
+
+    r = client.get("/expenses", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 2
+
+
+def test_account_not_found(client, auth_header):
+    r = client.get("/accounts/9999", headers=auth_header)
+    assert r.status_code == 404
+    r = client.patch("/accounts/9999", json={"name": "X"}, headers=auth_header)
+    assert r.status_code == 404
+    r = client.delete("/accounts/9999", headers=auth_header)
+    assert r.status_code == 404
+    r = client.get("/accounts/9999/summary", headers=auth_header)
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

Adds multi-account support to FinMind, allowing users to manage multiple financial accounts (checking, savings, credit, investment) and view aggregated financial data across all accounts in a unified dashboard.

Closes #132

## Changes

### New Account Model
- `Account` model with fields: id, user_id, name, account_type (CHECKING/SAVINGS/CREDIT/INVESTMENT), balance, currency, is_default, is_active (soft delete), created_at, updated_at
- `AccountType` enum for type safety
- Nullable `account_id` FK added to `Expense` model for backward compatibility

### API Endpoints
- **`POST /accounts`** — Create account (first account auto-defaults)
- **`GET /accounts`** — List user's active accounts (cached, 5min TTL)
- **`GET /accounts/<id>`** — Account detail
- **`PATCH /accounts/<id>`** — Update account fields
- **`DELETE /accounts/<id>`** — Soft delete with automatic default promotion
- **`GET /accounts/<id>/summary?month=YYYY-MM`** — Per-account expense summary with category breakdown
- **`GET /dashboard/overview?month=YYYY-MM`** — Aggregated view across all accounts (total balance, per-account income/expenses/net flow)
- **`GET /dashboard/summary?account_id=N`** — Existing dashboard now supports optional account filtering
- **`GET /expenses?account_id=N`** — Existing expense list now supports account filtering

### Database
- Idempotent migration: `packages/backend/app/db/migrations/001_add_accounts.sql`
- Schema compatibility patch in `__init__.py` for existing deployments
- Updated `schema.sql` with accounts table and expense FK

### Caching & Invalidation
- New Redis cache keys: `user:{id}:accounts`, `user:{id}:account_summary:{acct}:{ym}`, `user:{id}:dashboard_overview:{ym}`
- Account mutations invalidate all related caches including dashboard summaries

### Tests
- 8 pytest tests covering: full CRUD lifecycle, input validation, default account logic, per-account summaries, dashboard overview aggregation, dashboard filtering, expense filtering, 404 handling

## Backward Compatibility
- `account_id` on expenses is nullable — existing expenses without accounts continue to work
- Existing `/dashboard/summary` endpoint behavior is unchanged when `account_id` param is omitted
- Migration is idempotent (`IF NOT EXISTS` / `IF NOT EXISTS`)

## Test Plan
- [ ] Run `pytest tests/test_accounts.py` — 8 new tests
- [ ] Run `pytest tests/` — all 30 tests pass (existing tests unaffected)
- [ ] Verify accounts CRUD via API manually
- [ ] Verify `/dashboard/overview` aggregates correctly across accounts
- [ ] Verify `/dashboard/summary?account_id=N` filters correctly
- [ ] Verify soft delete promotes next account to default
