### PR TITLE
feat: add financial scenario simulator (what-if planning)

### DIFF
--- a/app/src/api/scenarios.ts
+++ b/app/src/api/scenarios.ts
@@ -1,0 +1,3 @@
+import { api } from './client';
+export type SimResult = { baseline: { monthly_income: number; monthly_expenses: number }; projection: { month: number; income: number; expenses: number; net: number; cumulative: number }[]; summary: { total_saved: number; months: number } };
+export async function simulate(params: { months?: number; income_change_pct?: number; expense_change_pct?: number; one_time_expense?: number; one_time_income?: number; savings_rate?: number }): Promise<SimResult> { return api('/scenarios/simulate', { method: 'POST', body: params }); }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .scenarios import bp as scenarios_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(scenarios_bp, url_prefix="/scenarios")

--- a/packages/backend/app/routes/scenarios.py
+++ b/packages/backend/app/routes/scenarios.py
@@ -1,0 +1,52 @@
+"""Financial scenario simulator (what-if planning)."""
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Expense
+from datetime import date, timedelta
+import logging
+
+bp = Blueprint("scenarios", __name__)
+logger = logging.getLogger("finmind.scenarios")
+
+@bp.post("/simulate")
+@jwt_required()
+def simulate():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    months = min(int(data.get("months", 6)), 24)
+    income_change_pct = float(data.get("income_change_pct", 0))
+    expense_change_pct = float(data.get("expense_change_pct", 0))
+    one_time_expense = float(data.get("one_time_expense", 0))
+    one_time_income = float(data.get("one_time_income", 0))
+    savings_rate = float(data.get("savings_rate", 0)) / 100
+
+    today = date.today()
+    ninety_ago = today - timedelta(days=90)
+    expenses = db.session.query(Expense).filter(Expense.user_id == uid, Expense.spent_at >= ninety_ago).all()
+    
+    total_exp = sum(float(e.amount) for e in expenses if e.expense_type == "EXPENSE")
+    total_inc = sum(float(e.amount) for e in expenses if e.expense_type == "INCOME")
+    days = max((today - ninety_ago).days, 1)
+    monthly_exp = (total_exp / days) * 30
+    monthly_inc = (total_inc / days) * 30
+
+    adj_income = monthly_inc * (1 + income_change_pct / 100)
+    adj_expense = monthly_exp * (1 + expense_change_pct / 100)
+
+    projection = []
+    cumulative_savings = 0
+    for m in range(1, months + 1):
+        inc = adj_income + (one_time_income if m == 1 else 0)
+        exp = adj_expense + (one_time_expense if m == 1 else 0)
+        savings = (inc - exp) * (1 - savings_rate) if savings_rate else inc - exp
+        cumulative_savings += savings
+        projection.append({"month": m, "income": round(inc, 2), "expenses": round(exp, 2), "net": round(savings, 2), "cumulative": round(cumulative_savings, 2)})
+
+    return jsonify(
+        baseline={"monthly_income": round(monthly_inc, 2), "monthly_expenses": round(monthly_exp, 2)},
+        adjustments={"income_change_pct": income_change_pct, "expense_change_pct": expense_change_pct},
+        projection=projection,
+        summary={"total_saved": round(cumulative_savings, 2), "months": months}
+    )

--- a/packages/backend/tests/test_scenarios.py
+++ b/packages/backend/tests/test_scenarios.py
@@ -1,0 +1,28 @@
+from datetime import date, timedelta
+def _add(c, h, amt, desc, typ="EXPENSE"):
+    c.post("/expenses", json={"amount": amt, "description": desc, "expense_type": typ}, headers=h)
+
+def test_auth(client): assert client.post("/scenarios/simulate").status_code in (401, 422)
+
+def test_simulate_empty(client, auth_header):
+    r = client.post("/scenarios/simulate", json={"months": 3}, headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()["projection"]) == 3
+
+def test_simulate_with_data(client, auth_header):
+    _add(client, auth_header, 1000, "Salary", "INCOME")
+    _add(client, auth_header, 500, "Rent")
+    r = client.post("/scenarios/simulate", json={"months": 6, "income_change_pct": 10}, headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["adjustments"]["income_change_pct"] == 10
+
+def test_one_time_expense(client, auth_header):
+    r = client.post("/scenarios/simulate", json={"months": 3, "one_time_expense": 5000}, headers=auth_header)
+    assert r.status_code == 200
+    p = r.get_json()["projection"]
+    assert p[0]["expenses"] >= 5000
+
+def test_max_months(client, auth_header):
+    r = client.post("/scenarios/simulate", json={"months": 99}, headers=auth_header)
+    assert len(r.get_json()["projection"]) == 24


### PR DESCRIPTION
## Summary
/claim #94

POST /scenarios/simulate with income/expense % changes, one-time events, savings rate. Monthly projections. 5 tests + TS client.

Fixes #94