### PR TITLE
feat: add recurring transaction anomaly alerts

### DIFF
--- a/app/src/api/anomalies.ts
+++ b/app/src/api/anomalies.ts
@@ -1,0 +1,22 @@
+import { api } from './client';
+
+export type AnomalyAlert = {
+  id: number; alert_type: string; severity: string;
+  message: string; expense_id: number | null;
+  acknowledged: boolean; created_at: string;
+};
+
+export type ScanResult = { alerts_created: number; alerts: AnomalyAlert[] };
+
+export async function listAlerts(unacknowledged?: boolean): Promise<AnomalyAlert[]> {
+  const q = unacknowledged ? '?unacknowledged=true' : '';
+  return api<AnomalyAlert[]>('/anomalies' + q);
+}
+
+export async function acknowledgeAlert(id: number): Promise<AnomalyAlert> {
+  return api<AnomalyAlert>('/anomalies/' + id + '/acknowledge', { method: 'POST' });
+}
+
+export async function scanAnomalies(): Promise<ScanResult> {
+  return api<ScanResult>('/anomalies/scan', { method: 'POST' });
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,15 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class AnomalyAlert(db.Model):
+    __tablename__ = "anomaly_alerts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    expense_id = db.Column(db.Integer, db.ForeignKey("expenses.id"), nullable=True)
+    alert_type = db.Column(db.String(50), nullable=False)  # spike, unusual_category, large_transaction, frequency
+    severity = db.Column(db.String(20), default="medium", nullable=False)  # low, medium, high
+    message = db.Column(db.String(500), nullable=False)
+    acknowledged = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .anomalies import bp as anomalies_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(anomalies_bp, url_prefix="/anomalies")

--- a/packages/backend/app/routes/anomalies.py
+++ b/packages/backend/app/routes/anomalies.py
@@ -1,0 +1,119 @@
+"""Recurring transaction anomaly detection & alerts."""
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import AnomalyAlert, Expense, Category
+import logging
+
+bp = Blueprint("anomalies", __name__)
+logger = logging.getLogger("finmind.anomalies")
+
+
+def _alert_to_dict(a):
+    return {
+        "id": a.id, "alert_type": a.alert_type, "severity": a.severity,
+        "message": a.message, "expense_id": a.expense_id,
+        "acknowledged": a.acknowledged, "created_at": a.created_at.isoformat(),
+    }
+
+
+@bp.get("")
+@jwt_required()
+def list_alerts():
+    uid = int(get_jwt_identity())
+    only_unack = request.args.get("unacknowledged", "").lower() == "true"
+    q = db.session.query(AnomalyAlert).filter_by(user_id=uid)
+    if only_unack:
+        q = q.filter_by(acknowledged=False)
+    alerts = q.order_by(AnomalyAlert.created_at.desc()).limit(50).all()
+    return jsonify([_alert_to_dict(a) for a in alerts])
+
+
+@bp.post("/<int:alert_id>/acknowledge")
+@jwt_required()
+def acknowledge(alert_id):
+    uid = int(get_jwt_identity())
+    alert = db.session.get(AnomalyAlert, alert_id)
+    if not alert or alert.user_id != uid:
+        return jsonify(error="not found"), 404
+    alert.acknowledged = True
+    db.session.commit()
+    return jsonify(_alert_to_dict(alert))
+
+
+@bp.post("/scan")
+@jwt_required()
+def scan_anomalies():
+    """Scan recent transactions for anomalies and generate alerts."""
+    uid = int(get_jwt_identity())
+    today = date.today()
+    week_ago = today - timedelta(days=7)
+    month_ago = today - timedelta(days=30)
+
+    recent = db.session.query(Expense).filter(
+        Expense.user_id == uid, Expense.spent_at >= week_ago
+    ).all()
+    historical = db.session.query(Expense).filter(
+        Expense.user_id == uid, Expense.spent_at >= month_ago, Expense.spent_at < week_ago
+    ).all()
+
+    alerts_created = []
+
+    # 1. Large transaction detection (> 2x average)
+    if historical:
+        avg = sum(float(e.amount) for e in historical) / len(historical)
+        threshold = max(avg * 2, 100)
+        for e in recent:
+            if float(e.amount) > threshold:
+                alert = _create_alert(uid, "large_transaction", "high",
+                    f"Transaction of {float(e.amount):.2f} is {float(e.amount)/avg:.1f}x your average ({avg:.2f})",
+                    e.id)
+                if alert:
+                    alerts_created.append(alert)
+
+    # 2. Spending spike (weekly total > 1.5x previous week average)
+    if historical:
+        weekly_avg = sum(float(e.amount) for e in historical) / max(1, (month_ago - week_ago).days / 7)
+        weekly_total = sum(float(e.amount) for e in recent)
+        if weekly_total > weekly_avg * 1.5 and weekly_avg > 0:
+            alert = _create_alert(uid, "spike", "medium",
+                f"This week's spending ({weekly_total:.2f}) is {weekly_total/weekly_avg:.1f}x your weekly average ({weekly_avg:.2f})")
+            if alert:
+                alerts_created.append(alert)
+
+    # 3. Unusual frequency (> 3 transactions per day)
+    from collections import Counter
+    daily_counts = Counter(e.spent_at for e in recent)
+    for day, count in daily_counts.items():
+        if count > 3:
+            alert = _create_alert(uid, "frequency", "low",
+                f"{count} transactions on {day.isoformat()} - unusually high activity")
+            if alert:
+                alerts_created.append(alert)
+
+    db.session.commit()
+    return jsonify(
+        alerts_created=len(alerts_created),
+        alerts=[_alert_to_dict(a) for a in alerts_created],
+    )
+
+
+def _create_alert(uid, alert_type, severity, message, expense_id=None):
+    existing = db.session.query(AnomalyAlert).filter_by(
+        user_id=uid, message=message, acknowledged=False
+    ).first()
+    if existing:
+        return None
+    alert = AnomalyAlert(
+        user_id=uid, alert_type=alert_type, severity=severity,
+        message=message, expense_id=expense_id,
+    )
+    db.session.add(alert)
+    db.session.flush()
+    return alert

--- a/packages/backend/tests/test_anomalies.py
+++ b/packages/backend/tests/test_anomalies.py
@@ -1,0 +1,89 @@
+"""Tests for recurring transaction anomaly alerts."""
+
+from datetime import date, timedelta
+
+
+def _add_expense(client, auth_header, amount, desc, spent_at=None):
+    payload = {"amount": amount, "description": desc, "expense_type": "EXPENSE"}
+    if spent_at:
+        payload["date"] = spent_at
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+# 1. Auth required
+def test_anomalies_requires_auth(client):
+    r = client.get("/anomalies")
+    assert r.status_code in (401, 422)
+
+
+# 2. Empty alerts
+def test_empty_alerts(client, auth_header):
+    r = client.get("/anomalies", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+# 3. Scan with no history returns no alerts
+def test_scan_no_history(client, auth_header):
+    r = client.post("/anomalies/scan", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["alerts_created"] == 0
+
+
+# 4. Large transaction detected
+def test_large_transaction_alert(client, auth_header):
+    today = date.today()
+    two_weeks_ago = today - timedelta(days=14)
+    for i in range(5):
+        _add_expense(client, auth_header, 20, f"Normal {i}", (two_weeks_ago + timedelta(days=i)).isoformat())
+    _add_expense(client, auth_header, 500, "Huge purchase", today.isoformat())
+    r = client.post("/anomalies/scan", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["alerts_created"] >= 1
+    assert any(a["alert_type"] == "large_transaction" for a in data["alerts"])
+
+
+# 5. Acknowledge alert
+def test_acknowledge_alert(client, auth_header):
+    today = date.today()
+    two_weeks_ago = today - timedelta(days=14)
+    for i in range(3):
+        _add_expense(client, auth_header, 10, f"Small {i}", (two_weeks_ago + timedelta(days=i)).isoformat())
+    _add_expense(client, auth_header, 300, "Big one", today.isoformat())
+    client.post("/anomalies/scan", headers=auth_header)
+    r = client.get("/anomalies", headers=auth_header)
+    alerts = r.get_json()
+    if alerts:
+        alert_id = alerts[0]["id"]
+        r = client.post(f"/anomalies/{alert_id}/acknowledge", headers=auth_header)
+        assert r.status_code == 200
+        assert r.get_json()["acknowledged"] is True
+
+
+# 6. Filter unacknowledged
+def test_filter_unacknowledged(client, auth_header):
+    r = client.get("/anomalies?unacknowledged=true", headers=auth_header)
+    assert r.status_code == 200
+
+
+# 7. No duplicate alerts on rescan
+def test_no_duplicate_alerts(client, auth_header):
+    today = date.today()
+    two_weeks_ago = today - timedelta(days=14)
+    for i in range(3):
+        _add_expense(client, auth_header, 15, f"Hist {i}", (two_weeks_ago + timedelta(days=i)).isoformat())
+    _add_expense(client, auth_header, 400, "Big", today.isoformat())
+    r1 = client.post("/anomalies/scan", headers=auth_header)
+    count1 = r1.get_json()["alerts_created"]
+    r2 = client.post("/anomalies/scan", headers=auth_header)
+    count2 = r2.get_json()["alerts_created"]
+    assert count2 == 0  # no duplicates
+
+
+# 8. Alert not found returns 404
+def test_acknowledge_not_found(client, auth_header):
+    r = client.post("/anomalies/99999/acknowledge", headers=auth_header)
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary
/claim #108

## What this PR does
- Anomaly scanner: large transactions (>2x avg), spending spikes (>1.5x weekly), high frequency (>3/day)
- GET /anomalies (with unacknowledged filter)
- POST /anomalies/scan to detect anomalies
- POST /anomalies/:id/acknowledge
- Deduplication on rescan
- 8 tests + TypeScript client

Fixes #108