### PR TITLE
feat: PII export & delete workflow (GDPR-ready)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .gdpr import bp as gdpr_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(gdpr_bp, url_prefix="/gdpr")

--- a/packages/backend/app/routes/gdpr.py
+++ b/packages/backend/app/routes/gdpr.py
@@ -1,0 +1,155 @@
+"""GDPR PII export and delete workflow routes."""
+
+import json
+from datetime import datetime
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import User, Expense, Category, Bill, Reminder, RecurringExpense, AuditLog
+
+bp = Blueprint("gdpr", __name__)
+
+
+@bp.post("/export")
+@jwt_required()
+def export_data():
+    """Generate a full PII export package for the authenticated user."""
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="not found"), 404
+
+    export = {
+        "exported_at": datetime.utcnow().isoformat(),
+        "user": {
+            "id": user.id,
+            "email": user.email,
+            "preferred_currency": user.preferred_currency,
+            "created_at": user.created_at.isoformat(),
+        },
+        "expenses": _export_expenses(uid),
+        "categories": _export_categories(uid),
+        "bills": _export_bills(uid),
+        "reminders": _export_reminders(uid),
+        "recurring_expenses": _export_recurring(uid),
+    }
+
+    # Log the export action
+    _audit(uid, "pii_export_requested")
+
+    return jsonify(export=export)
+
+
+@bp.post("/delete")
+@jwt_required()
+def delete_data():
+    """Permanently delete all user data (irreversible)."""
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+
+    # Require explicit confirmation
+    if data.get("confirm") != "DELETE_MY_DATA":
+        return jsonify(
+            error="Must send {\"confirm\": \"DELETE_MY_DATA\"} to proceed"
+        ), 400
+
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="not found"), 404
+
+    # Delete in dependency order
+    db.session.query(Reminder).filter_by(user_id=uid).delete()
+    db.session.query(Bill).filter_by(user_id=uid).delete()
+    db.session.query(Expense).filter_by(user_id=uid).delete()
+    db.session.query(RecurringExpense).filter_by(user_id=uid).delete()
+    db.session.query(Category).filter_by(user_id=uid).delete()
+
+    # Log deletion before removing user (audit trail preserved with null user)
+    _audit(uid, "pii_deletion_completed")
+
+    # Delete user last
+    db.session.delete(user)
+    db.session.commit()
+
+    return jsonify(message="All personal data has been permanently deleted"), 200
+
+
+@bp.get("/status")
+@jwt_required()
+def data_status():
+    """Show what data exists for the user."""
+    uid = int(get_jwt_identity())
+    return jsonify(
+        data_summary={
+            "expenses": db.session.query(Expense).filter_by(user_id=uid).count(),
+            "categories": db.session.query(Category).filter_by(user_id=uid).count(),
+            "bills": db.session.query(Bill).filter_by(user_id=uid).count(),
+            "reminders": db.session.query(Reminder).filter_by(user_id=uid).count(),
+            "recurring_expenses": db.session.query(RecurringExpense).filter_by(user_id=uid).count(),
+        }
+    )
+
+
+def _export_expenses(uid):
+    rows = db.session.query(Expense).filter_by(user_id=uid).all()
+    return [
+        {
+            "id": r.id,
+            "amount": float(r.amount),
+            "currency": r.currency,
+            "expense_type": r.expense_type,
+            "notes": r.notes,
+            "spent_at": r.spent_at.isoformat() if r.spent_at else None,
+            "created_at": r.created_at.isoformat(),
+        }
+        for r in rows
+    ]
+
+
+def _export_categories(uid):
+    rows = db.session.query(Category).filter_by(user_id=uid).all()
+    return [{"id": r.id, "name": r.name, "created_at": r.created_at.isoformat()} for r in rows]
+
+
+def _export_bills(uid):
+    rows = db.session.query(Bill).filter_by(user_id=uid).all()
+    return [
+        {
+            "id": r.id,
+            "name": r.name,
+            "amount": float(r.amount),
+            "currency": r.currency,
+            "next_due_date": r.next_due_date.isoformat() if r.next_due_date else None,
+            "cadence": r.cadence.value if r.cadence else None,
+        }
+        for r in rows
+    ]
+
+
+def _export_reminders(uid):
+    rows = db.session.query(Reminder).filter_by(user_id=uid).all()
+    return [
+        {"id": r.id, "message": r.message, "send_at": r.send_at.isoformat(), "channel": r.channel}
+        for r in rows
+    ]
+
+
+def _export_recurring(uid):
+    rows = db.session.query(RecurringExpense).filter_by(user_id=uid).all()
+    return [
+        {
+            "id": r.id,
+            "amount": float(r.amount),
+            "currency": r.currency,
+            "notes": r.notes,
+            "cadence": r.cadence.value if r.cadence else None,
+            "start_date": r.start_date.isoformat() if r.start_date else None,
+        }
+        for r in rows
+    ]
+
+
+def _audit(uid, action):
+    log = AuditLog(user_id=uid, action=action)
+    db.session.add(log)
+    db.session.flush()

