### PR TITLE
feat: add rule-based auto-tagging and categorization

### DIFF
--- a/app/src/api/tagging.ts
+++ b/app/src/api/tagging.ts
@@ -1,0 +1,51 @@
+import { api } from './client';
+
+export type TaggingRule = {
+  id: number;
+  name: string;
+  field: string;
+  operator: string;
+  value: string;
+  category_id: number | null;
+  tag: string | null;
+  active: boolean;
+  created_at: string;
+};
+
+export type ApplyResult = {
+  matched: number;
+  total_expenses: number;
+  rules_applied: number;
+};
+
+export type TestMatch = {
+  expense_id: number;
+  expense_notes: string;
+  expense_amount: number;
+  matched_rule: string;
+  would_assign_category: number | null;
+  would_assign_tag: string | null;
+};
+
+export async function listRules(): Promise<TaggingRule[]> {
+  return api<TaggingRule[]>('/tagging/rules');
+}
+
+export async function createRule(data: {
+  name: string; field: string; operator: string; value: string;
+  category_id?: number; tag?: string;
+}): Promise<TaggingRule> {
+  return api<TaggingRule>('/tagging/rules', { method: 'POST', body: data });
+}
+
+export async function deleteRule(id: number): Promise<void> {
+  return api<void>('/tagging/rules/' + id, { method: 'DELETE' });
+}
+
+export async function applyRules(): Promise<ApplyResult> {
+  return api<ApplyResult>('/tagging/rules/apply', { method: 'POST' });
+}
+
+export async function testRules(): Promise<{ matches: TestMatch[]; total_matches: number }> {
+  return api('/tagging/rules/test', { method: 'POST' });
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,17 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class TaggingRule(db.Model):
+    __tablename__ = "tagging_rules"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    field = db.Column(db.String(50), nullable=False)  # notes, amount, expense_type
+    operator = db.Column(db.String(20), nullable=False)  # contains, equals, gt, lt
+    value = db.Column(db.String(200), nullable=False)
+    category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    tag = db.Column(db.String(100), nullable=True)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .tagging import bp as tagging_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(tagging_bp, url_prefix="/tagging/rules")

--- a/packages/backend/app/routes/tagging.py
+++ b/packages/backend/app/routes/tagging.py
@@ -1,0 +1,144 @@
+"""Rule-based auto-tagging & categorization endpoints."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import TaggingRule, Expense
+import logging
+
+bp = Blueprint("tagging", __name__)
+logger = logging.getLogger("finmind.tagging")
+
+VALID_FIELDS = {"notes", "amount", "expense_type"}
+VALID_OPERATORS = {"contains", "equals", "gt", "lt"}
+
+
+def _rule_to_dict(r):
+    return {
+        "id": r.id,
+        "name": r.name,
+        "field": r.field,
+        "operator": r.operator,
+        "value": r.value,
+        "category_id": r.category_id,
+        "tag": r.tag,
+        "active": r.active,
+        "created_at": r.created_at.isoformat(),
+    }
+
+
+def _matches(expense, rule):
+    """Check if an expense matches a tagging rule."""
+    if rule.field == "notes":
+        text = (expense.notes or "").lower()
+        if rule.operator == "contains":
+            return rule.value.lower() in text
+        if rule.operator == "equals":
+            return text == rule.value.lower()
+    elif rule.field == "amount":
+        try:
+            val = float(rule.value)
+        except ValueError:
+            return False
+        amt = float(expense.amount)
+        if rule.operator == "gt":
+            return amt > val
+        if rule.operator == "lt":
+            return amt < val
+        if rule.operator == "equals":
+            return amt == val
+    elif rule.field == "expense_type":
+        if rule.operator == "equals":
+            return (expense.expense_type or "").upper() == rule.value.upper()
+    return False
+
+
+@bp.get("")
+@jwt_required()
+def list_rules():
+    uid = int(get_jwt_identity())
+    rules = db.session.query(TaggingRule).filter_by(user_id=uid).order_by(TaggingRule.created_at.desc()).all()
+    return jsonify([_rule_to_dict(r) for r in rules])
+
+
+@bp.post("")
+@jwt_required()
+def create_rule():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    field = (data.get("field") or "").strip().lower()
+    if field not in VALID_FIELDS:
+        return jsonify(error=f"field must be one of: {', '.join(sorted(VALID_FIELDS))}"), 400
+    operator = (data.get("operator") or "").strip().lower()
+    if operator not in VALID_OPERATORS:
+        return jsonify(error=f"operator must be one of: {', '.join(sorted(VALID_OPERATORS))}"), 400
+    value = (data.get("value") or "").strip()
+    if not value:
+        return jsonify(error="value required"), 400
+    rule = TaggingRule(
+        user_id=uid, name=name, field=field, operator=operator, value=value,
+        category_id=data.get("category_id"), tag=data.get("tag"), active=True,
+    )
+    db.session.add(rule)
+    db.session.commit()
+    logger.info("Created tagging rule id=%s user=%s", rule.id, uid)
+    return jsonify(_rule_to_dict(rule)), 201
+
+
+@bp.delete("/<int:rule_id>")
+@jwt_required()
+def delete_rule(rule_id):
+    uid = int(get_jwt_identity())
+    rule = db.session.get(TaggingRule, rule_id)
+    if not rule or rule.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(rule)
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+@bp.post("/apply")
+@jwt_required()
+def apply_rules():
+    """Apply all active rules to uncategorized expenses."""
+    uid = int(get_jwt_identity())
+    rules = db.session.query(TaggingRule).filter_by(user_id=uid, active=True).all()
+    if not rules:
+        return jsonify(matched=0, message="no active rules")
+    expenses = db.session.query(Expense).filter_by(user_id=uid).all()
+    matched = 0
+    for expense in expenses:
+        for rule in rules:
+            if _matches(expense, rule):
+                if rule.category_id and not expense.category_id:
+                    expense.category_id = rule.category_id
+                    matched += 1
+    db.session.commit()
+    logger.info("Applied tagging rules user=%s matched=%d", uid, matched)
+    return jsonify(matched=matched, total_expenses=len(expenses), rules_applied=len(rules))
+
+
+@bp.post("/test")
+@jwt_required()
+def test_rules():
+    """Dry-run: show which expenses would be matched without applying."""
+    uid = int(get_jwt_identity())
+    rules = db.session.query(TaggingRule).filter_by(user_id=uid, active=True).all()
+    expenses = db.session.query(Expense).filter_by(user_id=uid).all()
+    matches = []
+    for expense in expenses:
+        for rule in rules:
+            if _matches(expense, rule):
+                matches.append({
+                    "expense_id": expense.id,
+                    "expense_notes": expense.notes,
+                    "expense_amount": float(expense.amount),
+                    "matched_rule": rule.name,
+                    "would_assign_category": rule.category_id,
+                    "would_assign_tag": rule.tag,
+                })
+    return jsonify(matches=matches, total_matches=len(matches))

--- a/packages/backend/tests/test_tagging.py
+++ b/packages/backend/tests/test_tagging.py
@@ -1,0 +1,94 @@
+"""Tests for rule-based auto-tagging."""
+
+
+def _create_rule(client, auth_header, name="Groceries Rule", field="notes", operator="contains", value="grocery", category_id=None, tag=None):
+    payload = {"name": name, "field": field, "operator": operator, "value": value}
+    if category_id:
+        payload["category_id"] = category_id
+    if tag:
+        payload["tag"] = tag
+    r = client.post("/tagging/rules", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def _add_expense(client, auth_header, amount, desc):
+    r = client.post("/expenses", json={"amount": amount, "description": desc, "expense_type": "EXPENSE"}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def _create_category(client, auth_header, name):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+# 1. Auth required
+def test_tagging_requires_auth(client):
+    r = client.get("/tagging/rules")
+    assert r.status_code in (401, 422)
+
+
+# 2. Create rule
+def test_create_rule(client, auth_header):
+    rule = _create_rule(client, auth_header, "Coffee", "notes", "contains", "coffee")
+    assert rule["name"] == "Coffee"
+    assert rule["field"] == "notes"
+    assert rule["operator"] == "contains"
+    assert rule["active"] is True
+
+
+# 3. List rules
+def test_list_rules(client, auth_header):
+    _create_rule(client, auth_header, "Rule A", "notes", "contains", "food")
+    _create_rule(client, auth_header, "Rule B", "amount", "gt", "100")
+    r = client.get("/tagging/rules", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) >= 2
+
+
+# 4. Delete rule
+def test_delete_rule(client, auth_header):
+    rule = _create_rule(client, auth_header, "ToDelete", "notes", "contains", "x")
+    r = client.delete(f"/tagging/rules/{rule['id']}", headers=auth_header)
+    assert r.status_code == 200
+
+
+# 5. Invalid field returns 400
+def test_invalid_field(client, auth_header):
+    r = client.post("/tagging/rules", json={"name": "Bad", "field": "invalid", "operator": "contains", "value": "x"}, headers=auth_header)
+    assert r.status_code == 400
+
+
+# 6. Apply rules categorizes expenses
+def test_apply_rules(client, auth_header):
+    cat = _create_category(client, auth_header, "Food")
+    _create_rule(client, auth_header, "Grocery auto", "notes", "contains", "grocery", category_id=cat["id"])
+    _add_expense(client, auth_header, 50, "Weekly grocery shopping")
+    _add_expense(client, auth_header, 30, "Gas station")
+    r = client.post("/tagging/rules/apply", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["matched"] >= 1
+
+
+# 7. Test rules (dry run)
+def test_dry_run(client, auth_header):
+    _create_rule(client, auth_header, "Big spend", "amount", "gt", "100")
+    _add_expense(client, auth_header, 200, "Large purchase")
+    _add_expense(client, auth_header, 20, "Small item")
+    r = client.post("/tagging/rules/test", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_matches"] >= 1
+    assert any(m["expense_amount"] == 200.0 for m in data["matches"])
+
+
+# 8. Contains operator case-insensitive
+def test_contains_case_insensitive(client, auth_header):
+    _create_rule(client, auth_header, "Coffee", "notes", "contains", "COFFEE")
+    _add_expense(client, auth_header, 5, "Morning coffee run")
+    r = client.post("/tagging/rules/test", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["total_matches"] >= 1


### PR DESCRIPTION
## Summary
/claim #107

## What this PR does
- TaggingRule model with field/operator/value matching engine
- CRUD at /tagging/rules
- POST /tagging/rules/apply - auto-categorize uncategorized expenses
- POST /tagging/rules/test - dry-run preview of matches
- Supports: notes contains/equals, amount gt/lt/equals, expense_type equals
- Case-insensitive text matching
- 8 tests + TypeScript API client

Fixes #107