### PR TITLE
feat: add login anomaly security alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,14 @@ finmind/
 ---
 
 MIT Licensed. Built with ❤️.
+
+
+### Login anomaly detection
+
+FinMind records login security events server-side and warns users about suspicious activity:
+
+- new IP address after a successful login baseline exists;
+- new browser/device user agent after a successful login baseline exists;
+- bursts of five failed login attempts within fifteen minutes.
+
+Successful `/auth/login` responses include a `security_alerts` array. Authenticated users can review recent alerts with `GET /auth/security/alerts` and acknowledge one with `POST /auth/security/alerts/<id>/acknowledge`.

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,27 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class LoginEvent(db.Model):
+    __tablename__ = "login_events"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    email = db.Column(db.String(255), nullable=False)
+    ip_address = db.Column(db.String(64), nullable=True)
+    user_agent = db.Column(db.String(500), nullable=True)
+    success = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SecurityAlert(db.Model):
+    __tablename__ = "security_alerts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    alert_type = db.Column(db.String(50), nullable=False)
+    severity = db.Column(db.String(20), default="medium", nullable=False)
+    message = db.Column(db.String(500), nullable=False)
+    ip_address = db.Column(db.String(64), nullable=True)
+    user_agent = db.Column(db.String(500), nullable=True)
+    acknowledged = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -9,9 +9,16 @@ from flask_jwt_extended import (
     get_jwt_identity,
 )
 from ..extensions import db, redis_client
-from ..models import User
+from ..models import SecurityAlert, User
 import logging
 import time
+from ..services.login_security import (
+    client_ip,
+    record_failed_login,
+    record_successful_login,
+    serialize_alert,
+    user_agent,
+)
 
 bp = Blueprint("auth", __name__)
 logger = logging.getLogger("finmind.auth")
@@ -55,15 +62,23 @@ def login():
     data = request.get_json() or {}
     email = data.get("email")
     password = data.get("password")
+    ip_address = client_ip(request)
+    agent = user_agent(request)
     user = db.session.query(User).filter_by(email=email).first()
     if not user or not check_password_hash(user.password_hash, password):
-        logger.warning("Login failed for email=%s", email)
+        record_failed_login(email, ip_address, agent)
+        logger.warning("Login failed for email=%s ip=%s", email, ip_address)
         return jsonify(error="invalid credentials"), 401
+    alerts = record_successful_login(user, ip_address, agent)
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
-    logger.info("Login success user_id=%s", user.id)
-    return jsonify(access_token=access, refresh_token=refresh)
+    logger.info("Login success user_id=%s ip=%s alerts=%s", user.id, ip_address, len(alerts))
+    return jsonify(
+        access_token=access,
+        refresh_token=refresh,
+        security_alerts=[serialize_alert(alert) for alert in alerts],
+    )
 
 
 @bp.get("/me")
@@ -99,6 +114,36 @@ def update_me():
         email=user.email,
         preferred_currency=user.preferred_currency or "INR",
     )
+
+
+@bp.get("/security/alerts")
+@jwt_required()
+def security_alerts():
+    uid = int(get_jwt_identity())
+    alerts = (
+        db.session.query(SecurityAlert)
+        .filter(SecurityAlert.user_id == uid)
+        .order_by(SecurityAlert.created_at.desc())
+        .limit(50)
+        .all()
+    )
+    return jsonify([serialize_alert(alert) for alert in alerts])
+
+
+@bp.post("/security/alerts/<int:alert_id>/acknowledge")
+@jwt_required()
+def acknowledge_security_alert(alert_id: int):
+    uid = int(get_jwt_identity())
+    alert = (
+        db.session.query(SecurityAlert)
+        .filter(SecurityAlert.id == alert_id, SecurityAlert.user_id == uid)
+        .first()
+    )
+    if not alert:
+        return jsonify(error="not found"), 404
+    alert.acknowledged = True
+    db.session.commit()
+    return jsonify(serialize_alert(alert))
 
 
 @bp.post("/refresh")

