### PR TITLE
feat: add reminder reliability tracking and delivery metrics

### DIFF
--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,24 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ReminderDeliveryStatus(str, Enum):
+  PENDING = "pending"
+  SENT = "sent"
+  DELIVERED = "delivered"
+  FAILED = "failed"
+  BOUNCED = "bounced"
+
+
+class ReminderDelivery(db.Model):
+  __tablename__ = "reminder_deliveries"
+  id = db.Column(db.Integer, primary_key=True)
+  reminder_id = db.Column(db.Integer, db.ForeignKey("reminders.id"), nullable=False)
+  status = db.Column(db.String(20), default=ReminderDeliveryStatus.PENDING.value, nullable=False)
+  channel = db.Column(db.String(20), nullable=False)
+  attempts = db.Column(db.Integer, default=0, nullable=False)
+  last_error = db.Column(db.Text, nullable=True)
+  delivered_at = db.Column(db.DateTime, nullable=True)
+  created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+  updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,8 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .notifications import bp as notifications_bp
+from .delivery import bp as delivery_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +20,5 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(notifications_bp, url_prefix="/notifications")
+    app.register_blueprint(delivery_bp, url_prefix="/delivery")

--- a/packages/backend/app/routes/delivery.py
+++ b/packages/backend/app/routes/delivery.py
@@ -1,0 +1,61 @@
+import logging
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.delivery import delivery_tracker
+
+bp = Blueprint("delivery", __name__)
+logger = logging.getLogger("finmind.delivery")
+
+
+@bp.get("/stats")
+@jwt_required()
+def delivery_stats():
+  uid = int(get_jwt_identity())
+  days = request.args.get("days", 30, type=int)
+  stats = delivery_tracker.get_delivery_stats(user_id=uid, days=days)
+  logger.info("Delivery stats user=%s days=%s", uid, days)
+  return jsonify(stats)
+
+
+@bp.get("/stats/channels")
+@jwt_required()
+def channel_stats():
+  uid = int(get_jwt_identity())
+  days = request.args.get("days", 30, type=int)
+  stats = delivery_tracker.get_channel_stats(days=days)
+  logger.info("Channel stats user=%s days=%s", uid, days)
+  return jsonify(stats)
+
+
+@bp.get("/history")
+@jwt_required()
+def delivery_history():
+  uid = int(get_jwt_identity())
+  page = max(int(request.args.get("page", 1)), 1)
+  page_size = min(max(int(request.args.get("page_size", 20)), 1), 100)
+
+  items, total = delivery_tracker.get_delivery_history(
+    user_id=uid,
+    page=page,
+    page_size=page_size,
+  )
+  logger.info("Delivery history user=%s count=%s", uid, total)
+  return jsonify({
+    "items": [
+      {
+        "id": d.id,
+        "reminder_id": d.reminder_id,
+        "status": d.status,
+        "channel": d.channel,
+        "attempts": d.attempts,
+        "last_error": d.last_error,
+        "delivered_at": d.delivered_at.isoformat() if d.delivered_at else None,
+        "created_at": d.created_at.isoformat(),
+        "updated_at": d.updated_at.isoformat(),
+      }
+      for d in items
+    ],
+    "total": total,
+    "page": page,
+    "page_size": page_size,
+  })

