### PR TITLE
feat: Client-Side Encryption key metadata and hash verification

### DIFF
--- a/app/src/api/encryption.ts
+++ b/app/src/api/encryption.ts
@@ -1,0 +1,23 @@
+import { api } from './client';
+
+export type KeyMetadata = {
+  key_id: string;
+  algorithm: string;
+  created_at: string;
+};
+
+export type VerifyResult = {
+  valid: boolean;
+};
+
+export async function storeKey(payload: { key_id: string; algorithm: string }): Promise<KeyMetadata> {
+  return api<KeyMetadata>('/encryption/keys', { method: 'POST', body: payload });
+}
+
+export async function listKeys(): Promise<KeyMetadata[]> {
+  return api<KeyMetadata[]>('/encryption/keys');
+}
+
+export async function verifyHash(payload: { data_hash: string; expected_hash: string }): Promise<VerifyResult> {
+  return api<VerifyResult>('/encryption/verify', { method: 'POST', body: payload });
+}

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .encryption import bp as encryption_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(encryption_bp, url_prefix="/encryption")

--- a/packages/backend/app/routes/encryption.py
+++ b/packages/backend/app/routes/encryption.py
@@ -1,0 +1,67 @@
+import json
+import logging
+from datetime import datetime
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import AuditLog
+
+bp = Blueprint("encryption", __name__)
+logger = logging.getLogger("finmind.encryption")
+
+
+@bp.post("/keys")
+@jwt_required()
+def store_key():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    key_id = (data.get("key_id") or "").strip()
+    algorithm = (data.get("algorithm") or "").strip()
+    if not key_id or not algorithm:
+        return jsonify(error="key_id and algorithm required"), 400
+
+    meta = {
+        "key_id": key_id,
+        "algorithm": algorithm,
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    log = AuditLog(user_id=uid, action=f"encryption_key:{json.dumps(meta)}")
+    db.session.add(log)
+    db.session.commit()
+    logger.info("Stored key metadata user=%s key_id=%s", uid, key_id)
+    return jsonify(meta), 201
+
+
+@bp.get("/keys")
+@jwt_required()
+def list_keys():
+    uid = int(get_jwt_identity())
+    rows = (
+        db.session.query(AuditLog)
+        .filter(AuditLog.user_id == uid, AuditLog.action.like("encryption_key:%"))
+        .order_by(AuditLog.created_at.desc())
+        .all()
+    )
+    keys = []
+    for r in rows:
+        try:
+            meta = json.loads(r.action.split(":", 1)[1])
+            keys.append(meta)
+        except (json.JSONDecodeError, IndexError):
+            continue
+    return jsonify(keys)
+
+
+@bp.post("/verify")
+@jwt_required()
+def verify_hash():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    data_hash = (data.get("data_hash") or "").strip()
+    expected_hash = (data.get("expected_hash") or "").strip()
+    if not data_hash or not expected_hash:
+        return jsonify(error="data_hash and expected_hash required"), 400
+
+    valid = data_hash == expected_hash
+    logger.info("Hash verify user=%s valid=%s", uid, valid)
+    return jsonify({"valid": valid})

--- a/packages/backend/tests/test_encryption.py
+++ b/packages/backend/tests/test_encryption.py
@@ -1,0 +1,62 @@
+def test_encryption_requires_auth(client):
+    r = client.get("/encryption/keys")
+    assert r.status_code in (401, 422)
+
+    r = client.post("/encryption/keys", json={"key_id": "k1", "algorithm": "AES-256"})
+    assert r.status_code in (401, 422)
+
+    r = client.post("/encryption/verify", json={"data_hash": "a", "expected_hash": "a"})
+    assert r.status_code in (401, 422)
+
+
+def test_create_key_metadata(client, auth_header):
+    r = client.post(
+        "/encryption/keys",
+        json={"key_id": "key-001", "algorithm": "AES-256"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["key_id"] == "key-001"
+    assert data["algorithm"] == "AES-256"
+    assert "created_at" in data
+
+
+def test_list_key_metadata(client, auth_header):
+    client.post(
+        "/encryption/keys",
+        json={"key_id": "key-a", "algorithm": "RSA-2048"},
+        headers=auth_header,
+    )
+    client.post(
+        "/encryption/keys",
+        json={"key_id": "key-b", "algorithm": "AES-128"},
+        headers=auth_header,
+    )
+    r = client.get("/encryption/keys", headers=auth_header)
+    assert r.status_code == 200
+    keys = r.get_json()
+    assert len(keys) >= 2
+    ids = [k["key_id"] for k in keys]
+    assert "key-a" in ids
+    assert "key-b" in ids
+
+
+def test_verify_hash_match(client, auth_header):
+    r = client.post(
+        "/encryption/verify",
+        json={"data_hash": "abc123", "expected_hash": "abc123"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["valid"] is True
+
+
+def test_verify_hash_mismatch(client, auth_header):
+    r = client.post(
+        "/encryption/verify",
+        json={"data_hash": "abc123", "expected_hash": "xyz789"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["valid"] is False


### PR DESCRIPTION
/claim #99

Add client-side encryption endpoints for managing key metadata and verifying data hashes. Implements POST/GET /encryption/keys for storing/listing key metadata (key_id, algorithm, created_at) and POST /encryption/verify for hash comparison. Includes 5 tests and TypeScript client.

Fixes #99