### PR TITLE
feat: login anomaly detection and security alerts endpoint (#124)

### DIFF
--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -10,6 +10,7 @@ from flask_jwt_extended import (
 )
 from ..extensions import db, redis_client
 from ..models import User
+from ..services.security import record_login_attempt, get_security_alerts
 import logging
 import time
 
@@ -53,17 +54,37 @@ def register():
 @bp.post("/login")
 def login():
     data = request.get_json() or {}
-    email = data.get("email")
+    email = data.get("email") or ""
     password = data.get("password")
+    ip = (
+        request.headers.get("X-Forwarded-For", request.remote_addr or "unknown")
+        .split(",")[0]
+        .strip()
+    )
+
     user = db.session.query(User).filter_by(email=email).first()
     if not user or not check_password_hash(user.password_hash, password):
-        logger.warning("Login failed for email=%s", email)
+        logger.warning("Login failed for email=%s ip=%s", email, ip)
+        record_login_attempt(
+            email=email, ip=ip, success=False, user_id=user.id if user else None
+        )
         return jsonify(error="invalid credentials"), 401
+
+    record_login_attempt(email=email, ip=ip, success=True, user_id=user.id)
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
-    logger.info("Login success user_id=%s", user.id)
+    logger.info("Login success user_id=%s ip=%s", user.id, ip)
     return jsonify(access_token=access, refresh_token=refresh)
+
+
+@bp.get("/security-alerts")
+@jwt_required()
+def security_alerts():
+    """Return recent login security events for the current user."""
+    uid = int(get_jwt_identity())
+    alerts = get_security_alerts(uid)
+    return jsonify(alerts=alerts)
 
 
 @bp.get("/me")

--- a/packages/backend/app/services/security.py
+++ b/packages/backend/app/services/security.py
@@ -1,0 +1,131 @@
+"""
+Login anomaly detection service.
+
+Tracks login attempts per IP/email in Redis and flags suspicious patterns:
+- More than 3 failed attempts from the same IP within 15 minutes
+- More than 5 failed attempts for the same email within 1 hour
+- Stores the 20 most recent login events per user for the security-alerts endpoint
+"""
+
+import json
+import logging
+import time
+
+from ..extensions import redis_client
+
+logger = logging.getLogger("finmind.security")
+
+_FAIL_IP_KEY = "security:fails:ip:{ip}"
+_FAIL_EMAIL_KEY = "security:fails:email:{email}"
+_EVENTS_KEY = "security:events:{user_id}"
+
+_IP_FAIL_LIMIT = 3
+_IP_FAIL_WINDOW = 900  # 15 minutes
+_EMAIL_FAIL_LIMIT = 5
+_EMAIL_FAIL_WINDOW = 3600  # 1 hour
+_MAX_EVENTS = 20
+_EVENTS_TTL = 30 * 24 * 3600  # 30 days
+
+
+def record_login_attempt(
+    email: str,
+    ip: str,
+    success: bool,
+    user_id: int | None = None,
+) -> None:
+    """
+    Record a login attempt and log suspicious patterns.
+
+    On success: clears failure counters and appends a login_success event.
+    On failure: increments per-IP and per-email counters, appends a
+    login_failed or suspicious_login event when thresholds are exceeded.
+    All Redis errors are caught so the login flow is never disrupted.
+    """
+    try:
+        ip_key = _FAIL_IP_KEY.format(ip=ip)
+        email_key = _FAIL_EMAIL_KEY.format(email=email)
+
+        if success:
+            redis_client.delete(ip_key, email_key)
+            if user_id is not None:
+                _append_event(user_id, ip, email, "login_success", "Login successful")
+        else:
+            pipe = redis_client.pipeline()
+            pipe.incr(ip_key)
+            pipe.expire(ip_key, _IP_FAIL_WINDOW)
+            pipe.incr(email_key)
+            pipe.expire(email_key, _EMAIL_FAIL_WINDOW)
+            ip_count, _, email_count, _ = pipe.execute()
+
+            suspicious = ip_count > _IP_FAIL_LIMIT or email_count > _EMAIL_FAIL_LIMIT
+            if suspicious:
+                logger.warning(
+                    "Suspicious login activity — ip=%s ip_fails=%d email_fails=%d",
+                    ip,
+                    ip_count,
+                    email_count,
+                )
+
+            if user_id is not None:
+                event_type = "suspicious_login" if suspicious else "login_failed"
+                _append_event(
+                    user_id,
+                    ip,
+                    email,
+                    event_type,
+                    _build_alert_msg(ip_count, email_count),
+                )
+
+    except Exception:
+        logger.exception("Error recording login attempt — anomaly detection skipped")
+
+
+def get_security_alerts(user_id: int, limit: int = 20) -> list[dict]:
+    """
+    Return the most recent security events for a user (newest first).
+    Each event has: type, ip, email, ts (Unix timestamp), msg
+    """
+    try:
+        raw = redis_client.lrange(_EVENTS_KEY.format(user_id=user_id), 0, limit - 1)
+        events = []
+        for item in raw:
+            try:
+                events.append(json.loads(item))
+            except (ValueError, TypeError):
+                continue
+        return events
+    except Exception:
+        logger.exception("Error fetching security alerts for user_id=%s", user_id)
+        return []
+
+
+# ── private helpers ──────────────────────────────────────────────────────────
+
+
+def _append_event(user_id: int, ip: str, email: str, event_type: str, msg: str) -> None:
+    key = _EVENTS_KEY.format(user_id=user_id)
+    event = json.dumps(
+        {
+            "type": event_type,
+            "ip": ip,
+            "email": email,
+            "ts": int(time.time()),
+            "msg": msg,
+        }
+    )
+    pipe = redis_client.pipeline()
+    pipe.lpush(key, event)
+    pipe.ltrim(key, 0, _MAX_EVENTS - 1)
+    pipe.expire(key, _EVENTS_TTL)
+    pipe.execute()
+
+
+def _build_alert_msg(ip_count: int, email_count: int) -> str:
+    parts = []
+    if ip_count > _IP_FAIL_LIMIT:
+        parts.append(f"IP exceeded failed-login limit ({ip_count} attempts in 15 min)")
+    if email_count > _EMAIL_FAIL_LIMIT:
+        parts.append(
+            f"account exceeded failed-login limit ({email_count} attempts in 1 hr)"
+        )
+    return "; ".join(parts) if parts else "Failed login attempt"

--- a/packages/backend/tests/test_security.py
+++ b/packages/backend/tests/test_security.py
@@ -1,0 +1,166 @@
+"""
+Tests for login anomaly detection (issue #124).
+
+Covers:
+- Failed login attempt tracking via Redis
+- IP-level failure threshold triggers ip_blocked flag
+- Email-level failure threshold triggers email_blocked flag
+- Successful login resets failure counters
+- /auth/security-alerts endpoint returns per-user events
+- service gracefully degrades when Redis is unavailable
+"""
+
+from unittest.mock import patch
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _register_and_login(client, email="user@sec.test", password="pass1234"):
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    return r.get_json()["access_token"]
+
+
+# ── record_login_attempt unit tests ──────────────────────────────────────────
+
+
+def test_record_failed_attempt_increments_counters(app_fixture):
+    from app.services.security import (
+        record_login_attempt,
+        _FAIL_IP_KEY,
+        _FAIL_EMAIL_KEY,
+    )
+    from app.extensions import redis_client
+
+    with app_fixture.app_context():
+        record_login_attempt("a@x.com", "1.2.3.4", success=False)
+        assert int(redis_client.get(_FAIL_IP_KEY.format(ip="1.2.3.4")) or 0) == 1
+        assert int(redis_client.get(_FAIL_EMAIL_KEY.format(email="a@x.com")) or 0) == 1
+
+
+def test_ip_blocked_after_threshold(app_fixture):
+    from app.services.security import record_login_attempt, _FAIL_IP_KEY, _IP_FAIL_LIMIT
+    from app.extensions import redis_client
+
+    with app_fixture.app_context():
+        for _ in range(_IP_FAIL_LIMIT + 1):
+            record_login_attempt("b@x.com", "5.5.5.5", success=False)
+        count = int(redis_client.get(_FAIL_IP_KEY.format(ip="5.5.5.5")) or 0)
+        assert count > _IP_FAIL_LIMIT
+
+
+def test_email_blocked_after_threshold(app_fixture):
+    from app.services.security import (
+        record_login_attempt,
+        _FAIL_EMAIL_KEY,
+        _EMAIL_FAIL_LIMIT,
+    )
+    from app.extensions import redis_client
+
+    with app_fixture.app_context():
+        for _ in range(_EMAIL_FAIL_LIMIT + 1):
+            record_login_attempt("c@x.com", "6.6.6.1", success=False)
+        count = int(redis_client.get(_FAIL_EMAIL_KEY.format(email="c@x.com")) or 0)
+        assert count > _EMAIL_FAIL_LIMIT
+
+
+def test_success_resets_failure_counters(app_fixture):
+    from app.services.security import (
+        record_login_attempt,
+        _FAIL_IP_KEY,
+        _FAIL_EMAIL_KEY,
+    )
+    from app.extensions import redis_client
+
+    with app_fixture.app_context():
+        for _ in range(3):
+            record_login_attempt("d@x.com", "7.7.7.7", success=False)
+        # Successful login should clear counters
+        record_login_attempt("d@x.com", "7.7.7.7", success=True, user_id=99)
+        assert redis_client.get(_FAIL_IP_KEY.format(ip="7.7.7.7")) is None
+        assert redis_client.get(_FAIL_EMAIL_KEY.format(email="d@x.com")) is None
+
+
+def test_events_stored_for_user(app_fixture):
+    from app.services.security import record_login_attempt, get_security_alerts
+
+    with app_fixture.app_context():
+        record_login_attempt("e@x.com", "9.9.9.9", success=False, user_id=42)
+        record_login_attempt("e@x.com", "9.9.9.9", success=True, user_id=42)
+        alerts = get_security_alerts(42)
+        assert len(alerts) == 2
+        # Events are newest-first (LPUSH)
+        assert alerts[0]["type"] == "login_success"
+        assert alerts[1]["type"] == "login_failed"
+
+
+def test_graceful_degradation_when_redis_down(app_fixture):
+    from app.services.security import record_login_attempt
+
+    with app_fixture.app_context():
+        with patch("app.services.security.redis_client") as mock_redis:
+            mock_redis.pipeline.side_effect = Exception("Redis unavailable")
+            # Should not raise — login flow must not be disrupted
+            record_login_attempt("f@x.com", "10.0.0.1", success=False)
+
+
+# ── /auth/security-alerts endpoint integration tests ─────────────────────────
+
+
+def test_security_alerts_endpoint_requires_auth(client):
+    r = client.get("/auth/security-alerts")
+    assert r.status_code == 401
+
+
+def test_security_alerts_empty_for_new_user(client):
+    token = _register_and_login(client)
+    r = client.get(
+        "/auth/security-alerts", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert "alerts" in data
+    assert isinstance(data["alerts"], list)
+
+
+def test_security_alerts_records_failed_attempts(client):
+    email = "sec_fail@test.com"
+    password = "pass5678"
+    client.post("/auth/register", json={"email": email, "password": password})
+
+    # Trigger some failed logins
+    for _ in range(2):
+        client.post("/auth/login", json={"email": email, "password": "wrongpass"})
+
+    # Successful login records a success event
+    token = _register_and_login(client, email=email, password=password)
+    r = client.get(
+        "/auth/security-alerts", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert r.status_code == 200
+    alerts = r.get_json()["alerts"]
+    types = [a["type"] for a in alerts]
+    assert "login_success" in types
+    assert any(t in ("login_failed", "suspicious_login") for t in types)
+
+
+def test_security_alerts_suspicious_flag_on_excess_failures(client):
+    email = "sus@test.com"
+    password = "securepass"
+    client.post("/auth/register", json={"email": email, "password": password})
+
+    from app.services.security import _IP_FAIL_LIMIT
+
+    # Exceed the IP failure threshold
+    for _ in range(_IP_FAIL_LIMIT + 1):
+        client.post("/auth/login", json={"email": email, "password": "bad"})
+
+    token = _register_and_login(client, email=email, password=password)
+    r = client.get(
+        "/auth/security-alerts", headers={"Authorization": f"Bearer {token}"}
+    )
+    alerts = r.get_json()["alerts"]
+    types = [a["type"] for a in alerts]
+    assert "suspicious_login" in types


### PR DESCRIPTION
Closes #124

/claim #124

## Summary

- **`app/services/security.py`** (new): Redis-backed service that tracks failed login attempts per IP (15-min window, threshold 3) and per email (1-hr window, threshold 5). Stores the 20 most recent login events per user (newest-first via `LPUSH`). All Redis errors are caught so the login flow is never disrupted.
- **`app/routes/auth.py`**: wires `record_login_attempt()` into the existing `POST /auth/login` handler; adds `GET /auth/security-alerts` (JWT-protected) that returns per-user events.
- **`tests/test_security.py`** (new): 10 tests — unit tests for counter increments, threshold detection, counter reset on success, event storage, and graceful Redis degradation; integration tests for the `/auth/security-alerts` endpoint (auth required, empty state, failed-attempt recording, suspicious-login flagging).

## Behaviour

| Scenario | Result |
|---|---|
| Failed login | IP and email counters incremented with TTL |
| IP failures > 3 in 15 min | `suspicious_login` event stored |
| Email failures > 5 in 1 hr | `suspicious_login` event stored |
| Successful login | Counters cleared, `login_success` event stored |
| Redis down | Exception caught, login proceeds normally |
| `GET /auth/security-alerts` | Returns last 20 events for the authenticated user |

## Test plan

- [x] `test_record_failed_attempt_increments_counters`
- [x] `test_ip_blocked_after_threshold`
- [x] `test_email_blocked_after_threshold`
- [x] `test_success_resets_failure_counters`
- [x] `test_events_stored_for_user`
- [x] `test_graceful_degradation_when_redis_down`
- [x] `test_security_alerts_endpoint_requires_auth`
- [x] `test_security_alerts_empty_for_new_user`
- [x] `test_security_alerts_records_failed_attempts`
- [x] `test_security_alerts_suspicious_flag_on_excess_failures`
- [x] `black` and `flake8` pass on all changed files