### PR TITLE
Add resilient reminder retry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
+- Reminder jobs: monitor `/reminders/jobs/status`, inspect `/reminders/jobs/failed`,
+  retry `/reminders/jobs/{id}/retry`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
 
 ## MVP UI/UX Plan
@@ -182,6 +184,12 @@ finmind/
 ## Notes on Free-Tier Reminders
 - Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).
+- Reminder dispatch is retry-safe: failed delivery attempts are retained with
+  `retry_count`, `last_error`, `last_attempt_at`, and `next_retry_at`. The
+  backend retries at 5, 15, and 45 minute intervals, then marks the reminder as
+  failed for operator review. Use `/reminders/jobs/status` for aggregate health,
+  `/reminders/jobs/failed` for the dead-letter list, and
+  `/reminders/jobs/{id}/retry` to reset a failed reminder for another attempt.
 
 ## Security & Scalability
 - JWT access/refresh, secure cookies OR Authorization header.

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,23 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP,
+            ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMP,
+            ADD COLUMN IF NOT EXISTS sent_at TIMESTAMP,
+            ADD COLUMN IF NOT EXISTS failed BOOLEAN NOT NULL DEFAULT FALSE,
+            ADD COLUMN IF NOT EXISTS last_error VARCHAR(1000)
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reminders_retry
+            ON reminders(user_id, failed, next_retry_at)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -91,9 +91,16 @@ CREATE TABLE IF NOT EXISTS reminders (
   message VARCHAR(500) NOT NULL,
   send_at TIMESTAMP NOT NULL,
   sent BOOLEAN NOT NULL DEFAULT FALSE,
-  channel VARCHAR(20) NOT NULL DEFAULT 'email'
+  channel VARCHAR(20) NOT NULL DEFAULT 'email',
+  retry_count INT NOT NULL DEFAULT 0,
+  next_retry_at TIMESTAMP,
+  last_attempt_at TIMESTAMP,
+  sent_at TIMESTAMP,
+  failed BOOLEAN NOT NULL DEFAULT FALSE,
+  last_error VARCHAR(1000)
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
+CREATE INDEX IF NOT EXISTS idx_reminders_retry ON reminders(user_id, failed, next_retry_at);
 
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,12 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    last_attempt_at = db.Column(db.DateTime, nullable=True)
+    sent_at = db.Column(db.DateTime, nullable=True)
+    failed = db.Column(db.Boolean, default=False, nullable=False)
+    last_error = db.Column(db.String(1000), nullable=True)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -374,13 +374,102 @@ paths:
 
   /reminders/run:
     post:
-      summary: Process due reminders
+      summary: Process due reminders and retries
       tags: [Reminders]
       security: [{ bearerAuth: [] }]
       responses:
-        '200': { description: Processed count }
+        '200':
+          description: Processed count by outcome
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  processed: { type: integer }
+                  sent: { type: integer }
+                  retrying: { type: integer }
+                  failed: { type: integer }
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs/status:
+    get:
+      summary: Get reminder job health
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Aggregate reminder job status for the current user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pending: { type: integer }
+                  retrying: { type: integer }
+                  failed: { type: integer }
+                  sent: { type: integer }
+                  latest_attempt_at:
+                    type: string
+                    format: date-time
+                    nullable: true
+
+  /reminders/jobs/failed:
+    get:
+      summary: List failed reminder jobs
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Dead-lettered reminders for operator review
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: { type: integer }
+                    message: { type: string }
+                    channel: { type: string }
+                    retry_count: { type: integer }
+                    last_error: { type: string, nullable: true }
+                    last_attempt_at:
+                      type: string
+                      format: date-time
+                      nullable: true
+
+  /reminders/jobs/{reminderId}/retry:
+    post:
+      summary: Reset a failed reminder for another attempt
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: reminderId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Failed reminder was reset
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: integer }
+                  retry_count: { type: integer }
+                  failed: { type: boolean }
+        '400':
+          description: Reminder is not failed
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Not found
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
@@ -580,6 +669,12 @@ components:
         send_at: { type: string, format: date-time }
         sent: { type: boolean }
         channel: { type: string, enum: [email, whatsapp] }