--- a/packages/backend/app/services/README_DELIVERY.md
+++ b/packages/backend/app/services/README_DELIVERY.md
@@ -1,0 +1,113 @@
+# Reminder Delivery Tracking
+
+Service for tracking reminder delivery reliability and metrics.
+
+## Overview
+
+The `DeliveryTracker` service monitors every reminder delivery attempt, recording
+success/failure outcomes and exposing aggregated statistics via REST API and
+Prometheus metrics.
+
+## Models
+
+### ReminderDeliveryStatus
+
+Enum defining the lifecycle states of a delivery:
+
+- `PENDING` — delivery has not been attempted yet
+- `SENT` — message was dispatched to the provider
+- `DELIVERED` — provider confirmed delivery
+- `FAILED` — delivery attempt failed (transient or permanent)
+- `BOUNCED` — message was rejected by the recipient (e.g. invalid email)
+
+### ReminderDelivery
+
+Tracks per-reminder delivery state:
+
+| Column        | Type        | Description                            |
+|---------------|-------------|----------------------------------------|
+| id            | Integer PK  | Auto-increment ID                      |
+| reminder_id   | FK → reminders | The reminder being tracked           |
+| status        | String(20)  | Current delivery status                |
+| channel       | String(20)  | Delivery channel (email, whatsapp)     |
+| attempts      | Integer     | Number of delivery attempts made       |
+| last_error    | Text        | Error message from the last failure    |
+| delivered_at  | DateTime    | Timestamp when delivery was confirmed  |
+| created_at    | DateTime    | Row creation timestamp                 |
+| updated_at    | DateTime    | Row last-update timestamp              |
+
+## Service API
+
+### `delivery_tracker.record_attempt(reminder_id, channel, status, error=None)`
+
+Records a delivery attempt. Creates a new `ReminderDelivery` row if one does not
+exist for the given `reminder_id`, otherwise increments the attempt counter.
+Sets `delivered_at` when status is `"delivered"`. Also fires a Prometheus
+`reminder_events_total` counter via `track_reminder_event()`.
+
+### `delivery_tracker.get_delivery_stats(user_id=None, days=30)`
+
+Returns aggregated delivery statistics for the last N days:
+
+```json
+{
+  "total": 150,
+  "delivered": 140,
+  "failed": 8,
+  "success_rate": 93.33,
+  "avg_attempts": 1.12
+}
+```
+
+Pass `user_id` to scope results to a specific user.
+
+### `delivery_tracker.get_channel_stats(days=30)`
+
+Returns stats grouped by delivery channel:
+
+```json
+{
+  "email": {"total": 100, "delivered": 95, "failed": 5},
+  "whatsapp": {"total": 50, "delivered": 45, "failed": 3}
+}
+```
+
+### `delivery_tracker.get_delivery_history(user_id=None, page=1, page_size=20)`
+
+Returns a paginated list of `ReminderDelivery` rows ordered by `created_at`
+descending. Returns `(items, total)` tuple.
+
+## REST Endpoints
+
+All endpoints require JWT authentication.
+
+| Method | Path                    | Description                       |
+|--------|-------------------------|-----------------------------------|
+| GET    | `/delivery/stats`       | Aggregated delivery statistics    |
+| GET    | `/delivery/stats/channels` | Per-channel delivery stats     |
+| GET    | `/delivery/history`     | Paginated delivery history        |
+
+### Query Parameters
+
+- `days` (int, default 30) — lookback window for stats endpoints
+- `page` (int, default 1) — page number for history
+- `page_size` (int, default 20, max 100) — items per page for history
+
+## Prometheus Integration
+
+Every `record_attempt()` call emits a `reminder_events_total` counter increment
+with labels `event="delivery_attempt"`, `channel`, and `status`. This feeds
+into the existing observability pipeline alongside the other reminder events.
+
+## Usage
+
+```python
+from app.services.delivery import delivery_tracker
+
+# After sending a reminder
+success = send_reminder(reminder)
+if success:
+    delivery_tracker.record_attempt(reminder.id, reminder.channel, "delivered")
+else:
+    delivery_tracker.record_attempt(reminder.id, reminder.channel, "failed", error="SMTP timeout")
+```

