### PR TITLE
feat: add essential vs discretionary spending split endpoint

### DIFF
--- a/app/src/api/spendingSplit.ts
+++ b/app/src/api/spendingSplit.ts
@@ -1,0 +1,31 @@
+import { api } from './client';
+
+export type SpendingCategory = {
+  category_id: number | null;
+  category_name: string;
+  total: number;
+  transaction_count: number;
+  classification: 'essential' | 'discretionary';
+};
+
+export type SpendingSplitResponse = {
+  essential_total: number;
+  discretionary_total: number;
+  total: number;
+  ratio: number | null;
+  essential_pct: number;
+  discretionary_pct: number;
+  categories: SpendingCategory[];
+  period: {
+    start: string;
+    end: string;
+    days: number;
+  };
+};
+
+export async function getSpendingSplit(params?: {
+  days?: number;
+}): Promise<SpendingSplitResponse> {
+  const qs = params?.days ? `?days=${params.days}` : '';
+  return api<SpendingSplitResponse>(`/spending-split${qs}`);
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .spending_split import bp as spending_split_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(spending_split_bp, url_prefix="/spending-split")

--- a/packages/backend/app/routes/spending_split.py
+++ b/packages/backend/app/routes/spending_split.py
@@ -1,0 +1,137 @@
+from datetime import date, timedelta
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Expense, Category
+import logging
+
+bp = Blueprint("spending_split", __name__)
+logger = logging.getLogger("finmind.spending_split")
+
+# Categories classified as essential spending
+ESSENTIAL_KEYWORDS = {
+    "rent", "mortgage", "utilities", "electricity", "water", "gas",
+    "groceries", "grocery", "insurance", "healthcare", "health",
+    "medical", "pharmacy", "medicine", "housing", "internet",
+    "phone", "transport", "transportation", "fuel", "petrol",
+    "childcare", "education", "loan", "debt",
+}
+
+# Categories classified as discretionary spending
+DISCRETIONARY_KEYWORDS = {
+    "dining", "restaurant", "food delivery", "entertainment",
+    "movies", "streaming", "shopping", "clothing", "clothes",
+    "fashion", "hobby", "hobbies", "travel", "vacation",
+    "gaming", "subscription", "gym", "fitness", "beauty",
+    "salon", "spa", "coffee", "alcohol", "bar", "gifts",
+    "electronics", "gadgets",
+}
+
+
+def _classify_category(name):
+    """Classify a category name as essential or discretionary."""
+    lower_name = (name or "").lower().strip()
+    for keyword in ESSENTIAL_KEYWORDS:
+        if keyword in lower_name:
+            return "essential"
+    for keyword in DISCRETIONARY_KEYWORDS:
+        if keyword in lower_name:
+            return "discretionary"
+    # Default: uncategorized expenses go to discretionary
+    return "discretionary"
+
+
+@bp.get("")
+@jwt_required()
+def get_spending_split():
+    uid = int(get_jwt_identity())
+
+    # Determine date range
+    days = int(request.args.get("days", "30"))
+    end_date = date.today()
+    start_date = end_date - timedelta(days=days)
+
+    # Get expenses grouped by category
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.sum(Expense.amount).label("total"),
+            func.count(Expense.id).label("count"),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type == "EXPENSE",
+            Expense.spent_at >= start_date,
+            Expense.spent_at <= end_date,
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+
+    # Load category names
+    cat_ids = {row.category_id for row in rows if row.category_id}
+    categories_map = {}
+    if cat_ids:
+        cats = db.session.query(Category).filter(Category.id.in_(cat_ids)).all()
+        categories_map = {c.id: c.name for c in cats}
+
+    essential_total = 0.0
+    discretionary_total = 0.0
+    categories = []
+
+    for row in rows:
+        cat_id = row.category_id
+        cat_name = categories_map.get(cat_id, "Uncategorized")
+        amount = float(row.total)
+        classification = _classify_category(cat_name)
+
+        if classification == "essential":
+            essential_total += amount
+        else:
+            discretionary_total += amount
+
+        categories.append({
+            "category_id": cat_id,
+            "category_name": cat_name,
+            "total": round(amount, 2),
+            "transaction_count": row.count,
+            "classification": classification,
+        })
+
+    grand_total = essential_total + discretionary_total
+    ratio = (
+        round(essential_total / discretionary_total, 2)
+        if discretionary_total > 0
+        else None
+    )
+
+    logger.info(
+        "Spending split served user=%s essential=%.2f discretionary=%.2f",
+        uid, essential_total, discretionary_total,
+    )
+
+    return jsonify({
+        "essential_total": round(essential_total, 2),
+        "discretionary_total": round(discretionary_total, 2),
+        "total": round(grand_total, 2),
+        "ratio": ratio,
+        "essential_pct": (
+            round((essential_total / grand_total) * 100, 1)
+            if grand_total > 0
+            else 0.0
+        ),
+        "discretionary_pct": (
+            round((discretionary_total / grand_total) * 100, 1)
+            if grand_total > 0
+            else 0.0
+        ),
+        "categories": categories,
+        "period": {
+            "start": start_date.isoformat(),
+            "end": end_date.isoformat(),
+            "days": days,
+        },
+    })

--- a/packages/backend/tests/test_spending_split.py
+++ b/packages/backend/tests/test_spending_split.py
@@ -1,0 +1,125 @@
+from datetime import date, timedelta
+
+
+def test_spending_split_requires_auth(client):
+    r = client.get("/spending-split")
+    assert r.status_code == 401
+
+
+def test_spending_split_empty_state(client, auth_header):
+    r = client.get("/spending-split", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["essential_total"] == 0
+    assert payload["discretionary_total"] == 0
+    assert payload["total"] == 0
+    assert payload["categories"] == []
+    assert "period" in payload
+
+
+def test_spending_split_with_data(client, auth_header):
+    today = date.today()
+
+    # Create essential category
+    r = client.post("/categories", json={"name": "Groceries"}, headers=auth_header)
+    assert r.status_code == 201
+    grocery_id = r.get_json()["id"]
+
+    # Create discretionary category
+    r = client.post("/categories", json={"name": "Entertainment"}, headers=auth_header)
+    assert r.status_code == 201
+    ent_id = r.get_json()["id"]
+
+    # Add essential expense
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "Weekly groceries",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": grocery_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Add discretionary expense
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 50,
+            "description": "Movie tickets",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": ent_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/spending-split", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["essential_total"] == 200.0
+    assert payload["discretionary_total"] == 50.0
+    assert payload["total"] == 250.0
+
+    # Check categories are classified
+    cats = {c["category_name"]: c for c in payload["categories"]}
+    assert cats["Groceries"]["classification"] == "essential"
+    assert cats["Entertainment"]["classification"] == "discretionary"
+
+
+def test_spending_split_ratio_calculation(client, auth_header):
+    today = date.today()
+
+    # Create essential category
+    r = client.post("/categories", json={"name": "Rent"}, headers=auth_header)
+    assert r.status_code == 201
+    rent_id = r.get_json()["id"]
+
+    # Create discretionary category
+    r = client.post("/categories", json={"name": "Shopping"}, headers=auth_header)
+    assert r.status_code == 201
+    shop_id = r.get_json()["id"]
+
+    # Add essential expense
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 1000,
+            "description": "Monthly rent",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": rent_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Add discretionary expense
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 500,
+            "description": "Clothes",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": shop_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/spending-split", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    # Ratio should be essential / discretionary = 1000 / 500 = 2.0
+    assert payload["ratio"] == 2.0
+    assert payload["essential_pct"] > 0
+    assert payload["discretionary_pct"] > 0
+    # Percentages should add up to 100
+    assert round(payload["essential_pct"] + payload["discretionary_pct"], 1) == 100.0


### PR DESCRIPTION
## Summary
- Add `GET /spending-split` endpoint that classifies expenses as essential vs discretionary
- Essential categories: rent, utilities, groceries, insurance, healthcare, transport, etc.
- Discretionary categories: dining, entertainment, shopping, travel, hobbies, etc.
- Return essential_total, discretionary_total, ratio, percentages, and per-category breakdown
- Add comprehensive test suite (auth required, empty state, with data, ratio calculation)
- Add TypeScript API client (`app/src/api/spendingSplit.ts`)
- Register blueprint in `__init__.py`

## Test plan
- [x] Auth required returns 401
- [x] Empty state returns zeroed totals
- [x] With data classifies Groceries as essential and Entertainment as discretionary
- [x] Ratio calculation (essential/discretionary) is correct
- [x] Percentages add up to 100%

/claim #120
Fixes #120