### PR TITLE
feat: add weekly smart financial digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Digest: JWT-protected `GET /digest/weekly` with optional `date=YYYY-MM-DD` and `currency=USD`; returns the Monday-Sunday income, expenses, net cash flow, previous-week comparison, category trends, top expenses, upcoming bills, and plain-language highlights for the authenticated user.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -12,6 +12,7 @@ tags:
   - name: Bills
   - name: Reminders
   - name: Insights
+  - name: Digest
 paths:
   /auth/register:
     post:
@@ -475,6 +476,61 @@ paths:
                   wants: 360
                   savings: 240
                 tips: ["Cap dining spend to 80% of last month", "Automate weekly transfer to savings"]
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /digest/weekly:
+    get:
+      summary: Get smart weekly financial digest
+      description: Returns the Monday-Sunday summary containing the optional date, scoped to the authenticated user and selected currency.
+      tags: [Digest]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: date
+          required: false
+          schema: { type: string, format: date }
+          description: Anchor date for the week. Defaults to today.
+        - in: query
+          name: currency
+          required: false
+          schema: { type: string, example: USD }
+          description: Currency to summarize. Defaults to the user's preferred currency.
+      responses:
+        '200':
+          description: Weekly digest
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                period: { start_date: 2026-02-09, end_date: 2026-02-15 }
+                comparison:
+                  previous_period: { start_date: 2026-02-02, end_date: 2026-02-08 }
+                  previous_expenses: 50
+                  expense_delta: 7.75
+                  expense_percent_change: 15.5
+                currency: USD
+                totals: { income: 1000, expenses: 57.75, net_cash_flow: 942.25, transaction_count: 3 }
+                category_breakdown:
+                  - { category: Groceries, amount: 57.75, transaction_count: 2 }
+                category_trends:
+                  - { category: Groceries, current_amount: 57.75, previous_amount: 20, delta: 37.75, percent_change: 188.75, trend: up }
+                top_expenses:
+                  - { id: 1, description: Groceries, amount: 45.5, currency: USD, category: Groceries, date: 2026-02-09 }
+                upcoming_bills:
+                  - { id: 1, name: Electricity, amount: 80, currency: USD, due_date: 2026-02-15, cadence: MONTHLY }
+                highlights:
+                  - You ended the week positive by USD 942.25.
+        '400':
+          description: Invalid date
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
         '401':
           description: Unauthorized
           content:

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,23 @@
+from datetime import date
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..services.digest import build_weekly_digest
+
+bp = Blueprint("digest", __name__)
+
+
+@bp.get("/weekly")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    anchor_raw = (request.args.get("date") or "").strip()
+    currency = (request.args.get("currency") or "").strip().upper() or None
+
+    try:
+        anchor_date = date.fromisoformat(anchor_raw) if anchor_raw else date.today()
+    except ValueError:
+        return jsonify(error="invalid date"), 400
+
+    return jsonify(build_weekly_digest(uid, anchor_date=anchor_date, currency=currency))

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,221 @@
+from collections import defaultdict
+from datetime import date, timedelta
+
+from ..extensions import db
+from ..models import Bill, Category, Expense, User
+
+
+def build_weekly_digest(
+    user_id: int,
+    anchor_date: date | None = None,
+    currency: str | None = None,
+):
+    """Build a deterministic weekly financial summary for one user.
+
+    The digest covers the Monday-Sunday week containing ``anchor_date`` and only
+    includes records owned by ``user_id``. Amounts are returned as floats rounded
+    to two decimals so API clients receive stable JSON values.
+    """
+    anchor = anchor_date or date.today()
+    start_date = anchor - timedelta(days=anchor.weekday())
+    end_date = start_date + timedelta(days=6)
+    user = db.session.get(User, user_id)
+    selected_currency = (
+        currency or (user.preferred_currency if user else None) or "INR"
+    ).upper()
+
+    current = _summarize_expenses(user_id, selected_currency, start_date, end_date)
+    previous_start_date = start_date - timedelta(days=7)
+    previous_end_date = start_date - timedelta(days=1)
+    previous = _summarize_expenses(
+        user_id, selected_currency, previous_start_date, previous_end_date
+    )
+
+    category_breakdown = [
+        {
+            "category": category,
+            "amount": _money(amount),
+            "transaction_count": current["category_counts"][category],
+        }
+        for category, amount in sorted(
+            current["category_amounts"].items(), key=lambda item: (-item[1], item[0])
+        )
+    ]
+    category_trends = _build_category_trends(
+        current["category_amounts"], previous["category_amounts"]
+    )
+    top_expenses = sorted(
+        current["top_expense_rows"],
+        key=lambda item: (-item["amount"], item["date"], item["id"]),
+    )[:5]
+
+    upcoming_bills = [
+        {
+            "id": bill.id,
+            "name": bill.name,
+            "amount": _money(bill.amount),
+            "currency": bill.currency,
+            "due_date": bill.next_due_date.isoformat(),
+            "cadence": bill.cadence.value,
+        }
+        for bill in db.session.query(Bill)
+        .filter(
+            Bill.user_id == user_id,
+            Bill.active.is_(True),
+            Bill.currency == selected_currency,
+            Bill.next_due_date >= start_date,
+            Bill.next_due_date <= end_date,
+        )
+        .order_by(Bill.next_due_date.asc(), Bill.id.asc())
+        .all()
+    ]
+
+    net_cash_flow = _money(current["income_total"] - current["expense_total"])
+    expense_delta = _money(current["expense_total"] - previous["expense_total"])
+    expense_percent_change = _percent_change(
+        current["expense_total"], previous["expense_total"]
+    )
+    return {
+        "period": {
+            "start_date": start_date.isoformat(),
+            "end_date": end_date.isoformat(),
+        },
+        "comparison": {
+            "previous_period": {
+                "start_date": previous_start_date.isoformat(),
+                "end_date": previous_end_date.isoformat(),
+            },
+            "previous_expenses": _money(previous["expense_total"]),
+            "expense_delta": expense_delta,
+            "expense_percent_change": expense_percent_change,
+        },
+        "currency": selected_currency,
+        "totals": {
+            "income": _money(current["income_total"]),
+            "expenses": _money(current["expense_total"]),
+            "net_cash_flow": net_cash_flow,
+            "transaction_count": current["transaction_count"],
+        },
+        "category_breakdown": category_breakdown,
+        "category_trends": category_trends,
+        "top_expenses": top_expenses,
+        "upcoming_bills": upcoming_bills,
+        "highlights": _build_highlights(
+            selected_currency, net_cash_flow, category_breakdown, upcoming_bills
+        ),
+    }
+
+
+def _summarize_expenses(user_id: int, currency: str, start_date: date, end_date: date):
+    expenses = (
+        db.session.query(Expense, Category.name)
+        .outerjoin(Category, Expense.category_id == Category.id)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.currency == currency,
+            Expense.spent_at >= start_date,
+            Expense.spent_at <= end_date,
+        )
+        .order_by(Expense.spent_at.asc(), Expense.id.asc())
+        .all()
+    )
+
+    income_total = 0.0
+    expense_total = 0.0
+    transaction_count = 0
+    category_amounts: dict[str, float] = defaultdict(float)
+    category_counts: dict[str, int] = defaultdict(int)
+    top_expense_rows = []
+
+    for expense, category_name in expenses:
+        amount = _money(expense.amount)
+        expense_type = (expense.expense_type or "EXPENSE").upper()
+        transaction_count += 1
+        if expense_type == "INCOME":
+            income_total += amount
+            continue
+
+        expense_total += amount
+        category = category_name or "Uncategorized"
+        category_amounts[category] += amount
+        category_counts[category] += 1
+        top_expense_rows.append(
+            {
+                "id": expense.id,
+                "description": expense.notes or "",
+                "amount": amount,
+                "currency": expense.currency,
+                "category": category,
+                "date": expense.spent_at.isoformat(),
+            }
+        )
+
+    return {
+        "income_total": income_total,
+        "expense_total": expense_total,
+        "transaction_count": transaction_count,
+        "category_amounts": category_amounts,
+        "category_counts": category_counts,
+        "top_expense_rows": top_expense_rows,
+    }
+
+
+def _build_category_trends(current_amounts, previous_amounts):
+    trends = []
+    categories = sorted(set(current_amounts) | set(previous_amounts))
+    for category in categories:
+        current = _money(current_amounts.get(category, 0.0))
+        previous = _money(previous_amounts.get(category, 0.0))
+        delta = _money(current - previous)
+        if delta > 0:
+            direction = "up"
+        elif delta < 0:
+            direction = "down"
+        else:
+            direction = "flat"
+        trends.append(
+            {
+                "category": category,
+                "current_amount": current,
+                "previous_amount": previous,
+                "delta": delta,
+                "percent_change": _percent_change(current, previous),
+                "trend": direction,
+            }
+        )
+    return sorted(trends, key=lambda item: (-abs(item["delta"]), item["category"]))
+
+
+def _percent_change(current: float, previous: float) -> float | None:
+    if previous == 0:
+        if current == 0:
+            return 0.0
+        return None
+    return _money(((current - previous) / previous) * 100)
+
+
+def _build_highlights(
+    currency: str,
+    net_cash_flow: float,
+    category_breakdown,
+    upcoming_bills,
+):
+    direction = "positive" if net_cash_flow >= 0 else "negative"
+    highlights = [
+        f"You ended the week {direction} by {currency} {abs(net_cash_flow):.2f}."
+    ]
+    if category_breakdown:
+        top_category = category_breakdown[0]
+        highlights.append(
+            f"{top_category['category']} was your highest spending category at "
+            f"{currency} {top_category['amount']:.2f}."
+        )
+    else:
+        highlights.append("No expenses were recorded for this week.")
+    if upcoming_bills:
+        highlights.append(f"{len(upcoming_bills)} bill(s) are due during this week.")
+    return highlights
+
+
+def _money(value) -> float:
+    return round(float(value or 0), 2)

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,213 @@
+import pytest
+
+
+class _FakeRedis:
+    def __init__(self):
+        self._data = {}
+
+    def setex(self, key, _ttl, value):
+        self._data[key] = value
+        return True
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            removed += int(key in self._data)
+            self._data.pop(key, None)
+        return removed
+
+    def scan_iter(self, match=None):
+        return []
+
+    def scan(self, cursor=0, match=None, count=None):
+        return 0, []
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr("app.routes.auth.redis_client", fake)
+    monkeypatch.setattr("app.services.cache.redis_client", fake)
+
+
+def _create_category(client, auth_header, name):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code in (201, 409)
+    r = client.get("/categories", headers=auth_header)
+    assert r.status_code == 200
+    for item in r.get_json():
+        if item["name"] == name:
+            return item["id"]
+    raise AssertionError(f"category {name!r} not found")
+
+
+def test_weekly_digest_requires_jwt(client):
+    r = client.get("/digest/weekly?date=2026-02-12")
+    assert r.status_code == 401
+
+
+def test_weekly_digest_returns_financial_summary_for_anchor_week(client, auth_header):
+    groceries_id = _create_category(client, auth_header, "Groceries")
+    salary_id = _create_category(client, auth_header, "Salary")
+
+    expenses = [
+        {
+            "amount": 45.50,
+            "currency": "USD",
+            "category_id": groceries_id,
+            "description": "Groceries",
+            "date": "2026-02-09",
+            "expense_type": "EXPENSE",
+        },
+        {
+            "amount": 12.25,
+            "currency": "USD",
+            "category_id": groceries_id,
+            "description": "Coffee",
+            "date": "2026-02-11",
+            "expense_type": "EXPENSE",
+        },
+        {
+            "amount": 1000,
+            "currency": "USD",
+            "category_id": salary_id,
+            "description": "Paycheck",
+            "date": "2026-02-13",
+            "expense_type": "INCOME",
+        },
+        {
+            "amount": 20,
+            "currency": "USD",
+            "category_id": groceries_id,
+            "description": "Previous groceries",
+            "date": "2026-02-04",
+            "expense_type": "EXPENSE",
+        },
+        {
+            "amount": 30,
+            "currency": "USD",
+            "description": "Previous uncategorized",
+            "date": "2026-02-05",
+            "expense_type": "EXPENSE",
+        },
+        {
+            "amount": 999,
+            "currency": "USD",
+            "description": "Outside selected week",
+            "date": "2026-02-16",
+            "expense_type": "EXPENSE",
+        },
+    ]
+    for payload in expenses:
+        r = client.post("/expenses", json=payload, headers=auth_header)
+        assert r.status_code == 201
+
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Electricity",
+            "amount": 80,
+            "currency": "USD",
+            "next_due_date": "2026-02-15",
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/digest/weekly?date=2026-02-12&currency=USD", headers=auth_header)
+    assert r.status_code == 200
+    digest = r.get_json()
+
+    assert digest["period"] == {
+        "start_date": "2026-02-09",
+        "end_date": "2026-02-15",
+    }
+    assert digest["currency"] == "USD"
+    assert digest["totals"] == {
+        "income": 1000.0,
+        "expenses": 57.75,
+        "net_cash_flow": 942.25,
+        "transaction_count": 3,
+    }
+    assert digest["comparison"] == {
+        "previous_period": {
+            "start_date": "2026-02-02",
+            "end_date": "2026-02-08",
+        },
+        "previous_expenses": 50.0,
+        "expense_delta": 7.75,
+        "expense_percent_change": 15.5,
+    }
+    assert digest["category_trends"] == [
+        {
+            "category": "Groceries",
+            "current_amount": 57.75,
+            "previous_amount": 20.0,
+            "delta": 37.75,
+            "percent_change": 188.75,
+            "trend": "up",
+        },
+        {
+            "category": "Uncategorized",
+            "current_amount": 0.0,
+            "previous_amount": 30.0,
+            "delta": -30.0,
+            "percent_change": -100.0,
+            "trend": "down",
+        },
+    ]
+    assert digest["category_breakdown"] == [
+        {"category": "Groceries", "amount": 57.75, "transaction_count": 2}
+    ]
+    assert digest["top_expenses"][0]["description"] == "Groceries"
+    assert digest["top_expenses"][0]["amount"] == 45.5
+    assert digest["upcoming_bills"] == [
+        {
+            "id": 1,
+            "name": "Electricity",
+            "amount": 80.0,
+            "currency": "USD",
+            "due_date": "2026-02-15",
+            "cadence": "MONTHLY",
+        }
+    ]
+    assert digest["highlights"][0] == "You ended the week positive by USD 942.25."
+    assert any(
+        "Groceries was your highest spending category" in item
+        for item in digest["highlights"]
+    )
+
+
+def test_weekly_digest_defaults_currency_to_user_preference_and_validates_date(
+    client, auth_header
+):
+    r = client.patch(
+        "/auth/me", json={"preferred_currency": "EUR"}, headers=auth_header
+    )
+    assert r.status_code == 200
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 25,
+            "description": "Transit",
+            "currency": "EUR",
+            "date": "2026-03-03",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/digest/weekly?date=2026-03-04", headers=auth_header)
+    assert r.status_code == 200
+    digest = r.get_json()
+    assert digest["currency"] == "EUR"
+    assert digest["totals"]["expenses"] == 25.0
+
+    r = client.get("/digest/weekly?date=not-a-date", headers=auth_header)
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid date"


### PR DESCRIPTION
## Summary
- Adds a JWT-protected `GET /digest/weekly` endpoint for smart weekly financial summaries.
- Computes Monday-Sunday totals, net cash flow, previous-week comparison, category trends, top expenses, upcoming bills, and deterministic highlights.
- Registers the digest route, documents it in OpenAPI/README, and adds focused backend tests.

## Bounty claim
/claim #121

## Demo
- The endpoint is covered by focused backend tests that build sample users, transactions, recurring bills, and assert the weekly digest response.
- Short demo video: preparing/uploading if the maintainer requires a visual walkthrough; the test command below currently verifies the behavior end-to-end at service/API level.

## Test Plan
- `cd packages/backend && python3 -m pytest -q tests/test_digest.py` → `3 passed`

Closes #121