--- a/packages/backend/app/services/login_security.py
+++ b/packages/backend/app/services/login_security.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from ..extensions import db
+from ..models import LoginEvent, SecurityAlert, User
+
+FAILED_LOGIN_THRESHOLD = 5
+FAILED_LOGIN_WINDOW_MINUTES = 15
+
+
+def client_ip(request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For", "")
+    if forwarded:
+        return forwarded.split(",", 1)[0].strip()
+    return request.remote_addr or "unknown"
+
+
+def user_agent(request) -> str:
+    return (request.headers.get("User-Agent") or "unknown")[:500]
+
+
+def record_failed_login(email: str | None, ip_address: str, agent: str) -> None:
+    normalized_email = (email or "").strip().lower() or "unknown"
+    event = LoginEvent(
+        email=normalized_email,
+        ip_address=ip_address,
+        user_agent=agent,
+        success=False,
+    )
+    db.session.add(event)
+    db.session.commit()
+
+
+def record_successful_login(user: User, ip_address: str, agent: str) -> list[SecurityAlert]:
+    email = (user.email or "").strip().lower()
+    previous_successes = (
+        db.session.query(LoginEvent)
+        .filter(LoginEvent.user_id == user.id, LoginEvent.success.is_(True))
+        .all()
+    )
+
+    known_ips = {item.ip_address for item in previous_successes if item.ip_address}
+    known_agents = {item.user_agent for item in previous_successes if item.user_agent}
+    alerts: list[SecurityAlert] = []
+
+    if previous_successes and ip_address not in known_ips:
+        alerts.append(
+            _build_alert(
+                user.id,
+                "new_ip",
+                "medium",
+                "New sign-in location detected for your account.",
+                ip_address,
+                agent,
+            )
+        )
+    if previous_successes and agent not in known_agents:
+        alerts.append(
+            _build_alert(
+                user.id,
+                "new_device",
+                "medium",
+                "New device or browser detected for your account.",
+                ip_address,
+                agent,
+            )
+        )
+
+    cutoff = datetime.utcnow() - timedelta(minutes=FAILED_LOGIN_WINDOW_MINUTES)
+    failures = (
+        db.session.query(LoginEvent)
+        .filter(
+            LoginEvent.email == email,
+            LoginEvent.success.is_(False),
+            LoginEvent.created_at >= cutoff,
+        )
+        .count()
+    )
+    if failures >= FAILED_LOGIN_THRESHOLD:
+        alerts.append(
+            _build_alert(
+                user.id,
+                "failed_login_burst",
+                "high",
+                f"{failures} failed login attempts were detected in the last {FAILED_LOGIN_WINDOW_MINUTES} minutes.",
+                ip_address,
+                agent,
+            )
+        )
+
+    db.session.add(
+        LoginEvent(
+            user_id=user.id,
+            email=email,
+            ip_address=ip_address,
+            user_agent=agent,
+            success=True,
+        )
+    )
+    for alert in alerts:
+        db.session.add(alert)
+    db.session.commit()
+    return alerts
+
+
+def serialize_alert(alert: SecurityAlert) -> dict:
+    return {
+        "id": alert.id,
+        "type": alert.alert_type,
+        "severity": alert.severity,
+        "message": alert.message,
+        "ip_address": alert.ip_address,
+        "user_agent": alert.user_agent,
+        "acknowledged": alert.acknowledged,
+        "created_at": alert.created_at.isoformat() + "Z",
+    }
+
+
+def _build_alert(user_id: int, alert_type: str, severity: str, message: str, ip_address: str, agent: str) -> SecurityAlert:
+    return SecurityAlert(
+        user_id=user_id,
+        alert_type=alert_type,
+        severity=severity,
+        message=message,
+        ip_address=ip_address,
+        user_agent=agent,
+    )

--- a/packages/backend/tests/test_login_security.py
+++ b/packages/backend/tests/test_login_security.py
@@ -1,0 +1,79 @@
+import pytest
+
+
+class _FakeRedis:
+    def __init__(self):
+        self._data = {}
+
+    def setex(self, key, _ttl, value):
+        self._data[key] = value
+        return True
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            removed += int(key in self._data)
+            self._data.pop(key, None)
+        return removed
+
+
+@pytest.fixture(autouse=True)
+def _fake_redis(monkeypatch):
+    fake = _FakeRedis()
+    monkeypatch.setattr("app.routes.auth.redis_client", fake)
+
+
+def _register(client):
+    r = client.post("/auth/register", json={"email": "secure@example.com", "password": "password123"})
+    assert r.status_code == 201
+
+
+def _login(client, ip="203.0.113.10", agent="FinMindTest/1.0", password="password123"):
+    return client.post(
+        "/auth/login",
+        json={"email": "secure@example.com", "password": password},
+        headers={"X-Forwarded-For": ip, "User-Agent": agent},
+    )
+
+
+def test_login_records_new_ip_and_device_alerts(client):
+    _register(client)
+    first = _login(client)
+    assert first.status_code == 200
+    assert first.get_json()["security_alerts"] == []
+
+    second = _login(client, ip="198.51.100.7", agent="DifferentBrowser/2.0")
+    assert second.status_code == 200
+    alerts = second.get_json()["security_alerts"]
+    assert {alert["type"] for alert in alerts} == {"new_ip", "new_device"}
+
+    token = second.get_json()["access_token"]
+    listed = client.get("/auth/security/alerts", headers={"Authorization": f"Bearer {token}"})
+    assert listed.status_code == 200
+    assert len(listed.get_json()) == 2
+
+
+def test_failed_login_burst_alerts_on_next_success(client):
+    _register(client)
+    for _ in range(5):
+        r = _login(client, password="wrong")
+        assert r.status_code == 401
+
+    success = _login(client)
+    assert success.status_code == 200
+    alerts = success.get_json()["security_alerts"]
+    assert len(alerts) == 1
+    assert alerts[0]["type"] == "failed_login_burst"
+    assert alerts[0]["severity"] == "high"
+
+    token = success.get_json()["access_token"]
+    alert_id = alerts[0]["id"]
+    ack = client.post(
+        f"/auth/security/alerts/{alert_id}/acknowledge",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert ack.status_code == 200
+    assert ack.get_json()["acknowledged"] is True


### PR DESCRIPTION
/claim #124

## Summary
- Adds persistent login event tracking and security alerts.
- Detects new IPs, new devices/browsers, and failed-login bursts.
- Exposes authenticated alert listing and acknowledge endpoints.
- Documents API behavior in README.

## Tests
- `cd packages/backend && /home/vito7b/FinMind/packages/backend/.venv/bin/python -m pytest -q tests/test_login_security.py`
- Result: `2 passed in 38.35s`

Note: full backend suite still has pre-existing environment/service blockers outside this change; the new focused tests pass.