### PR TITLE
feat: Add keyboard shortcuts hook for navigation and search

### DIFF
--- a/app/src/api/shortcuts.ts
+++ b/app/src/api/shortcuts.ts
@@ -1,0 +1,14 @@
+export type ShortcutConfig = {
+  key: string;
+  ctrlKey: boolean;
+  description: string;
+  action: string;
+};
+
+export const DEFAULT_SHORTCUTS: ShortcutConfig[] = [
+  { key: 'e', ctrlKey: true, description: 'Go to Expenses', action: 'navigate:/expenses' },
+  { key: 'b', ctrlKey: true, description: 'Go to Bills', action: 'navigate:/bills' },
+  { key: 'd', ctrlKey: true, description: 'Go to Dashboard', action: 'navigate:/dashboard' },
+  { key: 'k', ctrlKey: true, description: 'Open Search', action: 'open:search' },
+  { key: 'Escape', ctrlKey: false, description: 'Close current dialog', action: 'close:modal' },
+];

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,33 @@
+import { useEffect, useCallback } from 'react';
+import { ShortcutConfig, DEFAULT_SHORTCUTS } from '../api/shortcuts';
+
+export type ShortcutHandler = (action: string) => void;
+
+export function useKeyboardShortcuts(onAction: ShortcutHandler) {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      for (const shortcut of DEFAULT_SHORTCUTS) {
+        const ctrlMatch = shortcut.ctrlKey
+          ? event.ctrlKey || event.metaKey
+          : true;
+        const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase();
+
+        if (ctrlMatch && keyMatch && (shortcut.ctrlKey === (event.ctrlKey || event.metaKey))) {
+          event.preventDefault();
+          onAction(shortcut.action);
+          return;
+        }
+      }
+    },
+    [onAction],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
+
+  return DEFAULT_SHORTCUTS;
+}


### PR DESCRIPTION
/claim #106

Add useKeyboardShortcuts React hook with Ctrl+E (expenses), Ctrl+B (bills), Ctrl+D (dashboard), Ctrl+K (search), and Escape (close modal) bindings. Frontend-only implementation with ShortcutConfig type.

Fixes #106