### PR TITLE
feat: add explainable spending insights endpoint

### DIFF
--- a/app/src/api/spendingInsights.ts
+++ b/app/src/api/spendingInsights.ts
@@ -1,0 +1,38 @@
+import { api } from './client';
+
+export type SpendingInsight = {
+  type: 'spike' | 'drop' | 'concentration' | 'new_category';
+  category_id: number | null;
+  category_name: string;
+  change_pct?: number;
+  concentration_pct?: number;
+  explanation: string;
+};
+
+export type CategorySpending = {
+  category_id: number | null;
+  category_name: string;
+  current_total: number;
+  previous_total: number;
+  transaction_count: number;
+  change_pct?: number | null;
+};
+
+export type SpendingInsightsResponse = {
+  insights: SpendingInsight[];
+  categories: CategorySpending[];
+  total_spent: number;
+  daily_average: number;
+  period: {
+    start: string;
+    end: string;
+    days: number;
+  };
+};
+
+export async function getSpendingInsights(params?: {
+  days?: number;
+}): Promise<SpendingInsightsResponse> {
+  const qs = params?.days ? `?days=${params.days}` : '';
+  return api<SpendingInsightsResponse>(`/spending-insights${qs}`);
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .spending_insights import bp as spending_insights_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(spending_insights_bp, url_prefix="/spending-insights")

--- a/packages/backend/app/routes/spending_insights.py
+++ b/packages/backend/app/routes/spending_insights.py
@@ -1,0 +1,166 @@
+from datetime import date, timedelta
+from collections import defaultdict
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Expense, Category
+import logging
+
+bp = Blueprint("spending_insights", __name__)
+logger = logging.getLogger("finmind.spending_insights")
+
+CONCENTRATION_THRESHOLD = 0.40  # warn if one category > 40%
+SPIKE_THRESHOLD = 0.30  # > 30% increase
+DROP_THRESHOLD = 0.30  # > 30% decrease
+
+
+@bp.get("")
+@jwt_required()
+def get_spending_insights():
+    uid = int(get_jwt_identity())
+
+    # Determine date range: default last 30 days
+    days = int(request.args.get("days", "30"))
+    end_date = date.today()
+    start_date = end_date - timedelta(days=days)
+
+    # Previous period for comparison
+    prev_start = start_date - timedelta(days=days)
+    prev_end = start_date - timedelta(days=1)
+
+    # Current period expenses by category
+    current_rows = (
+        db.session.query(
+            Expense.category_id,
+            func.sum(Expense.amount).label("total"),
+            func.count(Expense.id).label("count"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type == "EXPENSE",
+            Expense.spent_at >= start_date,
+            Expense.spent_at <= end_date,
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+
+    # Previous period expenses by category
+    prev_rows = (
+        db.session.query(
+            Expense.category_id,
+            func.sum(Expense.amount).label("total"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type == "EXPENSE",
+            Expense.spent_at >= prev_start,
+            Expense.spent_at <= prev_end,
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+
+    prev_by_cat = {row.category_id: float(row.total) for row in prev_rows}
+
+    # Load category names
+    cat_ids = {row.category_id for row in current_rows if row.category_id}
+    cat_ids.update(cid for cid in prev_by_cat if cid)
+    categories_map = {}
+    if cat_ids:
+        cats = db.session.query(Category).filter(Category.id.in_(cat_ids)).all()
+        categories_map = {c.id: c.name for c in cats}
+
+    total_spent = sum(float(row.total) for row in current_rows)
+    daily_average = round(total_spent / days, 2) if days > 0 else 0.0
+
+    insights = []
+    categories = []
+
+    for row in current_rows:
+        cat_id = row.category_id
+        cat_name = categories_map.get(cat_id, "Uncategorized")
+        current_total = float(row.total)
+        prev_total = prev_by_cat.get(cat_id, 0.0)
+
+        cat_entry = {
+            "category_id": cat_id,
+            "category_name": cat_name,
+            "current_total": round(current_total, 2),
+            "previous_total": round(prev_total, 2),
+            "transaction_count": row.count,
+        }
+
+        # Spike detection
+        if prev_total > 0:
+            change_pct = (current_total - prev_total) / prev_total
+            cat_entry["change_pct"] = round(change_pct * 100, 1)
+
+            if change_pct > SPIKE_THRESHOLD:
+                insights.append({
+                    "type": "spike",
+                    "category_id": cat_id,
+                    "category_name": cat_name,
+                    "change_pct": round(change_pct * 100, 1),
+                    "explanation": (
+                        f"Spending on {cat_name} increased by "
+                        f"{round(change_pct * 100, 1)}% compared to the "
+                        f"previous {days}-day period."
+                    ),
+                })
+            elif change_pct < -DROP_THRESHOLD:
+                insights.append({
+                    "type": "drop",
+                    "category_id": cat_id,
+                    "category_name": cat_name,
+                    "change_pct": round(change_pct * 100, 1),
+                    "explanation": (
+                        f"Spending on {cat_name} decreased by "
+                        f"{round(abs(change_pct) * 100, 1)}% compared to the "
+                        f"previous {days}-day period."
+                    ),
+                })
+        elif current_total > 0:
+            cat_entry["change_pct"] = None
+            insights.append({
+                "type": "new_category",
+                "category_id": cat_id,
+                "category_name": cat_name,
+                "explanation": (
+                    f"New spending detected in {cat_name} with no "
+                    f"activity in the previous period."
+                ),
+            })
+
+        # Concentration warning
+        if total_spent > 0 and (current_total / total_spent) > CONCENTRATION_THRESHOLD:
+            pct = round((current_total / total_spent) * 100, 1)
+            insights.append({
+                "type": "concentration",
+                "category_id": cat_id,
+                "category_name": cat_name,
+                "concentration_pct": pct,
+                "explanation": (
+                    f"{cat_name} accounts for {pct}% of total spending. "
+                    f"Consider diversifying or reviewing this category."
+                ),
+            })
+
+        categories.append(cat_entry)
+
+    logger.info("Spending insights served user=%s insights=%s", uid, len(insights))
+
+    return jsonify({
+        "insights": insights,
+        "categories": categories,
+        "total_spent": round(total_spent, 2),
+        "daily_average": daily_average,
+        "period": {
+            "start": start_date.isoformat(),
+            "end": end_date.isoformat(),
+            "days": days,
+        },
+    })

--- a/packages/backend/tests/test_spending_insights.py
+++ b/packages/backend/tests/test_spending_insights.py
@@ -1,0 +1,88 @@
+from datetime import date, timedelta
+
+
+def test_spending_insights_requires_auth(client):
+    r = client.get("/spending-insights")
+    assert r.status_code == 401
+
+
+def test_spending_insights_empty_state(client, auth_header):
+    r = client.get("/spending-insights", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["total_spent"] == 0
+    assert payload["daily_average"] == 0
+    assert payload["insights"] == []
+    assert payload["categories"] == []
+    assert "period" in payload
+
+
+def test_spending_insights_with_data(client, auth_header):
+    today = date.today()
+    # Create a category
+    r = client.post("/categories", json={"name": "Food"}, headers=auth_header)
+    assert r.status_code == 201
+    cat_id = r.get_json()["id"]
+
+    # Add current period expenses
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "Groceries",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": cat_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Add previous period expense (smaller, to trigger spike)
+    prev_date = (today - timedelta(days=35)).isoformat()
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 50,
+            "description": "Old groceries",
+            "date": prev_date,
+            "expense_type": "EXPENSE",
+            "category_id": cat_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/spending-insights?days=30", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["total_spent"] == 200.0
+    assert len(payload["categories"]) >= 1
+    assert payload["categories"][0]["category_name"] == "Food"
+    # Should detect a spike (200 vs 50 = 300% increase)
+    spike_insights = [i for i in payload["insights"] if i["type"] == "spike"]
+    assert len(spike_insights) >= 1
+    assert "explanation" in spike_insights[0]
+
+
+def test_spending_insights_daily_average(client, auth_header):
+    today = date.today()
+    # Add two expenses in the current period
+    for i in range(3):
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": 30,
+                "description": f"Expense {i}",
+                "date": (today - timedelta(days=i)).isoformat(),
+                "expense_type": "EXPENSE",
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get("/spending-insights?days=30", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["total_spent"] == 90.0
+    assert payload["daily_average"] == 3.0  # 90 / 30


### PR DESCRIPTION
## Summary
- Add `GET /spending-insights` endpoint that analyzes spending by category
- Detect spending spikes (>30% increase) and drops (>30% decrease) compared to previous period
- Warn when a single category exceeds 40% concentration of total spending
- Return insights with human-readable explanations, category breakdowns, total_spent, and daily_average
- Add comprehensive test suite (auth required, empty state, with data, daily average)
- Add TypeScript API client (`app/src/api/spendingInsights.ts`)
- Register blueprint in `__init__.py`

## Test plan
- [x] Auth required returns 401
- [x] Empty state returns zeroed response
- [x] With data detects spikes correctly
- [x] Daily average calculation is correct

/claim #89
Fixes #89