### PR TITLE
Add GDPR-ready personal data export and deletion workflow

### DIFF
--- a/app/src/api/privacy.ts
+++ b/app/src/api/privacy.ts
@@ -1,0 +1,31 @@
+import { api } from './client';
+
+export type PrivacyExportPackage = {
+  generated_at: string;
+  user: {
+    id: number;
+    email: string;
+    preferred_currency: string;
+    role: string;
+    created_at: string;
+  };
+  categories: unknown[];
+  expenses: unknown[];
+  recurring_expenses: unknown[];
+  bills: unknown[];
+  reminders: unknown[];
+  subscriptions: unknown[];
+  ad_impressions: unknown[];
+  audit_logs: unknown[];
+};
+
+export async function exportPersonalData(): Promise<PrivacyExportPackage> {
+  return api<PrivacyExportPackage>('/privacy/export');
+}
+
+export async function deletePersonalData(): Promise<{ message: string }> {
+  return api<{ message: string }>('/privacy/delete', {
+    method: 'DELETE',
+    body: { confirmation: 'DELETE' },
+  });
+}

--- a/app/src/pages/Account.tsx
+++ b/app/src/pages/Account.tsx
@@ -3,7 +3,9 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { me, updateMe } from '@/api/auth';
+import { deletePersonalData, exportPersonalData } from '@/api/privacy';
 import { setCurrency } from '@/lib/auth';
