### PR TITLE
feat: add weekly financial summary insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-summary`
+  - `/insights/weekly-summary?week_start=YYYY-MM-DD` returns weekly income, expenses, net flow, top categories, prior-week expense delta, and trend insight copy for the Analytics page.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/__tests__/Analytics.integration.test.tsx
+++ b/app/src/__tests__/Analytics.integration.test.tsx
@@ -30,8 +30,10 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 
 const getBudgetSuggestionMock = jest.fn();
+const getWeeklySummaryMock = jest.fn();
 jest.mock('@/api/insights', () => ({
   getBudgetSuggestion: (...args: unknown[]) => getBudgetSuggestionMock(...args),
+  getWeeklySummary: (...args: unknown[]) => getWeeklySummaryMock(...args),
 }));
 
 describe('Analytics integration', () => {
@@ -52,12 +54,28 @@ describe('Analytics integration', () => {
       method: 'heuristic',
       warnings: [],
     });
+    getWeeklySummaryMock.mockResolvedValue({
+      week_start: '2026-02-02',
+      week_end: '2026-02-08',
+      total_income: 500,
+      total_expenses: 200,
+      previous_week_expenses: 150,
+      expense_change_pct: 33.33,
+      net_flow: 300,
+      transaction_count: 3,
+      average_daily_expense: 28.57,
+      top_categories: [{ category_id: 'uncat', amount: 200 }],
+      trend_insights: ['Weekly expenses are up 33.33% versus the prior week.'],
+    });
   });
 
   it('loads and renders insights data', async () => {
     render(<Analytics />);
     await waitFor(() => expect(getBudgetSuggestionMock).toHaveBeenCalled());
+    await waitFor(() => expect(getWeeklySummaryMock).toHaveBeenCalled());
     expect(screen.getByText(/live spending analytics/i)).toBeInTheDocument();
+    expect(screen.getByText(/weekly summary/i)).toBeInTheDocument();
+    expect(screen.getByText(/weekly expenses are up 33\.33%/i)).toBeInTheDocument();
     expect(screen.getByText(/suggested budget/i)).toBeInTheDocument();
     expect(screen.getByText(/tip a/i)).toBeInTheDocument();
   });

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -1,5 +1,19 @@
 import { api } from './client';
 
+export type WeeklySummary = {
+  week_start: string;
+  week_end: string;
+  total_income: number;
+  total_expenses: number;
+  previous_week_expenses: number;
+  expense_change_pct: number;
+  net_flow: number;
+  transaction_count: number;
+  average_daily_expense: number;
+  top_categories: Array<{ category_id: string; amount: number }>;
+  trend_insights: string[];
+};
+
 export type BudgetSuggestion = {
   month: string;
   suggested_total: number;
@@ -20,6 +34,11 @@ export type BudgetSuggestion = {
   warnings?: string[];
   net_flow?: number;
 };
+
+export async function getWeeklySummary(params?: { weekStart?: string }): Promise<WeeklySummary> {
+  const query = params?.weekStart ? `?week_start=${encodeURIComponent(params.weekStart)}` : '';
+  return api<WeeklySummary>(`/insights/weekly-summary${query}`);
+}
 
 export async function getBudgetSuggestion(params?: {
   month?: string;

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -10,7 +10,7 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
-import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
+import { getBudgetSuggestion, getWeeklySummary, type BudgetSuggestion, type WeeklySummary } from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
 
 const PERSONAS = [
@@ -26,18 +26,23 @@ export function Analytics() {
   const [geminiKey, setGeminiKey] = useState('');
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BudgetSuggestion | null>(null);
+  const [weeklySummary, setWeeklySummary] = useState<WeeklySummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
     setLoading(true);
     setError(null);
     try {
-      const payload = await getBudgetSuggestion({
-        month,
-        persona,
-        geminiApiKey: geminiKey.trim() || undefined,
-      });
+      const [payload, weeklyPayload] = await Promise.all([
+        getBudgetSuggestion({
+          month,
+          persona,
+          geminiApiKey: geminiKey.trim() || undefined,
+        }),
+        getWeeklySummary(),
+      ]);
       setData(payload);
+      setWeeklySummary(weeklyPayload);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
@@ -122,6 +127,43 @@ export function Analytics() {
         <div className="card text-red-600">{error}</div>
       ) : data ? (
         <div className="space-y-6">
+          {weeklySummary ? (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Weekly Summary</FinancialCardTitle>
+                <FinancialCardDescription>
+                  {weeklySummary.week_start} to {weeklySummary.week_end}
+                </FinancialCardDescription>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid gap-3 md:grid-cols-4">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Income</div>
+                    <div className="font-semibold">{formatMoney(weeklySummary.total_income)}</div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expenses</div>
+                    <div className="font-semibold">{formatMoney(weeklySummary.total_expenses)}</div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Net Flow</div>
+                    <div className="font-semibold">{formatMoney(weeklySummary.net_flow)}</div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expense Trend</div>
+                    <div className="font-semibold">{weeklySummary.expense_change_pct.toFixed(2)}%</div>
+                  </div>
+                </div>
+                {weeklySummary.trend_insights.length ? (
+                  <ul className="mt-4 list-disc pl-5 space-y-1">
+                    {weeklySummary.trend_insights.map((insight) => (
+                      <li key={insight}>{insight}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </FinancialCardContent>
+            </FinancialCard>
+          ) : null}
           <div className="grid gap-4 md:grid-cols-4">
             <FinancialCard variant="financial">
               <FinancialCardHeader className="pb-2">

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -444,6 +444,51 @@ paths:
                 properties:
                   created: { type: integer }
 
+  /insights/weekly-summary:
+    get:
+      summary: Get weekly financial summary
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          schema: { type: string, format: date }
+          description: Monday/start date for the 7-day summary window. Defaults to current week.
+      responses:
+        '200':
+          description: Weekly income, expense trends, and summary insights
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                week_start: 2026-02-02
+                week_end: 2026-02-08
+                total_income: 500
+                total_expenses: 200
+                previous_week_expenses: 150
+                expense_change_pct: 33.33
+                net_flow: 300
+                transaction_count: 3
+                average_daily_expense: 28.57
+                top_categories:
+                  - category_id: uncat
+                    amount: 200
+                trend_insights:
+                  - Weekly expenses are up 33.33% versus the prior week.
+        '400':
+          description: Invalid week_start
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
   /insights/budget-suggestion:
     get:
       summary: Get monthly budget suggestion

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,11 +1,28 @@
 from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from ..services.ai import monthly_budget_suggestion
+from ..services.ai import monthly_budget_suggestion, weekly_financial_summary
 import logging
 
 bp = Blueprint("insights", __name__)
 logger = logging.getLogger("finmind.insights")
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    week_start = (request.args.get("week_start") or "").strip() or None
+    try:
+        summary = weekly_financial_summary(uid, week_start=week_start)
+    except ValueError:
+        return jsonify(error="invalid week_start"), 400
+    logger.info(
+        "Weekly financial summary served user=%s week_start=%s",
+        uid,
+        summary["week_start"],
+    )
+    return jsonify(summary)
 
 
 @bp.get("/budget-suggestion")

--- a/packages/backend/app/services/ai.py
+++ b/packages/backend/app/services/ai.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date, timedelta
 from urllib import request
 
 from sqlalchemy import extract, func
@@ -62,6 +63,116 @@ def _previous_month(ym: str) -> str:
     if month == 1:
         return f"{year - 1:04d}-12"
     return f"{year:04d}-{month - 1:02d}"
+
+
+def _weekly_totals(uid: int, start: date, end: date) -> tuple[float, float, int]:
+    rows = (
+        db.session.query(
+            Expense.expense_type, func.coalesce(func.sum(Expense.amount), 0)
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .group_by(Expense.expense_type)
+        .all()
+    )
+    income = 0.0
+    expenses = 0.0
+    for expense_type, amount in rows:
+        if expense_type == "INCOME":
+            income += float(amount or 0)
+        else:
+            expenses += float(amount or 0)
+    transaction_count = (
+        db.session.query(func.count(Expense.id))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .scalar()
+        or 0
+    )
+    return income, expenses, int(transaction_count)
+
+
+def _weekly_category_spend(uid: int, start: date, end: date) -> list[dict]:
+    rows = (
+        db.session.query(
+            Expense.category_id, func.coalesce(func.sum(Expense.amount), 0)
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id)
+        .all()
+    )
+    top = sorted(
+        ((str(k or "uncat"), float(v or 0)) for k, v in rows),
+        key=lambda x: x[1],
+        reverse=True,
+    )[:3]
+    return [{"category_id": k, "amount": round(v, 2)} for k, v in top]
+
+
+def _trend_insights(
+    current_expenses: float, previous_expenses: float, net_flow: float
+) -> tuple[float, list[str]]:
+    if previous_expenses > 0:
+        change_pct = round(
+            ((current_expenses - previous_expenses) / previous_expenses) * 100, 2
+        )
+    else:
+        change_pct = 0.0
+
+    direction = "up" if change_pct > 0 else "down" if change_pct < 0 else "flat"
+    insights = [
+        f"Weekly expenses are {direction} {abs(change_pct):.2f}% versus the prior week."
+    ]
+    if net_flow >= 0:
+        insights.append(
+            f"Positive weekly net flow of {net_flow:.2f}; protect the surplus before discretionary spend."
+        )
+    else:
+        insights.append(
+            f"Negative weekly net flow of {abs(net_flow):.2f}; reduce the largest expense category first."
+        )
+    return change_pct, insights
+
+
+def weekly_financial_summary(uid: int, week_start: str | None = None) -> dict:
+    start = (
+        date.fromisoformat(week_start)
+        if week_start
+        else date.today() - timedelta(days=date.today().weekday())
+    )
+    end = start + timedelta(days=6)
+    previous_start = start - timedelta(days=7)
+    previous_end = start - timedelta(days=1)
+
+    income, expenses, transaction_count = _weekly_totals(uid, start, end)
+    _, previous_expenses, _ = _weekly_totals(uid, previous_start, previous_end)
+    net_flow = income - expenses
+    change_pct, insights = _trend_insights(expenses, previous_expenses, net_flow)
+
+    return {
+        "week_start": start.isoformat(),
+        "week_end": end.isoformat(),
+        "total_income": round(income, 2),
+        "total_expenses": round(expenses, 2),
+        "previous_week_expenses": round(previous_expenses, 2),
+        "expense_change_pct": change_pct,
+        "net_flow": round(net_flow, 2),
+        "transaction_count": transaction_count,
+        "average_daily_expense": round(expenses / 7, 2),
+        "top_categories": _weekly_category_spend(uid, start, end),
+        "trend_insights": insights,
+    }
 
 
 def _build_analytics(uid: int, ym: str) -> dict:

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,6 +1,50 @@
 from datetime import date, timedelta
 
 
+def test_weekly_summary_highlights_trends_and_insights(client, auth_header):
+    week_start = date(2026, 2, 2)
+    current_items = [
+        ("Groceries", 120, week_start),
+        ("Transport", 80, week_start + timedelta(days=2)),
+        ("Paycheck", 500, week_start + timedelta(days=4), "INCOME"),
+    ]
+    previous_items = [
+        ("Previous groceries", 100, week_start - timedelta(days=7)),
+        ("Previous transport", 50, week_start - timedelta(days=5)),
+    ]
+
+    for item in current_items + previous_items:
+        description, amount, spent_at, *expense_type = item
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": amount,
+                "description": description,
+                "date": spent_at.isoformat(),
+                "expense_type": expense_type[0] if expense_type else "EXPENSE",
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get(
+        f"/insights/weekly-summary?week_start={week_start.isoformat()}",
+        headers=auth_header,
+    )
+
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["week_start"] == "2026-02-02"
+    assert payload["week_end"] == "2026-02-08"
+    assert payload["total_expenses"] == 200.0
+    assert payload["total_income"] == 500.0
+    assert payload["net_flow"] == 300.0
+    assert payload["transaction_count"] == 3
+    assert payload["expense_change_pct"] == 33.33
+    assert payload["top_categories"][0] == {"category_id": "uncat", "amount": 200.0}
+    assert any("up 33.33%" in insight for insight in payload["trend_insights"])
+
+
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
     previous = (current.replace(day=1) - timedelta(days=1)).replace(day=10)


### PR DESCRIPTION
Hi — I implemented the weekly financial summary feature for bounty issue #121.

## What changed
- Added authenticated backend endpoint `GET /insights/weekly-summary?week_start=YYYY-MM-DD`
- Computes weekly income, expenses, net flow, transaction count, average daily expense, top categories, prior-week expense delta, and human-readable trend insights
- Added Analytics page UI section showing the weekly summary and trend insights
- Added frontend API client typing/function for weekly summaries
- Updated OpenAPI docs and README
- Added backend and frontend tests

## Demo
- Short demo video: https://github.com/dherman-dev/FinMind/releases/download/demo-weekly-summary-pr-973/finmind-weekly-summary-demo.mp4
- Screenshot: https://github.com/dherman-dev/FinMind/releases/download/demo-weekly-summary-pr-973/finmind-weekly-summary-demo.png
- Release page with both assets: https://github.com/dherman-dev/FinMind/releases/tag/demo-weekly-summary-pr-973

## Verification
- Backend targeted check: `cd packages/backend && .venv311/bin/python -m pytest -q tests/test_insights.py` → `4 passed in 0.72s`
- Frontend targeted check: `cd app && npm test -- Analytics.integration.test.tsx -- --runInBand` → `2 passed, 1 suite passed`
- Prior full package verification from implementation run: backend `23 passed`, frontend `27 passed / 9 suites`, frontend production build successful via `npm run build`

Closes #121

/claim #121