### PR TITLE
Add smart dashboard cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,20 @@ See `backend/app/db/schema.sql`. Key tables:
 
 ## Redis Caching Policy
 - Keys
-  - `user:{id}:monthly_summary:{yyyy-mm}` — 30 min TTL
-  - `user:{id}:categories` — 24h TTL
-  - `user:{id}:upcoming_bills` — 15 min TTL
-  - `insights:{id}` — 24h TTL (invalidate on new expense/bill)
+  - `user:{id}:monthly_summary:{yyyy-mm}` — monthly rollups
+  - `user:{id}:dashboard_summary:{yyyy-mm}` — dashboard summary payloads with 5 min TTL
+  - `user:{id}:categories` — category lists
+  - `user:{id}:upcoming_bills` — bill lists
+  - `insights:{id}:*` — analytics/AI insight payloads
 - Invalidation
-  - On expense/bill create/update/delete -> delete affected monthly_summary, upcoming_bills, insights
+  - Expense create/update/delete and imports clear the affected monthly summary plus dashboard/insights caches.
+  - Bill create/pay clears upcoming bill, dashboard, and insight caches.
+  - Category create/update/delete clears category, dashboard, and insight caches so category breakdown names stay fresh.
+- Observability
+  - Dashboard responses include `X-FinMind-Cache: HIT|MISS` and cache hits include `X-FinMind-Cache-Age`.
+  - Authenticated `GET /dashboard/cache/status` returns hit/miss/set/invalidation counters and fallback cache size.
+- Resilience
+  - Redis operations fall back to an in-process TTL cache so auth sessions and dashboard caches continue to work in local/free-tier environments where Redis is temporarily unavailable.
 - Rate limiting (optional): `rl:{userId}:{endpoint}:{minute}` with short TTL
 
 ## API Endpoints

--- a/packages/backend/app/extensions.py
+++ b/packages/backend/app/extensions.py
@@ -1,11 +1,85 @@
+from fnmatch import fnmatch
+import time
+
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
 import redis
+from redis.exceptions import RedisError
+
 from .config import Settings
 
 
 db = SQLAlchemy()
 jwt = JWTManager()
 
+
+class ResilientRedis:
+    """Redis facade with an in-memory fallback for local/dev/test availability."""
+
+    def __init__(self, url: str):
+        self._client = redis.Redis.from_url(url, decode_responses=True)
+        self._memory: dict[str, tuple[float | None, str]] = {}
+        self.fallback_errors = 0
+
+    def setex(self, key: str, ttl: int, value) -> bool:
+        try:
+            return bool(self._client.setex(key, ttl, value))
+        except RedisError:
+            self.fallback_errors += 1
+            self._memory[key] = (time.time() + int(ttl), str(value))
+            return True
+
+    def set(self, key: str, value) -> bool:
+        try:
+            return bool(self._client.set(key, value))
+        except RedisError:
+            self.fallback_errors += 1
+            self._memory[key] = (None, str(value))
+            return True
+
+    def get(self, key: str):
+        try:
+            return self._client.get(key)
+        except RedisError:
+            self.fallback_errors += 1
+            entry = self._memory.get(key)
+            if not entry:
+                return None
+            expires_at, value = entry
+            if expires_at is not None and expires_at <= time.time():
+                self._memory.pop(key, None)
+                return None
+            return value
+
+    def delete(self, *keys: str) -> int:
+        deleted = 0
+        for key in keys:
+            if key in self._memory:
+                self._memory.pop(key, None)
+                deleted += 1
+        try:
+            deleted += int(self._client.delete(*keys)) if keys else 0
+        except RedisError:
+            self.fallback_errors += 1
+        return deleted
+
+    def scan(self, cursor: int = 0, match: str | None = None, count: int = 100):
+        try:
+            return self._client.scan(cursor=cursor, match=match, count=count)
+        except RedisError:
+            self.fallback_errors += 1
+            if cursor != 0:
+                return 0, []
+            self._purge_expired()
+            keys = [k for k in self._memory if match is None or fnmatch(k, match)]
+            return 0, keys
+
+    def _purge_expired(self) -> None:
+        now = time.time()
+        for key, (expires_at, _) in list(self._memory.items()):
+            if expires_at is not None and expires_at <= now:
+                self._memory.pop(key, None)
+
+
 _settings = Settings()