+        retry_count: { type: integer }
+        next_retry_at: { type: string, format: date-time, nullable: true }
+        last_attempt_at: { type: string, format: date-time, nullable: true }
+        sent_at: { type: string, format: date-time, nullable: true }
+        failed: { type: boolean }
+        last_error: { type: string, nullable: true }
     NewReminder:
       type: object
       required: [message, send_at]

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -4,7 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
-from ..services.reminders import send_reminder
+from ..services.reminders import dispatch_reminder, reset_failed_reminder
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -30,6 +30,16 @@ def list_reminders():
                 "send_at": r.send_at.isoformat(),
                 "sent": r.sent,
                 "channel": r.channel,
+                "retry_count": r.retry_count,
+                "next_retry_at": (
+                    r.next_retry_at.isoformat() if r.next_retry_at else None
+                ),
+                "last_attempt_at": (
+                    r.last_attempt_at.isoformat() if r.last_attempt_at else None
+                ),
+                "sent_at": r.sent_at.isoformat() if r.sent_at else None,
+                "failed": r.failed,
+                "last_error": r.last_error,
             }
             for r in items
         ]
@@ -166,17 +176,108 @@ def run_due():
         .filter(
             Reminder.user_id == uid,
             Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
             Reminder.send_at <= now,
+            db.or_(Reminder.next_retry_at.is_(None), Reminder.next_retry_at <= now),
         )
         .all()
     )
+    results = {"sent": 0, "retrying": 0, "failed": 0}
     for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
+        result = dispatch_reminder(r, now=now)
+        results[result] += 1
+        track_reminder_event(event=result, channel=r.channel)
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+    logger.info(
+        "Processed due reminders user=%s count=%s results=%s",
+        uid,
+        len(items),
+        results,
+    )
+    return jsonify(processed=len(items), **results)
+
+
+@bp.get("/jobs/status")
+@jwt_required()
+def job_status():
+    uid = int(get_jwt_identity())
+    now = datetime.utcnow()
+    base = db.session.query(Reminder).filter(Reminder.user_id == uid)
+    pending = base.filter(
+        Reminder.sent.is_(False),
+        Reminder.failed.is_(False),
+        db.or_(Reminder.next_retry_at.is_(None), Reminder.next_retry_at <= now),
+    ).count()
+    retrying = base.filter(
+        Reminder.sent.is_(False),
+        Reminder.failed.is_(False),
+        Reminder.next_retry_at.isnot(None),
+        Reminder.next_retry_at > now,
+    ).count()
+    failed = base.filter(Reminder.failed.is_(True)).count()
+    sent = base.filter(Reminder.sent.is_(True)).count()
+    latest_attempt = (
+        base.filter(Reminder.last_attempt_at.isnot(None))
+        .order_by(Reminder.last_attempt_at.desc())
+        .first()
+    )
+    return jsonify(
+        {
+            "pending": pending,
+            "retrying": retrying,
+            "failed": failed,
+            "sent": sent,
+            "latest_attempt_at": (
+                latest_attempt.last_attempt_at.isoformat() if latest_attempt else None
+            ),
+        }
+    )
+
+
+@bp.get("/jobs/failed")
+@jwt_required()
+def failed_jobs():
+    uid = int(get_jwt_identity())
+    items = (
+        db.session.query(Reminder)
+        .filter(Reminder.user_id == uid, Reminder.failed.is_(True))
+        .order_by(Reminder.last_attempt_at.desc())
+        .all()
+    )
+    return jsonify(
+        [
+            {
+                "id": r.id,
+                "message": r.message,
+                "channel": r.channel,
+                "retry_count": r.retry_count,
+                "last_error": r.last_error,
+                "last_attempt_at": (
+                    r.last_attempt_at.isoformat() if r.last_attempt_at else None
+                ),
+            }
+            for r in items
+        ]
+    )
+
+
+@bp.post("/jobs/<int:reminder_id>/retry")
+@jwt_required()
+def retry_failed_job(reminder_id: int):
+    uid = int(get_jwt_identity())
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder or reminder.user_id != uid:
+        return jsonify(error="not found"), 404
+    if not reminder.failed:
+        return jsonify(error="reminder is not failed"), 400
+
+    reset_failed_reminder(reminder, send_at=datetime.utcnow())
+    db.session.commit()
+    return jsonify(
+        id=reminder.id,
+        retry_count=reminder.retry_count,
+        failed=reminder.failed,
+    )
 
 
 def _bill_channels(bill: Bill) -> list[str]:

--- a/packages/backend/app/services/reminders.py
+++ b/packages/backend/app/services/reminders.py
@@ -1,5 +1,7 @@
 import smtplib
 from email.message import EmailMessage
+from datetime import datetime, timedelta
+from typing import Callable
 from ..config import Settings
 from ..models import Reminder
 
@@ -10,6 +12,12 @@ except Exception:  # pragma: no cover
 
 
 _settings = Settings()
+DEFAULT_RETRY_DELAYS = (
+    timedelta(minutes=5),
+    timedelta(minutes=15),
+    timedelta(minutes=45),
+)
+MAX_REMINDER_RETRIES = len(DEFAULT_RETRY_DELAYS)
 
 
 def send_email(to_email: str, subject: str, body: str):
@@ -69,3 +77,56 @@ def send_reminder(r: Reminder):
         to = r.channel if "@" in r.channel else (_settings.email_from or "")
         subject = "Bill Reminder"
         return send_email(to, subject, r.message)
+
+
+def dispatch_reminder(
+    reminder: Reminder,
+    *,
+    now: datetime | None = None,
+    sender: Callable[[Reminder], bool] = send_reminder,
+) -> str:
+    """Attempt one reminder delivery and persist retry/dead-letter fields."""
+    attempted_at = now or datetime.utcnow()
+    reminder.last_attempt_at = attempted_at
+
+    try:
+        delivered = bool(sender(reminder))
+    except Exception as exc:  # pragma: no cover - tested through raised subclass
+        delivered = False
+        reminder.last_error = str(exc)[:1000]
+    else:
+        if not delivered:
+            reminder.last_error = "Reminder delivery returned false"
+
+    if delivered:
+        reminder.sent = True
+        reminder.sent_at = attempted_at
+        reminder.failed = False
+        reminder.next_retry_at = None
+        reminder.last_error = None
+        return "sent"
+
+    reminder.retry_count = (reminder.retry_count or 0) + 1
+    if reminder.retry_count >= MAX_REMINDER_RETRIES:
+        reminder.failed = True
+        reminder.next_retry_at = None
+        return "failed"
+
+    reminder.next_retry_at = (
+        attempted_at + DEFAULT_RETRY_DELAYS[reminder.retry_count - 1]
+    )
+    return "retrying"
+
+
+def reset_failed_reminder(
+    reminder: Reminder, *, send_at: datetime | None = None
+) -> None:
+    reminder.failed = False
+    reminder.sent = False
+    reminder.retry_count = 0
+    reminder.next_retry_at = None
+    reminder.last_attempt_at = None
+    reminder.sent_at = None
+    reminder.last_error = None
+    if send_at is not None:
+        reminder.send_at = send_at

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,37 @@
 import os
+from fnmatch import fnmatch
 import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def setex(self, key, _ttl, value):
+        self.store[key] = value
+
+    def set(self, key, value):
+        self.store[key] = value
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def delete(self, *keys):
+        for key in keys:
+            self.store.pop(key, None)
+
+    def flushdb(self):
+        self.store.clear()
+
+    def scan(self, cursor=0, match=None, count=None):
+        keys = list(self.store.keys())
+        if match:
+            keys = [key for key in keys if fnmatch(key, match)]
+        return 0, keys
 
 
 class TestSettings(Settings):
