### PR TITLE
feat: add locale-aware date, currency and number formatting

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -33,6 +33,9 @@ def create_app(settings: Settings | None = None) -> Flask:
         TWILIO_AUTH_TOKEN=cfg.twilio_auth_token,
         TWILIO_WHATSAPP_FROM=cfg.twilio_whatsapp_from,
         EMAIL_FROM=cfg.email_from,
+        DEFAULT_LOCALE=cfg.default_locale,
+        DEFAULT_CURRENCY=cfg.default_currency,
+        DEFAULT_TIMEZONE=cfg.default_timezone,
     )
 
     # Logging
@@ -114,6 +117,29 @@ def _ensure_schema_compatibility(app: Flask) -> None:
     except Exception:
         app.logger.exception(
             "Schema compatibility patch failed for users.preferred_currency"
+        )
+        conn.rollback()
+
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            ALTER TABLE users
+            ADD COLUMN IF NOT EXISTS preferred_locale VARCHAR(10)
+            NOT NULL DEFAULT 'en-US'
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE users
+            ADD COLUMN IF NOT EXISTS preferred_timezone VARCHAR(50)
+            NOT NULL DEFAULT 'UTC'
+            """
+        )
+        conn.commit()
+    except Exception:
+        app.logger.exception(
+            "Schema compatibility patch failed for users locale columns"
         )
         conn.rollback()
     finally:

--- a/packages/backend/app/config.py
+++ b/packages/backend/app/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     email_from: str | None = None
     smtp_url: str | None = None  # e.g. smtp+ssl://user:pass@mail:465
 
+    default_locale: str = "en-US"
+    default_currency: str = "INR"
+    default_timezone: str = "UTC"
+
     # pydantic-settings v2 configuration
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -15,6 +15,8 @@ class User(db.Model):
     email = db.Column(db.String(255), unique=True, nullable=False)
     password_hash = db.Column(db.String(255), nullable=False)
     preferred_currency = db.Column(db.String(10), default="INR", nullable=False)
+    preferred_locale = db.Column(db.String(10), default="en-US", nullable=False)
+    preferred_timezone = db.Column(db.String(50), default="UTC", nullable=False)
     role = db.Column(db.String(20), default=Role.USER.value, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -10,6 +10,7 @@ from flask_jwt_extended import (
 )
 from ..extensions import db, redis_client
 from ..models import User
+from ..services.locale import get_formatter, LocaleFormatter
 import logging
 import time
 
@@ -25,6 +26,23 @@ SUPPORTED_CURRENCIES = {
     "AUD",
     "CAD",
     "JPY",
+}
+
+SUPPORTED_TIMEZONES = {
+    "UTC",
+    "Asia/Kolkata",
+    "America/New_York",
+    "America/Los_Angeles",
+    "America/Chicago",
+    "Europe/London",
+    "Europe/Paris",
+    "Europe/Berlin",
+    "Asia/Tokyo",
+    "Asia/Shanghai",
+    "Asia/Singapore",
+    "Asia/Dubai",
+    "Australia/Sydney",
+    "Pacific/Auckland",
 }
 
 
@@ -77,6 +95,8 @@ def me():
         id=user.id,
         email=user.email,
         preferred_currency=user.preferred_currency or "INR",
+        preferred_locale=user.preferred_locale or "en-US",
+        preferred_timezone=user.preferred_timezone or "UTC",
     )
 
 
@@ -93,11 +113,49 @@ def update_me():
         if cur not in SUPPORTED_CURRENCIES:
             return jsonify(error="unsupported preferred_currency"), 400
         user.preferred_currency = cur
+    if "preferred_locale" in data:
+        loc = str(data.get("preferred_locale") or "").strip()
+        if loc not in LocaleFormatter.SUPPORTED_LOCALES:
+            return jsonify(error="unsupported preferred_locale"), 400
+        user.preferred_locale = loc
+    if "preferred_timezone" in data:
+        tz = str(data.get("preferred_timezone") or "").strip()
+        if tz not in SUPPORTED_TIMEZONES:
+            return jsonify(error="unsupported preferred_timezone"), 400
+        user.preferred_timezone = tz
     db.session.commit()
     return jsonify(
         id=user.id,
         email=user.email,
         preferred_currency=user.preferred_currency or "INR",
+        preferred_locale=user.preferred_locale or "en-US",
+        preferred_timezone=user.preferred_timezone or "UTC",
+    )
+
+
+@bp.get("/locale")
+@jwt_required()
+def get_locale():
+    """Get locale formatting info for the current user."""
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="not found"), 404
+    formatter = get_formatter(
+        getattr(user, "preferred_locale", None),
+        user.preferred_currency,
+    )
+    return jsonify(formatter.to_dict())
+
+
+@bp.get("/locale/options")
+@jwt_required()
+def get_locale_options():
+    """Get supported locale, currency, and timezone options."""
+    return jsonify(
+        locales=LocaleFormatter.SUPPORTED_LOCALES,
+        currencies=sorted(LocaleFormatter.CURRENCY_SYMBOLS.keys()),
+        timezones=sorted(SUPPORTED_TIMEZONES),
     )
 
 

--- a/packages/backend/app/services/README_LOCALE.md
+++ b/packages/backend/app/services/README_LOCALE.md
@@ -1,0 +1,232 @@
+# Locale-Aware Formatting
+
+## Overview
+
+FinMind provides locale-aware formatting for dates, numbers, and currencies using the
+[Babel](https://babel.pocoo.org/) library. Users can set their preferred locale and
+currency, and API responses will include properly formatted values.
+
+## Supported Locales
+
+| Locale    | Language/Region        |
+|-----------|------------------------|
+| en-US     | English (United States)|
+| en-GB     | English (United Kingdom)|
+| en-IN     | English (India)        |
+| en-AU     | English (Australia)    |
+| en-CA     | English (Canada)       |
+| de-DE     | German (Germany)       |
+| fr-FR     | French (France)        |
+| es-ES     | Spanish (Spain)        |
+| it-IT     | Italian (Italy)        |
+| pt-BR     | Portuguese (Brazil)    |
+| ja-JP     | Japanese (Japan)       |
+| ko-KR     | Korean (South Korea)   |
+| zh-CN     | Chinese (Simplified)   |
+| zh-TW     | Chinese (Traditional)  |
+| hi-IN     | Hindi (India)          |
+| ar-SA     | Arabic (Saudi Arabia)  |
+| th-TH     | Thai (Thailand)        |
+| vi-VN     | Vietnamese (Vietnam)   |
+| tr-TR     | Turkish (Turkey)       |
+| pl-PL     | Polish (Poland)        |
+| ru-RU     | Russian (Russia)       |
+| nl-NL     | Dutch (Netherlands)    |
+| sv-SE     | Swedish (Sweden)       |
+| da-DK     | Danish (Denmark)       |
+| fi-FI     | Finnish (Finland)      |
+| nb-NO     | Norwegian Bokmål       |
+| id-ID     | Indonesian (Indonesia) |
+| ms-MY     | Malay (Malaysia)       |
+| tl-PH     | Filipino (Philippines) |
+
+## Supported Currencies
+
+| Code | Symbol | Name              |
+|------|--------|-------------------|
+| USD  | $      | US Dollar         |
+| EUR  | €      | Euro              |
+| GBP  | £      | British Pound     |
+| INR  | ₹      | Indian Rupee      |
+| JPY  | ¥      | Japanese Yen      |
+| CNY  | ¥      | Chinese Yuan      |
+| KRW  | ₩      | South Korean Won  |
+| BRL  | R$     | Brazilian Real    |
+| AED  | د.إ    | UAE Dirham        |
+| SGD  | S$     | Singapore Dollar  |
+| AUD  | A$     | Australian Dollar |
+| CAD  | C$     | Canadian Dollar   |
+| CHF  | CHF    | Swiss Franc       |
+| HKD  | HK$    | Hong Kong Dollar  |
+| NZD  | NZ$    | New Zealand Dollar|
+| THB  | ฿      | Thai Baht         |
+| MXN  | MX$    | Mexican Peso      |
+| ZAR  | R      | South African Rand|
+| RUB  | ₽      | Russian Ruble     |
+| TRY  | ₺      | Turkish Lira      |
+| PKR  | ₨      | Pakistani Rupee   |
+
+## API Endpoints
+
+### Get Locale Info
+
+```
+GET /auth/locale
+Authorization: Bearer <access_token>
+```
+
+Returns the user's locale formatting information:
+
+```json
+{
+  "locale": "en-US",
+  "currency": "USD",
+  "currency_symbol": "$",
+  "decimal_symbol": ".",
+  "grouping_symbol": ",",
+  "supported_locales": ["en-US", "en-GB", ...]
+}
+```
+
+### Get Supported Options
+
+```
+GET /auth/locale/options
+Authorization: Bearer <access_token>
+```
+
+Returns all supported locale, currency, and timezone options:
+
+```json
+{
+  "locales": ["en-US", "de-DE", ...],
+  "currencies": ["AED", "AUD", "BRL", ...],
+  "timezones": ["Asia/Kolkata", "UTC", ...]
+}
+```
+
+### Update User Preferences
+
+```
+PATCH /auth/me
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "preferred_currency": "EUR",
+  "preferred_locale": "de-DE",
+  "preferred_timezone": "Europe/Berlin"
+}
+```
+
+### Get User Profile (includes locale fields)
+
+```
+GET /auth/me
+Authorization: Bearer <access_token>
+```
+
+Response:
+
+```json
+{
+  "id": 1,
+  "email": "user@example.com",
+  "preferred_currency": "EUR",
+  "preferred_locale": "de-DE",
+  "preferred_timezone": "Europe/Berlin"
+}
+```
+
+## Using the Locale Service
+
+### In Route Handlers
+
+```python
+from ..services.locale import get_formatter
+
+@bp.get("/some-endpoint")
+@jwt_required()
+def my_endpoint():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+
+    formatter = get_formatter(
+        user.preferred_locale,
+        user.preferred_currency
+    )
+
+    return jsonify(
+        formatted_amount=formatter.format_currency(1234.56),
+        formatted_date=formatter.format_date(date.today()),
+        formatted_number=formatter.format_number(98765.43),
+    )
+```
+
+### Direct Instantiation
+
+```python
+from app.services.locale import LocaleFormatter
+
+# German locale with Euro
+fmt = LocaleFormatter("de-DE", "EUR")
+print(fmt.format_currency(1234.56))    # "1.234,56 €"
+print(fmt.format_number(1234567.89))   # "1.234.567,89"
+print(fmt.format_date(date.today()))   # "15.01.2024"
+
+# Indian locale with Rupee
+fmt = LocaleFormatter("en-IN", "INR")
+print(fmt.format_currency(1234567.89))  # "₹12,34,567.89"
+
+# Japanese locale with Yen
+fmt = LocaleFormatter("ja-JP", "JPY")
+print(fmt.format_currency(123456))      # "￥123,456"
+```
+
+### Formatting Examples by Locale
+
+| Locale | Amount       | Number        | Date          |
+|--------|-------------|---------------|---------------|
+| en-US  | $1,234.56   | 1,234,567.89  | Jan 15, 2024  |
+| de-DE  | 1.234,56 €  | 1.234.567,89  | 15.01.2024    |
+| fr-FR  | 1 234,56 €  | 1 234 567,89  | 15 janv. 2024 |
+| ja-JP  | ￥1,235     | 1,234,568     | 2024/01/15    |
+| hi-IN  | ₹12,34,567  | 12,34,567.89  | 15 Jan 2024   |
+
+## Adding New Locales
+
+1. Add the locale string to `LocaleFormatter.SUPPORTED_LOCALES` in `app/services/locale.py`
+2. Babel handles the formatting automatically for any locale it supports
+3. For new currencies, add the symbol to `LocaleFormatter.CURRENCY_SYMBOLS`
+4. Add the currency code to `SUPPORTED_CURRENCIES` in `app/routes/auth.py`
+
+## Database Migration
+
+For existing deployments, the new columns are added automatically via
+`_ensure_schema_compatibility()` in `app/__init__.py`:
+
+```sql
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS preferred_locale VARCHAR(10) NOT NULL DEFAULT 'en-US';
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS preferred_timezone VARCHAR(50) NOT NULL DEFAULT 'UTC';
+```
+
+## Configuration
+
+Default locale settings in `app/config.py`:
+
+```python
+default_locale: str = "en-US"
+default_currency: str = "INR"
+default_timezone: str = "UTC"
+```
+
+Override via environment variables:
+
+```bash
+DEFAULT_LOCALE=en-GB
+DEFAULT_CURRENCY=GBP
+DEFAULT_TIMEZONE=Europe/London
+```

--- a/packages/backend/app/services/locale.py
+++ b/packages/backend/app/services/locale.py
@@ -1,0 +1,128 @@
+from babel import Locale, numbers, dates
+from flask import current_app
+
+
+class LocaleFormatter:
+  """Locale-aware formatting for dates, numbers, and currencies."""
+
+  CURRENCY_SYMBOLS = {
+    "USD": "$",
+    "EUR": "€",
+    "GBP": "£",
+    "INR": "₹",
+    "JPY": "¥",
+    "CNY": "¥",
+    "KRW": "₩",
+    "BRL": "R$",
+    "AED": "د.إ",
+    "SGD": "S$",
+    "AUD": "A$",
+    "CAD": "C$",
+    "CHF": "CHF",
+    "HKD": "HK$",
+    "NZD": "NZ$",
+    "SEK": "kr",
+    "NOK": "kr",
+    "DKK": "kr",
+    "PLN": "zł",
+    "THB": "฿",
+    "MXN": "MX$",
+    "ZAR": "R",
+    "RUB": "₽",
+    "TRY": "₺",
+    "IDR": "Rp",
+    "MYR": "RM",
+    "PHP": "₱",
+    "VND": "₫",
+    "EGP": "E£",
+    "NGN": "₦",
+    "PKR": "₨",
+    "BDT": "৳",
+    "LKR": "Rs",
+    "QAR": "ر.ق",
+    "KWD": "د.ك",
+    "SAR": "﷼",
+    "BHD": "د.ب",
+    "OMR": "ر.ع",
+  }
+
+  SUPPORTED_LOCALES = [
+    "en-US",
+    "en-GB",
+    "en-IN",
+    "en-AU",
+    "en-CA",
+    "de-DE",
+    "fr-FR",
+    "es-ES",
+    "it-IT",
+    "pt-BR",
+    "ja-JP",
+    "ko-KR",
+    "zh-CN",
+    "zh-TW",
+    "hi-IN",
+    "ar-SA",
+    "th-TH",
+    "vi-VN",
+    "tr-TR",
+    "pl-PL",
+    "ru-RU",
+    "nl-NL",
+    "sv-SE",
+    "da-DK",
+    "fi-FI",
+    "nb-NO",
+    "id-ID",
+    "ms-MY",
+    "tl-PH",
+  ]
+
+  def __init__(self, locale_str="en-US", currency="INR"):
+    self.locale = Locale.parse(locale_str, sep="-")
+    self.currency = currency
+    self.locale_str = locale_str
+
+  def format_currency(self, amount, currency=None):
+    """Format amount as currency string."""
+    curr = currency or self.currency
+    return numbers.format_currency(amount, curr, locale=self.locale)
+
+  def format_number(self, number):
+    """Format number with locale-specific grouping."""
+    return numbers.format_decimal(number, locale=self.locale)
+
+  def format_date(self, date_obj, format="medium"):
+    """Format date according to locale."""
+    return dates.format_date(date_obj, format=format, locale=self.locale)
+
+  def format_datetime(self, datetime_obj, format="medium"):
+    """Format datetime according to locale."""
+    return dates.format_datetime(
+      datetime_obj, format=format, locale=self.locale
+    )
+
+  def format_percent(self, number):
+    """Format number as percentage."""
+    return numbers.format_percent(number, locale=self.locale)
+
+  def to_dict(self):
+    """Return locale info as dict."""
+    num_symbols = self.locale.number_symbols
+    return {
+      "locale": self.locale_str,
+      "currency": self.currency,
+      "currency_symbol": self.CURRENCY_SYMBOLS.get(
+        self.currency, self.currency
+      ),
+      "decimal_symbol": num_symbols.get("decimal", "."),
+      "grouping_symbol": num_symbols.get("group", ","),
+      "supported_locales": self.SUPPORTED_LOCALES,
+    }
+
+
+def get_formatter(user_locale=None, currency=None):
+  """Get a LocaleFormatter for the given locale and currency."""
+  loc = user_locale or current_app.config.get("DEFAULT_LOCALE", "en-US")
+  curr = currency or current_app.config.get("DEFAULT_CURRENCY", "INR")
+  return LocaleFormatter(loc, curr)

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -11,6 +11,7 @@ pydantic-settings==2.4.0
 python-dotenv==1.0.1
 apscheduler==3.10.4
 requests==2.32.3
+babel==2.14.0
 pypdf==4.3.1
 openai==1.37.1
 twilio==9.3.2

--- a/packages/backend/tests/test_locale.py
+++ b/packages/backend/tests/test_locale.py
@@ -1,0 +1,272 @@
+from datetime import date, datetime
+
+import pytest
+from app import create_app
+from app.config import Settings
+from app.extensions import db
+from app.models import User
+from app.services.locale import LocaleFormatter, get_formatter
+
+
+class TestLocaleFormatter:
+  """Tests for LocaleFormatter class."""
+
+  def test_format_currency_inr(self):
+    fmt = LocaleFormatter("en-IN", "INR")
+    result = fmt.format_currency(1234567.89)
+    assert "₹" in result
+    assert "12" in result
+
+  def test_format_currency_usd(self):
+    fmt = LocaleFormatter("en-US", "USD")
+    result = fmt.format_currency(1234.56)
+    assert "$" in result
+    assert "1,234.56" in result
+
+  def test_format_currency_eur_de(self):
+    fmt = LocaleFormatter("de-DE", "EUR")
+    result = fmt.format_currency(1234.56)
+    assert "€" in result
+
+  def test_format_currency_override(self):
+    fmt = LocaleFormatter("en-US", "USD")
+    result = fmt.format_currency(100.00, currency="GBP")
+    assert "£" in result
+
+  def test_format_number_en_us(self):
+    fmt = LocaleFormatter("en-US")
+    result = fmt.format_number(1234567.89)
+    assert result == "1,234,567.89"
+
+  def test_format_number_de_de(self):
+    fmt = LocaleFormatter("de-DE")
+    result = fmt.format_number(1234567.89)
+    assert "1.234.567" in result
+
+  def test_format_number_fr_fr(self):
+    fmt = LocaleFormatter("fr-FR")
+    result = fmt.format_number(1234.56)
+    assert "1" in result
+    assert "234" in result
+
+  def test_format_date_en_us(self):
+    fmt = LocaleFormatter("en-US")
+    d = date(2024, 1, 15)
+    result = fmt.format_date(d)
+    assert "Jan" in result
+    assert "2024" in result
+
+  def test_format_date_de_de(self):
+    fmt = LocaleFormatter("de-DE")
+    d = date(2024, 1, 15)
+    result = fmt.format_date(d)
+    assert "2024" in result
+
+  def test_format_datetime_en_us(self):
+    fmt = LocaleFormatter("en-US")
+    dt = datetime(2024, 1, 15, 14, 30, 0)
+    result = fmt.format_datetime(dt)
+    assert "2024" in result
+    assert "Jan" in result
+
+  def test_format_percent(self):
+    fmt = LocaleFormatter("en-US")
+    result = fmt.format_percent(0.856)
+    assert "%" in result
+    # 0.856 rounds to 86%
+    assert "86" in result
+
+  def test_to_dict_en_us(self):
+    fmt = LocaleFormatter("en-US", "USD")
+    info = fmt.to_dict()
+    assert info["locale"] == "en-US"
+    assert info["currency"] == "USD"
+    assert info["currency_symbol"] == "$"
+    assert info["decimal_symbol"] == "."
+    assert info["grouping_symbol"] == ","
+    assert "supported_locales" in info
+
+  def test_to_dict_de_de(self):
+    fmt = LocaleFormatter("de-DE", "EUR")
+    info = fmt.to_dict()
+    assert info["locale"] == "de-DE"
+    assert info["currency"] == "EUR"
+    assert info["currency_symbol"] == "€"
+
+  def test_to_dict_inr(self):
+    fmt = LocaleFormatter("en-IN", "INR")
+    info = fmt.to_dict()
+    assert info["currency_symbol"] == "₹"
+
+  def test_supported_locales_not_empty(self):
+    assert len(LocaleFormatter.SUPPORTED_LOCALES) > 0
+
+  def test_currency_symbols_not_empty(self):
+    assert len(LocaleFormatter.CURRENCY_SYMBOLS) > 0
+
+  def test_format_currency_zero(self):
+    fmt = LocaleFormatter("en-US", "USD")
+    result = fmt.format_currency(0)
+    assert "$" in result
+    assert "0" in result
+
+  def test_format_currency_large_amount(self):
+    fmt = LocaleFormatter("en-US", "USD")
+    result = fmt.format_currency(9999999.99)
+    assert "$" in result
+    assert "9,999,999.99" in result
+
+  def test_format_number_small(self):
+    fmt = LocaleFormatter("en-US")
+    result = fmt.format_number(0.5)
+    assert "0.5" in result
+
+  def test_format_date_short(self):
+    fmt = LocaleFormatter("en-US")
+    d = date(2024, 12, 25)
+    result = fmt.format_date(d, format="short")
+    assert "24" in result
+
+
+class TestGetFormatter:
+  """Tests for get_formatter factory function."""
+
+  def test_get_formatter_defaults(self, app_fixture):
+    with app_fixture.app_context():
+      fmt = get_formatter()
+      assert fmt.locale_str == "en-US"
+      assert fmt.currency == "INR"
+
+  def test_get_formatter_custom(self, app_fixture):
+    with app_fixture.app_context():
+      fmt = get_formatter("de-DE", "EUR")
+      assert fmt.locale_str == "de-DE"
+      assert fmt.currency == "EUR"
+
+  def test_get_formatter_partial_override(self, app_fixture):
+    with app_fixture.app_context():
+      fmt = get_formatter("fr-FR")
+      assert fmt.locale_str == "fr-FR"
+      assert fmt.currency == "INR"
+
+
+class TestLocaleEndpoint:
+  """Tests for /auth/locale and /auth/locale/options endpoints."""
+
+  def test_get_locale_default(self, client, auth_header):
+    """Locale endpoint should return default locale info."""
+    response = client.get("/auth/locale", headers=auth_header)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["locale"] == "en-US"
+    assert data["currency"] == "INR"
+    assert data["currency_symbol"] == "₹"
+    assert "decimal_symbol" in data
+    assert "grouping_symbol" in data
+    assert "supported_locales" in data
+
+  def test_get_locale_after_update(self, client, auth_header):
+    """Locale endpoint should reflect user's locale preference."""
+    client.patch(
+      "/auth/me",
+      json={"preferred_locale": "de-DE", "preferred_currency": "EUR"},
+      headers=auth_header,
+    )
+    response = client.get("/auth/locale", headers=auth_header)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["locale"] == "de-DE"
+    assert data["currency"] == "EUR"
+    assert data["currency_symbol"] == "€"
+
+  def test_get_locale_requires_auth(self, client):
+    """Locale endpoint should require authentication."""
+    response = client.get("/auth/locale")
+    assert response.status_code == 401
+
+  def test_get_locale_options(self, client, auth_header):
+    """Options endpoint should return supported values."""
+    response = client.get("/auth/locale/options", headers=auth_header)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "locales" in data
+    assert "currencies" in data
+    assert "timezones" in data
+    assert "en-US" in data["locales"]
+    assert "USD" in data["currencies"]
+    assert "UTC" in data["timezones"]
+
+
+class TestUserLocaleUpdate:
+  """Tests for updating user locale preferences via /auth/me."""
+
+  def test_update_locale(self, client, auth_header):
+    """Should update preferred_locale."""
+    response = client.patch(
+      "/auth/me",
+      json={"preferred_locale": "fr-FR"},
+      headers=auth_header,
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["preferred_locale"] == "fr-FR"
+
+  def test_update_timezone(self, client, auth_header):
+    """Should update preferred_timezone."""
+    response = client.patch(
+      "/auth/me",
+      json={"preferred_timezone": "Asia/Kolkata"},
+      headers=auth_header,
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["preferred_timezone"] == "Asia/Kolkata"
+
+  def test_update_invalid_locale(self, client, auth_header):
+    """Should reject unsupported locale."""
+    response = client.patch(
+      "/auth/me",
+      json={"preferred_locale": "xx-XX"},
+      headers=auth_header,
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "unsupported" in data["error"]
+
+  def test_update_invalid_timezone(self, client, auth_header):
+    """Should reject unsupported timezone."""
+    response = client.patch(
+      "/auth/me",
+      json={"preferred_timezone": "Invalid/Zone"},
+      headers=auth_header,
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "unsupported" in data["error"]
+
+  def test_me_returns_locale_fields(self, client, auth_header):
+    """GET /auth/me should return locale and timezone fields."""
+    response = client.get("/auth/me", headers=auth_header)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "preferred_locale" in data
+    assert "preferred_timezone" in data
+    assert data["preferred_locale"] == "en-US"
+    assert data["preferred_timezone"] == "UTC"
+
+  def test_update_multiple_preferences(self, client, auth_header):
+    """Should update currency, locale, and timezone together."""
+    response = client.patch(
+      "/auth/me",
+      json={
+        "preferred_currency": "EUR",
+        "preferred_locale": "de-DE",
+        "preferred_timezone": "Europe/Berlin",
+      },
+      headers=auth_header,
+    )
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["preferred_currency"] == "EUR"
+    assert data["preferred_locale"] == "de-DE"
+    assert data["preferred_timezone"] == "Europe/Berlin"


### PR DESCRIPTION
## Changes

Implement internationalization support using Babel.

### Features
- LocaleFormatter class for currency, number, date, datetime, percent formatting
- 29 supported locales (en-US, en-GB, de-DE, fr-FR, ja-JP, zh-CN, etc.)
- 37 currency symbols (USD, EUR, GBP, INR, JPY, CNY, etc.)
- GET /auth/locale - user's locale formatting info
- GET /auth/locale/options - supported locales, currencies, timezones
- PATCH /auth/me - update user locale/timezone preferences
- Schema migration for existing databases

### Files Modified
- packages/backend/app/config.py - Added locale/currency/timezone settings
- packages/backend/app/models.py - Added preferred_locale, preferred_timezone to User
- packages/backend/app/__init__.py - Config propagation and schema migration
- packages/backend/app/routes/auth.py - Locale endpoints
- packages/backend/requirements.txt - Added babel==2.14.0
- packages/backend/app/services/locale.py - NEW: LocaleFormatter service
- packages/backend/app/services/README_LOCALE.md - NEW: Documentation
- packages/backend/tests/test_locale.py - NEW: 33 tests

Fixes #131