+import { clearRefreshToken, clearToken } from '@/lib/auth';
 
 const SUPPORTED_CURRENCIES = [
   { code: 'INR', label: 'Indian Rupee (INR)' },
@@ -23,6 +25,7 @@ export default function Account() {
   const [currency, setCurrencyState] = useState('INR');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [privacyBusy, setPrivacyBusy] = useState(false);
 
   useEffect(() => {
     const load = async () => {
@@ -57,6 +60,51 @@ export default function Account() {
       toast({ title: 'Failed to update account', description: message });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const onExportData = async () => {
+    setPrivacyBusy(true);
+    try {
+      const data = await exportPersonalData();
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `finmind-export-${new Date().toISOString().slice(0, 10)}.json`;
+      link.click();
+      URL.revokeObjectURL(url);
+      toast({ title: 'Export ready', description: 'Your personal data package was generated.' });
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to export data';
+      toast({ title: 'Failed to export data', description: message });
+    } finally {
+      setPrivacyBusy(false);
+    }
+  };
+
+  const onDeleteData = async () => {
+    const confirmed = window.confirm(
+      'This permanently deletes your FinMind account and financial data. This cannot be undone. Continue?',
+    );
+    if (!confirmed) return;
+
+    setPrivacyBusy(true);
+    try {
+      await deletePersonalData();
+      clearToken();
+      clearRefreshToken();
+      toast({ title: 'Account deleted', description: 'Your personal data was permanently deleted.' });
+      window.location.href = '/';
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to delete data';
+      toast({ title: 'Failed to delete data', description: message });
+    } finally {
+      setPrivacyBusy(false);
     }
   };
 
@@ -107,6 +155,23 @@ export default function Account() {
             </div>
           </>
         )}
+      </div>
+
+      <div className="card card-interactive space-y-4 fade-in-up">
+        <div>
+          <h2 className="text-lg font-semibold">Privacy & Data</h2>
+          <p className="text-sm text-muted-foreground">
+            Export a copy of your data or permanently delete your account and stored financial records.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Button variant="outline" onClick={onExportData} disabled={privacyBusy}>
+            Export Data
+          </Button>
+          <Button variant="destructive" onClick={onDeleteData} disabled={privacyBusy}>
+            Delete Account Data
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .privacy import bp as privacy_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(privacy_bp, url_prefix="/privacy")

--- a/packages/backend/app/routes/privacy.py
+++ b/packages/backend/app/routes/privacy.py
@@ -1,0 +1,189 @@
+import hashlib
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import (
+    AdImpression,
+    AuditLog,
+    Bill,
+    Category,
+    Expense,
+    RecurringExpense,
+    Reminder,
+    User,
+    UserSubscription,
+)
+from ..services.cache import cache_delete_patterns
+
+bp = Blueprint("privacy", __name__)
+
+
+@bp.get("/export")
+@jwt_required()
+def export_personal_data():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="not found"), 404
+
+    _write_audit_log(uid, "privacy.export_requested")
+    db.session.commit()
+
+    return jsonify(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        user=_user_to_dict(user),
+        categories=[_category_to_dict(row) for row in _for_user(Category, uid)],
+        expenses=[_expense_to_dict(row) for row in _for_user(Expense, uid)],
+        recurring_expenses=[
+            _recurring_expense_to_dict(row) for row in _for_user(RecurringExpense, uid)
+        ],
+        bills=[_bill_to_dict(row) for row in _for_user(Bill, uid)],
+        reminders=[_reminder_to_dict(row) for row in _for_user(Reminder, uid)],
+        subscriptions=[_subscription_to_dict(row) for row in _for_user(UserSubscription, uid)],
+        ad_impressions=[_ad_impression_to_dict(row) for row in _for_user(AdImpression, uid)],
+        audit_logs=[_audit_log_to_dict(row) for row in _for_user(AuditLog, uid)],
+    )
+
+
+@bp.delete("/delete")
+@jwt_required()
+def delete_personal_data():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json(silent=True) or {}
+    if data.get("confirmation") != "DELETE":
+        return jsonify(error='confirmation must equal "DELETE"'), 400
+
+    email_hash = hashlib.sha256(user.email.encode("utf-8")).hexdigest()
+
+    for model in (
+        Reminder,
+        Bill,
+        Expense,
+        RecurringExpense,
+        Category,
+        UserSubscription,
+        AdImpression,
+    ):
+        db.session.query(model).filter_by(user_id=uid).delete(synchronize_session=False)
+
+    db.session.query(AuditLog).filter_by(user_id=uid).update(
+        {"user_id": None}, synchronize_session=False
+    )
+    db.session.delete(user)
+    db.session.add(
+        AuditLog(
+            user_id=None,
+            action=f"privacy.delete_completed:{email_hash}",
+        )
+    )
+    db.session.commit()
+
+    cache_delete_patterns([f"user:{uid}:*", f"insights:{uid}:*"])
+    return jsonify(message="personal data permanently deleted"), 200
+
+
+def _for_user(model, uid: int):
+    return db.session.query(model).filter_by(user_id=uid).all()
+
+
+def _write_audit_log(uid: int, action: str) -> None:
+    db.session.add(AuditLog(user_id=uid, action=action))
+
+
+def _iso(value):
+    return value.isoformat() if value else None
+
+
+def _user_to_dict(user: User) -> dict:
+    return {
+        "id": user.id,
+        "email": user.email,
+        "preferred_currency": user.preferred_currency,
+        "role": user.role,
+        "created_at": _iso(user.created_at),
+    }
+
+
+def _category_to_dict(row: Category) -> dict:
+    return {"id": row.id, "name": row.name, "created_at": _iso(row.created_at)}
+
+
+def _expense_to_dict(row: Expense) -> dict:
+    return {
+        "id": row.id,
+        "category_id": row.category_id,
+        "amount": float(row.amount),
+        "currency": row.currency,
+        "expense_type": row.expense_type,
+        "description": row.notes or "",
+        "spent_at": _iso(row.spent_at),
+        "source_recurring_id": row.source_recurring_id,
+        "created_at": _iso(row.created_at),
+    }
+
+
+def _recurring_expense_to_dict(row: RecurringExpense) -> dict:
+    return {
+        "id": row.id,
+        "category_id": row.category_id,
+        "amount": float(row.amount),
+        "currency": row.currency,
+        "expense_type": row.expense_type,
+        "description": row.notes,
+        "cadence": row.cadence.value,
+        "start_date": _iso(row.start_date),
+        "end_date": _iso(row.end_date),
+        "active": row.active,
+        "created_at": _iso(row.created_at),
+    }
+
+
+def _bill_to_dict(row: Bill) -> dict:
+    return {
+        "id": row.id,
+        "name": row.name,
+        "amount": float(row.amount),
+        "currency": row.currency,
+        "next_due_date": _iso(row.next_due_date),
+        "cadence": row.cadence.value,
+        "autopay_enabled": row.autopay_enabled,
+        "channel_whatsapp": row.channel_whatsapp,
+        "channel_email": row.channel_email,
+        "active": row.active,
+        "created_at": _iso(row.created_at),
+    }
+
+
+def _reminder_to_dict(row: Reminder) -> dict:
+    return {
+        "id": row.id,
+        "bill_id": row.bill_id,
+        "message": row.message,
+        "send_at": _iso(row.send_at),
+        "sent": row.sent,
+        "channel": row.channel,
+    }
+
+
+def _subscription_to_dict(row: UserSubscription) -> dict:
+    return {
+        "id": row.id,
+        "plan_id": row.plan_id,
+        "active": row.active,
+        "started_at": _iso(row.started_at),
+    }
+
+
+def _ad_impression_to_dict(row: AdImpression) -> dict:
+    return {"id": row.id, "placement": row.placement, "created_at": _iso(row.created_at)}
+
+
+def _audit_log_to_dict(row: AuditLog) -> dict:
+    return {"id": row.id, "action": row.action, "created_at": _iso(row.created_at)}

--- a/packages/backend/tests/test_privacy.py
+++ b/packages/backend/tests/test_privacy.py
@@ -1,0 +1,65 @@
+from app.extensions import db
+from app.models import AuditLog, User
+
+
+def test_export_personal_data_package(client, auth_header):
+    client.post(
+        "/categories",
+        json={"name": "Food"},
+        headers=auth_header,
+    )
+    client.post(
+        "/expenses",
+        json={"amount": 12.5, "description": "Lunch", "date": "2026-04-01"},
+        headers=auth_header,
+    )
+    client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 50,
+            "next_due_date": "2026-05-01",
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+
+    response = client.get("/privacy/export", headers=auth_header)
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["user"]["email"] == "test@example.com"
+    assert payload["categories"][0]["name"] == "Food"
+    assert payload["expenses"][0]["description"] == "Lunch"
+    assert payload["bills"][0]["name"] == "Internet"
+    assert payload["audit_logs"]
+
+
+def test_delete_requires_confirmation(client, auth_header):
+    response = client.delete("/privacy/delete", json={}, headers=auth_header)
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == 'confirmation must equal "DELETE"'
+
+
+def test_delete_personal_data_is_irreversible_and_audited(client, auth_header, app_fixture):
+    client.post(
+        "/expenses",
+        json={"amount": 25, "description": "Taxi", "date": "2026-04-02"},
+        headers=auth_header,
+    )
+
+    response = client.delete(
+        "/privacy/delete",
+        json={"confirmation": "DELETE"},
+        headers=auth_header,
+    )
+
+    assert response.status_code == 200
+    with app_fixture.app_context():
+        assert db.session.query(User).filter_by(email="test@example.com").first() is None
+        audit = db.session.query(AuditLog).filter(
+            AuditLog.action.like("privacy.delete_completed:%")
+        ).first()
+        assert audit is not None
+        assert audit.user_id is None


### PR DESCRIPTION
Closes #76

## Summary
- Add authenticated `/privacy/export` endpoint that returns a personal data package covering profile, categories, expenses, recurring expenses, bills, reminders, subscriptions, ad impressions, and audit logs.
- Add authenticated `/privacy/delete` endpoint requiring explicit `DELETE` confirmation, deleting user-owned records and preserving a non-PII audit trail with an email hash.
- Add Account page controls to export data as JSON and trigger irreversible account data deletion.
- Add backend tests for export, delete confirmation, irreversible deletion, and audit logging.

## Validation
- `npm run build` from `app/`
- Backend tests were prepared in `packages/backend/tests/test_privacy.py`, but could not be executed in this local environment because the available Python is 3.14 and the project-pinned `pydantic-core==2.18.4`/`psycopg2-binary==2.9.9` dependency set does not build on Python 3.14 here. Please run `pytest packages/backend/tests/test_privacy.py` under the project-supported Python 3.12 environment.