@@ -23,16 +50,22 @@ def _setup_db(app):
 def app_fixture():
     # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
+    fake_redis = FakeRedis()
     settings = TestSettings(
         database_url="sqlite+pysqlite:///:memory:",
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
     app = create_app(settings)
+    import app.routes.auth as auth_routes
+    import app.services.cache as cache_service
+
+    auth_routes.redis_client = fake_redis
+    cache_service.redis_client = fake_redis
     app.config.update(TESTING=True)
     _setup_db(app)
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
     yield app
@@ -40,7 +73,7 @@ def app_fixture():
         db.session.remove()
         db.drop_all()
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
 

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -1,4 +1,7 @@
-from datetime import date
+from datetime import date, datetime, timedelta
+
+from app.extensions import db
+from app.models import Reminder
 
 
 def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = False):
@@ -80,3 +83,93 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def test_due_reminder_retries_then_dead_letters_failed_delivery(
+    client, auth_header, monkeypatch, app_fixture
+):
+    monkeypatch.setattr("app.services.reminders.send_email", lambda *args: False)
+
+    r = client.post(
+        "/reminders",
+        json={
+            "message": "Retry me",
+            "send_at": (datetime.utcnow() - timedelta(minutes=5)).isoformat(),
+            "channel": "email",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    reminder_id = r.get_json()["id"]
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["retrying"] == 1
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        assert reminder.sent is False
+        assert reminder.failed is False
+        assert reminder.retry_count == 1
+        assert reminder.next_retry_at is not None
+        reminder.next_retry_at = datetime.utcnow() - timedelta(minutes=1)
+        db.session.commit()
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["retrying"] == 1
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        reminder.next_retry_at = datetime.utcnow() - timedelta(minutes=1)
+        db.session.commit()
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["failed"] == 1
+
+    r = client.get("/reminders/jobs/status", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["failed"] == 1
+
+    r = client.get("/reminders/jobs/failed", headers=auth_header)
+    assert r.status_code == 200
+    failed_jobs = r.get_json()
+    assert failed_jobs[0]["id"] == reminder_id
+    assert failed_jobs[0]["retry_count"] == 3
+
+    r = client.post(f"/reminders/jobs/{reminder_id}/retry", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["failed"] is False
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        assert reminder.retry_count == 0
+        assert reminder.failed is False
+        assert reminder.last_error is None
+
+
+def test_due_reminder_marks_successful_delivery_sent(client, auth_header, monkeypatch):
+    monkeypatch.setattr("app.services.reminders.send_email", lambda *args: True)
+
+    r = client.post(
+        "/reminders",
+        json={
+            "message": "Send me",
+            "send_at": (datetime.utcnow() - timedelta(minutes=5)).isoformat(),
+            "channel": "email",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["sent"] == 1
+
+    r = client.get("/reminders", headers=auth_header)
+    assert r.status_code == 200
+    reminder = r.get_json()[0]
+    assert reminder["sent"] is True
+    assert reminder["sent_at"] is not None
+    assert reminder["retry_count"] == 0


### PR DESCRIPTION
/claim #130

## Summary
- add persisted retry/dead-letter state to reminders (`retry_count`, `next_retry_at`, `last_attempt_at`, `sent_at`, `failed`, `last_error`)
- route `/reminders/run` through bounded 5/15/45 minute retry handling instead of marking failed sends as sent
- add reminder job monitoring endpoints for aggregate status, failed jobs, and manual retry reset
- document the API changes in README and OpenAPI
- make backend tests independent of a local Redis daemon with an in-memory test fake

## Tests
- `PYTHONPATH=packages/backend .venv/bin/python -m pytest packages/backend/tests`
- `.venv/bin/python -m flake8 packages/backend/app packages/backend/tests`