### PR TITLE
feat: add login anomaly detection and suspicious activity alerts

### DIFF
--- a/app/src/api/loginSecurity.ts
+++ b/app/src/api/loginSecurity.ts
@@ -1,0 +1,6 @@
+import { api } from './client';
+export type LoginEvent = { id: number; ip_address: string; user_agent: string; success: boolean; suspicious: boolean; reason: string | null; created_at: string; };
+export type LoginStats = { total_logins: number; failed_attempts: number; suspicious_events: number; unique_ips: number; };
+export async function getLoginHistory(): Promise<LoginEvent[]> { return api('/login-security/history'); }
+export async function getSuspiciousLogins(): Promise<LoginEvent[]> { return api('/login-security/suspicious'); }
+export async function getLoginStats(): Promise<LoginStats> { return api('/login-security/stats'); }

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,15 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class LoginEvent(db.Model):
+    __tablename__ = "login_events"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    ip_address = db.Column(db.String(50), nullable=True)
+    user_agent = db.Column(db.String(500), nullable=True)
+    success = db.Column(db.Boolean, nullable=False)
+    suspicious = db.Column(db.Boolean, default=False, nullable=False)
+    reason = db.Column(db.String(200), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .login_security import bp as login_security_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(login_security_bp, url_prefix="/login-security")

--- a/packages/backend/app/routes/login_security.py
+++ b/packages/backend/app/routes/login_security.py
@@ -1,0 +1,62 @@
+"""Login anomaly detection and suspicious activity alerts."""
+from datetime import datetime, timedelta
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import LoginEvent
+import logging
+
+bp = Blueprint("login_security", __name__)
+logger = logging.getLogger("finmind.login_security")
+
+def _event_to_dict(e):
+    return {"id": e.id, "ip_address": e.ip_address, "user_agent": e.user_agent, "success": e.success, "suspicious": e.suspicious, "reason": e.reason, "created_at": e.created_at.isoformat()}
+
+def record_login(user_id, ip, user_agent, success):
+    suspicious = False
+    reason = None
+    if success:
+        recent = db.session.query(LoginEvent).filter(
+            LoginEvent.user_id == user_id, LoginEvent.success == True,
+            LoginEvent.created_at >= datetime.utcnow() - timedelta(hours=24)
+        ).all()
+        known_ips = {e.ip_address for e in recent}
+        if known_ips and ip not in known_ips and len(known_ips) >= 1:
+            suspicious = True
+            reason = f"New IP address: {ip}"
+    else:
+        failed_count = db.session.query(LoginEvent).filter(
+            LoginEvent.user_id == user_id, LoginEvent.success == False,
+            LoginEvent.created_at >= datetime.utcnow() - timedelta(minutes=30)
+        ).count()
+        if failed_count >= 3:
+            suspicious = True
+            reason = f"Brute force: {failed_count + 1} failed attempts in 30 min"
+    event = LoginEvent(user_id=user_id, ip_address=ip, user_agent=user_agent, success=success, suspicious=suspicious, reason=reason)
+    db.session.add(event)
+    db.session.commit()
+    return event
+
+@bp.get("/history")
+@jwt_required()
+def login_history():
+    uid = int(get_jwt_identity())
+    events = db.session.query(LoginEvent).filter_by(user_id=uid).order_by(LoginEvent.created_at.desc()).limit(50).all()
+    return jsonify([_event_to_dict(e) for e in events])
+
+@bp.get("/suspicious")
+@jwt_required()
+def suspicious_logins():
+    uid = int(get_jwt_identity())
+    events = db.session.query(LoginEvent).filter_by(user_id=uid, suspicious=True).order_by(LoginEvent.created_at.desc()).limit(20).all()
+    return jsonify([_event_to_dict(e) for e in events])
+
+@bp.get("/stats")
+@jwt_required()
+def login_stats():
+    uid = int(get_jwt_identity())
+    total = db.session.query(LoginEvent).filter_by(user_id=uid).count()
+    failed = db.session.query(LoginEvent).filter_by(user_id=uid, success=False).count()
+    suspicious = db.session.query(LoginEvent).filter_by(user_id=uid, suspicious=True).count()
+    ips = db.session.query(LoginEvent.ip_address).filter_by(user_id=uid, success=True).distinct().count()
+    return jsonify(total_logins=total, failed_attempts=failed, suspicious_events=suspicious, unique_ips=ips)

--- a/packages/backend/tests/test_login_security.py
+++ b/packages/backend/tests/test_login_security.py
@@ -1,0 +1,51 @@
+"""Tests for login anomaly detection."""
+from app.routes.login_security import record_login
+
+def test_requires_auth(client):
+    assert client.get("/login-security/history").status_code in (401, 422)
+
+def test_login_history(client, auth_header):
+    r = client.get("/login-security/history", headers=auth_header)
+    assert r.status_code == 200
+
+def test_suspicious_endpoint(client, auth_header):
+    r = client.get("/login-security/suspicious", headers=auth_header)
+    assert r.status_code == 200
+    assert isinstance(r.get_json(), list)
+
+def test_login_stats(client, auth_header):
+    r = client.get("/login-security/stats", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "total_logins" in data
+    assert "failed_attempts" in data
+    assert "suspicious_events" in data
+
+def test_record_login(app_fixture):
+    with app_fixture.app_context():
+        from app.extensions import db
+        from app.models import User
+        user = db.session.query(User).first()
+        if not user:
+            from werkzeug.security import generate_password_hash
+            user = User(email="sec@test.com", password_hash=generate_password_hash("test"))
+            db.session.add(user)
+            db.session.commit()
+        event = record_login(user.id, "1.2.3.4", "TestAgent", True)
+        assert event.success is True
+        assert event.suspicious is False
+
+def test_new_ip_suspicious(app_fixture):
+    with app_fixture.app_context():
+        from app.extensions import db
+        from app.models import User
+        user = db.session.query(User).first()
+        if not user:
+            from werkzeug.security import generate_password_hash
+            user = User(email="sec2@test.com", password_hash=generate_password_hash("test"))
+            db.session.add(user)
+            db.session.commit()
+        record_login(user.id, "10.0.0.1", "Agent1", True)
+        event2 = record_login(user.id, "99.99.99.99", "Agent2", True)
+        assert event2.suspicious is True
+        assert "New IP" in (event2.reason or "")


### PR DESCRIPTION
## Summary
/claim #124

## What this PR does
- LoginEvent model: IP, user agent, success, suspicious flag, reason
- New IP detection: flags logins from previously unseen IPs
- Brute force: flags 3+ failed attempts in 30 minutes
- GET /login-security/history, /suspicious, /stats
- 6 tests + TypeScript client

Fixes #124