### PR TITLE
feat: Smart weekly financial digest with trends & insights (bounty #121)

### DIFF
--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,20 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+-- Smart weekly financial digest
+CREATE TABLE IF NOT EXISTS weekly_digests (
+    id SERIAL PRIMARY KEY,
+    user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    period_start DATE NOT NULL,
+    period_end DATE NOT NULL,
+    period_type VARCHAR(20) NOT NULL DEFAULT 'weekly',
+    total_spent NUMERIC(12,2) NOT NULL DEFAULT 0,
+    category_breakdown JSONB NOT NULL DEFAULT '{}',
+    trends JSONB NOT NULL DEFAULT '[]',
+    insights JSONB NOT NULL DEFAULT '[]',
+    generated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_weekly_digests_user_period
+    ON weekly_digests(user_id, period_start, period_end);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,19 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WeeklyDigest(db.Model):
+    __tablename__ = "weekly_digests"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    period_start = db.Column(db.Date, nullable=False)
+    period_end = db.Column(db.Date, nullable=False)
+    period_type = db.Column(db.String(20), default="weekly", nullable=False)
+    total_spent = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    category_breakdown = db.Column(db.JSON, default=dict, nullable=False)
+    trends = db.Column(db.JSON, default=list, nullable=False)
+    insights = db.Column(db.JSON, default=list, nullable=False)
+    generated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, nullable=False
+    )

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask
+
 from .auth import bp as auth_bp
 from .expenses import bp as expenses_bp
 from .bills import bp as bills_bp
@@ -7,6 +8,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +20,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,60 @@
+"""Smart digest routes — weekly financial summaries with trends."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services import digest as digest_service
+
+bp = Blueprint("digest", __name__)
+
+
+@bp.route("", methods=["GET"])
+@jwt_required()
+def get_digest():
+    """Generate or retrieve digest for the current period."""
+    user_id = get_jwt_identity()
+    period = request.args.get("period", "weekly")
+    if period not in ("weekly", "monthly"):
+        return jsonify({"error": "period must be 'weekly' or 'monthly'"}), 400
+
+    data = digest_service.generate_digest(user_id, period=period)
+    return jsonify(data), 200
+
+
+@bp.route("/history", methods=["GET"])
+@jwt_required()
+def get_digest_history():
+    """Return historical digests."""
+    user_id = get_jwt_identity()
+    limit = request.args.get("limit", 10, type=int)
+    period = request.args.get("period")
+
+    data = digest_service.get_digest_history(user_id, limit=limit, period=period)
+    return jsonify(data), 200
+
+
+@bp.route("/generate", methods=["POST"])
+@jwt_required()
+def force_generate():
+    """Force generate a digest for a specific period."""
+    user_id = get_jwt_identity()
+    body = request.get_json(silent=True) or {}
+    period = body.get("period", "weekly")
+    reference_date_str = body.get("reference_date")
+
+    if period not in ("weekly", "monthly"):
+        return jsonify({"error": "period must be 'weekly' or 'monthly'"}), 400
+
+    reference_date = None
+    if reference_date_str:
+        try:
+            from datetime import date
+
+            reference_date = date.fromisoformat(reference_date_str)
+        except ValueError:
+            return jsonify({"error": "Invalid reference_date format"}), 400
+
+    data = digest_service.generate_digest(
+        user_id, period=period, reference_date=reference_date
+    )
+    return jsonify(data), 201

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,239 @@
+"""Smart digest service — weekly financial summary with trends and insights."""
+
+from datetime import datetime, timedelta
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Expense, WeeklyDigest
+
+import logging
+
+logger = logging.getLogger("finmind.digest")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _period_bounds(period="weekly", reference_date=None):
+    """Return (start, end) for the requested period.
+
+    Weekly periods start on Monday.  Monthly periods start on the 1st.
+    """
+    ref = reference_date or datetime.utcnow().date()
+    if period == "weekly":
+        start = ref - timedelta(days=ref.weekday())
+        end = start + timedelta(days=6)
+    elif period == "monthly":
+        start = ref.replace(day=1)
+        if ref.month == 12:
+            end = ref.replace(year=ref.year + 1, month=1, day=1) - timedelta(days=1)
+        else:
+            end = ref.replace(month=ref.month + 1, day=1) - timedelta(days=1)
+    else:
+        raise ValueError(f"Unknown period: {period}")
+    return start, end
+
+
+def _category_breakdown(query_result):
+    """Convert raw query rows into {category: total} dict."""
+    breakdown = {}
+    for cat, total in query_result:
+        if cat:
+            breakdown[cat] = float(total)
+    return breakdown
+
+
+def _detect_trends(current, previous):
+    """Compare two breakdown dicts and return trend list."""
+    trends = []
+    all_cats = set(current) | set(previous)
+    for cat in sorted(all_cats):
+        cur = current.get(cat, 0)
+        prev = previous.get(cat, 0)
+        if prev == 0:
+            if cur > 0:
+                change_pct = 100.0
+                direction = "new"
+            else:
+                continue
+        else:
+            change_pct = round(((cur - prev) / prev) * 100, 1)
+            direction = "up" if change_pct > 0 else "down"
+
+        if abs(change_pct) >= 15:
+            trends.append(
+                {
+                    "category": cat,
+                    "current": cur,
+                    "previous": prev,
+                    "change_pct": change_pct,
+                    "direction": direction,
+                }
+            )
+    return trends
+
+
+def _generate_insights(total_current, total_previous, breakdown, trends):
+    """Produce human-readable insight strings."""
+    insights = []
+
+    # Top spending category
+    if breakdown:
+        top_cat = max(breakdown, key=breakdown.get)
+        top_amount = breakdown[top_cat]
+        if total_current > 0:
+            pct = round((top_amount / total_current) * 100, 1)
+            insights.append(f"Top category: {top_cat} ({pct}% of total spending)")
+
+    # Significant changes
+    for t in trends:
+        if t["direction"] == "up":
+            insights.append(
+                f"{t['category']} spending up {abs(t['change_pct'])}% "
+                f"({t['previous']:.0f} -> {t['current']:.0f})"
+            )
+        elif t["direction"] == "down":
+            insights.append(
+                f"{t['category']} spending down {abs(t['change_pct'])}% "
+                f"({t['previous']:.0f} -> {t['current']:.0f})"
+            )
+        elif t["direction"] == "new":
+            insights.append(f"New spending in {t['category']} ({t['current']:.0f})")
+
+    # Overall comparison
+    if total_previous > 0:
+        overall_change = round(
+            ((total_current - total_previous) / total_previous) * 100, 1
+        )
+        if overall_change > 10:
+            insights.append(f"Overall spending up {overall_change}% from last period")
+        elif overall_change < -10:
+            insights.append(
+                f"Overall spending down {abs(overall_change)}% from last period"
+            )
+
+    if not insights:
+        insights.append("Spending patterns are stable this period.")
+
+    return insights
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_digest(user_id, period="weekly", reference_date=None):
+    """Generate a financial digest for the given period.
+
+    Returns a dict with total, breakdown, trends, and insights.
+    Creates/updates a WeeklyDigest record.
+    """
+    start, end = _period_bounds(period, reference_date)
+
+    # --- Current period ---
+    current_rows = (
+        db.session.query(Expense.category, func.sum(Expense.amount))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.date >= start,
+            Expense.date <= end,
+        )
+        .group_by(Expense.category)
+        .all()
+    )
+    current_breakdown = _category_breakdown(current_rows)
+    total_current = sum(current_breakdown.values())
+
+    # --- Previous period ---
+    period_days = (end - start).days + 1
+    prev_end = start - timedelta(days=1)
+    prev_start = prev_end - timedelta(days=period_days - 1)
+
+    previous_rows = (
+        db.session.query(Expense.category, func.sum(Expense.amount))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.date >= prev_start,
+            Expense.date <= prev_end,
+        )
+        .group_by(Expense.category)
+        .all()
+    )
+    previous_breakdown = _category_breakdown(previous_rows)
+    total_previous = sum(previous_breakdown.values())
+
+    # --- Trends & insights ---
+    trends = _detect_trends(current_breakdown, previous_breakdown)
+    insights = _generate_insights(
+        total_current, total_previous, current_breakdown, trends
+    )
+
+    digest_data = {
+        "period_start": start.isoformat(),
+        "period_end": end.isoformat(),
+        "period_type": period,
+        "total_spent": total_current,
+        "total_previous": total_previous,
+        "category_breakdown": current_breakdown,
+        "trends": trends,
+        "insights": insights,
+    }
+
+    # Upsert digest record
+    existing = WeeklyDigest.query.filter_by(
+        user_id=user_id,
+        period_start=start,
+        period_end=end,
+    ).first()
+
+    if existing:
+        existing.total_spent = total_current
+        existing.category_breakdown = current_breakdown
+        existing.trends = trends
+        existing.insights = insights
+        existing.generated_at = datetime.utcnow()
+    else:
+        existing = WeeklyDigest(
+            user_id=user_id,
+            period_start=start,
+            period_end=end,
+            period_type=period,
+            total_spent=total_current,
+            category_breakdown=current_breakdown,
+            trends=trends,
+            insights=insights,
+            generated_at=datetime.utcnow(),
+        )
+        db.session.add(existing)
+
+    db.session.commit()
+    digest_data["id"] = existing.id
+    return digest_data
+
+
+def get_digest_history(user_id, limit=10, period=None):
+    """Return historical digests for a user."""
+    q = WeeklyDigest.query.filter_by(user_id=user_id)
+    if period:
+        q = q.filter_by(period_type=period)
+    q = q.order_by(WeeklyDigest.period_start.desc())
+    if limit:
+        q = q.limit(limit)
+    digests = q.all()
+    return [
+        {
+            "id": d.id,
+            "period_start": d.period_start.isoformat(),
+            "period_end": d.period_end.isoformat(),
+            "period_type": d.period_type,
+            "total_spent": d.total_spent,
+            "category_breakdown": d.category_breakdown,
+            "trends": d.trends,
+            "insights": d.insights,
+            "generated_at": d.generated_at.isoformat(),
+        }
+        for d in digests
+    ]

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,151 @@
+"""Tests for smart digest API (bounty #121)."""
+
+from datetime import date, timedelta
+
+
+def test_digest_generate_weekly(client, auth_header):
+    """Test generating a weekly digest."""
+    r = client.get("/digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "period_start" in data
+    assert "period_end" in data
+    assert "total_spent" in data
+    assert "category_breakdown" in data
+    assert "trends" in data
+    assert "insights" in data
+    assert data["period_type"] == "weekly"
+
+
+def test_digest_generate_monthly(client, auth_header):
+    """Test generating a monthly digest."""
+    r = client.get("/digest?period=monthly", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["period_type"] == "monthly"
+
+
+def test_digest_invalid_period(client, auth_header):
+    """Test invalid period parameter."""
+    r = client.get("/digest?period=yearly", headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_digest_with_expenses(client, auth_header):
+    """Test digest includes expenses when present."""
+    # Create some expenses first
+    today = date.today().isoformat()
+    for cat in ["food", "transport", "food"]:
+        client.post(
+            "/expenses",
+            json={
+                "amount": 50.0,
+                "category": cat,
+                "date": today,
+                "description": f"Test {cat}",
+            },
+            headers=auth_header,
+        )
+
+    r = client.get("/digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_spent"] > 0
+    assert "food" in data["category_breakdown"]
+
+
+def test_digest_history(client, auth_header):
+    """Test digest history endpoint."""
+    # Generate a digest first
+    r = client.get("/digest", headers=auth_header)
+    assert r.status_code == 200
+
+    r = client.get("/digest/history", headers=auth_header)
+    assert r.status_code == 200
+    history = r.get_json()
+    assert isinstance(history, list)
+    assert len(history) >= 1
+
+
+def test_digest_history_with_limit(client, auth_header):
+    """Test digest history with limit parameter."""
+    r = client.get("/digest/history?limit=5", headers=auth_header)
+    assert r.status_code == 200
+
+
+def test_digest_history_filter_period(client, auth_header):
+    """Test digest history filtered by period type."""
+    r = client.get("/digest/history?period=weekly", headers=auth_header)
+    assert r.status_code == 200
+
+
+def test_digest_force_generate(client, auth_header):
+    """Test force generating a digest for a specific date."""
+    ref_date = date.today().isoformat()
+    r = client.post(
+        "/digest/generate",
+        json={"period": "weekly", "reference_date": ref_date},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["total_spent"] >= 0
+
+
+def test_digest_force_generate_invalid_date(client, auth_header):
+    """Test force generate with invalid date."""
+    r = client.post(
+        "/digest/generate",
+        json={"period": "weekly", "reference_date": "not-a-date"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_digest_force_generate_invalid_period(client, auth_header):
+    """Test force generate with invalid period."""
+    r = client.post(
+        "/digest/generate",
+        json={"period": "quarterly"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_digest_trend_detection(client, auth_header):
+    """Test that trends are detected when spending changes."""
+    today = date.today()
+    last_week = today - timedelta(days=7)
+
+    # Create expenses for current period
+    for i in range(5):
+        client.post(
+            "/expenses",
+            json={
+                "amount": 100.0,
+                "category": "food",
+                "date": today.isoformat(),
+                "description": "Current food",
+            },
+            headers=auth_header,
+        )
+
+    # Create smaller expenses for previous period
+    for i in range(2):
+        client.post(
+            "/expenses",
+            json={
+                "amount": 50.0,
+                "category": "food",
+                "date": last_week.isoformat(),
+                "description": "Previous food",
+            },
+            headers=auth_header,
+        )
+
+    r = client.get("/digest", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    # Food should show up as a trend (>15% change)
+    food_trends = [t for t in data["trends"] if t["category"] == "food"]
+    assert len(food_trends) > 0


### PR DESCRIPTION
## Bounty Claim: $500 — Issue #121

### Implementation

Production-ready smart digest system with weekly/monthly financial summaries, trend detection, and auto-generated insights.

#### Backend Changes

**Model** (`app/models.py`):
- `WeeklyDigest`: user_id, period_start, period_end, period_type, total_spent, category_breakdown (JSON), trends (JSON), insights (JSON), generated_at

**Service** (`app/services/digest.py`):
- `generate_digest()` — aggregate expenses by category for current/previous period
- `_category_breakdown()` — convert query results to {category: total} dict
- `_detect_trends()` — compare current vs previous, flag >15% changes as significant
- `_generate_insights()` — produce human-readable insights: top category, spending spikes, overall change
- `_period_bounds()` — compute week/month date ranges (Monday-based weeks, 1st-based months)
- Upsert logic — updates existing digest or creates new one
- `get_digest_history()` — paginated historical digest listing with period filter

**Routes** (`app/routes/digest.py`):
- `GET /digest?period=weekly|monthly` — generate/retrieve current period digest
- `GET /digest/history?limit=10&period=weekly` — list historical digests
- `POST /digest/generate` — force generate for specific period/date

**Schema** (`app/db/schema.sql`):
- `weekly_digests` table with JSONB columns for breakdown/trends/insights
- Unique index on (user_id, period_start, period_end) for upsert

#### Tests

11 tests covering:
- Weekly and monthly digest generation
- Invalid period parameter validation
- Digest with actual expenses (category breakdown)
- History endpoint with limit and period filters
- Force generation with reference date
- Invalid date/period validation
- Trend detection for spending changes

Closes #121