### PR TITLE
feat: add resilient background job system with retry and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ flowchart LR
 
 ## PostgreSQL Schema (DDL)
 See `backend/app/db/schema.sql`. Key tables:
-- users, categories, expenses, bills, reminders
+- users, categories, expenses, bills, reminders, background_jobs
 - ad_impressions, subscription_plans, user_subscriptions
 - refresh_tokens (optional if rotating), audit_logs
 
@@ -65,6 +65,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
+- Jobs: `GET /jobs/stats`, `GET /jobs/<id>`, `POST /jobs/process`, `POST /jobs/cleanup`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
 
 ## MVP UI/UX Plan
@@ -104,10 +105,12 @@ finmind/
         bills.py
         reminders.py
         insights.py
+        jobs.py
       services/
         __init__.py
         ai.py
         cache.py
+        jobs.py
         reminders.py
       db/
         schema.sql
@@ -168,11 +171,25 @@ finmind/
 - Backend: pytest, flake8, black. Frontend: vitest, eslint.
 - GitHub Actions `ci.yml` runs lint, tests, and builds both apps; optional docker build.
 
+## Background Job System
+- Resilient queued job processing with automatic retry and dead-letter handling.
+- `POST /reminders/run` now enqueues jobs instead of sending synchronously.
+- Retry logic: exponential backoff (30s, 2min, 8min) with configurable `max_attempts` (default 3).
+- After `max_attempts` failures, jobs are marked `DEAD` for manual review.
+- Job types: `REMINDER`, `DIGEST` (extensible via `_dispatch_job` in `services/jobs.py`).
+- Endpoints:
+  - `GET /jobs/stats` -- aggregate counts by status (pending, running, completed, failed, dead).
+  - `GET /jobs/<id>` -- detailed status for a single job.
+  - `POST /jobs/process` -- manually trigger processing of all due pending/failed jobs.
+  - `POST /jobs/cleanup` -- remove completed jobs older than 30 days.
+- All job endpoints are JWT-protected.
+
 ## Monitoring (Grafana OSS)
 - Backend exposes Prometheus metrics at `/metrics` with:
   - request count by endpoint/status
   - request duration histograms (latency, including dashboard p95 KPI)
   - reminder event counters (engagement KPI)
+  - background job counters: `finmind_jobs_total` (by type/status), `finmind_job_duration_seconds`, `finmind_jobs_retry_total`, `finmind_jobs_dead_letter_total`
 - Logs are emitted as JSON with `request_id` and shipped to Loki via Promtail.
 - Pre-provisioned Grafana dashboard: `FinMind Operations and KPI`.
 
@@ -180,7 +197,7 @@ finmind/
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.
 
 ## Notes on Free-Tier Reminders
-- Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
+- Primary: `/reminders/run` enqueues due reminders as background jobs, then `/jobs/process` executes them with retry. Use APScheduler in-process or Railway/Render cron to trigger both endpoints.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).
 
 ## Security & Scalability

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,22 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS background_jobs (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  job_type VARCHAR(30) NOT NULL,
+  payload TEXT NOT NULL DEFAULT '{}',
+  status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+  attempts INT NOT NULL DEFAULT 0,
+  max_attempts INT NOT NULL DEFAULT 3,
+  next_retry_at TIMESTAMP,
+  last_error TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_background_jobs_status_retry
+  ON background_jobs(status, next_retry_at);
+CREATE INDEX IF NOT EXISTS idx_background_jobs_user
+  ON background_jobs(user_id, created_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,36 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class JobType(str, Enum):
+    REMINDER = "REMINDER"
+    DIGEST = "DIGEST"
+
+
+class JobStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    DEAD = "DEAD"
+
+
+class BackgroundJob(db.Model):
+    __tablename__ = "background_jobs"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    job_type = db.Column(db.String(30), nullable=False)
+    payload = db.Column(db.Text, nullable=False, default="{}")
+    status = db.Column(
+        db.String(20), nullable=False, default=JobStatus.PENDING.value
+    )
+    attempts = db.Column(db.Integer, nullable=False, default=0)
+    max_attempts = db.Column(db.Integer, nullable=False, default=3)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    last_error = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    completed_at = db.Column(db.DateTime, nullable=True)

--- a/packages/backend/app/observability.py
+++ b/packages/backend/app/observability.py
@@ -60,6 +60,31 @@ class Observability:
             ["event", "channel", "status"],
             registry=self.registry,
         )
+        self.jobs_total = Counter(
+            "finmind_jobs_total",
+            "Total background jobs by type and status.",
+            ["job_type", "status"],
+            registry=self.registry,
+        )
+        self.job_duration_seconds = Histogram(
+            "finmind_job_duration_seconds",
+            "Background job execution duration in seconds.",
+            ["job_type"],
+            buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60),
+            registry=self.registry,
+        )
+        self.jobs_retry_total = Counter(
+            "finmind_jobs_retry_total",
+            "Total background job retries by type.",
+            ["job_type"],
+            registry=self.registry,
+        )
+        self.jobs_dead_letter_total = Counter(
+            "finmind_jobs_dead_letter_total",
+            "Total background jobs moved to dead letter by type.",
+            ["job_type"],
+            registry=self.registry,
+        )
 
     def observe_http_request(
         self, method: str, endpoint: str, status_code: int, duration_seconds: float
@@ -78,6 +103,22 @@ class Observability:
         self.reminder_events_total.labels(
             event=event, channel=channel, status=status
         ).inc()
+
+    def record_job_completed(
+        self, job_type: str, duration_seconds: float
+    ) -> None:
+        self.jobs_total.labels(job_type=job_type, status="completed").inc()
+        self.job_duration_seconds.labels(job_type=job_type).observe(
+            duration_seconds
+        )
+
+    def record_job_retry(self, job_type: str) -> None:
+        self.jobs_total.labels(job_type=job_type, status="failed").inc()
+        self.jobs_retry_total.labels(job_type=job_type).inc()
+
+    def record_job_dead_letter(self, job_type: str) -> None:
+        self.jobs_total.labels(job_type=job_type, status="dead").inc()
+        self.jobs_dead_letter_total.labels(job_type=job_type).inc()
 
     def metrics_response(self) -> Response:
         if self.multiprocess_enabled:
@@ -137,3 +178,19 @@ def track_reminder_event(event: str, channel: str, status: str = "ok") -> None:
     obs = current_app.extensions.get("observability")
     if obs:
         obs.record_reminder_event(event=event, channel=channel, status=status)
+
+
+def track_job_event(
+    job_type: str,
+    status: str,
+    duration_seconds: float = 0.0,
+) -> None:
+    obs = current_app.extensions.get("observability")
+    if not obs:
+        return
+    if status == "completed":
+        obs.record_job_completed(job_type, duration_seconds)
+    elif status == "failed":
+        obs.record_job_retry(job_type)
+    elif status == "dead":
+        obs.record_job_dead_letter(job_type)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .jobs import bp as jobs_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(jobs_bp, url_prefix="/jobs")

--- a/packages/backend/app/routes/jobs.py
+++ b/packages/backend/app/routes/jobs.py
@@ -1,0 +1,50 @@
+import logging
+from flask import Blueprint, jsonify
+from flask_jwt_extended import jwt_required
+
+from ..services.jobs import (
+    get_job_stats,
+    get_job_status,
+    process_pending_jobs,
+    cleanup_old_jobs,
+)
+
+bp = Blueprint("jobs", __name__)
+logger = logging.getLogger("finmind.jobs.routes")
+
+
+@bp.get("/stats")
+@jwt_required()
+def job_stats():
+    """Return aggregate job statistics for monitoring."""
+    stats = get_job_stats()
+    logger.info("Job stats requested: %s", stats)
+    return jsonify(stats)
+
+
+@bp.get("/<int:job_id>")
+@jwt_required()
+def job_detail(job_id: int):
+    """Return details for a specific job."""
+    job = get_job_status(job_id)
+    if not job:
+        return jsonify(error="not found"), 404
+    return jsonify(job)
+
+
+@bp.post("/process")
+@jwt_required()
+def trigger_processing():
+    """Manually trigger processing of pending jobs."""
+    results = process_pending_jobs()
+    logger.info("Manual job processing triggered: %s", results)
+    return jsonify(results)
+
+
+@bp.post("/cleanup")
+@jwt_required()
+def trigger_cleanup():
+    """Remove completed jobs older than 30 days."""
+    deleted = cleanup_old_jobs(days=30)
+    logger.info("Job cleanup triggered: deleted=%s", deleted)
+    return jsonify(deleted=deleted)

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -2,9 +2,9 @@ from datetime import datetime, time, timedelta
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
-from ..models import Bill, Reminder
+from ..models import Bill, JobType, Reminder
 from ..observability import track_reminder_event
-from ..services.reminders import send_reminder
+from ..services.jobs import enqueue_job
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -170,13 +170,17 @@ def run_due():
         )
         .all()
     )