--- a/packages/backend/tests/test_gdpr.py
+++ b/packages/backend/tests/test_gdpr.py
@@ -1,0 +1,55 @@
+"""Tests for GDPR PII export and delete workflow."""
+
+
+def _auth_header(client):
+    email = "gdpr@test.com"
+    password = "secret123"
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def test_export_data(client):
+    headers = _auth_header(client)
+    r = client.post("/gdpr/export", headers=headers)
+    assert r.status_code == 200
+    export = r.get_json()["export"]
+    assert "user" in export
+    assert export["user"]["email"] == "gdpr@test.com"
+    assert "expenses" in export
+    assert "categories" in export
+    assert "bills" in export
+
+
+def test_data_status(client):
+    headers = _auth_header(client)
+    r = client.get("/gdpr/status", headers=headers)
+    assert r.status_code == 200
+    summary = r.get_json()["data_summary"]
+    assert "expenses" in summary
+    assert "bills" in summary
+
+
+def test_delete_requires_confirmation(client):
+    headers = _auth_header(client)
+    r = client.post("/gdpr/delete", json={}, headers=headers)
+    assert r.status_code == 400
+    assert "confirm" in r.get_json()["error"]
+
+
+def test_delete_with_confirmation(client):
+    # Create a fresh user for deletion
+    email = "deleteme@test.com"
+    password = "secret123"
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    headers = {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+    r = client.post("/gdpr/delete", json={"confirm": "DELETE_MY_DATA"}, headers=headers)
+    assert r.status_code == 200
+    assert "permanently deleted" in r.get_json()["message"]
+
+    # Verify user can no longer access API
+    r = client.get("/gdpr/status", headers=headers)
+    # Token still valid but user gone - should get 404 or similar
+    assert r.status_code in (401, 404, 422)


### PR DESCRIPTION
## Summary

Implements GDPR-compliant PII export and permanent deletion workflow (#76).

## API

| Method | Path | Description |
|--------|------|-------------|
| POST | /gdpr/export | Generate full PII export package |
| GET | /gdpr/status | Show data summary (record counts) |
| POST | /gdpr/delete | Permanently delete all user data |

## Export Package

Includes all user PII: profile, expenses, categories, bills, reminders, recurring expenses.

## Deletion Workflow

1. User must send `{"confirm": "DELETE_MY_DATA"}` — prevents accidental deletion
2. All data deleted in FK-safe order (reminders → bills → expenses → recurring → categories → user)
3. Audit log entry created before user deletion (preserved with nullable user_id)
4. Irreversible — no soft-delete, data is permanently removed

## Audit Trail

- `pii_export_requested` — logged when user exports data
- `pii_deletion_completed` — logged when deletion completes

## Testing

4 tests: export, status, delete rejection without confirmation, delete with confirmation.

Closes #76