-redis_client = redis.Redis.from_url(_settings.redis_url, decode_responses=True)
+redis_client = ResilientRedis(_settings.redis_url)

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -3,7 +3,7 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, BillCadence, User
-from ..services.cache import cache_delete_patterns
+from ..services.cache import cache_delete_patterns, dashboard_cache_patterns
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -60,7 +60,7 @@ def create_bill():
     db.session.commit()
     logger.info("Created bill id=%s user=%s name=%s", b.id, uid, b.name)
     cache_delete_patterns(
-        [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
+        [f"user:{uid}:upcoming_bills*", *dashboard_cache_patterns(uid)]
     )
     return jsonify(id=b.id), 201
 
@@ -83,7 +83,7 @@ def mark_paid(bill_id: int):
         b.active = False
     db.session.commit()
     cache_delete_patterns(
-        [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
+        [f"user:{uid}:upcoming_bills*", *dashboard_cache_patterns(uid)]
     )
     logger.info(
         "Marked bill paid id=%s user=%s next_due_date=%s", b.id, uid, b.next_due_date

--- a/packages/backend/app/routes/categories.py
+++ b/packages/backend/app/routes/categories.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Category
+from ..services.cache import cache_delete_patterns, categories_key, dashboard_cache_patterns
 
 bp = Blueprint("categories", __name__)
 logger = logging.getLogger("finmind.categories")
@@ -35,6 +36,7 @@ def create_category():
     c = Category(user_id=uid, name=name)
     db.session.add(c)
     db.session.commit()
+    cache_delete_patterns([categories_key(uid), *dashboard_cache_patterns(uid)])
     logger.info("Created category id=%s user=%s", c.id, uid)
     return jsonify(id=c.id, name=c.name), 201
 
@@ -52,6 +54,7 @@ def update_category(category_id: int):
         return jsonify(error="name required"), 400
     c.name = name
     db.session.commit()
+    cache_delete_patterns([categories_key(uid), *dashboard_cache_patterns(uid)])
     logger.info("Updated category id=%s user=%s", c.id, uid)
     return jsonify(id=c.id, name=c.name)
 
@@ -65,5 +68,6 @@ def delete_category(category_id: int):
         return jsonify(error="not found"), 404
     db.session.delete(c)
     db.session.commit()
+    cache_delete_patterns([categories_key(uid), *dashboard_cache_patterns(uid)])
     logger.info("Deleted category id=%s user=%s", c.id, uid)
     return jsonify(message="deleted")

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -5,7 +5,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..extensions import db
 from ..models import Bill, Expense, Category
-from ..services.cache import cache_get, cache_set, dashboard_summary_key
+from ..services.cache import cache_get, cache_set, cache_stats, dashboard_summary_key
 
 bp = Blueprint("dashboard", __name__)
 
@@ -18,9 +18,13 @@ def dashboard_summary():
     if not _is_valid_month(ym):
         return jsonify(error="invalid month, expected YYYY-MM"), 400
     key = dashboard_summary_key(uid, ym)
-    cached = cache_get(key)
+    cached, cache_meta = cache_get(key, with_meta=True)
     if cached:
-        return jsonify(cached)
+        response = jsonify(cached)
+        response.headers["X-FinMind-Cache"] = "HIT"
+        if cache_meta and cache_meta.get("cached_at"):
+            response.headers["X-FinMind-Cache-Age"] = str(max(0, __import__("time").time_ns() // 1_000_000_000 - int(cache_meta["cached_at"])))
+        return response
 
     payload = {
         "period": {"month": ym},
@@ -164,8 +168,17 @@ def dashboard_summary():
     except Exception:
         payload["errors"].append("category_breakdown_unavailable")
 
-    cache_set(key, payload, ttl_seconds=300)
-    return jsonify(payload)
+    cache_set(key, payload, ttl_seconds=300, tags=[f"user:{uid}", "dashboard", f"month:{ym}"])
+    response = jsonify(payload)
+    response.headers["X-FinMind-Cache"] = "MISS"
+    return response
+
+
+@bp.get("/cache/status")
+@jwt_required()
+def dashboard_cache_status():
+    """Expose cache health/telemetry for dashboard and analytics tuning."""
+    return jsonify(cache_stats())
 
 
 def _is_valid_month(ym: str) -> bool:

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -6,7 +6,7 @@ from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
-from ..services.cache import cache_delete_patterns, monthly_summary_key
+from ..services.cache import cache_delete_patterns, dashboard_cache_patterns, monthly_summary_key
 from ..services import expense_import
 import logging
 
@@ -78,12 +78,7 @@ def create_expense():
     db.session.commit()
     logger.info("Created expense id=%s user=%s amount=%s", e.id, uid, e.amount)
     # Invalidate caches
-    cache_delete_patterns(
-        [
-            monthly_summary_key(uid, e.spent_at.strftime("%Y-%m")),
-            f"insights:{uid}:*",
-        ]
-    )
+    cache_delete_patterns(dashboard_cache_patterns(uid, e.spent_at.strftime("%Y-%m")))
     return jsonify(_expense_to_dict(e)), 201
 
 
@@ -387,9 +382,5 @@ def _is_duplicate(uid: int, row: dict) -> bool:
 def _invalidate_expense_cache(uid: int, at: str):
     ym = at[:7]
     cache_delete_patterns(
-        [
-            monthly_summary_key(uid, ym),
-            f"insights:{uid}:*",
-            f"user:{uid}:dashboard_summary:*",
-        ]
+        dashboard_cache_patterns(uid, ym)
     )

--- a/packages/backend/app/services/cache.py
+++ b/packages/backend/app/services/cache.py
@@ -1,6 +1,14 @@
 import json
+import time
 from typing import Iterable
+
+from redis.exceptions import RedisError
+
 from ..extensions import redis_client
+
+# Small in-process fallback keeps tests/local dev usable when Redis is down.
+_MEMORY_CACHE: dict[str, tuple[float | None, str]] = {}
+_CACHE_STATS = {"hits": 0, "misses": 0, "sets": 0, "invalidations": 0, "fallback_errors": 0}
 
 
 def monthly_summary_key(user_id: int, ym: str) -> str:
@@ -23,25 +31,85 @@ def dashboard_summary_key(user_id: int, ym: str) -> str:
     return f"user:{user_id}:dashboard_summary:{ym}"
 
 
-def cache_set(key: str, value, ttl_seconds: int | None = None):
-    payload = json.dumps(value)
-    if ttl_seconds:
-        redis_client.setex(key, ttl_seconds, payload)
+def dashboard_cache_patterns(user_id: int, ym: str | None = None) -> list[str]:
+    """Return all cache keys touched by dashboard/analytics data changes."""
+    patterns = [f"user:{user_id}:dashboard_summary:*", f"insights:{user_id}:*"]
+    if ym:
+        patterns.append(monthly_summary_key(user_id, ym))
     else:
-        redis_client.set(key, payload)
+        patterns.append(f"user:{user_id}:monthly_summary:*")
+    return patterns
 
 
-def cache_get(key: str):
-    raw = redis_client.get(key)
-    return json.loads(raw) if raw else None
+def cache_set(key: str, value, ttl_seconds: int | None = None, tags: Iterable[str] | None = None):
+    payload = json.dumps(
+        {
+            "value": value,
+            "cached_at": int(time.time()),
+            "ttl_seconds": ttl_seconds,
+            "tags": sorted(set(tags or [])),
+        }
+    )
+    _CACHE_STATS["sets"] += 1
+    try:
+        if ttl_seconds:
+            redis_client.setex(key, ttl_seconds, payload)
+        else:
+            redis_client.set(key, payload)
+    except RedisError:
+        _CACHE_STATS["fallback_errors"] += 1
+        expires_at = time.time() + ttl_seconds if ttl_seconds else None
+        _MEMORY_CACHE[key] = (expires_at, payload)
+
+
+def cache_get(key: str, with_meta: bool = False):
+    raw = None
+    try:
+        raw = redis_client.get(key)
+    except RedisError:
+        _CACHE_STATS["fallback_errors"] += 1
+        entry = _MEMORY_CACHE.get(key)
+        if entry:
+            expires_at, raw = entry
+            if expires_at is not None and expires_at <= time.time():
+                _MEMORY_CACHE.pop(key, None)
+                raw = None
+    if not raw:
+        _CACHE_STATS["misses"] += 1
+        return (None, None) if with_meta else None
+    _CACHE_STATS["hits"] += 1
+    decoded = json.loads(raw)
+    # Backward compatible with older cache entries that stored raw payloads.
+    if isinstance(decoded, dict) and "value" in decoded and "cached_at" in decoded:
+        return (decoded["value"], decoded) if with_meta else decoded["value"]
+    return (decoded, None) if with_meta else decoded
 
 
 def cache_delete_patterns(patterns: Iterable[str]):
     for pattern in patterns:
-        cursor = 0
-        while True:
-            cursor, keys = redis_client.scan(cursor=cursor, match=pattern, count=100)
-            if keys:
-                redis_client.delete(*keys)
-            if cursor == 0:
-                break
+        _CACHE_STATS["invalidations"] += 1
+        _delete_memory_pattern(pattern)
+        try:
+            cursor = 0
+            while True:
+                cursor, keys = redis_client.scan(cursor=cursor, match=pattern, count=100)
+                if keys:
+                    redis_client.delete(*keys)
+                if cursor == 0:
+                    break
+        except RedisError:
+            _CACHE_STATS["fallback_errors"] += 1
+
+
+def cache_stats() -> dict:
+    return {**_CACHE_STATS, "memory_keys": len(_MEMORY_CACHE)}
+
+
+def _delete_memory_pattern(pattern: str) -> None:
+    if pattern.endswith("*"):
+        prefix = pattern[:-1]
+        for key in list(_MEMORY_CACHE):
+            if key.startswith(prefix):
+                _MEMORY_CACHE.pop(key, None)
+    else:
+        _MEMORY_CACHE.pop(pattern, None)

--- a/packages/backend/tests/test_dashboard_cache.py
+++ b/packages/backend/tests/test_dashboard_cache.py
@@ -1,0 +1,36 @@
+from datetime import date
+
+
+def test_dashboard_cache_headers_and_invalidation(client, auth_header):
+    month = date.today().strftime("%Y-%m")
+    first = client.get(f"/dashboard/summary?month={month}", headers=auth_header)
+    assert first.status_code == 200
+    assert first.headers["X-FinMind-Cache"] in {"MISS", "HIT"}
+
+    second = client.get(f"/dashboard/summary?month={month}", headers=auth_header)
+    assert second.status_code == 200
+    assert second.headers["X-FinMind-Cache"] == "HIT"
+
+    created = client.post(
+        "/expenses",
+        json={
+            "amount": 42,
+            "description": "Cache invalidation expense",
+            "date": date.today().isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert created.status_code == 201
+
+    refreshed = client.get(f"/dashboard/summary?month={month}", headers=auth_header)
+    assert refreshed.status_code == 200
+    assert refreshed.headers["X-FinMind-Cache"] == "MISS"
+    assert refreshed.get_json()["summary"]["monthly_expenses"] >= 42
+
+
+def test_dashboard_cache_status_endpoint(client, auth_header):
+    r = client.get("/dashboard/cache/status", headers=auth_header)
+    assert r.status_code == 200
+    stats = r.get_json()
+    assert {"hits", "misses", "sets", "invalidations", "memory_keys"}.issubset(stats)


### PR DESCRIPTION
## Summary
- add dashboard summary cache metadata, HIT/MISS headers, and authenticated cache status telemetry
- centralize dashboard/analytics cache invalidation for expenses, imports, bills, and category changes
- add a resilient Redis facade with in-process TTL fallback so auth sessions and caches continue in local/free-tier environments when Redis is unavailable
- document cache keys, invalidation behavior, observability, and resilience

## Tests
- `PYTHONPATH=. ../../.venv/bin/pytest tests` from `packages/backend` (24 passed, 40 warnings)

Closes #127