--- a/packages/backend/app/services/delivery.py
+++ b/packages/backend/app/services/delivery.py
@@ -1,0 +1,110 @@
+from datetime import datetime, timedelta
+from sqlalchemy import func
+from ..extensions import db
+from ..models import ReminderDelivery, ReminderDeliveryStatus
+from ..observability import track_reminder_event
+
+
+class DeliveryTracker:
+  """Track reminder delivery reliability and metrics."""
+
+  def record_attempt(self, reminder_id: int, channel: str, status: str, error: str | None = None) -> ReminderDelivery:
+    """Record a delivery attempt."""
+    delivery = ReminderDelivery.query.filter_by(reminder_id=reminder_id).first()
+    if not delivery:
+      delivery = ReminderDelivery(
+        reminder_id=reminder_id,
+        channel=channel,
+        attempts=0,
+      )
+      db.session.add(delivery)
+
+    delivery.attempts = (delivery.attempts or 0) + 1
+    delivery.status = status
+    delivery.last_error = error
+    if status == ReminderDeliveryStatus.DELIVERED.value:
+      delivery.delivered_at = datetime.utcnow()
+
+    db.session.commit()
+
+    # Track in Prometheus
+    track_reminder_event("delivery_attempt", channel, status)
+
+    return delivery
+
+  def get_delivery_stats(self, user_id: int | None = None, days: int = 30) -> dict:
+    """Get delivery statistics."""
+    since = datetime.utcnow() - timedelta(days=days)
+    query = ReminderDelivery.query.filter(ReminderDelivery.created_at >= since)
+
+    if user_id is not None:
+      from ..models import Reminder
+      query = query.join(Reminder, ReminderDelivery.reminder_id == Reminder.id).filter(Reminder.user_id == user_id)
+
+    total = query.count()
+    delivered = query.filter(ReminderDelivery.status == ReminderDeliveryStatus.DELIVERED.value).count()
+    failed = query.filter(ReminderDelivery.status.in_([
+      ReminderDeliveryStatus.FAILED.value,
+      ReminderDeliveryStatus.BOUNCED.value,
+    ])).count()
+
+    avg_query = db.session.query(func.avg(ReminderDelivery.attempts)).filter(
+      ReminderDelivery.created_at >= since
+    )
+    if user_id is not None:
+      from ..models import Reminder
+      avg_query = avg_query.join(Reminder, ReminderDelivery.reminder_id == Reminder.id).filter(Reminder.user_id == user_id)
+    avg_attempts = avg_query.scalar() or 0
+
+    return {
+      "total": total,
+      "delivered": delivered,
+      "failed": failed,
+      "success_rate": round((delivered / total * 100), 2) if total > 0 else 0,
+      "avg_attempts": round(float(avg_attempts), 2),
+    }
+
+  def get_channel_stats(self, days: int = 30) -> dict:
+    """Get stats broken down by channel."""
+    since = datetime.utcnow() - timedelta(days=days)
+    results = db.session.query(
+      ReminderDelivery.channel,
+      ReminderDelivery.status,
+      func.count(ReminderDelivery.id),
+    ).filter(
+      ReminderDelivery.created_at >= since
+    ).group_by(
+      ReminderDelivery.channel, ReminderDelivery.status
+    ).all()
+
+    stats: dict = {}
+    for channel, status, count in results:
+      if channel not in stats:
+        stats[channel] = {"total": 0, "delivered": 0, "failed": 0}
+      stats[channel]["total"] += count
+      if status == ReminderDeliveryStatus.DELIVERED.value:
+        stats[channel]["delivered"] += count
+      elif status in [ReminderDeliveryStatus.FAILED.value, ReminderDeliveryStatus.BOUNCED.value]:
+        stats[channel]["failed"] += count
+
+    return stats
+
+  def get_delivery_history(self, user_id: int | None = None, page: int = 1, page_size: int = 20) -> tuple[list[ReminderDelivery], int]:
+    """Get paginated delivery history."""
+    query = ReminderDelivery.query
+
+    if user_id is not None:
+      from ..models import Reminder
+      query = query.join(Reminder, ReminderDelivery.reminder_id == Reminder.id).filter(Reminder.user_id == user_id)
+
+    total = query.count()
+    items = (
+      query.order_by(ReminderDelivery.created_at.desc())
+      .offset((page - 1) * page_size)
+      .limit(page_size)
+      .all()
+    )
+    return items, total
+
+
+delivery_tracker = DeliveryTracker()

