### PR TITLE
feat: add login anomaly alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,7 @@ finmind/
 ---
 
 MIT Licensed. Built with ❤️.
+
+
+## Login anomaly alerts
+FinMind records successful login environments (IP address and user agent) and returns a `security_alert` object from `/auth/login`. A login is flagged as suspicious when it comes from a new IP address or browser/user-agent compared with recent successful logins for the same account. Suspicious events are also written to application logs for operator review.

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -117,6 +117,18 @@ CREATE TABLE IF NOT EXISTS user_subscriptions (
   started_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+
+CREATE TABLE IF NOT EXISTS login_activities (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  ip_address VARCHAR(45) NOT NULL,
+  user_agent VARCHAR(255) NOT NULL,
+  suspicious BOOLEAN NOT NULL DEFAULT FALSE,
+  reason VARCHAR(255),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_login_activities_user_created ON login_activities(user_id, created_at DESC);
+
 CREATE TABLE IF NOT EXISTS audit_logs (
   id SERIAL PRIMARY KEY,
   user_id INT REFERENCES users(id) ON DELETE SET NULL,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,17 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class LoginActivity(db.Model):
+    __tablename__ = "login_activities"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    ip_address = db.Column(db.String(45), nullable=False)
+    user_agent = db.Column(db.String(255), nullable=False)
+    suspicious = db.Column(db.Boolean, default=False, nullable=False)
+    reason = db.Column(db.String(255), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -9,7 +9,7 @@ from flask_jwt_extended import (
     get_jwt_identity,
 )
 from ..extensions import db, redis_client
-from ..models import User
+from ..models import LoginActivity, User
 import logging
 import time
 
@@ -59,11 +59,12 @@ def login():
     if not user or not check_password_hash(user.password_hash, password):
         logger.warning("Login failed for email=%s", email)
         return jsonify(error="invalid credentials"), 401
+    alert = _record_login_activity(user)
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
     logger.info("Login success user_id=%s", user.id)
-    return jsonify(access_token=access, refresh_token=refresh)
+    return jsonify(access_token=access, refresh_token=refresh, security_alert=alert)
 
 
 @bp.get("/me")
@@ -123,6 +124,60 @@ def logout():
     if jti:
         redis_client.delete(_refresh_key(jti))
     return jsonify(message="logged out"), 200
+
+
+def _client_ip() -> str:
+    forwarded_for = request.headers.get("X-Forwarded-For", "").split(",")[0].strip()
+    return forwarded_for or request.remote_addr or "unknown"
+
+
+def _record_login_activity(user: User) -> dict:
+    ip_address = _client_ip()[:45]
+    user_agent = (request.headers.get("User-Agent") or "unknown")[:255]
+    previous = (
+        db.session.query(LoginActivity)
+        .filter_by(user_id=user.id)
+        .order_by(LoginActivity.created_at.desc())
+        .limit(20)
+        .all()
+    )
+
+    reasons = []
+    if previous and ip_address not in {item.ip_address for item in previous}:
+        reasons.append("new_ip")
+    if previous and user_agent not in {item.user_agent for item in previous}:
+        reasons.append("new_user_agent")
+
+    suspicious = bool(reasons)
+    reason = ",".join(reasons) if suspicious else None
+    activity = LoginActivity(
+        user_id=user.id,
+        ip_address=ip_address,
+        user_agent=user_agent,
+        suspicious=suspicious,
+        reason=reason,
+    )
+    db.session.add(activity)
+    db.session.commit()
+
+    if suspicious:
+        logger.warning(
+            "Suspicious login user_id=%s ip=%s user_agent=%s reason=%s",
+            user.id,
+            ip_address,
+            user_agent,
+            reason,
+        )
+
+    return {
+        "suspicious": suspicious,
+        "reason": reason,
+        "message": (
+            "New login environment detected. Review your account activity."
+            if suspicious
+            else "No unusual login activity detected."
+        ),
+    }
 
 
 def _refresh_key(jti: str) -> str:

--- a/packages/backend/tests/test_auth.py
+++ b/packages/backend/tests/test_auth.py
@@ -66,3 +66,32 @@ def test_auth_me_and_update_preferred_currency(client):
 
     r = client.patch("/auth/me", json={"preferred_currency": "ZZZ"}, headers=auth)
     assert r.status_code == 400
+
+
+def test_login_security_alert_flags_new_ip_and_user_agent(client):
+    email = "security-alert@test.com"
+    password = "secret123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+        headers={"User-Agent": "FinMindTest/1.0"},
+    )
+    assert r.status_code == 200
+    alert = r.get_json()["security_alert"]
+    assert alert["suspicious"] is False
+
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        environ_base={"REMOTE_ADDR": "198.51.100.25"},
+        headers={"User-Agent": "UnexpectedBrowser/9.9"},
+    )
+    assert r.status_code == 200
+    alert = r.get_json()["security_alert"]
+    assert alert["suspicious"] is True
+    assert "new_ip" in alert["reason"]
+    assert "new_user_agent" in alert["reason"]


### PR DESCRIPTION
## Summary
- add persistent login activity tracking for successful auth events
- flag new IP/user-agent combinations as suspicious and return a `security_alert` in `/auth/login`
- document the alert behavior and add backend coverage for the anomaly case

## Validation
- `python3 -m py_compile packages/backend/app/models.py packages/backend/app/routes/auth.py`
- smoke-tested `/auth/login` with Redis calls mocked locally: first known environment returns `suspicious: false`; second new IP/user-agent returns `suspicious: true` with `new_ip,new_user_agent`

Note: the repository's existing pytest auth suite requires a reachable Redis service in this environment; without Redis it fails before/around refresh-token storage, so I used the targeted smoke test above for local verification.