### PR TITLE
Bounty Submission: Resilient background job retry & monitoring (#130)

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -13,6 +13,7 @@ import click
 import os
 import logging
 from datetime import timedelta
+from .models import Reminder
 
 
 def create_app(settings: Settings | None = None) -> Flask:
@@ -92,6 +93,34 @@ def create_app(settings: Settings | None = None) -> Flask:
                 click.echo("Database initialized.")
             finally:
                 conn.close()
+
+    # ------------------------------------------------------------------
+    # Background task: send_reminder handler
+    # ------------------------------------------------------------------
+    from .services import taskqueue
+    from .services.reminders import send_reminder
+
+    def _handle_send_reminder(payload: dict) -> bool:
+        reminder_id = payload.get("reminder_id")
+        if reminder_id is None:
+            return False
+        reminder = db.session.get(Reminder, reminder_id)
+        if reminder is None:
+            return False
+        ok = send_reminder(reminder)
+        if ok:
+            reminder.sent = True
+            db.session.commit()
+        return ok
+
+    taskqueue.register_handler("send_reminder", _handle_send_reminder)
+
+    @app.cli.command("worker")
+    @click.option("--poll-interval", default=1.0, help="Seconds between polls")
+    @click.option("--max-iterations", default=None, type=int, help="Stop after N iterations")
+    def worker(poll_interval, max_iterations):
+        """Run the background task worker."""
+        taskqueue.worker_loop(poll_interval=poll_interval, max_iterations=max_iterations)
 
     return app
 

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,55 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+# ---------------------------------------------------------------------------
+# Background Task Queue Models
+# ---------------------------------------------------------------------------
+
+
+class TaskStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+    DEAD = "DEAD"
+
+
+class Task(db.Model):
+    """Persistent record for every background task."""
+
+    __tablename__ = "background_tasks"
+
+    id = db.Column(db.Integer, primary_key=True)
+    task_type = db.Column(db.String(100), nullable=False, index=True)
+    payload = db.Column(db.Text, nullable=False)  # JSON-encoded
+    status = db.Column(
+        SAEnum(TaskStatus), default=TaskStatus.PENDING, nullable=False, index=True
+    )
+    max_retries = db.Column(db.Integer, default=3, nullable=False)
+    attempt = db.Column(db.Integer, default=0, nullable=False)
+    last_error = db.Column(db.Text, nullable=True)
+    scheduled_at = db.Column(
+        db.DateTime, default=datetime.utcnow, nullable=False, index=True
+    )
+    started_at = db.Column(db.DateTime, nullable=True)
+    finished_at = db.Column(db.DateTime, nullable=True)
+    next_retry_at = db.Column(db.DateTime, nullable=True, index=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "task_type": self.task_type,
+            "payload": self.payload,
+            "status": self.status.value if isinstance(self.status, TaskStatus) else self.status,
+            "max_retries": self.max_retries,
+            "attempt": self.attempt,
+            "last_error": self.last_error,
+            "scheduled_at": self.scheduled_at.isoformat() if self.scheduled_at else None,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "next_retry_at": self.next_retry_at.isoformat() if self.next_retry_at else None,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+        }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .tasks import bp as tasks_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(tasks_bp, url_prefix="/tasks")

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -5,6 +5,7 @@ from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
+from ..services import taskqueue
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -171,12 +172,13 @@ def run_due():
         .all()
     )
     for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
-    db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+        taskqueue.enqueue(
+            "send_reminder",
+            payload={"reminder_id": r.id},
+            max_retries=3,
+        )
+    logger.info("Enqueued %s reminder tasks for user=%s", len(items), uid)
+    return jsonify(enqueued=len(items))
 
 
 def _bill_channels(bill: Bill) -> list[str]:

--- a/packages/backend/app/routes/tasks.py
+++ b/packages/backend/app/routes/tasks.py
@@ -1,0 +1,86 @@
+"""Admin routes for background task monitoring and management."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import Task, TaskStatus, User, Role
+from ..services.taskqueue import queue_stats, retry_dead_task, purge_dead_tasks
+
+bp = Blueprint("tasks", __name__)
+
+
+def _is_admin(uid: int) -> bool:
+    user = db.session.get(User, uid)
+    return user is not None and user.role == Role.ADMIN.value
+
+
+@bp.get("")
+@bp.get("/")
+@jwt_required()
+def list_tasks():
+    uid = int(get_jwt_identity())
+    if not _is_admin(uid):
+        return jsonify(error="forbidden"), 403
+
+    status_filter = request.args.get("status")
+    task_type = request.args.get("task_type")
+    limit = min(int(request.args.get("limit", 50)), 200)
+    offset = int(request.args.get("offset", 0))
+
+    q = Task.query
+    if status_filter:
+        try:
+            status_filter = TaskStatus(status_filter)
+            q = q.filter_by(status=status_filter)
+        except ValueError:
+            return jsonify(error=f"invalid status. Use: {[s.value for s in TaskStatus]}"), 400
+    if task_type:
+        q = q.filter_by(task_type=task_type)
+
+    tasks = q.order_by(Task.created_at.desc()).offset(offset).limit(limit).all()
+    return jsonify([t.to_dict() for t in tasks])
+
+
+@bp.get("/stats")
+@jwt_required()
+def get_stats():
+    uid = int(get_jwt_identity())
+    if not _is_admin(uid):
+        return jsonify(error="forbidden"), 403
+    return jsonify(queue_stats())
+
+
+@bp.get("/<int:task_id>")
+@jwt_required()
+def get_task(task_id: int):
+    uid = int(get_jwt_identity())
+    if not _is_admin(uid):
+        return jsonify(error="forbidden"), 403
+    task = db.session.get(Task, task_id)
+    if not task:
+        return jsonify(error="not found"), 404
+    return jsonify(task.to_dict())
+
+
+@bp.post("/<int:task_id>/retry")
+@jwt_required()
+def retry_task(task_id: int):
+    uid = int(get_jwt_identity())
+    if not _is_admin(uid):
+        return jsonify(error="forbidden"), 403
+    ok = retry_dead_task(task_id)
+    if not ok:
+        return jsonify(error="task not found or not dead"), 404
+    return jsonify(status="retried"), 200
+
+
+@bp.post("/purge")
+@jwt_required()
+def purge():
+    uid = int(get_jwt_identity())
+    if not _is_admin(uid):
+        return jsonify(error="forbidden"), 403
+    hours = int(request.args.get("older_than_hours", 168))
+    count = purge_dead_tasks(hours)
+    return jsonify(purged=count), 200

--- a/packages/backend/app/services/taskqueue.py
+++ b/packages/backend/app/services/taskqueue.py
@@ -1,0 +1,249 @@
+"""Lightweight Redis-backed task queue with retry logic and dead-letter handling.
+
+Design:
+- Tasks are persisted in SQLAlchemy (ground truth) *and* tracked in Redis sorted
+  sets for fast queue operations.
+- Redis keys:
+    taskq:pending   — sorted set scored by scheduled_at timestamp
+    taskq:running   — set of currently-processing task ids
+    taskq:dead      — list of permanently-failed task ids
+- Worker loop: pull due tasks from ``taskq:pending``, run them, handle
+  success / retry / dead-letter.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from ..extensions import db, redis_client
+from ..models import Task, TaskStatus
+
+logger = logging.getLogger("finmind.taskqueue")
+
+# Redis key constants
+_PENDING_KEY = "taskq:pending"
+_RUNNING_KEY = "taskq:running"
+_DEAD_KEY = "taskq:dead"
+
+# Default retry settings
+DEFAULT_MAX_RETRIES = 3
+BASE_BACKOFF_SECONDS = 30  # first retry after 30 s, then 60, 120, …
+
+
+# ---------------------------------------------------------------------------
+# Enqueue
+# ---------------------------------------------------------------------------
+
+
+def enqueue(
+    task_type: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    scheduled_at: datetime | None = None,
+) -> Task:
+    """Create a task and push it onto the pending queue."""
+    run_at = scheduled_at or datetime.now(timezone.utc)
+    score = run_at.timestamp()
+
+    task = Task(
+        task_type=task_type,
+        payload=json.dumps(payload or {}),
+        status=TaskStatus.PENDING,
+        max_retries=max_retries,
+        scheduled_at=run_at,
+    )
+    db.session.add(task)
+    db.session.flush()  # assign id
+
+    redis_client.zadd(_PENDING_KEY, {str(task.id): score})
+    logger.info(
+        "Enqueued task id=%s type=%s scheduled_at=%s",
+        task.id, task.task_type, run_at.isoformat(),
+    )
+    return task
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+# Registry: task_type → callable(payload_dict) → bool (True = success)
+_HANDLERS: dict[str, Callable[[dict], bool]] = {}
+
+
+def register_handler(task_type: str, fn: Callable[[dict], bool]) -> None:
+    _HANDLERS[task_type] = fn
+
+
+def get_handler(task_type: str) -> Callable[[dict], bool] | None:
+    return _HANDLERS.get(task_type)
+
+
+def process_next_tick() -> bool:
+    """Try to claim and execute one due task.  Returns True if a task was run."""
+    now_ts = datetime.now(timezone.utc).timestamp()
+
+    # Fetch up to 1 task whose scheduled_at <= now
+    candidates = redis_client.zrangebyscore(_PENDING_KEY, "-inf", now_ts, start=0, num=1)
+    if not candidates:
+        return False
+
+    task_id_bytes = candidates[0]
+    task_id = int(task_id_bytes)
+
+    # Atomically move from pending → running (prevent duplicate claims)
+    removed = redis_client.zrem(_PENDING_KEY, task_id_bytes)
+    if not removed:
+        return False  # another worker grabbed it
+
+    redis_client.sadd(_RUNNING_KEY, task_id_bytes)
+
+    task = db.session.get(Task, task_id)
+    if task is None:
+        redis_client.srem(_RUNNING_KEY, task_id_bytes)
+        logger.warning("Task id=%s not found in DB; dropping from queue", task_id)
+        return False
+
+    handler = get_handler(task.task_type)
+    if handler is None:
+        logger.error("No handler registered for task_type=%s; dead-lettering id=%s", task.task_type, task_id)
+        _mark_dead(task, f"No handler for task_type={task.task_type}")
+        return True
+
+    # Execute
+    task.status = TaskStatus.RUNNING
+    task.attempt += 1
+    task.started_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    try:
+        payload = json.loads(task.payload)
+        success = handler(payload)
+    except Exception as exc:
+        success = False
+        task.last_error = str(exc)[:2000]
+        logger.exception("Task id=%s threw on attempt %s", task_id, task.attempt)
+
+    if success:
+        task.status = TaskStatus.SUCCESS
+        task.finished_at = datetime.now(timezone.utc)
+        db.session.commit()
+        redis_client.srem(_RUNNING_KEY, task_id_bytes)
+        logger.info("Task id=%s succeeded on attempt %s", task_id, task.attempt)
+    else:
+        _handle_failure(task)
+
+    return True
+
+
+def _handle_failure(task: Task) -> None:
+    """Retry with exponential back-off, or dead-letter."""
+    if task.attempt < task.max_retries:
+        backoff = BASE_BACKOFF_SECONDS * (2 ** (task.attempt - 1))
+        next_run = datetime.now(timezone.utc) + timedelta(seconds=backoff)
+        task.status = TaskStatus.PENDING
+        task.next_retry_at = next_run
+        db.session.commit()
+
+        # Re-enqueue in Redis
+        redis_client.srem(_RUNNING_KEY, str(task.id))
+        redis_client.zadd(_PENDING_KEY, {str(task.id): next_run.timestamp()})
+        logger.info(
+            "Task id=%s retry %s/%s, next at %s",
+            task.id, task.attempt, task.max_retries, next_run.isoformat(),
+        )
+    else:
+        _mark_dead(task, task.last_error or "Max retries exceeded")
+
+
+def _mark_dead(task: Task, reason: str) -> None:
+    task.status = TaskStatus.DEAD
+    task.finished_at = datetime.now(timezone.utc)
+    if not task.last_error:
+        task.last_error = reason
+    db.session.commit()
+    redis_client.srem(_RUNNING_KEY, str(task.id))
+    redis_client.rpush(_DEAD_KEY, str(task.id))
+    logger.error("Task id=%s DEAD: %s", task.id, reason)
+
+
+# ---------------------------------------------------------------------------
+# Worker loop (call from CLI or thread)
+# ---------------------------------------------------------------------------
+
+
+def worker_loop(poll_interval: float = 1.0, max_iterations: int | None = None) -> None:
+    """Blocking loop that continuously processes tasks."""
+    logger.info("Task worker starting (poll_interval=%.1fs)", poll_interval)
+    iteration = 0
+    while max_iterations is None or iteration < max_iterations:
+        did_work = process_next_tick()
+        if not did_work:
+            time.sleep(poll_interval)
+        iteration += 1
+
+
+# ---------------------------------------------------------------------------
+# Monitoring helpers
+# ---------------------------------------------------------------------------
+
+
+def queue_stats() -> dict[str, int]:
+    """Return counts for each queue and by-status."""
+    pending = redis_client.zcard(_PENDING_KEY)
+    running = redis_client.scard(_RUNNING_KEY)
+    dead = redis_client.llen(_DEAD_KEY)
+
+    # DB-level counts (more expensive, but accurate)
+    from sqlalchemy import func
+    status_counts = dict(
+        db.session.query(Task.status, func.count(Task.id))
+        .group_by(Task.status)
+        .all()
+    )
+    serialised = {s.value if isinstance(s, TaskStatus) else s: c for s, c in status_counts.items()}
+
+    return {
+        "redis_pending": pending,
+        "redis_running": running,
+        "redis_dead": dead,
+        "db_by_status": serialised,
+    }
+
+
+def retry_dead_task(task_id: int) -> bool:
+    """Move a dead task back to the pending queue for one more attempt."""
+    task = db.session.get(Task, task_id)
+    if task is None or task.status != TaskStatus.DEAD:
+        return False
+    task.status = TaskStatus.PENDING
+    task.attempt = 0
+    task.last_error = None
+    task.next_retry_at = None
+    task.scheduled_at = datetime.now(timezone.utc)
+    task.finished_at = None
+    db.session.commit()
+
+    # Remove from dead list (best-effort)
+    redis_client.lrem(_DEAD_KEY, 0, str(task_id))
+    redis_client.zadd(_PENDING_KEY, {str(task_id): task.scheduled_at.timestamp()})
+    logger.info("Retried dead task id=%s", task_id)
+    return True
+
+
+def purge_dead_tasks(older_than_hours: int = 168) -> int:
+    """Delete dead tasks older than *older_than_hours* (default 7 days)."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=older_than_hours)
+    count = Task.query.filter(
+        Task.status == TaskStatus.DEAD,
+        Task.finished_at < cutoff,
+    ).delete()
+    db.session.commit()
+    logger.info("Purged %s dead tasks older than %sh", count, older_than_hours)
+    return count

--- a/packages/backend/tests/test_taskqueue.py
+++ b/packages/backend/tests/test_taskqueue.py
@@ -1,0 +1,364 @@
+"""Tests for the background task queue (services/taskqueue.py + routes/tasks.py)."""
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import create_app
+from app.extensions import db as _db, redis_client
+from app.models import Task, TaskStatus, User, Role
+from app.services import taskqueue
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="function")
+def app():
+    """Create app with in-memory SQLite + fake Redis."""
+    import app.extensions as ext
+
+    # Patch redis_client to a fake before app is created
+    fake_redis = _FakeRedis()
+    ext.redis_client = fake_redis
+    # Also patch the module-level import in taskqueue
+    taskqueue.redis_client = fake_redis
+
+    # Use SQLite for testing
+    test_settings = type("S", (), {
+        "database_url": "sqlite:///:memory:",
+        "redis_url": "redis://fake",
+        "jwt_secret": "test-secret",
+        "jwt_access_minutes": 15,
+        "jwt_refresh_hours": 24,
+        "openai_api_key": None,
+        "gemini_api_key": None,
+        "gemini_model": "gemini-1.5-flash",
+        "twilio_account_sid": None,
+        "twilio_auth_token": None,
+        "twilio_whatsapp_from": None,
+        "email_from": None,
+        "smtp_url": None,
+    })()
+
+    app = create_app(settings=test_settings)
+
+    with app.app_context():
+        _db.create_all()
+        # Create admin user for testing
+        admin = User(
+            email="admin@test.com",
+            password_hash="x",
+            role=Role.ADMIN.value,
+        )
+        _db.session.add(admin)
+        _db.session.commit()
+
+        yield app
+
+        _db.session.remove()
+        _db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def admin_token(app, client):
+    """Get a JWT token for the admin user."""
+    from flask_jwt_extended import create_access_token
+    with app.app_context():
+        admin = User.query.filter_by(email="admin@test.com").first()
+        token = create_access_token(identity=str(admin.id))
+    return token
+
+
+def _auth_headers(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake Redis (only what taskqueue uses)
+# ---------------------------------------------------------------------------
+
+class _FakeRedis:
+    def __init__(self):
+        self._zset = {}  # name -> {member: score}
+        self._set = {}   # name -> set
+        self._list = {}  # name -> list
+
+    def zadd(self, name, mapping):
+        self._zset.setdefault(name, {})
+        self._zset[name].update({k: float(v) for k, v in mapping.items()})
+
+    def zrangebyscore(self, name, min_s, max_s, start=0, num=-1):
+        items = sorted(self._zset.get(name, {}).items(), key=lambda x: x[1])
+        result = [k.encode() for k, v in items if float(min_s) <= v <= float(max_s)]
+        if num == -1:
+            return result[start:]
+        return result[start:start + num]
+
+    def zrem(self, name, *members):
+        zs = self._zset.get(name, {})
+        removed = 0
+        for m in members:
+            key = m.decode() if isinstance(m, bytes) else m
+            if key in zs:
+                del zs[key]
+                removed += 1
+        return removed
+
+    def zcard(self, name):
+        return len(self._zset.get(name, {}))
+
+    def sadd(self, name, *members):
+        self._set.setdefault(name, set())
+        for m in members:
+            self._set[name].add(m.decode() if isinstance(m, bytes) else m)
+        return len(members)
+
+    def srem(self, name, *members):
+        s = self._set.get(name, set())
+        removed = 0
+        for m in members:
+            key = m.decode() if isinstance(m, bytes) else m
+            if key in s:
+                s.discard(key)
+                removed += 1
+        return removed
+
+    def scard(self, name):
+        return len(self._set.get(name, set()))
+
+    def rpush(self, name, *values):
+        self._list.setdefault(name, [])
+        for v in values:
+            self._list[name].append(v)
+        return len(self._list[name])
+
+    def llen(self, name):
+        return len(self._list.get(name, []))
+
+    def lrem(self, name, count, value):
+        lst = self._list.get(name, [])
+        v = str(value)
+        before = len(lst)
+        self._list[name] = [x for x in lst if str(x) != v]
+        return before - len(self._list[name])
+
+
+# ---------------------------------------------------------------------------
+# Tests: enqueue
+# ---------------------------------------------------------------------------
+
+class TestEnqueue:
+    def test_create_task(self, app):
+        with app.app_context():
+            task = taskqueue.enqueue("test_type", {"key": "val"})
+            assert task.id is not None
+            assert task.task_type == "test_type"
+            assert task.status == TaskStatus.PENDING
+            assert task.max_retries == 3
+            assert json.loads(task.payload) == {"key": "val"}
+
+    def test_custom_max_retries(self, app):
+        with app.app_context():
+            task = taskqueue.enqueue("t", max_retries=5)
+            assert task.max_retries == 5
+
+    def test_scheduled_at(self, app):
+        with app.app_context():
+            future = datetime.now(timezone.utc) + timedelta(hours=1)
+            task = taskqueue.enqueue("t", scheduled_at=future)
+            assert task.scheduled_at == future
+
+
+# ---------------------------------------------------------------------------
+# Tests: worker
+# ---------------------------------------------------------------------------
+
+class TestWorker:
+    def test_success(self, app):
+        with app.app_context():
+            handler = MagicMock(return_value=True)
+            taskqueue.register_handler("test_ok", handler)
+
+            task = taskqueue.enqueue("test_ok", {"x": 1})
+            ran = taskqueue.process_next_tick()
+
+            assert ran is True
+            assert handler.called
+            assert task.status == TaskStatus.SUCCESS
+            assert task.finished_at is not None
+
+    def test_no_handler_dead_letters(self, app):
+        with app.app_context():
+            task = taskqueue.enqueue("nonexistent_type")
+            ran = taskqueue.process_next_tick()
+
+            assert ran is True
+            assert task.status == TaskStatus.DEAD
+
+    def test_retry_on_failure(self, app):
+        with app.app_context():
+            fail_then_pass = MagicMock(side_effect=[False, True])
+            taskqueue.register_handler("flaky", fail_then_pass)
+
+            task = taskqueue.enqueue("flaky", max_retries=3)
+
+            # First run: fails, should retry
+            taskqueue.process_next_tick()
+            assert task.status == TaskStatus.PENDING
+            assert task.attempt == 1
+            assert task.next_retry_at is not None
+
+            # Simulate backoff passing: move scheduled_at to now
+            task.next_retry_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+            task.scheduled_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+            _db.session.commit()
+            fake_redis = taskqueue.redis_client
+            fake_redis.zadd(taskqueue._PENDING_KEY, {str(task.id): time.time()})
+
+            # Second run: succeeds
+            taskqueue.process_next_tick()
+            assert task.status == TaskStatus.SUCCESS
+            assert task.attempt == 2
+
+    def test_dead_after_max_retries(self, app):
+        with app.app_context():
+            always_fail = MagicMock(return_value=False)
+            taskqueue.register_handler("alwaysfail", always_fail)
+
+            task = taskqueue.enqueue("alwaysfail", max_retries=2)
+
+            # Attempt 1
+            taskqueue.process_next_tick()
+            assert task.status == TaskStatus.PENDING
+
+            # Simulate backoff
+            task.next_retry_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+            task.scheduled_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+            _db.session.commit()
+            taskqueue.redis_client.zadd(taskqueue._PENDING_KEY, {str(task.id): time.time()})
+
+            # Attempt 2 (max_retries=2, attempt was already 1, now 2 = max)
+            taskqueue.process_next_tick()
+            assert task.status == TaskStatus.DEAD
+            assert task.attempt == 2
+
+    def test_exception_caught(self, app):
+        with app.app_context():
+            raise_handler = MagicMock(side_effect=RuntimeError("boom"))
+            taskqueue.register_handler("exploder", raise_handler)
+
+            task = taskqueue.enqueue("exploder", max_retries=1)
+            taskqueue.process_next_tick()
+
+            # Should have caught the exception and marked as DEAD (attempt 1 >= max_retries 1)
+            assert task.status == TaskStatus.DEAD
+            assert "boom" in (task.last_error or "")
+
+    def test_empty_queue(self, app):
+        with app.app_context():
+            ran = taskqueue.process_next_tick()
+            assert ran is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: monitoring routes
+# ---------------------------------------------------------------------------
+
+class TestTaskRoutes:
+    def test_list_tasks(self, app, client, admin_token):
+        with app.app_context():
+            taskqueue.enqueue("route_test", {"a": 1})
+            _db.session.commit()
+
+        with app.app_context():
+            resp = client.get("/tasks", headers=_auth_headers(admin_token))
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert len(data) >= 1
+            assert data[0]["task_type"] == "route_test"
+
+    def test_stats(self, app, client, admin_token):
+        resp = client.get("/tasks/stats", headers=_auth_headers(admin_token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "redis_pending" in data
+        assert "db_by_status" in data
+
+    def test_forbidden_non_admin(self, app, client):
+        with app.app_context():
+            user = User(email="user@test.com", password_hash="x", role=Role.USER.value)
+            _db.session.add(user)
+            _db.session.commit()
+            from flask_jwt_extended import create_access_token
+            token = create_access_token(identity=str(user.id))
+
+        resp = client.get("/tasks/stats", headers=_auth_headers(token))
+        assert resp.status_code == 403
+
+    def test_retry_dead_task(self, app, client, admin_token):
+        with app.app_context():
+            # Create and dead-letter a task
+            raise_h = MagicMock(side_effect=RuntimeError("nope"))
+            taskqueue.register_handler("dead_test", raise_h)
+            task = taskqueue.enqueue("dead_test", max_retries=1)
+            taskqueue.process_next_tick()
+            assert task.status == TaskStatus.DEAD
+
+            tid = task.id
+
+        resp = client.post(f"/tasks/{tid}/retry", headers=_auth_headers(admin_token))
+        assert resp.status_code == 200
+
+        with app.app_context():
+            task = _db.session.get(Task, tid)
+            assert task.status == TaskStatus.PENDING
+            assert task.attempt == 0
+
+    def test_purge_dead(self, app, client, admin_token):
+        with app.app_context():
+            raise_h = MagicMock(side_effect=RuntimeError("die"))
+            taskqueue.register_handler("purge_test", raise_h)
+            taskqueue.enqueue("purge_test", max_retries=1)
+            taskqueue.process_next_tick()
+
+        resp = client.post("/tasks/purge?older_than_hours=0", headers=_auth_headers(admin_token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["purged"] >= 1
+
+    def test_filter_by_status(self, app, client, admin_token):
+        with app.app_context():
+            taskqueue.enqueue("filter_test")
+
+        resp = client.get("/tasks?status=PENDING", headers=_auth_headers(admin_token))
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert all(t["status"] == "PENDING" for t in data)
+
+    def test_invalid_status_filter(self, client, admin_token):
+        resp = client.get("/tasks?status=INVALID", headers=_auth_headers(admin_token))
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Tests: queue_stats helper
+# ---------------------------------------------------------------------------
+
+class TestQueueStats:
+    def test_counts(self, app):
+        with app.app_context():
+            taskqueue.enqueue("stat_test")
+            stats = taskqueue.queue_stats()
+            assert stats["redis_pending"] >= 1
+            assert "PENDING" in stats["db_by_status"]
+            assert stats["db_by_status"]["PENDING"] >= 1


### PR DESCRIPTION
## Bounty: Resilient Background Job Retry & Monitoring
**Issue:** #130 | **Bounty:** $250

### What this implements

A production-grade, zero-dependency background task queue built on the app's existing Redis instance:

#### Core Engine (`app/services/taskqueue.py`)
- **Redis-backed priority queue** — sorted sets scored by `scheduled_at` timestamp
- **Exponential backoff retry** — 30s → 60s → 120s → ... (configurable `max_retries`)
- **Dead-letter queue** — permanently failed tasks tracked in Redis `taskq:dead`
- **Atomic claim** — `ZREM` prevents duplicate processing across workers
- **Worker loop** — blocking `process_next_tick()` loop, or `flask worker` CLI

#### Persistent Task Model (`app/models.py`)
- Full lifecycle tracking: PENDING → RUNNING → SUCCESS / DEAD
- Attempt count, last error, timestamps, retry scheduling
- Indexed on `status`, `task_type`, `scheduled_at`, `next_retry_at`

#### Admin Monitoring API (`app/routes/tasks.py`)
- `GET /tasks` — list/filter tasks (by status, task_type, paginated)
- `GET /tasks/stats` — queue depth metrics (Redis + DB counts)
- `GET /tasks/<id>` — individual task detail
- `POST /tasks/<id>/retry` — re-queue a dead task
- `POST /tasks/purge` — clean up old dead tasks (configurable age)
- All endpoints require admin role

#### Integration
- `send_reminder` migrated from synchronous to async via task queue
- Reminders now enqueue as background tasks with automatic retry

### Test Coverage
**17 tests, all passing** (`tests/test_taskqueue.py`):
- Enqueue: basic creation, custom retries, scheduled_at
- Worker: success, dead-letter on no handler, retry on failure, max retries → dead, exception catching, empty queue
- Routes: list, stats, forbidden for non-admin, retry dead, purge, filter by status, invalid status
- Stats helper: Redis + DB count accuracy

### No New Dependencies
Uses only existing infrastructure (Redis, SQLAlchemy, Flask). No Celery, RQ, or new packages required.

### How to Test
```bash
# Run the test suite
cd packages/backend && python -m pytest tests/test_taskqueue.py -v

# Start the worker
flask worker --poll-interval 1.0

# Monitor via API (admin auth required)
curl -H "Authorization: Bearer <token>" /tasks/stats
```

---
*Note: This PR was submitted via the t4net-crawbot GitHub account (infrastructure account). The work was performed by Alex Reed, an AI operator running an independent studio. The code, tests, and design are original work.*