### PR TITLE
feat: add resilient background job system with retry and monitoring

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -2,6 +2,16 @@ from datetime import datetime, date
 from enum import Enum
 from sqlalchemy import Enum as SAEnum
 from .extensions import db
+import enum as _enum
+
+
+class JobStatus(str, _enum.Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    DEAD_LETTER = "dead_letter"
+    CANCELLED = "cancelled"
 
 
 class Role(str, Enum):
@@ -133,3 +143,18 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class BackgroundJob(db.Model):
+    __tablename__ = "background_jobs"
+    id = db.Column(db.Integer, primary_key=True)
+    job_type = db.Column(db.String(100), nullable=False)
+    payload = db.Column(db.JSON, nullable=True)
+    status = db.Column(db.String(20), default=JobStatus.PENDING.value, nullable=False)
+    attempts = db.Column(db.Integer, default=0, nullable=False)
+    max_retries = db.Column(db.Integer, default=5, nullable=False)
+    last_error = db.Column(db.Text, nullable=True)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    started_at = db.Column(db.DateTime, nullable=True)
+    completed_at = db.Column(db.DateTime, nullable=True)

--- a/packages/backend/app/observability.py
+++ b/packages/backend/app/observability.py
@@ -60,6 +60,19 @@ class Observability:
             ["event", "channel", "status"],
             registry=self.registry,
         )
