### PR TITLE
Add weekly financial digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-summary`
+
+### Weekly Financial Digest
+`GET /insights/weekly-summary` returns an authenticated, on-demand digest for the current ISO week. Pass `week_start=YYYY-MM-DD` to inspect another Monday-starting week and `currency=USD` to isolate one currency. The response includes weekly income, expenses, net flow, transaction count, average daily spend, previous-week deltas, daily totals, category shares, upcoming bills due that week, and deterministic smart insights.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/__tests__/Analytics.integration.test.tsx
+++ b/app/src/__tests__/Analytics.integration.test.tsx
@@ -30,8 +30,10 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 
 const getBudgetSuggestionMock = jest.fn();
+const getWeeklySummaryMock = jest.fn();
 jest.mock('@/api/insights', () => ({
   getBudgetSuggestion: (...args: unknown[]) => getBudgetSuggestionMock(...args),
+  getWeeklySummary: (...args: unknown[]) => getWeeklySummaryMock(...args),
 }));
 
 describe('Analytics integration', () => {
@@ -52,12 +54,68 @@ describe('Analytics integration', () => {
       method: 'heuristic',
       warnings: [],
     });
+    getWeeklySummaryMock.mockResolvedValue({
+      period: {
+        week_start: '2026-05-04',
+        week_end: '2026-05-10',
+        previous_week_start: '2026-04-27',
+        currency: 'USD',
+      },
+      summary: {
+        income: 1000,
+        expenses: 250,
+        net_flow: 750,
+        transaction_count: 4,
+        average_daily_expense: 35.71,
+      },
+      previous_week: {
+        income: 0,
+        expenses: 70,
+        net_flow: -70,
+        expense_delta: 180,
+        expense_delta_pct: 257.14,
+      },
+      daily_breakdown: [],
+      category_breakdown: [
+        {
+          category_id: 1,
+          category_name: 'Food',
+          amount: 200,
+          transaction_count: 2,
+          share_pct: 80,
+          previous_amount: 70,
+          change_amount: 130,
+          change_pct: 185.71,
+        },
+      ],
+      upcoming_bills: [
+        {
+          id: 1,
+          name: 'Internet',
+          amount: 45,
+          currency: 'USD',
+          next_due_date: '2026-05-09',
+          cadence: 'MONTHLY',
+          autopay_enabled: false,
+        },
+      ],
+      insights: [
+        {
+          type: 'top_category',
+          severity: 'info',
+          message: 'Food is the top spending category at 80% of weekly expenses.',
+        },
+      ],
+    });
   });
 
   it('loads and renders insights data', async () => {
     render(<Analytics />);
     await waitFor(() => expect(getBudgetSuggestionMock).toHaveBeenCalled());
+    await waitFor(() => expect(getWeeklySummaryMock).toHaveBeenCalled());
     expect(screen.getByText(/live spending analytics/i)).toBeInTheDocument();
+    expect(screen.getByText(/weekly digest/i)).toBeInTheDocument();
+    expect(screen.getByText(/food is the top spending category/i)).toBeInTheDocument();
     expect(screen.getByText(/suggested budget/i)).toBeInTheDocument();
     expect(screen.getByText(/tip a/i)).toBeInTheDocument();
   });
@@ -68,6 +126,9 @@ describe('Analytics integration', () => {
 
     await userEvent.clear(screen.getByLabelText(/analytics month/i));
     await userEvent.type(screen.getByLabelText(/analytics month/i), '2026-01');
+    await userEvent.clear(screen.getByLabelText(/weekly summary week start/i));
+    await userEvent.type(screen.getByLabelText(/weekly summary week start/i), '2026-05-04');
+    await userEvent.type(screen.getByLabelText(/weekly summary currency/i), 'usd');
     await userEvent.selectOptions(screen.getByLabelText(/analytics persona/i), 'Debt-focused planner');
     await userEvent.type(screen.getByLabelText(/gemini api key/i), 'abc123');
     await userEvent.click(screen.getByRole('button', { name: /refresh insights/i }));
@@ -78,6 +139,14 @@ describe('Analytics integration', () => {
           month: '2026-01',
           persona: 'Debt-focused planner',
           geminiApiKey: 'abc123',
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(getWeeklySummaryMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          weekStart: '2026-05-04',
+          currency: 'USD',
         }),
       ),
     );

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,59 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklySummary = {
+  period: {
+    week_start: string;
+    week_end: string;
+    previous_week_start: string;
+    currency: string | null;
+  };
+  summary: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+    average_daily_expense: number;
+  };
+  previous_week: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    expense_delta: number;
+    expense_delta_pct: number | null;
+  };
+  daily_breakdown: Array<{
+    date: string;
+    income: number;
+    expenses: number;
+    net_flow: number;
+  }>;
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    transaction_count: number;
+    share_pct: number;
+    previous_amount: number;
+    change_amount: number;
+    change_pct: number | null;
+  }>;
+  upcoming_bills: Array<{
+    id: number;
+    name: string;
+    amount: number;
+    currency: string;
+    next_due_date: string;
+    cadence: string;
+    autopay_enabled: boolean;
+  }>;
+  insights: Array<{
+    type: string;
+    severity: 'info' | 'success' | 'warning' | string;
+    message: string;
+  }>;
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +84,15 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklySummary(params?: {
+  weekStart?: string;
+  currency?: string;
+}): Promise<WeeklySummary> {
+  const query = new URLSearchParams();
+  if (params?.weekStart) query.set('week_start', params.weekStart);
+  if (params?.currency) query.set('currency', params.currency);
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+  return api<WeeklySummary>(`/insights/weekly-summary${suffix}`);
 }

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -10,7 +10,7 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
-import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
+import { getBudgetSuggestion, getWeeklySummary, type BudgetSuggestion, type WeeklySummary } from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
 
 const PERSONAS = [
@@ -22,22 +22,32 @@ const PERSONAS = [
 export function Analytics() {
   const { toast } = useToast();
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [weekStart, setWeekStart] = useState(getCurrentMonday);
+  const [currency, setCurrency] = useState('');
   const [persona, setPersona] = useState(PERSONAS[0]);
   const [geminiKey, setGeminiKey] = useState('');
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BudgetSuggestion | null>(null);
+  const [weekly, setWeekly] = useState<WeeklySummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
     setLoading(true);
     setError(null);
     try {
-      const payload = await getBudgetSuggestion({
-        month,
-        persona,
-        geminiApiKey: geminiKey.trim() || undefined,
-      });
+      const [payload, weeklyPayload] = await Promise.all([
+        getBudgetSuggestion({
+          month,
+          persona,
+          geminiApiKey: geminiKey.trim() || undefined,
+        }),
+        getWeeklySummary({
+          weekStart,
+          currency: currency.trim().toUpperCase() || undefined,
+        }),
+      ]);
       setData(payload);
+      setWeekly(weeklyPayload);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
@@ -83,6 +93,16 @@ export function Analytics() {
               />
             </div>
             <div>
+              <Label htmlFor="analytics-week">Week Start</Label>
+              <Input
+                id="analytics-week"
+                aria-label="weekly summary week start"
+                type="date"
+                value={weekStart}
+                onChange={(e) => setWeekStart(e.target.value)}
+              />
+            </div>
+            <div>
               <Label htmlFor="analytics-persona">Persona</Label>
               <select
                 id="analytics-persona"
@@ -97,6 +117,17 @@ export function Analytics() {
                   </option>
                 ))}
               </select>
+            </div>
+            <div>
+              <Label htmlFor="analytics-currency">Currency</Label>
+              <Input
+                id="analytics-currency"
+                aria-label="weekly summary currency"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+                placeholder="All"
+                maxLength={10}
+              />
             </div>
             <div className="md:col-span-2">
               <Label htmlFor="analytics-key">Gemini API Key (optional BYOK)</Label>
@@ -122,6 +153,83 @@ export function Analytics() {
         <div className="card text-red-600">{error}</div>
       ) : data ? (
         <div className="space-y-6">
+          {weekly ? (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Weekly Digest</FinancialCardTitle>
+                <FinancialCardDescription>
+                  {weekly.period.week_start} to {weekly.period.week_end}
+                </FinancialCardDescription>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid gap-3 md:grid-cols-4">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Income</div>
+                    <div className="font-semibold">
+                      {formatMoney(weekly.summary.income, weekly.period.currency || undefined)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expenses</div>
+                    <div className="font-semibold">
+                      {formatMoney(weekly.summary.expenses, weekly.period.currency || undefined)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Net Flow</div>
+                    <div className="font-semibold">
+                      {formatMoney(weekly.summary.net_flow, weekly.period.currency || undefined)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Vs Last Week</div>
+                    <div className="font-semibold">
+                      {formatMoney(weekly.previous_week.expense_delta, weekly.period.currency || undefined)}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Top Categories</div>
+                    {weekly.category_breakdown.length ? (
+                      <div className="space-y-2">
+                        {weekly.category_breakdown.slice(0, 4).map((item) => (
+                          <div key={`${item.category_id}-${item.category_name}`} className="rounded-lg border p-3">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="font-medium">{item.category_name}</span>
+                              <span>{formatMoney(item.amount, weekly.period.currency || undefined)}</span>
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {item.share_pct}% of weekly expenses, change {formatMoney(item.change_amount, weekly.period.currency || undefined)}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-sm text-muted-foreground">No category spending this week.</div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Smart Signals</div>
+                    <div className="space-y-2">
+                      {weekly.insights.map((item) => (
+                        <div key={`${item.type}-${item.message}`} className="rounded-lg border p-3 text-sm">
+                          {item.message}
+                        </div>
+                      ))}
+                      {weekly.upcoming_bills.length ? (
+                        <div className="rounded-lg border p-3 text-sm">
+                          Next bill: {weekly.upcoming_bills[0].name} on {weekly.upcoming_bills[0].next_due_date}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          ) : null}
+
           <div className="grid gap-4 md:grid-cols-4">
             <FinancialCard variant="financial">
               <FinancialCardHeader className="pb-2">
@@ -195,4 +303,12 @@ export function Analytics() {
       ) : null}
     </div>
   );
+}
+
+function getCurrentMonday() {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  now.setDate(now.getDate() + diff);
+  return now.toISOString().slice(0, 10);
 }

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,70 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/weekly-summary:
+    get:
+      summary: Get weekly financial digest
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          description: Monday date for the requested week. Defaults to the current ISO week.
+          schema: { type: string, format: date }
+        - in: query
+          name: currency
+          required: false
+          description: Optional currency filter such as USD or INR.
+          schema: { type: string }
+      responses:
+        '200':
+          description: Weekly digest with totals, comparisons, category shares, bills, and insights.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                period:
+                  week_start: 2026-05-04
+                  week_end: 2026-05-10
+                  previous_week_start: 2026-04-27
+                  currency: USD
+                summary:
+                  income: 1000
+                  expenses: 250
+                  net_flow: 750
+                  transaction_count: 4
+                  average_daily_expense: 35.71
+                previous_week:
+                  income: 0
+                  expenses: 70
+                  net_flow: -70
+                  expense_delta: 180
+                  expense_delta_pct: 257.14
+                category_breakdown:
+                  - category_id: 1
+                    category_name: Food
+                    amount: 200
+                    share_pct: 80
+                    previous_amount: 70
+                    change_amount: 130
+                insights:
+                  - type: top_category
+                    severity: info
+                    message: Food is the top spending category at 80% of weekly expenses.
+        '400':
+          description: Invalid week_start
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,6 +1,9 @@
-from datetime import date
+from datetime import date, timedelta
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import func
+from ..extensions import db
+from ..models import Bill, Category, Expense
 from ..services.ai import monthly_budget_suggestion
 import logging
 
@@ -23,3 +26,309 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    try:
+        week_start = _parse_week_start(request.args.get("week_start"))
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+
+    currency = (request.args.get("currency") or "").strip().upper() or None
+    payload = _build_weekly_summary(uid, week_start, currency)
+    logger.info(
+        "Weekly summary served user=%s week_start=%s currency=%s",
+        uid,
+        week_start.isoformat(),
+        currency or "ALL",
+    )
+    return jsonify(payload)
+
+
+def _parse_week_start(raw_value: str | None) -> date:
+    if not raw_value:
+        today = date.today()
+        return today - timedelta(days=today.weekday())
+    try:
+        week_start = date.fromisoformat(raw_value.strip())
+    except ValueError as exc:
+        raise ValueError("invalid week_start, expected YYYY-MM-DD") from exc
+    if week_start.weekday() != 0:
+        raise ValueError("week_start must be a Monday")
+    return week_start
+
+
+def _build_weekly_summary(uid: int, week_start: date, currency: str | None):
+    week_end = week_start + timedelta(days=6)
+    next_week_start = week_start + timedelta(days=7)
+    previous_week_start = week_start - timedelta(days=7)
+
+    current_rows = _expense_rows(uid, week_start, next_week_start, currency)
+    previous_rows = _expense_rows(uid, previous_week_start, week_start, currency)
+    upcoming_bills = _upcoming_bills(uid, week_start, next_week_start, currency)
+
+    current_totals = _totals(current_rows)
+    previous_totals = _totals(previous_rows)
+    categories = _category_breakdown(current_rows, previous_rows)
+    daily = _daily_breakdown(current_rows, week_start)
+
+    summary = {
+        "income": current_totals["income"],
+        "expenses": current_totals["expenses"],
+        "net_flow": round(current_totals["income"] - current_totals["expenses"], 2),
+        "transaction_count": len(current_rows),
+        "average_daily_expense": round(current_totals["expenses"] / 7, 2),
+    }
+    previous_summary = {
+        "income": previous_totals["income"],
+        "expenses": previous_totals["expenses"],
+        "net_flow": round(previous_totals["income"] - previous_totals["expenses"], 2),
+        "expense_delta": round(
+            current_totals["expenses"] - previous_totals["expenses"], 2
+        ),
+        "expense_delta_pct": _pct_change(
+            previous_totals["expenses"], current_totals["expenses"]
+        ),
+    }
+
+    return {
+        "period": {
+            "week_start": week_start.isoformat(),
+            "week_end": week_end.isoformat(),
+            "previous_week_start": previous_week_start.isoformat(),
+            "currency": currency,
+        },
+        "summary": summary,
+        "previous_week": previous_summary,
+        "daily_breakdown": daily,
+        "category_breakdown": categories,
+        "upcoming_bills": upcoming_bills,
+        "insights": _insights(
+            summary, previous_summary, categories, daily, upcoming_bills
+        ),
+    }
+
+
+def _expense_rows(uid: int, start: date, end: date, currency: str | None):
+    query = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at < end,
+        )
+        .order_by(Expense.spent_at.asc(), Expense.id.asc())
+    )
+    if currency:
+        query = query.filter(func.upper(Expense.currency) == currency)
+    return query.all()
+
+
+def _totals(rows: list[Expense]) -> dict[str, float]:
+    income = 0.0
+    expenses = 0.0
+    for row in rows:
+        amount = float(row.amount or 0)
+        if row.expense_type == "INCOME":
+            income += amount
+        else:
+            expenses += amount
+    return {"income": round(income, 2), "expenses": round(expenses, 2)}
+
+
+def _category_breakdown(current_rows: list[Expense], previous_rows: list[Expense]):
+    current = _category_amounts(current_rows)
+    previous = _category_amounts(previous_rows)
+    total = sum(item["amount"] for item in current.values())
+    rows = []
+    for key, item in current.items():
+        prev_amount = previous.get(key, {"amount": 0.0})["amount"]
+        rows.append(
+            {
+                "category_id": item["category_id"],
+                "category_name": item["category_name"],
+                "amount": round(item["amount"], 2),
+                "transaction_count": item["transaction_count"],
+                "share_pct": (
+                    round((item["amount"] / total) * 100, 2) if total > 0 else 0
+                ),
+                "previous_amount": round(prev_amount, 2),
+                "change_amount": round(item["amount"] - prev_amount, 2),
+                "change_pct": _pct_change(prev_amount, item["amount"]),
+            }
+        )
+    return sorted(rows, key=lambda item: item["amount"], reverse=True)
+
+
+def _category_amounts(rows: list[Expense]):
+    category_ids = {row.category_id for row in rows if row.category_id is not None}
+    names = {}
+    if category_ids:
+        names = {
+            category.id: category.name
+            for category in db.session.query(Category)
+            .filter(Category.id.in_(category_ids))
+            .all()
+        }
+    grouped = {}
+    for row in rows:
+        if row.expense_type == "INCOME":
+            continue
+        key = row.category_id or 0
+        if key not in grouped:
+            grouped[key] = {
+                "category_id": row.category_id,
+                "category_name": names.get(row.category_id, "Uncategorized"),
+                "amount": 0.0,
+                "transaction_count": 0,
+            }
+        grouped[key]["amount"] += float(row.amount or 0)
+        grouped[key]["transaction_count"] += 1
+    return grouped
+
+
+def _daily_breakdown(rows: list[Expense], week_start: date):
+    by_day = {
+        (week_start + timedelta(days=offset)): {"income": 0.0, "expenses": 0.0}
+        for offset in range(7)
+    }
+    for row in rows:
+        if row.spent_at not in by_day:
+            continue
+        key = "income" if row.expense_type == "INCOME" else "expenses"
+        by_day[row.spent_at][key] += float(row.amount or 0)
+    return [
+        {
+            "date": day.isoformat(),
+            "income": round(values["income"], 2),
+            "expenses": round(values["expenses"], 2),
+            "net_flow": round(values["income"] - values["expenses"], 2),
+        }
+        for day, values in by_day.items()
+    ]
+
+
+def _upcoming_bills(uid: int, start: date, end: date, currency: str | None):
+    query = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == uid,
+            Bill.active.is_(True),
+            Bill.next_due_date >= start,
+            Bill.next_due_date < end,
+        )
+        .order_by(Bill.next_due_date.asc())
+    )
+    if currency:
+        query = query.filter(func.upper(Bill.currency) == currency)
+    return [
+        {
+            "id": bill.id,
+            "name": bill.name,
+            "amount": float(bill.amount or 0),
+            "currency": bill.currency,
+            "next_due_date": bill.next_due_date.isoformat(),
+            "cadence": bill.cadence.value,
+            "autopay_enabled": bill.autopay_enabled,
+        }
+        for bill in query.limit(8).all()
+    ]
+
+
+def _pct_change(previous: float, current: float):
+    if previous == 0:
+        return None if current > 0 else 0.0
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def _insights(summary, previous_summary, categories, daily, upcoming_bills):
+    insights = []
+    if summary["transaction_count"] == 0:
+        insights.append(
+            {
+                "type": "empty_week",
+                "severity": "info",
+                "message": "No transactions were recorded for this week.",
+            }
+        )
+        return insights
+
+    if categories:
+        top = categories[0]
+        insights.append(
+            {
+                "type": "top_category",
+                "severity": "info",
+                "message": (
+                    f"{top['category_name']} is the top spending category at "
+                    f"{top['share_pct']}% of weekly expenses."
+                ),
+            }
+        )
+
+    delta = previous_summary["expense_delta"]
+    if delta > 0:
+        insights.append(
+            {
+                "type": "spending_increase",
+                "severity": "warning",
+                "message": (
+                    f"Weekly expenses increased by {delta:.2f} versus last week."
+                ),
+            }
+        )
+    elif delta < 0:
+        insights.append(
+            {
+                "type": "spending_decrease",
+                "severity": "success",
+                "message": (
+                    "Weekly expenses decreased by "
+                    f"{abs(delta):.2f} versus last week."
+                ),
+            }
+        )
+
+    no_spend_days = [item["date"] for item in daily if item["expenses"] == 0]
+    if no_spend_days:
+        insights.append(
+            {
+                "type": "no_spend_days",
+                "severity": "info",
+                "message": f"{len(no_spend_days)} day(s) had no recorded expenses.",
+            }
+        )
+
+    if upcoming_bills:
+        total_due = round(sum(item["amount"] for item in upcoming_bills), 2)
+        insights.append(
+            {
+                "type": "upcoming_bills",
+                "severity": "warning",
+                "message": (
+                    f"{len(upcoming_bills)} bill(s) totaling {total_due:.2f} "
+                    "are due during this week."
+                ),
+            }
+        )
+
+    if summary["net_flow"] >= 0:
+        insights.append(
+            {
+                "type": "positive_cash_flow",
+                "severity": "success",
+                "message": "Income covered expenses for this week.",
+            }
+        )
+    else:
+        insights.append(
+            {
+                "type": "negative_cash_flow",
+                "severity": "warning",
+                "message": "Expenses exceeded income for this week.",
+            }
+        )
+    return insights

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -3,8 +3,55 @@ import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class InMemoryRedis:
+    def __init__(self):
+        self._data = {}
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def set(self, key, value):
+        self._data[key] = value
+        return True
+
+    def setex(self, key, _ttl, value):
+        self._data[key] = value
+        return True
+
+    def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            if key in self._data:
+                deleted += 1
+                del self._data[key]
+        return deleted
+
+    def flushdb(self):
+        self._data.clear()
+        return True
+
+    def scan(self, cursor=0, match=None, count=100):
+        import fnmatch
+
+        keys = list(self._data)
+        if match:
+            keys = [key for key in keys if fnmatch.fnmatch(key, match)]
+        return 0, keys[:count]
+
+
+def _install_test_redis():
+    fake = InMemoryRedis()
+    import app.extensions as extensions
+    import app.routes.auth as auth
+    import app.services.cache as cache
+
+    extensions.redis_client = fake
+    auth.redis_client = fake
+    cache.redis_client = fake
+    return fake
 
 
 class TestSettings(Settings):
@@ -28,11 +75,12 @@ def app_fixture():
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
+    fake_redis = _install_test_redis()
     app = create_app(settings)
     app.config.update(TESTING=True)
     _setup_db(app)
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
     yield app
@@ -40,7 +88,7 @@ def app_fixture():
         db.session.remove()
         db.drop_all()
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
 

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -90,3 +90,118 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_weekly_summary_requires_auth(client):
+    r = client.get("/insights/weekly-summary?week_start=2026-05-04")
+    assert r.status_code == 401
+
+
+def test_weekly_summary_validates_monday_week_start(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-05", headers=auth_header
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "week_start must be a Monday"
+
+
+def test_weekly_summary_returns_empty_digest(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-04", headers=auth_header
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period"]["week_start"] == "2026-05-04"
+    assert payload["summary"]["expenses"] == 0.0
+    assert payload["summary"]["income"] == 0.0
+    assert payload["daily_breakdown"][0]["date"] == "2026-05-04"
+    assert payload["daily_breakdown"][-1]["date"] == "2026-05-10"
+    assert payload["insights"][0]["type"] == "empty_week"
+
+
+def test_weekly_summary_aggregates_categories_days_previous_week_and_bills(
+    client, auth_header
+):
+    r = client.post("/categories", json={"name": "Food"}, headers=auth_header)
+    assert r.status_code == 201
+    food_id = r.get_json()["id"]
+
+    r = client.post("/categories", json={"name": "Travel"}, headers=auth_header)
+    assert r.status_code == 201
+    travel_id = r.get_json()["id"]
+
+    expenses = [
+        (1000, "Salary", "2026-05-04", "INCOME", None),
+        (120, "Groceries", "2026-05-04", "EXPENSE", food_id),
+        (80, "Dinner", "2026-05-06", "EXPENSE", food_id),
+        (50, "Taxi", "2026-05-10", "EXPENSE", travel_id),
+        (70, "Previous groceries", "2026-04-28", "EXPENSE", food_id),
+        (999, "EUR hidden", "2026-05-04", "EXPENSE", None),
+    ]
+    for amount, description, spent_at, expense_type, category_id in expenses:
+        payload = {
+            "amount": amount,
+            "currency": "EUR" if description == "EUR hidden" else "USD",
+            "description": description,
+            "date": spent_at,
+            "expense_type": expense_type,
+        }
+        if category_id is not None:
+            payload["category_id"] = category_id
+        r = client.post("/expenses", json=payload, headers=auth_header)
+        assert r.status_code == 201
+
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 45,
+            "currency": "USD",
+            "next_due_date": "2026-05-09",
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-04&currency=USD",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["period"]["currency"] == "USD"
+    assert payload["summary"] == {
+        "income": 1000.0,
+        "expenses": 250.0,
+        "net_flow": 750.0,
+        "transaction_count": 4,
+        "average_daily_expense": 35.71,
+    }
+    assert payload["previous_week"]["expenses"] == 70.0
+    assert payload["previous_week"]["expense_delta"] == 180.0
+    assert payload["previous_week"]["expense_delta_pct"] == 257.14
+
+    categories = payload["category_breakdown"]
+    assert categories[0]["category_name"] == "Food"
+    assert categories[0]["amount"] == 200.0
+    assert categories[0]["transaction_count"] == 2
+    assert categories[0]["share_pct"] == 80.0
+    assert categories[0]["previous_amount"] == 70.0
+    assert categories[1]["category_name"] == "Travel"
+
+    by_date = {item["date"]: item for item in payload["daily_breakdown"]}
+    assert by_date["2026-05-04"]["income"] == 1000.0
+    assert by_date["2026-05-04"]["expenses"] == 120.0
+    assert by_date["2026-05-06"]["expenses"] == 80.0
+    assert by_date["2026-05-10"]["expenses"] == 50.0
+
+    assert payload["upcoming_bills"][0]["name"] == "Internet"
+    insight_types = {item["type"] for item in payload["insights"]}
+    assert {
+        "top_category",
+        "spending_increase",
+        "upcoming_bills",
+        "positive_cash_flow",
+    }.issubset(insight_types)


### PR DESCRIPTION
﻿/claim #121

## Summary
- Adds an authenticated `GET /insights/weekly-summary` endpoint with optional `week_start` and `currency` filters.
- Computes weekly income, expenses, net flow, transaction count, average daily spend, previous-week deltas, daily totals, category shares, upcoming bills, and deterministic smart insights.
- Surfaces the weekly digest in the existing Analytics page using the current API and financial card patterns.
- Updates README and OpenAPI docs.
- Improves backend test isolation with an in-memory Redis double so auth/cache tests run without a live Redis service.

## Demo video
- Short UI proof video: https://github.com/Iineman2/FinMind/releases/download/finmind-weekly-demo-990/page%409ec5c84d33b97902bdbfa254848de533.webm
- Shows the authenticated Analytics weekly digest UI rendering summary cards, top categories, smart signals, currency input, and refresh behavior with controlled local API fixtures.

## Verification
- `cd packages/backend && .\.venv\Scripts\python -m pytest -q` -> `26 passed, 44 warnings`
- `cd packages/backend && .\.venv\Scripts\python -m black --check app tests` -> passed
- `cd packages/backend && .\.venv\Scripts\python -m flake8 app tests` -> passed
- `cd app && npm test -- Analytics.integration.test.tsx --runInBand` -> `2 passed, 1 suite passed`
- `cd app && npm run lint` -> passed
- `cd app && npm run build` -> passed

## Notes
This implementation is deterministic and dependency-free: no scheduler or LLM is required for the digest, so it stays available immediately from the user's existing transaction and bill data.