+    enqueued = 0
     for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
-    db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+        enqueue_job(
+            user_id=uid,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": r.id},
+        )
+        enqueued += 1
+        track_reminder_event(event="enqueued", channel=r.channel)
+    logger.info("Enqueued due reminders user=%s count=%s", uid, enqueued)
+    return jsonify(enqueued=enqueued)
 
 
 def _bill_channels(bill: Bill) -> list[str]:

--- a/packages/backend/app/services/jobs.py
+++ b/packages/backend/app/services/jobs.py
@@ -1,0 +1,247 @@
+import json
+import logging
+import time
+import traceback
+from datetime import datetime, timedelta
+
+from ..extensions import db
+from ..models import BackgroundJob, JobStatus, JobType, Reminder
+from ..services.reminders import send_reminder
+
+logger = logging.getLogger("finmind.jobs")
+
+# Exponential backoff intervals in seconds: 30s, 2min, 8min
+BACKOFF_INTERVALS = [30, 120, 480]
+
+
+def enqueue_job(
+    user_id: int,
+    job_type: str,
+    payload: dict | None = None,
+    max_attempts: int = 3,
+) -> BackgroundJob:
+    """Create a new PENDING background job."""
+    job = BackgroundJob(
+        user_id=user_id,
+        job_type=job_type,
+        payload=json.dumps(payload or {}),
+        status=JobStatus.PENDING.value,
+        attempts=0,
+        max_attempts=max_attempts,
+        next_retry_at=datetime.utcnow(),
+    )
+    db.session.add(job)
+    db.session.commit()
+    logger.info(
+        "Enqueued job id=%s type=%s user=%s", job.id, job_type, user_id
+    )
+    return job
+
+
+def process_pending_jobs() -> dict:
+    """Find and process all due jobs. Returns processing summary."""
+    now = datetime.utcnow()
+    jobs = (
+        db.session.query(BackgroundJob)
+        .filter(
+            BackgroundJob.status.in_(
+                [JobStatus.PENDING.value, JobStatus.FAILED.value]
+            ),
+            db.or_(
+                BackgroundJob.next_retry_at.is_(None),
+                BackgroundJob.next_retry_at <= now,
+            ),
+        )
+        .order_by(BackgroundJob.created_at)
+        .all()
+    )
+
+    results = {"processed": 0, "succeeded": 0, "failed": 0, "dead": 0}
+    for job in jobs:
+        result = execute_job(job)
+        results["processed"] += 1
+        if result == "completed":
+            results["succeeded"] += 1
+        elif result == "dead":
+            results["dead"] += 1
+        else:
+            results["failed"] += 1
+
+    logger.info("Job processing complete: %s", results)
+    return results
+
+
+def execute_job(job: BackgroundJob) -> str:
+    """Execute a single job, handling retries and dead-lettering."""
+    from flask import current_app
+
+    job.status = JobStatus.RUNNING.value
+    job.attempts += 1
+    job.updated_at = datetime.utcnow()
+    db.session.commit()
+
+    start = time.perf_counter()
+    obs = current_app.extensions.get("observability")
+
+    try:
+        _dispatch_job(job)
+        elapsed = time.perf_counter() - start
+
+        job.status = JobStatus.COMPLETED.value
+        job.completed_at = datetime.utcnow()
+        job.last_error = None
+        job.updated_at = datetime.utcnow()
+        db.session.commit()
+
+        if obs:
+            obs.record_job_completed(job.job_type, elapsed)
+        logger.info(
+            "Job completed id=%s type=%s elapsed=%.3fs",
+            job.id,
+            job.job_type,
+            elapsed,
+        )
+        return "completed"
+
+    except Exception as exc:
+        elapsed = time.perf_counter() - start
+        error_msg = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+        job.last_error = error_msg[:2000]
+        job.updated_at = datetime.utcnow()
+
+        if job.attempts >= job.max_attempts:
+            # Dead letter: exceeded max attempts
+            job.status = JobStatus.DEAD.value
+            db.session.commit()
+            if obs:
+                obs.record_job_dead_letter(job.job_type)
+            logger.error(
+                "Job dead-lettered id=%s type=%s attempts=%s error=%s",
+                job.id,
+                job.job_type,
+                job.attempts,
+                str(exc),
+            )
+            return "dead"
+        else:
+            # Schedule retry with exponential backoff
+            backoff_idx = min(job.attempts - 1, len(BACKOFF_INTERVALS) - 1)
+            backoff_seconds = BACKOFF_INTERVALS[backoff_idx]
+            job.status = JobStatus.FAILED.value
+            job.next_retry_at = datetime.utcnow() + timedelta(
+                seconds=backoff_seconds
+            )
+            db.session.commit()
+            if obs:
+                obs.record_job_retry(job.job_type)
+            logger.warning(
+                "Job failed id=%s type=%s attempt=%s/%s "
+                "next_retry_at=%s error=%s",
+                job.id,
+                job.job_type,
+                job.attempts,
+                job.max_attempts,
+                job.next_retry_at.isoformat(),
+                str(exc),
+            )
+            return "failed"
+
+
+def _dispatch_job(job: BackgroundJob) -> None:
+    """Route job to appropriate handler based on job_type."""
+    payload = json.loads(job.payload)
+
+    if job.job_type == JobType.REMINDER.value:
+        _handle_reminder_job(job.user_id, payload)
+    elif job.job_type == JobType.DIGEST.value:
+        _handle_digest_job(job.user_id, payload)
+    else:
+        raise ValueError(f"Unknown job type: {job.job_type}")
+
+
+def _handle_reminder_job(user_id: int, payload: dict) -> None:
+    """Process a single reminder job."""
+    reminder_id = payload.get("reminder_id")
+    if not reminder_id:
+        raise ValueError("Missing reminder_id in job payload")
+
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder:
+        raise ValueError(f"Reminder {reminder_id} not found")
+    if reminder.user_id != user_id:
+        raise ValueError(f"Reminder {reminder_id} does not belong to user")
+    if reminder.sent:
+        logger.info("Reminder %s already sent, skipping", reminder_id)
+        return
+
+    success = send_reminder(reminder)
+    if not success:
+        raise RuntimeError(f"Failed to send reminder {reminder_id}")
+
+    reminder.sent = True
+    db.session.commit()
+
+
+def _handle_digest_job(user_id: int, payload: dict) -> None:
+    """Process a digest generation job (placeholder for future use)."""
+    logger.info("Digest job processed for user=%s payload=%s", user_id, payload)
+
+
+def get_job_status(job_id: int) -> dict | None:
+    """Return job details as a dictionary."""
+    job = db.session.get(BackgroundJob, job_id)
+    if not job:
+        return None
+    return _serialize_job(job)
+
+
+def get_job_stats() -> dict:
+    """Return aggregate job statistics."""
+    stats = {}
+    for status in JobStatus:
+        count = (
+            db.session.query(BackgroundJob)
+            .filter_by(status=status.value)
+            .count()
+        )
+        stats[status.value.lower()] = count
+    stats["total"] = sum(stats.values())
+    return stats
+
+
+def cleanup_old_jobs(days: int = 30) -> int:
+    """Remove completed jobs older than the specified number of days."""
+    cutoff = datetime.utcnow() - timedelta(days=days)
+    deleted = (
+        db.session.query(BackgroundJob)
+        .filter(
+            BackgroundJob.status == JobStatus.COMPLETED.value,
+            BackgroundJob.completed_at <= cutoff,
+        )
+        .delete(synchronize_session=False)
+    )
+    db.session.commit()
+    logger.info("Cleaned up %s old completed jobs", deleted)
+    return deleted
+
+
+def _serialize_job(job: BackgroundJob) -> dict:
+    """Serialize a BackgroundJob to a dictionary."""
+    return {
+        "id": job.id,
+        "user_id": job.user_id,
+        "job_type": job.job_type,
+        "payload": json.loads(job.payload),
+        "status": job.status,
+        "attempts": job.attempts,
+        "max_attempts": job.max_attempts,
+        "next_retry_at": (
+            job.next_retry_at.isoformat() if job.next_retry_at else None
+        ),
+        "last_error": job.last_error,
+        "created_at": job.created_at.isoformat(),
+        "updated_at": job.updated_at.isoformat(),
+        "completed_at": (
+            job.completed_at.isoformat() if job.completed_at else None
+        ),
+    }

