### PR TITLE
feat: add multi-account financial overview dashboard

### DIFF
--- a/app/src/api/accounts.ts
+++ b/app/src/api/accounts.ts
@@ -1,0 +1,55 @@
+import { api } from './client';
+
+export type FinancialAccount = {
+  id: number;
+  name: string;
+  account_type: string;
+  currency: string;
+  balance: number;
+  institution: string | null;
+  active: boolean;
+  created_at: string;
+};
+
+export type AccountOverview = {
+  total_accounts: number;
+  total_balance: number;
+  net_worth: number;
+  assets: number;
+  liabilities: number;
+  by_type: Record<string, { count: number; total_balance: number }>;
+  accounts: FinancialAccount[];
+};
+
+export async function listAccounts(): Promise<FinancialAccount[]> {
+  return api<FinancialAccount[]>('/accounts');
+}
+
+export async function createAccount(data: {
+  name: string;
+  account_type: string;
+  balance?: number;
+  currency?: string;
+  institution?: string;
+}): Promise<FinancialAccount> {
+  return api<FinancialAccount>('/accounts', { method: 'POST', body: data });
+}
+
+export async function getAccount(id: number): Promise<FinancialAccount> {
+  return api<FinancialAccount>(`/accounts/${id}`);
+}
+
+export async function updateAccount(
+  id: number,
+  data: Partial<{ name: string; balance: number; institution: string; active: boolean; account_type: string }>,
+): Promise<FinancialAccount> {
+  return api<FinancialAccount>(`/accounts/${id}`, { method: 'PATCH', body: data });
+}
+
+export async function deleteAccount(id: number): Promise<void> {
+  return api<void>(`/accounts/${id}`, { method: 'DELETE' });
+}
+
+export async function getOverview(): Promise<AccountOverview> {
+  return api<AccountOverview>('/accounts/overview');
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,16 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    account_type = db.Column(db.String(50), nullable=False)  # checking, savings, credit, investment
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    balance = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    institution = db.Column(db.String(200), nullable=True)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,156 @@
+"""Multi-account financial overview endpoints."""
+
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import FinancialAccount
+import logging
+
+bp = Blueprint("accounts", __name__)
+logger = logging.getLogger("finmind.accounts")
+
+VALID_TYPES = {"checking", "savings", "credit", "investment", "cash", "other"}
+
+
+def _account_to_dict(a: FinancialAccount) -> dict:
+    return {
+        "id": a.id,
+        "name": a.name,
+        "account_type": a.account_type,
+        "currency": a.currency,
+        "balance": float(a.balance),
+        "institution": a.institution,
+        "active": a.active,
+        "created_at": a.created_at.isoformat(),
+    }
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    accounts = (
+        db.session.query(FinancialAccount)
+        .filter_by(user_id=uid)
+        .order_by(FinancialAccount.created_at.desc())
+        .all()
+    )
+    return jsonify([_account_to_dict(a) for a in accounts])
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    account_type = (data.get("account_type") or "").strip().lower()
+    if account_type not in VALID_TYPES:
+        return jsonify(error=f"account_type must be one of: {', '.join(sorted(VALID_TYPES))}"), 400
+    balance = _parse_amount(data.get("balance", 0)) or Decimal("0")
+    account = FinancialAccount(
+        user_id=uid,
+        name=name,
+        account_type=account_type,
+        currency=data.get("currency", "INR"),
+        balance=balance,
+        institution=(data.get("institution") or "").strip() or None,
+    )
+    db.session.add(account)
+    db.session.commit()
+    logger.info("Created account id=%s user=%s", account.id, uid)
+    return jsonify(_account_to_dict(account)), 201
+
+
+@bp.get("/<int:account_id>")
+@jwt_required()
+def get_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    return jsonify(_account_to_dict(account))
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = (data["name"] or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        account.name = name
+    if "balance" in data:
+        bal = _parse_amount(data["balance"])
+        if bal is None:
+            return jsonify(error="invalid balance"), 400
+        account.balance = bal
+    if "institution" in data:
+        account.institution = (data["institution"] or "").strip() or None
+    if "active" in data:
+        account.active = bool(data["active"])
+    if "account_type" in data:
+        at = (data["account_type"] or "").strip().lower()
+        if at not in VALID_TYPES:
+            return jsonify(error="invalid account_type"), 400
+        account.account_type = at
+    db.session.commit()
+    return jsonify(_account_to_dict(account))
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def delete_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(account)
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+@bp.get("/overview")
+@jwt_required()
+def accounts_overview():
+    """Aggregated multi-account overview dashboard."""
+    uid = int(get_jwt_identity())
+    accounts = (
+        db.session.query(FinancialAccount)
+        .filter_by(user_id=uid, active=True)
+        .all()
+    )
+    total_balance = sum(float(a.balance) for a in accounts)
+    by_type = {}
+    for a in accounts:
+        by_type.setdefault(a.account_type, {"count": 0, "total_balance": 0.0})
+        by_type[a.account_type]["count"] += 1
+        by_type[a.account_type]["total_balance"] += float(a.balance)
+    assets = sum(float(a.balance) for a in accounts if a.account_type != "credit")
+    liabilities = sum(abs(float(a.balance)) for a in accounts if a.account_type == "credit")
+    return jsonify(
+        total_accounts=len(accounts),
+        total_balance=round(total_balance, 2),
+        net_worth=round(assets - liabilities, 2),
+        assets=round(assets, 2),
+        liabilities=round(liabilities, 2),
+        by_type=by_type,
+        accounts=[_account_to_dict(a) for a in accounts],
+    )

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,95 @@
+"""Tests for multi-account financial overview."""
+
+
+def _create_account(client, auth_header, name="Checking", account_type="checking", balance=1000):
+    r = client.post("/accounts", json={"name": name, "account_type": account_type, "balance": balance}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+# 1. Auth required
+def test_accounts_requires_auth(client):
+    r = client.get("/accounts")
+    assert r.status_code in (401, 422)
+
+
+# 2. Create account
+def test_create_account(client, auth_header):
+    data = _create_account(client, auth_header, "My Checking", "checking", 5000)
+    assert data["name"] == "My Checking"
+    assert data["account_type"] == "checking"
+    assert data["balance"] == 5000.0
+    assert data["active"] is True
+
+
+# 3. List accounts
+def test_list_accounts(client, auth_header):
+    _create_account(client, auth_header, "Account A", "checking", 1000)
+    _create_account(client, auth_header, "Account B", "savings", 5000)
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) >= 2
+
+
+# 4. Update balance
+def test_update_balance(client, auth_header):
+    acc = _create_account(client, auth_header, "Savings", "savings", 2000)
+    r = client.patch(f"/accounts/{acc['id']}", json={"balance": 3500}, headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["balance"] == 3500.0
+
+
+# 5. Delete account
+def test_delete_account(client, auth_header):
+    acc = _create_account(client, auth_header, "ToDelete", "cash", 100)
+    r = client.delete(f"/accounts/{acc['id']}", headers=auth_header)
+    assert r.status_code == 200
+    r = client.get(f"/accounts/{acc['id']}", headers=auth_header)
+    assert r.status_code == 404
+
+
+# 6. Invalid account type
+def test_invalid_account_type(client, auth_header):
+    r = client.post("/accounts", json={"name": "Bad", "account_type": "invalid_type"}, headers=auth_header)
+    assert r.status_code == 400
+
+
+# 7. Missing name
+def test_missing_name(client, auth_header):
+    r = client.post("/accounts", json={"name": "", "account_type": "checking"}, headers=auth_header)
+    assert r.status_code == 400
+
+
+# 8. Overview aggregation
+def test_overview(client, auth_header):
+    _create_account(client, auth_header, "Checking", "checking", 10000)
+    _create_account(client, auth_header, "Savings", "savings", 25000)
+    _create_account(client, auth_header, "Credit Card", "credit", -3000)
+    r = client.get("/accounts/overview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_accounts"] == 3
+    assert data["total_balance"] == 32000.0
+    assert data["assets"] == 35000.0
+    assert data["liabilities"] == 3000.0
+    assert data["net_worth"] == 32000.0
+    assert "checking" in data["by_type"]
+    assert "savings" in data["by_type"]
+
+
+# 9. Get single account
+def test_get_single(client, auth_header):
+    acc = _create_account(client, auth_header, "Investment", "investment", 50000)
+    r = client.get(f"/accounts/{acc['id']}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["name"] == "Investment"
+
+
+# 10. Overview with no accounts
+def test_overview_empty(client, auth_header):
+    r = client.get("/accounts/overview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_accounts"] == 0
+    assert data["total_balance"] == 0
+    assert data["net_worth"] == 0


### PR DESCRIPTION
## Summary
/claim #132

## What this PR does
- FinancialAccount model (checking, savings, credit, investment, cash)
- Full CRUD at /accounts
- Aggregated overview at /accounts/overview: net worth, assets vs liabilities, by-type breakdown
- TypeScript API client
- 10 test cases

Fixes #132