+        self.background_jobs_total = Counter(
+            "finmind_background_jobs_total",
+            "Total background jobs processed by type and status.",
+            ["job_type", "status"],
+            registry=self.registry,
+        )
+        self.background_job_duration_seconds = Histogram(
+            "finmind_background_job_duration_seconds",
+            "Background job execution duration in seconds by type.",
+            ["job_type"],
+            buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+            registry=self.registry,
+        )
 
     def observe_http_request(
         self, method: str, endpoint: str, status_code: int, duration_seconds: float
@@ -78,6 +91,15 @@ class Observability:
         self.reminder_events_total.labels(
             event=event, channel=channel, status=status
         ).inc()
+
+    def record_background_job(
+        self, job_type: str, status: str, duration_seconds: float | None = None
+    ) -> None:
+        self.background_jobs_total.labels(job_type=job_type, status=status).inc()
+        if duration_seconds is not None:
+            self.background_job_duration_seconds.labels(job_type=job_type).observe(
+                duration_seconds
+            )
 
     def metrics_response(self) -> Response:
         if self.multiprocess_enabled:
@@ -137,3 +159,13 @@ def track_reminder_event(event: str, channel: str, status: str = "ok") -> None:
     obs = current_app.extensions.get("observability")
     if obs:
         obs.record_reminder_event(event=event, channel=channel, status=status)
+
+
+def track_background_job(
+    job_type: str, status: str, duration_seconds: float | None = None
+) -> None:
+    obs = current_app.extensions.get("observability")
+    if obs:
+        obs.record_background_job(
+            job_type=job_type, status=status, duration_seconds=duration_seconds
+        )

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .jobs import bp as jobs_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(jobs_bp, url_prefix="/jobs")

--- a/packages/backend/app/routes/jobs.py
+++ b/packages/backend/app/routes/jobs.py
@@ -1,0 +1,102 @@
+import logging
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+
+from ..extensions import db
+from ..models import BackgroundJob, JobStatus
+from ..services.job_runner import _job_to_dict, job_runner
+
+bp = Blueprint("jobs", __name__)
+logger = logging.getLogger("finmind.jobs")
+
+
+@bp.get("/stats")
+@jwt_required()
+def job_stats():
+    """Return job statistics: counts by status and recent failures."""
+    stats = job_runner.get_job_stats()
+    return jsonify(stats)
+
+
+@bp.get("")
+@jwt_required()
+def list_jobs():
+    """List jobs with pagination, filterable by status and job_type."""
+    try:
+        page = max(1, int(request.args.get("page", "1")))
+        page_size = min(200, max(1, int(request.args.get("page_size", "50"))))
+    except ValueError:
+        return jsonify(error="invalid pagination"), 400
+
+    q = BackgroundJob.query
+    status_filter = request.args.get("status")
+    job_type_filter = request.args.get("job_type")
+
+    if status_filter:
+        q = q.filter(BackgroundJob.status == status_filter)
+    if job_type_filter:
+        q = q.filter(BackgroundJob.job_type == job_type_filter)
+
+    total = q.count()
+    items = (
+        q.order_by(BackgroundJob.created_at.desc())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+        .all()
+    )
+    return jsonify(
+        jobs=[_job_to_dict(j) for j in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@bp.get("/<int:job_id>")
+@jwt_required()
+def get_job(job_id: int):
+    """Get a single job's details."""
+    job = db.session.get(BackgroundJob, job_id)
+    if not job:
+        return jsonify(error="not found"), 404
+    return jsonify(_job_to_dict(job))
+
+
+@bp.post("/<int:job_id>/retry")
+@jwt_required()
+def retry_job(job_id: int):
+    """Manually retry a dead-lettered job."""
+    job = db.session.get(BackgroundJob, job_id)
+    if not job:
+        return jsonify(error="not found"), 404
+    if job.status != JobStatus.DEAD_LETTER.value:
+        return jsonify(error="only dead_letter jobs can be retried"), 400
+
+    # Reset for retry
+    job.status = JobStatus.PENDING.value
+    job.last_error = None
+    job.next_retry_at = None
+    # Don't reset attempts so we can track total history
+    db.session.commit()
+    logger.info("Job id=%s manually reset to pending for retry", job.id)
+
+    # Execute immediately
+    result = job_runner.execute_job(job.id)
+    return jsonify(_job_to_dict(result))
+
+
+@bp.post("/<int:job_id>/cancel")
+@jwt_required()
+def cancel_job(job_id: int):
+    """Cancel a pending job."""
+    job = db.session.get(BackgroundJob, job_id)
+    if not job:
+        return jsonify(error="not found"), 404
+    if job.status != JobStatus.PENDING.value:
+        return jsonify(error="only pending jobs can be cancelled"), 400
+
+    job.status = JobStatus.CANCELLED.value
+    db.session.commit()
+    logger.info("Job id=%s cancelled", job.id)
+    return jsonify(_job_to_dict(job))

--- a/packages/backend/app/services/README_JOBS.md
+++ b/packages/backend/app/services/README_JOBS.md
@@ -1,0 +1,181 @@
+# Background Job System
+
+A resilient background job execution system with exponential backoff retries and dead-letter queue support.
+
+## Overview
+
+The job system provides:
+- **Job Registration**: Map job types to handler functions
+- **Automatic Retries**: Exponential backoff on failure (delay = min(2^attempt × 30, 3600) seconds)
+- **Dead-Letter Queue**: Jobs that exhaust retries are moved to dead_letter for manual inspection
+- **Prometheus Metrics**: Track job execution counts and durations
+- **REST API**: Full CRUD for jobs with filtering, pagination, and manual retry/cancel
+
+## Registering Job Types
+
+```python
+from app.services.job_runner import job_runner
+
+def send_email(payload):
+    user_id = payload["user_id"]
+    # ... send email logic ...
+
+def generate_report(payload):
+    # ... report generation logic ...
+    pass
+
+# Register handlers at startup
+job_runner.register("send_email", send_email)
+job_runner.register("generate_report", generate_report)
+```
+
+Handlers receive the job's `payload` dict (or `None`) and should raise an exception to signal failure. Returning normally signals success.
+
+## Enqueuing Jobs
+
+```python
+from app.services.job_runner import job_runner
+
+# With default max_retries (5)
+job = job_runner.enqueue_job("send_email", {"user_id": 42, "template": "welcome"})
+
+# With custom max_retries
+job = job_runner.enqueue_job("generate_report", {"report_id": 7}, max_retries=3)
+```
+
+## Processing Jobs
+
+```python
+# Process all pending and retry-ready jobs
+processed = job_runner.process_pending()
+
+# Or execute a single job by ID
+job = job_runner.execute_job(job_id)
+```
+
+## Retry Mechanism
+
+When a job handler raises an exception:
+
+1. **First failure**: Job marked as `FAILED`, scheduled for retry in 60s
+2. **Subsequent failures**: Backoff doubles each time (120s, 240s, 480s, ...)
+3. **Cap**: Maximum retry delay is 3600s (1 hour)
+4. **Dead-letter**: After `max_retries` attempts, job moves to `dead_letter` status
+
+```
+Attempt 1: retry in 60s   (2^1 × 30)
+Attempt 2: retry in 120s  (2^2 × 30)
+Attempt 3: retry in 240s  (2^3 × 30)
+Attempt 4: retry in 480s  (2^4 × 30)
+Attempt 5: retry in 960s  (2^5 × 30)
+Attempt 6: retry in 1920s (2^6 × 30)
+Attempt 7+: retry in 3600s (capped)
+```
+
+## Job Statuses
+
+| Status | Description |
+|---|---|
+| `pending` | Waiting to be executed |
+| `running` | Currently executing |
+| `completed` | Successfully finished |
+| `failed` | Failed, waiting for retry |
+| `dead_letter` | Exhausted all retries, needs manual intervention |
+| `cancelled` | Manually cancelled by user |
+
+## API Endpoints
+
+All endpoints require JWT authentication (`Authorization: Bearer <token>`).
+
+### GET /jobs/stats
+
+Returns job statistics: counts by status and recent failures.
+
+```json
+{
+  "counts": {
+    "pending": 5,
+    "running": 1,
+    "completed": 100,
+    "failed": 3,
+    "dead_letter": 1,
+    "cancelled": 0
+  },
+  "recent_failures": [...]
+}
+```
+
+### GET /jobs
+
+List jobs with pagination and optional filters.
+
+Query parameters:
+- `page` (default: 1)
+- `page_size` (default: 50, max: 200)
+- `status` - filter by status (e.g., `pending`, `failed`, `dead_letter`)
+- `job_type` - filter by job type (e.g., `send_email`)
+
+```json
+{
+  "jobs": [...],
+  "total": 42,
+  "page": 1,
+  "page_size": 50
+}
+```
+
+### GET /jobs/{id}
+
+Get a single job's details.
+
+### POST /jobs/{id}/retry
+
+Manually retry a dead-letter job. Resets the job to pending and executes immediately.
+
+### POST /jobs/{id}/cancel
+
+Cancel a pending job. Only works on jobs with `pending` status.
+
+## Prometheus Metrics
+
+The system exposes two metrics on the `/metrics` endpoint:
+
+- **`finmind_background_jobs_total`** (counter) — Labels: `job_type`, `status`. Incremented each time a job completes or fails.
+- **`finmind_background_job_duration_seconds`** (histogram) — Labels: `job_type`. Records execution duration.
+
+### Example PromQL Queries
+
+```promql
+# Job failure rate per minute
+rate(finmind_background_jobs_total{status="failed"}[5m])
+
+# Average job duration by type
+rate(finmind_background_job_duration_seconds_sum[5m]) / rate(finmind_background_job_duration_seconds_count[5m])
+```
+
+## Adding a New Job Type
+
+1. Create a handler function in your service:
+
+```python
+# app/services/my_service.py
+def process_webhook(payload):
+    url = payload["url"]
+    data = payload["data"]
+    # ... process ...
+```
+
+2. Register it at startup (in `__init__.py` or wherever appropriate):
+
+```python
+from app.services.job_runner import job_runner
+from app.services.my_service import process_webhook
+
+job_runner.register("process_webhook", process_webhook)
+```
+
+3. Enqueue jobs as needed:
+
+```python
+job_runner.enqueue_job("process_webhook", {"url": "...", "data": {...}})
+```

--- a/packages/backend/app/services/job_runner.py
+++ b/packages/backend/app/services/job_runner.py
@@ -1,0 +1,196 @@
+import logging
+import time
+import traceback
+from datetime import datetime, timedelta
+
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import BackgroundJob, JobStatus
+from ..observability import track_background_job
+
+logger = logging.getLogger("finmind.jobs")
+
+# Type alias for job handler functions
+JobHandler = callable  # (payload: dict | None) -> None
+
+
+class BackgroundJobRunner:
+    """Resilient background job runner with exponential backoff and dead-letter support."""
+
+    def __init__(self):
+        self._handlers: dict[str, JobHandler] = {}
+
+    def register(self, job_type: str, handler: JobHandler) -> None:
+        """Register a handler function for a given job type."""
+        self._handlers[job_type] = handler
+        logger.info("Registered job handler for type=%s", job_type)
+
+    def enqueue_job(
+        self,
+        job_type: str,
+        payload: dict | None = None,
+        max_retries: int = 5,
+    ) -> BackgroundJob:
+        """Create a new background job record in pending state."""
+        job = BackgroundJob(
+            job_type=job_type,
+            payload=payload,
+            status=JobStatus.PENDING.value,
+            max_retries=max_retries,
+        )
+        db.session.add(job)
+        db.session.commit()
+        logger.info("Enqueued job id=%s type=%s", job.id, job_type)
+        return job
+
+    def execute_job(self, job_id: int) -> BackgroundJob:
+        """Execute a single job by id with error handling and retry logic."""
+        job = db.session.get(BackgroundJob, job_id)
+        if not job:
+            raise ValueError(f"Job {job_id} not found")
+
+        if job.status not in (
+            JobStatus.PENDING.value,
+            JobStatus.FAILED.value,
+        ):
+            logger.warning(
+                "Job id=%s status=%s is not executable, skipping", job.id, job.status
+            )
+            return job
+
+        handler = self._handlers.get(job.job_type)
+        if not handler:
+            job.status = JobStatus.DEAD_LETTER.value
+            job.last_error = f"No handler registered for job type '{job.job_type}'"
+            job.completed_at = datetime.utcnow()
+            db.session.commit()
+            logger.error(
+                "Job id=%s type=%s dead-lettered: no handler", job.id, job.job_type
+            )
+            return job
+
+        job.status = JobStatus.RUNNING.value
+        job.started_at = datetime.utcnow()
+        job.attempts += 1
+        job.next_retry_at = None
+        db.session.commit()
+
+        start_time = time.monotonic()
+        try:
+            handler(job.payload)
+            elapsed = time.monotonic() - start_time
+            job.status = JobStatus.COMPLETED.value
+            job.completed_at = datetime.utcnow()
+            db.session.commit()
+            logger.info(
+                "Job id=%s type=%s completed in %.2fs", job.id, job.job_type, elapsed
+            )
+            track_background_job(job.job_type, "completed", elapsed)
+        except Exception as exc:
+            elapsed = time.monotonic() - start_time
+            job.last_error = f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}"
+            track_background_job(job.job_type, "failed", elapsed)
+
+            if job.attempts >= job.max_retries:
+                job.status = JobStatus.DEAD_LETTER.value
+                job.completed_at = datetime.utcnow()
+                logger.error(
+                    "Job id=%s type=%s dead-lettered after %d attempts: %s",
+                    job.id,
+                    job.job_type,
+                    job.attempts,
+                    exc,
+                )
+            else:
+                job.status = JobStatus.FAILED.value
+                delay = self._backoff_delay(job.attempts)
+                job.next_retry_at = datetime.utcnow() + timedelta(seconds=delay)
+                logger.warning(
+                    "Job id=%s type=%s failed (attempt %d/%d), retry in %ds: %s",
+                    job.id,
+                    job.job_type,
+                    job.attempts,
+                    job.max_retries,
+                    delay,
+                    exc,
+                )
+            db.session.commit()
+
+        return job
+
+    def process_pending(self) -> list[BackgroundJob]:
+        """Process all pending and retry-ready jobs. Returns list of processed jobs."""
+        now = datetime.utcnow()
+        jobs = (
+            BackgroundJob.query.filter(
+                (BackgroundJob.status == JobStatus.PENDING.value)
+                | (
+                    (BackgroundJob.status == JobStatus.FAILED.value)
+                    & (BackgroundJob.next_retry_at <= now)
+                )
+            )
+            .order_by(BackgroundJob.created_at)
+            .all()
+        )
+        processed = []
+        for job in jobs:
+            try:
+                result = self.execute_job(job.id)
+                processed.append(result)
+            except Exception:
+                logger.exception("Unexpected error processing job id=%s", job.id)
+        return processed
+
+    def get_job_stats(self) -> dict:
+        """Return counts by status and recent failure details."""
+        rows = (
+            db.session.query(BackgroundJob.status, func.count(BackgroundJob.id))
+            .group_by(BackgroundJob.status)
+            .all()
+        )
+        counts = {status: 0 for status in JobStatus.__members__.values()}
+        for status, count in rows:
+            counts[status] = count
+
+        recent_failures = (
+            BackgroundJob.query.filter(
+                BackgroundJob.status.in_(
+                    [JobStatus.FAILED.value, JobStatus.DEAD_LETTER.value]
+                )
+            )
+            .order_by(BackgroundJob.created_at.desc())
+            .limit(10)
+            .all()
+        )
+
+        return {
+            "counts": counts,
+            "recent_failures": [_job_to_dict(j) for j in recent_failures],
+        }
+
+    @staticmethod
+    def _backoff_delay(attempt: int) -> int:
+        """Calculate exponential backoff: min(2^attempt * 30, 3600) seconds."""
+        return min(2 ** attempt * 30, 3600)
+
+
+def _job_to_dict(job: BackgroundJob) -> dict:
+    """Serialize a BackgroundJob to a dict for JSON responses."""
+    return {
+        "id": job.id,
+        "job_type": job.job_type,
+        "payload": job.payload,
+        "status": job.status,
+        "attempts": job.attempts,
+        "max_retries": job.max_retries,
+        "last_error": job.last_error,
+        "next_retry_at": job.next_retry_at.isoformat() if job.next_retry_at else None,
+        "created_at": job.created_at.isoformat() if job.created_at else None,
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+    }
+
+
+# Module-level singleton for convenience
+job_runner = BackgroundJobRunner()

--- a/packages/backend/tests/test_jobs.py
+++ b/packages/backend/tests/test_jobs.py
@@ -1,0 +1,446 @@
+"""Tests for background job retry & monitoring system."""
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from app.extensions import db
+from app.models import BackgroundJob, JobStatus
+from app.services.job_runner import BackgroundJobRunner
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _create_job(app_fixture, job_type="test_job", payload=None, status=JobStatus.PENDING.value, max_retries=5):
+    """Helper to insert a job directly into the DB."""
+    with app_fixture.app_context():
+        job = BackgroundJob(
+            job_type=job_type,
+            payload=payload,
+            status=status,
+            max_retries=max_retries,
+        )
+        db.session.add(job)
+        db.session.commit()
+        return job.id
+
+
+def _get_auth(client, auth_header):
+    return auth_header
+
+
+# ---------------------------------------------------------------------------
+# Job Runner Unit Tests
+# ---------------------------------------------------------------------------
+
+def test_enqueue_and_execute_job(app_fixture):
+    """A registered handler should be called and job marked completed."""
+    runner = BackgroundJobRunner()
+    called_with = []
+
+    def handler(payload):
+        called_with.append(payload)
+
+    runner.register("my_job", handler)
+
+    with app_fixture.app_context():
+        job = runner.enqueue_job("my_job", {"key": "value"})
+        assert job.status == JobStatus.PENDING.value
+        assert job.id is not None
+
+        result = runner.execute_job(job.id)
+        assert result.status == JobStatus.COMPLETED.value
+        assert result.attempts == 1
+        assert result.completed_at is not None
+        assert called_with == [{"key": "value"}]
+
+
+def test_retry_on_failure(app_fixture):
+    """A failing job should be marked FAILED with next_retry_at set."""
+    runner = BackgroundJobRunner()
+    call_count = 0
+
+    def flaky_handler(payload):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("boom")
+
+    runner.register("flaky", flaky_handler)
+
+    with app_fixture.app_context():
+        job = runner.enqueue_job("flaky", max_retries=3)
+        result = runner.execute_job(job.id)
+
+        assert result.status == JobStatus.FAILED.value
+        assert result.attempts == 1
+        assert result.last_error is not None
+        assert "boom" in result.last_error
+        assert result.next_retry_at is not None
+        assert result.next_retry_at > datetime.utcnow()
+
+
+def test_dead_letter_after_max_retries(app_fixture):
+    """After max_retries failures the job should be dead-lettered."""
+    runner = BackgroundJobRunner()
+
+    def always_fail(payload):
+        raise ValueError("always fails")
+
+    runner.register("fail", always_fail)
+
+    with app_fixture.app_context():
+        job = runner.enqueue_job("fail", max_retries=2)
+        # First attempt
+        runner.execute_job(job.id)
+        # Second attempt
+        result = runner.execute_job(job.id)
+        assert result.status == JobStatus.DEAD_LETTER.value
+        assert result.attempts == 2
+        assert result.completed_at is not None
+
+
+def test_no_handler_dead_letters(app_fixture):
+    """A job with no registered handler should be dead-lettered immediately."""
+    runner = BackgroundJobRunner()
+
+    with app_fixture.app_context():
+        job = runner.enqueue_job("unknown_type")
+        result = runner.execute_job(job.id)
+        assert result.status == JobStatus.DEAD_LETTER.value
+        assert "No handler" in result.last_error
+
+
+def test_process_pending(app_fixture):
+    """process_pending should pick up pending jobs."""
+    runner = BackgroundJobRunner()
+    processed = []
+
+    def handler(payload):
+        processed.append(payload)
+
+    runner.register("batch", handler)
+
+    with app_fixture.app_context():
+        runner.enqueue_job("batch", {"a": 1})
+        runner.enqueue_job("batch", {"a": 2})
+        results = runner.process_pending()
+        assert len(results) == 2
+        assert all(r.status == JobStatus.COMPLETED.value for r in results)
+        assert len(processed) == 2
+
+
+def test_process_pending_includes_retry_ready(app_fixture):
+    """process_pending should also pick up failed jobs whose next_retry_at has passed."""
+    runner = BackgroundJobRunner()
+    call_count = 0
+
+    def handler(payload):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("first try fails")
+
+    runner.register("retry_test", handler)
+
+    with app_fixture.app_context():
+        job = runner.enqueue_job("retry_test", max_retries=3)
+        # First attempt - fails
+        runner.execute_job(job.id)
+        assert job.status == JobStatus.FAILED.value
+
+        # Simulate retry time having passed
+        job.next_retry_at = datetime.utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+        # process_pending should pick it up
+        results = runner.process_pending()
+        assert len(results) == 1
+        assert results[0].status == JobStatus.COMPLETED.value
+
+
+def test_backoff_delay():
+    """Exponential backoff should be min(2^attempt * 30, 3600)."""
+    assert BackgroundJobRunner._backoff_delay(1) == 60   # 2^1 * 30
+    assert BackgroundJobRunner._backoff_delay(2) == 120  # 2^2 * 30
+    assert BackgroundJobRunner._backoff_delay(3) == 240  # 2^3 * 30
+    assert BackgroundJobRunner._backoff_delay(4) == 480  # 2^4 * 30
+    assert BackgroundJobRunner._backoff_delay(5) == 960  # 2^5 * 30
+    assert BackgroundJobRunner._backoff_delay(6) == 1920 # 2^6 * 30
+    assert BackgroundJobRunner._backoff_delay(7) == 3600 # 2^7 * 30 = 3840, capped at 3600
+    assert BackgroundJobRunner._backoff_delay(8) == 3600
+
+
+def test_get_job_stats(app_fixture):
+    """get_job_stats should return counts by status."""
+    runner = BackgroundJobRunner()
+
+    def ok_handler(payload):
+        pass
+
+    def bad_handler(payload):
+        raise RuntimeError("fail")
+
+    runner.register("ok", ok_handler)
+    runner.register("bad", bad_handler)
+
+    with app_fixture.app_context():
+        runner.enqueue_job("ok")
+        runner.enqueue_job("bad", max_retries=1)
+        runner.enqueue_job("bad", max_retries=1)
+        runner.process_pending()  # ok completes, bad x2 fail then dead_letter
+
+        stats = runner.get_job_stats()
+        assert stats["counts"][JobStatus.COMPLETED.value] == 1
+        assert stats["counts"][JobStatus.DEAD_LETTER.value] == 2
+        assert len(stats["recent_failures"]) == 2
+
+
+def test_skip_non_executable_job(app_fixture):
+    """execute_job on a completed job should return it unchanged."""
+    runner = BackgroundJobRunner()
+
+    def handler(payload):
+        pass
+
+    runner.register("noop", handler)
+
+    with app_fixture.app_context():
+        job = runner.enqueue_job("noop")
+        runner.execute_job(job.id)
+        assert job.status == JobStatus.COMPLETED.value
+
+        # Try to execute again
+        result = runner.execute_job(job.id)
+        assert result.status == JobStatus.COMPLETED.value  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# API Route Tests
+# ---------------------------------------------------------------------------
+
+def test_job_stats_endpoint(client, auth_header):
+    """GET /jobs/stats should return stats with proper auth."""
+    r = client.get("/jobs/stats", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "counts" in data
+    assert "recent_failures" in data
+
+
+def test_job_stats_requires_auth(client):
+    """GET /jobs/stats without auth should return 401."""
+    r = client.get("/jobs/stats")
+    assert r.status_code == 401
+
+
+def test_list_jobs_empty(client, auth_header):
+    """GET /jobs should return empty list when no jobs exist."""
+    r = client.get("/jobs", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["jobs"] == []
+    assert data["total"] == 0
+
+
+def test_list_jobs_with_data(client, auth_header, app_fixture):
+    """GET /jobs should list jobs after creation."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("test", lambda p: None)
+        runner.enqueue_job("test", {"x": 1})
+        runner.enqueue_job("test", {"x": 2})
+
+    r = client.get("/jobs", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total"] == 2
+    assert len(data["jobs"]) == 2
+
+
+def test_list_jobs_filter_by_status(client, auth_header, app_fixture):
+    """GET /jobs?status=pending should filter results."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("test", lambda p: None)
+        runner.enqueue_job("test")
+        job2 = runner.enqueue_job("test")
+        runner.execute_job(job2.id)  # completes
+
+    r = client.get("/jobs?status=pending", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total"] == 1
+    assert all(j["status"] == "pending" for j in data["jobs"])
+
+
+def test_list_jobs_filter_by_job_type(client, auth_header, app_fixture):
+    """GET /jobs?job_type=email should filter results."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("email", lambda p: None)
+        runner.register("sms", lambda p: None)
+        runner.enqueue_job("email")
+        runner.enqueue_job("sms")
+
+    r = client.get("/jobs?job_type=email", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total"] == 1
+    assert data["jobs"][0]["job_type"] == "email"
+
+
+def test_list_jobs_pagination(client, auth_header, app_fixture):
+    """GET /jobs?page=1&page_size=1 should paginate."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("test", lambda p: None)
+        runner.enqueue_job("test")
+        runner.enqueue_job("test")
+        runner.enqueue_job("test")
+
+    r = client.get("/jobs?page=1&page_size=1", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["jobs"]) == 1
+    assert data["total"] == 3
+
+
+def test_get_single_job(client, auth_header, app_fixture):
+    """GET /jobs/<id> should return a single job."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("test", lambda p: None)
+        job = runner.enqueue_job("test", {"key": "val"})
+        job_id = job.id
+
+    r = client.get(f"/jobs/{job_id}", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["id"] == job_id
+    assert data["job_type"] == "test"
+    assert data["payload"] == {"key": "val"}
+
+
+def test_get_job_not_found(client, auth_header):
+    """GET /jobs/9999 should return 404."""
+    r = client.get("/jobs/9999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_retry_dead_letter_job(client, auth_header, app_fixture):
+    """POST /jobs/<id>/retry should retry a dead_letter job."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        call_count = 0
+
+        def handler(payload):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise RuntimeError("fail first tries")
+
+        runner.register("recover", handler)
+        job = runner.enqueue_job("recover", max_retries=2)
+        # Fail twice -> dead letter
+        runner.execute_job(job.id)
+        runner.execute_job(job.id)
+        assert job.status == JobStatus.DEAD_LETTER.value
+        job_id = job.id
+
+    # Manual retry - third try succeeds
+    r = client.post(f"/jobs/{job_id}/retry", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["status"] == "completed"
+
+
+def test_retry_non_dead_letter_rejected(client, auth_header, app_fixture):
+    """POST /jobs/<id>/retry on a pending job should return 400."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("test", lambda p: None)
+        job = runner.enqueue_job("test")
+        job_id = job.id
+
+    r = client.post(f"/jobs/{job_id}/retry", headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_cancel_pending_job(client, auth_header, app_fixture):
+    """POST /jobs/<id>/cancel should cancel a pending job."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("test", lambda p: None)
+        job = runner.enqueue_job("test")
+        job_id = job.id
+
+    r = client.post(f"/jobs/{job_id}/cancel", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["status"] == "cancelled"
+
+
+def test_cancel_non_pending_rejected(client, auth_header, app_fixture):
+    """POST /jobs/<id>/cancel on a completed job should return 400."""
+    with app_fixture.app_context():
+        runner = BackgroundJobRunner()
+        runner.register("test", lambda p: None)
+        job = runner.enqueue_job("test")
+        runner.execute_job(job.id)
+        job_id = job.id
+
+    r = client.post(f"/jobs/{job_id}/cancel", headers=auth_header)
+    assert r.status_code == 400
+
+
+def test_cancel_not_found(client, auth_header):
+    """POST /jobs/9999/cancel should return 404."""
+    r = client.post("/jobs/9999/cancel", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_retry_not_found(client, auth_header):
+    """POST /jobs/9999/retry should return 404."""
+    r = client.post("/jobs/9999/retry", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_invalid_pagination(client, auth_header):
+    """GET /jobs?page=abc should return 400."""
+    r = client.get("/jobs?page=abc", headers=auth_header)
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Model Tests
+# ---------------------------------------------------------------------------
+
+def test_background_job_model_defaults(app_fixture):
+    """BackgroundJob model should have correct defaults."""
+    with app_fixture.app_context():
+        job = BackgroundJob(job_type="test")
+        db.session.add(job)
+        db.session.commit()
+
+        assert job.id is not None
+        assert job.status == JobStatus.PENDING.value
+        assert job.attempts == 0
+        assert job.max_retries == 5
+        assert job.created_at is not None
+        assert job.payload is None
+        assert job.last_error is None
+        assert job.next_retry_at is not None is False or job.next_retry_at is None
+        assert job.started_at is None
+        assert job.completed_at is None
+
+
+def test_background_job_with_payload(app_fixture):
+    """BackgroundJob should store JSON payloads."""
+    with app_fixture.app_context():
+        payload = {"user_id": 1, "action": "send_email", "data": [1, 2, 3]}
+        job = BackgroundJob(job_type="email", payload=payload)
+        db.session.add(job)
+        db.session.commit()
+
+        loaded = db.session.get(BackgroundJob, job.id)
+        assert loaded.payload == payload


### PR DESCRIPTION
## Changes

Implement a production-ready background job execution system with automatic retry and monitoring.

### Backend
- `BackgroundJob` model for tracking job lifecycle (pending, running, completed, failed, dead_letter, cancelled)
- `BackgroundJobRunner` service with exponential backoff retry: `delay = min(2^attempt * 30, 3600)` seconds
- Dead-letter queue after `max_retries` exhausted (default 5)
- Job registration pattern: map job types to handler functions
- `process_pending()` processes all pending and retry-ready jobs

### API Endpoints (all JWT-protected)
- `GET /jobs/stats` — Job statistics (counts by status, recent failures)
- `GET /jobs` — List jobs with pagination, filterable by `status` and `job_type`
- `GET /jobs/<id>` — Single job details
- `POST /jobs/<id>/retry` — Manual retry of dead-letter jobs
- `POST /jobs/<id>/cancel` — Cancel pending jobs

### Monitoring
- Prometheus counter: `finmind_background_jobs_total` (labels: job_type, status)
- Prometheus histogram: `finmind_background_job_duration_seconds` (labels: job_type)

### Documentation
- `packages/backend/app/services/README_JOBS.md` — Full usage guide

### Files modified/added:
- `packages/backend/app/models.py` — Add BackgroundJob model and JobStatus enum
- `packages/backend/app/observability.py` — Add job metrics and track_background_job()
- `packages/backend/app/routes/__init__.py` — Register jobs blueprint
- `packages/backend/app/routes/jobs.py` — NEW: REST API endpoints
- `packages/backend/app/services/job_runner.py` — NEW: BackgroundJobRunner service
- `packages/backend/app/services/README_JOBS.md` — NEW: Documentation
- `packages/backend/tests/test_jobs.py` — NEW: 20+ tests (unit + API)

## Testing

All tests follow existing patterns in the codebase. Run with:
```bash
cd packages/backend && pytest tests/test_jobs.py -v
```

Fixes #130