--- a/packages/backend/tests/test_delivery.py
+++ b/packages/backend/tests/test_delivery.py
@@ -1,0 +1,224 @@
+from datetime import datetime, timedelta
+from app.extensions import db
+from app.models import Reminder, ReminderDelivery, ReminderDeliveryStatus
+from app.services.delivery import delivery_tracker
+
+
+def _create_reminder(client, auth_header, channel="email"):
+  """Helper to create a reminder and return its ID."""
+  r = client.post(
+    "/reminders",
+    json={
+      "message": "Test reminder",
+      "send_at": (datetime.utcnow() + timedelta(days=1)).isoformat(),
+      "channel": channel,
+    },
+    headers=auth_header,
+  )
+  return r.get_json()["id"]
+
+
+def test_record_delivery_attempt_pending(client, auth_header, app_fixture):
+  reminder_id = _create_reminder(client, auth_header)
+  with app_fixture.app_context():
+    delivery = delivery_tracker.record_attempt(reminder_id, "email", "pending")
+    assert delivery.reminder_id == reminder_id
+    assert delivery.status == "pending"
+    assert delivery.channel == "email"
+    assert delivery.attempts == 1
+    assert delivery.last_error is None
+    assert delivery.delivered_at is None
+
+
+def test_record_delivery_attempt_sent(client, auth_header, app_fixture):
+  reminder_id = _create_reminder(client, auth_header, channel="whatsapp")
+  with app_fixture.app_context():
+    delivery = delivery_tracker.record_attempt(reminder_id, "whatsapp", "sent")
+    assert delivery.status == "sent"
+    assert delivery.attempts == 1
+
+
+def test_record_delivery_attempt_delivered(client, auth_header, app_fixture):
+  reminder_id = _create_reminder(client, auth_header)
+  with app_fixture.app_context():
+    delivery = delivery_tracker.record_attempt(reminder_id, "email", "delivered")
+    assert delivery.status == "delivered"
+    assert delivery.delivered_at is not None
+
+
+def test_record_delivery_attempt_failed_with_error(client, auth_header, app_fixture):
+  reminder_id = _create_reminder(client, auth_header)
+  with app_fixture.app_context():
+    delivery = delivery_tracker.record_attempt(reminder_id, "email", "failed", error="SMTP connection refused")
+    assert delivery.status == "failed"
+    assert delivery.last_error == "SMTP connection refused"
+
+
+def test_record_multiple_attempts(client, auth_header, app_fixture):
+  reminder_id = _create_reminder(client, auth_header)
+  with app_fixture.app_context():
+    delivery_tracker.record_attempt(reminder_id, "email", "failed", error="timeout")
+    delivery = delivery_tracker.record_attempt(reminder_id, "email", "delivered")
+    assert delivery.attempts == 2
+    assert delivery.status == "delivered"
+    assert delivery.delivered_at is not None
+
+
+def test_get_delivery_stats_empty(client, auth_header, app_fixture):
+  with app_fixture.app_context():
+    stats = delivery_tracker.get_delivery_stats(days=30)
+    assert stats["total"] == 0
+    assert stats["delivered"] == 0
+    assert stats["failed"] == 0
+    assert stats["success_rate"] == 0
+    assert stats["avg_attempts"] == 0
+
+
+def test_get_delivery_stats(client, auth_header, app_fixture):
+  reminder1 = _create_reminder(client, auth_header, channel="email")
+  reminder2 = _create_reminder(client, auth_header, channel="email")
+  reminder3 = _create_reminder(client, auth_header, channel="whatsapp")
+
+  with app_fixture.app_context():
+    delivery_tracker.record_attempt(reminder1, "email", "delivered")
+    delivery_tracker.record_attempt(reminder2, "email", "failed", error="bounce")
+    delivery_tracker.record_attempt(reminder3, "whatsapp", "bounced", error="invalid number")
+
+    stats = delivery_tracker.get_delivery_stats(days=30)
+    assert stats["total"] == 3
+    assert stats["delivered"] == 1
+    assert stats["failed"] == 2
+    assert abs(stats["success_rate"] - 33.33) < 0.01
+    assert stats["avg_attempts"] == 1.0
+
+
+def test_get_delivery_stats_with_user_filter(client, auth_header, app_fixture):
+  reminder_id = _create_reminder(client, auth_header)
+  with app_fixture.app_context():
+    from flask_jwt_extended import get_jwt_identity
+    delivery_tracker.record_attempt(reminder_id, "email", "delivered")
+
+    # Get the user id from the auth flow
+    from app.models import Reminder
+    reminder = db.session.get(Reminder, reminder_id)
+    uid = reminder.user_id
+
+    stats = delivery_tracker.get_delivery_stats(user_id=uid, days=30)
+    assert stats["total"] == 1
+    assert stats["delivered"] == 1
+
+
+def test_get_channel_stats(client, auth_header, app_fixture):
+  reminder1 = _create_reminder(client, auth_header, channel="email")
+  reminder2 = _create_reminder(client, auth_header, channel="email")
+  reminder3 = _create_reminder(client, auth_header, channel="whatsapp")
+
+  with app_fixture.app_context():
+    delivery_tracker.record_attempt(reminder1, "email", "delivered")
+    delivery_tracker.record_attempt(reminder2, "email", "failed", error="bounce")
+    delivery_tracker.record_attempt(reminder3, "whatsapp", "delivered")
+
+    stats = delivery_tracker.get_channel_stats(days=30)
+    assert "email" in stats
+    assert "whatsapp" in stats
+    assert stats["email"]["total"] == 2
+    assert stats["email"]["delivered"] == 1
+    assert stats["email"]["failed"] == 1
+    assert stats["whatsapp"]["total"] == 1
+    assert stats["whatsapp"]["delivered"] == 1
+    assert stats["whatsapp"]["failed"] == 0
+
+
+def test_delivery_stats_endpoint(client, auth_header):
+  r = client.get("/delivery/stats", headers=auth_header)
+  assert r.status_code == 200
+  data = r.get_json()
+  assert "total" in data
+  assert "delivered" in data
+  assert "failed" in data
+  assert "success_rate" in data
+  assert "avg_attempts" in data
+
+
+def test_delivery_stats_endpoint_with_days(client, auth_header):
+  r = client.get("/delivery/stats?days=7", headers=auth_header)
+  assert r.status_code == 200
+
+
+def test_channel_stats_endpoint(client, auth_header):
+  r = client.get("/delivery/stats/channels", headers=auth_header)
+  assert r.status_code == 200
+  data = r.get_json()
+  assert isinstance(data, dict)
+
+
+def test_delivery_history_endpoint_empty(client, auth_header):
+  r = client.get("/delivery/history", headers=auth_header)
+  assert r.status_code == 200
+  data = r.get_json()
+  assert data["total"] == 0
+  assert data["items"] == []
+  assert data["page"] == 1
+  assert data["page_size"] == 20
+
+
+def test_delivery_history_with_pagination(client, auth_header, app_fixture):
+  # Create multiple reminders and deliveries
+  reminder_ids = []
+  for i in range(5):
+    rid = _create_reminder(client, auth_header, channel="email")
+    reminder_ids.append(rid)
+
+  with app_fixture.app_context():
+    for rid in reminder_ids:
+      delivery_tracker.record_attempt(rid, "email", "delivered")
+
+  r = client.get("/delivery/history?page=1&page_size=2", headers=auth_header)
+  assert r.status_code == 200
+  data = r.get_json()
+  assert data["total"] == 5
+  assert len(data["items"]) == 2
+  assert data["page"] == 1
+  assert data["page_size"] == 2
+
+  r = client.get("/delivery/history?page=3&page_size=2", headers=auth_header)
+  data = r.get_json()
+  assert len(data["items"]) == 1
+
+
+def test_delivery_history_item_fields(client, auth_header, app_fixture):
+  reminder_id = _create_reminder(client, auth_header, channel="email")
+  with app_fixture.app_context():
+    delivery_tracker.record_attempt(reminder_id, "email", "delivered")
+
+  r = client.get("/delivery/history", headers=auth_header)
+  data = r.get_json()
+  assert data["total"] == 1
+  item = data["items"][0]
+  assert "id" in item
+  assert "reminder_id" in item
+  assert "status" in item
+  assert "channel" in item
+  assert "attempts" in item
+  assert "delivered_at" in item
+  assert "created_at" in item
+  assert "updated_at" in item
+  assert item["status"] == "delivered"
+  assert item["channel"] == "email"
+  assert item["attempts"] == 1
+  assert item["delivered_at"] is not None
+
+
+def test_delivery_history_requires_auth(client):
+  r = client.get("/delivery/history")
+  assert r.status_code == 401
+
+
+def test_delivery_stats_requires_auth(client):
+  r = client.get("/delivery/stats")
+  assert r.status_code == 401
+
+
+def test_channel_stats_requires_auth(client):
+  r = client.get("/delivery/stats/channels")
+  assert r.status_code == 401


### PR DESCRIPTION
## Changes

Implement delivery tracking system for reminder reliability.

### Features
- ReminderDelivery model with status tracking (pending/sent/delivered/failed/bounced)
- DeliveryTracker service with attempt recording and statistics
- REST API: GET /delivery/stats, /delivery/stats/channels, /delivery/history
- Per-channel delivery breakdown
- Success rate and average attempts metrics
- Prometheus integration for delivery tracking

### Files Modified
- packages/backend/app/models.py - Added ReminderDelivery model, enum
- packages/backend/app/routes/__init__.py - Registered delivery blueprint
- packages/backend/app/routes/delivery.py - NEW: REST API
- packages/backend/app/services/delivery.py - NEW: DeliveryTracker service
- packages/backend/app/services/README_DELIVERY.md - NEW: Documentation
- packages/backend/tests/test_delivery.py - NEW: 18 tests

Fixes #123