--- a/packages/backend/tests/test_jobs.py
+++ b/packages/backend/tests/test_jobs.py
@@ -1,0 +1,391 @@
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from app.extensions import db
+from app.models import BackgroundJob, JobStatus, JobType, Reminder
+from app.services.jobs import (
+    BACKOFF_INTERVALS,
+    cleanup_old_jobs,
+    enqueue_job,
+    execute_job,
+    get_job_stats,
+    get_job_status,
+    process_pending_jobs,
+)
+
+
+def test_enqueue_job_creates_pending_job(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": 42},
+            max_attempts=3,
+        )
+        assert job.id is not None
+        assert job.status == JobStatus.PENDING.value
+        assert job.job_type == JobType.REMINDER.value
+        assert job.attempts == 0
+        assert job.max_attempts == 3
+        assert json.loads(job.payload) == {"reminder_id": 42}
+        assert job.next_retry_at is not None
+
+
+def test_enqueue_job_defaults(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        job = enqueue_job(user_id=1, job_type=JobType.DIGEST.value)
+        assert job.status == JobStatus.PENDING.value
+        assert job.max_attempts == 3
+        assert json.loads(job.payload) == {}
+
+
+def test_get_job_status_returns_details(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": 1},
+        )
+        result = get_job_status(job.id)
+        assert result is not None
+        assert result["id"] == job.id
+        assert result["status"] == JobStatus.PENDING.value
+        assert result["job_type"] == JobType.REMINDER.value
+        assert result["payload"] == {"reminder_id": 1}
+
+
+def test_get_job_status_returns_none_for_missing(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        result = get_job_status(999)
+        assert result is None
+
+
+def test_get_job_stats(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        enqueue_job(user_id=1, job_type=JobType.REMINDER.value)
+        enqueue_job(user_id=1, job_type=JobType.DIGEST.value)
+        stats = get_job_stats()
+        assert stats["pending"] == 2
+        assert stats["completed"] == 0
+        assert stats["failed"] == 0
+        assert stats["dead"] == 0
+        assert stats["total"] == 2
+
+
+def test_execute_job_success_with_reminder(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        # Create a reminder first
+        reminder = Reminder(
+            user_id=1,
+            message="Test reminder",
+            send_at=datetime.utcnow(),
+            channel="email",
+        )
+        db.session.add(reminder)
+        db.session.commit()
+
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": reminder.id},
+        )
+
+        with patch(
+            "app.services.jobs.send_reminder", return_value=True
+        ):
+            result = execute_job(job)
+
+        assert result == "completed"
+        assert job.status == JobStatus.COMPLETED.value
+        assert job.completed_at is not None
+        assert job.attempts == 1
+        assert job.last_error is None
+
+        # Reminder should be marked as sent
+        db.session.refresh(reminder)
+        assert reminder.sent is True
+
+
+def test_execute_job_failure_with_retry(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        reminder = Reminder(
+            user_id=1,
+            message="Test reminder",
+            send_at=datetime.utcnow(),
+            channel="email",
+        )
+        db.session.add(reminder)
+        db.session.commit()
+
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": reminder.id},
+            max_attempts=3,
+        )
+
+        with patch(
+            "app.services.jobs.send_reminder",
+            side_effect=RuntimeError("SMTP down"),
+        ):
+            result = execute_job(job)
+
+        assert result == "failed"
+        assert job.status == JobStatus.FAILED.value
+        assert job.attempts == 1
+        assert "SMTP down" in job.last_error
+        assert job.next_retry_at is not None
+        # Verify exponential backoff: first retry is 30s
+        expected_min = datetime.utcnow() + timedelta(
+            seconds=BACKOFF_INTERVALS[0] - 5
+        )
+        assert job.next_retry_at >= expected_min
+
+
+def test_execute_job_dead_letter_after_max_attempts(
+    app_fixture, auth_header, client
+):
+    with app_fixture.app_context():
+        reminder = Reminder(
+            user_id=1,
+            message="Test reminder",
+            send_at=datetime.utcnow(),
+            channel="email",
+        )
+        db.session.add(reminder)
+        db.session.commit()
+
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": reminder.id},
+            max_attempts=2,
+        )
+
+        with patch(
+            "app.services.jobs.send_reminder",
+            side_effect=RuntimeError("Permanent failure"),
+        ):
+            # First attempt
+            result = execute_job(job)
+            assert result == "failed"
+            assert job.attempts == 1
+
+            # Second attempt (hits max_attempts)
+            result = execute_job(job)
+            assert result == "dead"
+            assert job.status == JobStatus.DEAD.value
+            assert job.attempts == 2
+
+
+def test_process_pending_jobs(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        reminder1 = Reminder(
+            user_id=1,
+            message="Reminder 1",
+            send_at=datetime.utcnow(),
+            channel="email",
+        )
+        reminder2 = Reminder(
+            user_id=1,
+            message="Reminder 2",
+            send_at=datetime.utcnow(),
+            channel="email",
+        )
+        db.session.add_all([reminder1, reminder2])
+        db.session.commit()
+
+        enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": reminder1.id},
+        )
+        enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": reminder2.id},
+        )
+
+        with patch(
+            "app.services.jobs.send_reminder", return_value=True
+        ):
+            results = process_pending_jobs()
+
+        assert results["processed"] == 2
+        assert results["succeeded"] == 2
+        assert results["failed"] == 0
+        assert results["dead"] == 0
+
+
+def test_process_pending_jobs_skips_future_retries(
+    app_fixture, auth_header, client
+):
+    with app_fixture.app_context():
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.DIGEST.value,
+            payload={},
+        )
+        # Set next_retry_at far in the future
+        job.next_retry_at = datetime.utcnow() + timedelta(hours=1)
+        job.status = JobStatus.FAILED.value
+        db.session.commit()
+
+        results = process_pending_jobs()
+        assert results["processed"] == 0
+
+
+def test_cleanup_old_jobs(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        # Create an old completed job
+        old_job = enqueue_job(
+            user_id=1,
+            job_type=JobType.DIGEST.value,
+        )
+        old_job.status = JobStatus.COMPLETED.value
+        old_job.completed_at = datetime.utcnow() - timedelta(days=31)
+        db.session.commit()
+
+        # Create a recent completed job
+        recent_job = enqueue_job(
+            user_id=1,
+            job_type=JobType.DIGEST.value,
+        )
+        recent_job.status = JobStatus.COMPLETED.value
+        recent_job.completed_at = datetime.utcnow() - timedelta(days=5)
+        db.session.commit()
+
+        deleted = cleanup_old_jobs(days=30)
+        assert deleted == 1
+
+        # Recent job should still exist
+        assert db.session.get(BackgroundJob, recent_job.id) is not None
+        # Old job should be deleted
+        assert db.session.get(BackgroundJob, old_job.id) is None
+
+
+def test_job_stats_endpoint(client, auth_header):
+    r = client.get("/jobs/stats", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "pending" in data
+    assert "completed" in data
+    assert "failed" in data
+    assert "dead" in data
+    assert "running" in data
+    assert "total" in data
+
+
+def test_job_detail_endpoint(client, auth_header, app_fixture):
+    with app_fixture.app_context():
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": 1},
+        )
+        job_id = job.id
+
+    r = client.get(f"/jobs/{job_id}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["id"] == job_id
+    assert data["job_type"] == JobType.REMINDER.value
+
+
+def test_job_detail_endpoint_not_found(client, auth_header):
+    r = client.get("/jobs/99999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_job_process_endpoint(client, auth_header):
+    r = client.post("/jobs/process", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "processed" in data
+    assert "succeeded" in data
+
+
+def test_job_cleanup_endpoint(client, auth_header):
+    r = client.post("/jobs/cleanup", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "deleted" in data
+
+
+def test_reminders_run_enqueues_jobs(client, auth_header, app_fixture):
+    """Verify that POST /reminders/run now enqueues jobs instead of sending."""
+    with app_fixture.app_context():
+        reminder = Reminder(
+            user_id=1,
+            message="Due now",
+            send_at=datetime.utcnow() - timedelta(minutes=5),
+            channel="email",
+        )
+        db.session.add(reminder)
+        db.session.commit()
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["enqueued"] == 1
+
+    # Job should exist in DB
+    with app_fixture.app_context():
+        jobs = db.session.query(BackgroundJob).all()
+        assert len(jobs) >= 1
+        job = jobs[-1]
+        assert job.job_type == JobType.REMINDER.value
+        assert json.loads(job.payload)["reminder_id"] is not None
+
+
+def test_exponential_backoff_intervals(app_fixture, auth_header, client):
+    """Verify backoff increases across retries."""
+    with app_fixture.app_context():
+        reminder = Reminder(
+            user_id=1,
+            message="Backoff test",
+            send_at=datetime.utcnow(),
+            channel="email",
+        )
+        db.session.add(reminder)
+        db.session.commit()
+
+        job = enqueue_job(
+            user_id=1,
+            job_type=JobType.REMINDER.value,
+            payload={"reminder_id": reminder.id},
+            max_attempts=4,
+        )
+
+        retry_intervals = []
+        with patch(
+            "app.services.jobs.send_reminder",
+            side_effect=RuntimeError("fail"),
+        ):
+            for _ in range(3):
+                before = datetime.utcnow()
+                execute_job(job)
+                retry_delay = (job.next_retry_at - before).total_seconds()
+                retry_intervals.append(retry_delay)
+
+        # Each interval should be >= the configured backoff
+        assert retry_intervals[0] >= BACKOFF_INTERVALS[0] - 1
+        assert retry_intervals[1] >= BACKOFF_INTERVALS[1] - 1
+        assert retry_intervals[2] >= BACKOFF_INTERVALS[2] - 1
+        # Backoff should increase
+        assert retry_intervals[1] > retry_intervals[0]
+        assert retry_intervals[2] > retry_intervals[1]
+
+
+def test_unknown_job_type_fails(app_fixture, auth_header, client):
+    with app_fixture.app_context():
+        job = enqueue_job(
+            user_id=1,
+            job_type="UNKNOWN",
+            payload={},
+            max_attempts=1,
+        )
+        result = execute_job(job)
+        assert result == "dead"
+        assert "Unknown job type" in job.last_error


### PR DESCRIPTION
## Summary

Implements **Issue #130: Resilient background job retry & monitoring** — a queued background job system with exponential backoff retry, dead-letter handling, and Prometheus monitoring.

### What's included

**Backend:**
- `BackgroundJob` model with status tracking (PENDING → RUNNING → COMPLETED/FAILED/DEAD)
- Job service with exponential backoff retry (30s, 2min, 8min intervals)
- Dead-letter handling after max attempts exhausted
- Job dispatcher supporting REMINDER and DIGEST job types
- 4 Prometheus metrics: `jobs_total`, `job_duration_seconds`, `jobs_retry_total`, `jobs_dead_letter_total`
- REST endpoints for stats, status, manual processing, and cleanup
- Reminders refactored to enqueue jobs instead of synchronous execution

**Tests:**
- 19 pytest cases covering: creation, status transitions, retry logic, dead-letter, backoff verification, batch processing, cleanup, all endpoints

### Technical decisions
- Exponential backoff with configurable intervals (extensible for longer delays)
- Job coordination via database (no external queue dependency required)
- `POST /jobs/process` for manual/cron-triggered processing
- Cleanup endpoint removes completed jobs older than 30 days
- Existing reminder flow preserved — `POST /reminders/run` now enqueues jobs

Resolves #130

/claim #130