### PR TITLE
feat: multi-account financial overview dashboard

### DIFF
--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,17 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS financial_accounts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(200) NOT NULL,
+  account_type VARCHAR(50) NOT NULL,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  balance NUMERIC(14,2) NOT NULL DEFAULT 0,
+  institution VARCHAR(200),
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_financial_accounts_user ON financial_accounts(user_id);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,16 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(200), nullable=False)
+    account_type = db.Column(db.String(50), nullable=False)  # checking, savings, credit, investment
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    balance = db.Column(db.Numeric(14, 2), default=0, nullable=False)
+    institution = db.Column(db.String(200), nullable=True)
+    is_active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,132 @@
+"""Financial accounts routes for multi-account overview."""
+
+from decimal import Decimal
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import FinancialAccount
+
+bp = Blueprint("accounts", __name__)
+
+VALID_ACCOUNT_TYPES = {"checking", "savings", "credit", "investment", "cash", "other"}
+
+
+@bp.get("/")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    accounts = (
+        db.session.query(FinancialAccount)
+        .filter_by(user_id=uid, is_active=True)
+        .order_by(FinancialAccount.created_at.desc())
+        .all()
+    )
+    return jsonify(accounts=[_serialize(a) for a in accounts])
+
+
+@bp.get("/overview")
+@jwt_required()
+def overview():
+    """Aggregated multi-account financial overview."""
+    uid = int(get_jwt_identity())
+    accounts = (
+        db.session.query(FinancialAccount)
+        .filter_by(user_id=uid, is_active=True)
+        .all()
+    )
+
+    total_assets = Decimal("0")
+    total_liabilities = Decimal("0")
+    by_type = {}
+
+    for a in accounts:
+        bal = Decimal(str(a.balance))
+        if a.account_type == "credit":
+            total_liabilities += abs(bal)
+        else:
+            total_assets += bal
+
+        by_type.setdefault(a.account_type, Decimal("0"))
+        by_type[a.account_type] += bal
+
+    return jsonify(
+        total_assets=float(total_assets),
+        total_liabilities=float(total_liabilities),
+        net_worth=float(total_assets - total_liabilities),
+        account_count=len(accounts),
+        by_type={k: float(v) for k, v in by_type.items()},
+        accounts=[_serialize(a) for a in accounts],
+    )
+
+
+@bp.post("/")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    name = data.get("name")
+    account_type = data.get("account_type", "checking")
+    if not name:
+        return jsonify(error="name required"), 400
+    if account_type not in VALID_ACCOUNT_TYPES:
+        return jsonify(error=f"invalid account_type, must be one of: {sorted(VALID_ACCOUNT_TYPES)}"), 400
+
+    account = FinancialAccount(
+        user_id=uid,
+        name=name,
+        account_type=account_type,
+        currency=data.get("currency", "INR"),
+        balance=Decimal(str(data.get("balance", 0))),
+        institution=data.get("institution"),
+    )
+    db.session.add(account)
+    db.session.commit()
+    return jsonify(account=_serialize(account)), 201
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id):
+    uid = int(get_jwt_identity())
+    account = db.session.query(FinancialAccount).filter_by(id=account_id, user_id=uid).first()
+    if not account:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    if "name" in data:
+        account.name = data["name"]
+    if "balance" in data:
+        account.balance = Decimal(str(data["balance"]))
+    if "institution" in data:
+        account.institution = data["institution"]
+    if "is_active" in data:
+        account.is_active = bool(data["is_active"])
+
+    db.session.commit()
+    return jsonify(account=_serialize(account))
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def delete_account(account_id):
+    uid = int(get_jwt_identity())
+    account = db.session.query(FinancialAccount).filter_by(id=account_id, user_id=uid).first()
+    if not account:
+        return jsonify(error="not found"), 404
+    account.is_active = False
+    db.session.commit()
+    return jsonify(message="account deactivated"), 200
+
+
+def _serialize(a: FinancialAccount) -> dict:
+    return {
+        "id": a.id,
+        "name": a.name,
+        "account_type": a.account_type,
+        "currency": a.currency,
+        "balance": float(a.balance),
+        "institution": a.institution,
+        "is_active": a.is_active,
+        "created_at": a.created_at.isoformat(),
+    }

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,64 @@
+"""Tests for multi-account financial overview."""
+
+
+def _auth_header(client):
+    email = "accounts@test.com"
+    password = "secret123"
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def test_create_account(client):
+    headers = _auth_header(client)
+    r = client.post(
+        "/accounts/",
+        json={"name": "Main Checking", "account_type": "checking", "balance": 5000},
+        headers=headers,
+    )
+    assert r.status_code == 201
+    data = r.get_json()["account"]
+    assert data["name"] == "Main Checking"
+    assert data["balance"] == 5000
+
+
+def test_list_accounts(client):
+    headers = _auth_header(client)
+    client.post("/accounts/", json={"name": "Savings", "account_type": "savings", "balance": 10000}, headers=headers)
+    r = client.get("/accounts/", headers=headers)
+    assert r.status_code == 200
+    assert len(r.get_json()["accounts"]) >= 1
+
+
+def test_overview_aggregation(client):
+    headers = _auth_header(client)
+    client.post("/accounts/", json={"name": "Checking", "account_type": "checking", "balance": 3000}, headers=headers)
+    client.post("/accounts/", json={"name": "Credit Card", "account_type": "credit", "balance": -1000}, headers=headers)
+    client.post("/accounts/", json={"name": "Investment", "account_type": "investment", "balance": 5000}, headers=headers)
+
+    r = client.get("/accounts/overview", headers=headers)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_assets"] >= 8000
+    assert data["total_liabilities"] >= 1000
+    assert "net_worth" in data
+    assert "by_type" in data
+
+
+def test_update_balance(client):
+    headers = _auth_header(client)
+    r = client.post("/accounts/", json={"name": "Update Me", "account_type": "cash", "balance": 100}, headers=headers)
+    aid = r.get_json()["account"]["id"]
+
+    r = client.patch(f"/accounts/{aid}", json={"balance": 200}, headers=headers)
+    assert r.status_code == 200
+    assert r.get_json()["account"]["balance"] == 200
+
+
+def test_delete_deactivates(client):
+    headers = _auth_header(client)
+    r = client.post("/accounts/", json={"name": "Delete Me", "account_type": "other", "balance": 0}, headers=headers)
+    aid = r.get_json()["account"]["id"]
+
+    r = client.delete(f"/accounts/{aid}", headers=headers)
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary

Adds multi-account support with an aggregated financial overview (#132).

## API

| Method | Path | Description |
|--------|------|-------------|
| GET | /accounts/ | List all active accounts |
| GET | /accounts/overview | Aggregated net worth, assets, liabilities, by-type breakdown |
| POST | /accounts/ | Create account |
| PATCH | /accounts/:id | Update balance/name |
| DELETE | /accounts/:id | Soft-delete (deactivate) |

## Overview Response

```json
{
  "total_assets": 15000.00,
  "total_liabilities": 2000.00,
  "net_worth": 13000.00,
  "account_count": 4,
  "by_type": {"checking": 5000, "savings": 10000, "credit": -2000},
  "accounts": [...]
}
```

## Account Types

checking, savings, credit, investment, cash, other

## Testing

5 tests: create, list, overview aggregation, update balance, soft-delete.

Closes #132