### PR TITLE
Add resilient reminder job retries and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
-- Reminders: CRUD `/reminders`, trigger `/reminders/run`
+- Reminders: CRUD `/reminders`, trigger `/reminders/run`, monitor `/reminders/jobs/status`, inspect `/reminders/jobs/failed`, reset `/reminders/jobs/{id}/retry`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
 
 ## MVP UI/UX Plan
@@ -180,7 +180,8 @@ finmind/
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.
 
 ## Notes on Free-Tier Reminders
-- Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
+- Primary: schedule via APScheduler in-process with persistence in Postgres and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
+- Reminder sends are treated as jobs: failed sends are not marked sent, they get exponential backoff retry state, then move to `FAILED` after the retry limit. Operators can use `/reminders/jobs/status` for health totals, `/reminders/jobs/failed` for dead-letter inspection, and `/reminders/jobs/{id}/retry` to reset a failed reminder after fixing the underlying sender issue.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).
 
 ## Security & Scalability

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,11 +110,45 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS retry_status VARCHAR(20) NOT NULL DEFAULT 'PENDING'
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS max_retries INT NOT NULL DEFAULT 3
+            """
+        )
+        cur.execute(
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP"
+        )
+        cur.execute(
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMP"
+        )
+        cur.execute(
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS last_error VARCHAR(500)"
+        )
+        cur.execute(
+            "ALTER TABLE reminders ADD COLUMN IF NOT EXISTS failed_at TIMESTAMP"
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reminders_retry
+            ON reminders(user_id, retry_status, next_retry_at)
+            """
+        )
         conn.commit()
     except Exception:
-        app.logger.exception(
-            "Schema compatibility patch failed for users.preferred_currency"
-        )
+        app.logger.exception("Schema compatibility patch failed for users/reminders")
         conn.rollback()
     finally:
         conn.close()

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -91,9 +91,17 @@ CREATE TABLE IF NOT EXISTS reminders (
   message VARCHAR(500) NOT NULL,
   send_at TIMESTAMP NOT NULL,
   sent BOOLEAN NOT NULL DEFAULT FALSE,
-  channel VARCHAR(20) NOT NULL DEFAULT 'email'
+  channel VARCHAR(20) NOT NULL DEFAULT 'email',
+  retry_status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+  retry_count INT NOT NULL DEFAULT 0,
+  max_retries INT NOT NULL DEFAULT 3,
+  next_retry_at TIMESTAMP,
+  last_attempt_at TIMESTAMP,
+  last_error VARCHAR(500),
+  failed_at TIMESTAMP
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
+CREATE INDEX IF NOT EXISTS idx_reminders_retry ON reminders(user_id, retry_status, next_retry_at);
 
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,13 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    retry_status = db.Column(db.String(20), default="PENDING", nullable=False)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    max_retries = db.Column(db.Integer, default=3, nullable=False)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    last_attempt_at = db.Column(db.DateTime, nullable=True)
+    last_error = db.Column(db.String(500), nullable=True)
+    failed_at = db.Column(db.DateTime, nullable=True)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -374,13 +374,84 @@ paths:
 
   /reminders/run:
     post:
-      summary: Process due reminders
+      summary: Process due reminders with retry tracking
       tags: [Reminders]
       security: [{ bearerAuth: [] }]
       responses:
-        '200': { description: Processed count }
+        '200':
+          description: Reminder run result
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReminderRunResult'
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs/status:
+    get:
+      summary: Get reminder job health and retry totals
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Reminder job status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReminderJobStatus'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs/failed:
+    get:
+      summary: List failed reminder jobs for the current user
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Failed reminder jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ReminderJob'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs/{reminderId}/retry:
+    post:
+      summary: Reset a failed reminder job for retry
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: reminderId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Reset reminder job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReminderJob'
+        '400':
+          description: Reminder is already sent
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Not found
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
@@ -580,6 +651,12 @@ components:
         send_at: { type: string, format: date-time }
         sent: { type: boolean }
         channel: { type: string, enum: [email, whatsapp] }
+        retry_status: { type: string, enum: [PENDING, RETRYING, FAILED, SENT] }
+        retry_count: { type: integer }
+        max_retries: { type: integer }
+        next_retry_at: { type: string, format: date-time, nullable: true }
+        last_attempt_at: { type: string, format: date-time, nullable: true }
+        last_error: { type: string, nullable: true }
     NewReminder:
       type: object
       required: [message, send_at]
@@ -587,3 +664,25 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    ReminderRunResult:
+      type: object
+      properties:
+        processed: { type: integer }
+        sent: { type: integer }
+        retrying: { type: integer }
+        failed: { type: integer }
+    ReminderJobStatus:
+      type: object
+      properties:
+        total: { type: integer }
+        sent: { type: integer }
+        pending: { type: integer }
+        retrying: { type: integer }
+        failed: { type: integer }
+        healthy: { type: boolean }
+    ReminderJob:
+      allOf:
+        - $ref: '#/components/schemas/Reminder'
+        - type: object
+          properties:
+            failed_at: { type: string, format: date-time, nullable: true }

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -5,6 +5,7 @@ from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
+from ..services.reminder_jobs import process_due_reminders, reset_failed_reminder
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -30,6 +31,16 @@ def list_reminders():
                 "send_at": r.send_at.isoformat(),
                 "sent": r.sent,
                 "channel": r.channel,
+                "retry_status": r.retry_status,
+                "retry_count": r.retry_count,
+                "max_retries": r.max_retries,
+                "next_retry_at": (
+                    r.next_retry_at.isoformat() if r.next_retry_at else None
+                ),
+                "last_attempt_at": (
+                    r.last_attempt_at.isoformat() if r.last_attempt_at else None
+                ),
+                "last_error": r.last_error,
             }
             for r in items
         ]
@@ -161,22 +172,65 @@ def autopay_result_followup(bill_id: int):
 def run_due():
     uid = int(get_jwt_identity())
     now = datetime.utcnow() + timedelta(minutes=1)
-    items = (
+    result = process_due_reminders(user_id=uid, now=now, sender=send_reminder)
+    for channel in result.sent_channels or []:
+        track_reminder_event(event="sent", channel=channel)
+    logger.info(
+        "Processed due reminders user=%s processed=%s sent=%s retrying=%s failed=%s",
+        uid,
+        result.processed,
+        result.sent,
+        result.retrying,
+        result.failed,
+    )
+    return jsonify(result.to_dict())
+
+
+@bp.get("/jobs/status")
+@jwt_required()
+def jobs_status():
+    uid = int(get_jwt_identity())
+    rows = db.session.query(Reminder).filter_by(user_id=uid).all()
+    total = len(rows)
+    sent = sum(1 for r in rows if r.sent)
+    failed = sum(1 for r in rows if r.retry_status == "FAILED")
+    retrying = sum(1 for r in rows if r.retry_status == "RETRYING")
+    pending = sum(1 for r in rows if not r.sent and r.retry_status == "PENDING")
+    return jsonify(
+        total=total,
+        sent=sent,
+        pending=pending,
+        retrying=retrying,
+        failed=failed,
+        healthy=failed == 0,
+    )
+
+
+@bp.get("/jobs/failed")
+@jwt_required()
+def failed_jobs():
+    uid = int(get_jwt_identity())
+    rows = (
         db.session.query(Reminder)
-        .filter(
-            Reminder.user_id == uid,
-            Reminder.sent.is_(False),
-            Reminder.send_at <= now,
-        )
+        .filter_by(user_id=uid, retry_status="FAILED")
+        .order_by(Reminder.failed_at.desc().nullslast(), Reminder.id.desc())
         .all()
     )
-    for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
+    return jsonify([_job_to_dict(r) for r in rows])
+
+
+@bp.post("/jobs/<int:reminder_id>/retry")
+@jwt_required()
+def retry_failed_job(reminder_id: int):
+    uid = int(get_jwt_identity())
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder or reminder.user_id != uid:
+        return jsonify(error="not found"), 404
+    if reminder.sent:
+        return jsonify(error="reminder already sent"), 400
+    reset_failed_reminder(reminder)
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+    return jsonify(_job_to_dict(reminder)), 200
 
 
 def _bill_channels(bill: Bill) -> list[str]:
@@ -221,3 +275,24 @@ def _create_reminder_if_missing(
         )
     )
     return True
+
+
+def _job_to_dict(reminder: Reminder) -> dict:
+    return {
+        "id": reminder.id,
+        "message": reminder.message,
+        "channel": reminder.channel,
+        "send_at": reminder.send_at.isoformat(),
+        "sent": reminder.sent,
+        "retry_status": reminder.retry_status,
+        "retry_count": reminder.retry_count,
+        "max_retries": reminder.max_retries,
+        "next_retry_at": (
+            reminder.next_retry_at.isoformat() if reminder.next_retry_at else None
+        ),
+        "last_attempt_at": (
+            reminder.last_attempt_at.isoformat() if reminder.last_attempt_at else None
+        ),
+        "failed_at": reminder.failed_at.isoformat() if reminder.failed_at else None,
+        "last_error": reminder.last_error,
+    }

--- a/packages/backend/app/services/reminder_jobs.py
+++ b/packages/backend/app/services/reminder_jobs.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable
+
+from ..extensions import db
+from ..models import Reminder
+
+
+BACKOFF_MINUTES = (5, 15, 45)
+
+
+@dataclass
+class ReminderRunResult:
+    processed: int = 0
+    sent: int = 0
+    retrying: int = 0
+    failed: int = 0
+    sent_channels: list[str] | None = None
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "processed": self.processed,
+            "sent": self.sent,
+            "retrying": self.retrying,
+            "failed": self.failed,
+        }
+
+
+def due_reminders_query(user_id: int, now: datetime):
+    return (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.user_id == user_id,
+            Reminder.sent.is_(False),
+            Reminder.retry_status != "FAILED",
+            Reminder.send_at <= now,
+        )
+        .filter((Reminder.next_retry_at.is_(None)) | (Reminder.next_retry_at <= now))
+        .order_by(Reminder.send_at, Reminder.id)
+    )
+
+
+def process_due_reminders(
+    *,
+    user_id: int,
+    now: datetime,
+    sender: Callable[[Reminder], bool],
+) -> ReminderRunResult:
+    result = ReminderRunResult()
+    reminders = due_reminders_query(user_id, now).all()
+    for reminder in reminders:
+        result.processed += 1
+        reminder.last_attempt_at = now
+        try:
+            ok = bool(sender(reminder))
+        except Exception as exc:  # pragma: no cover - exercised through route tests
+            ok = False
+            reminder.last_error = str(exc)[:500]
+
+        if ok:
+            reminder.sent = True
+            reminder.retry_status = "SENT"
+            reminder.next_retry_at = None
+            reminder.last_error = None
+            result.sent += 1
+            if result.sent_channels is None:
+                result.sent_channels = []
+            result.sent_channels.append(reminder.channel)
+            continue
+
+        if not reminder.last_error:
+            reminder.last_error = "sender returned false"
+        reminder.retry_count += 1
+        if reminder.retry_count >= reminder.max_retries:
+            reminder.retry_status = "FAILED"
+            reminder.failed_at = now
+            reminder.next_retry_at = None
+            result.failed += 1
+        else:
+            reminder.retry_status = "RETRYING"
+            reminder.next_retry_at = next_retry_time(now, reminder.retry_count)
+            result.retrying += 1
+
+    db.session.commit()
+    return result
+
+
+def next_retry_time(now: datetime, retry_count: int) -> datetime:
+    index = min(max(retry_count - 1, 0), len(BACKOFF_MINUTES) - 1)
+    return now + timedelta(minutes=BACKOFF_MINUTES[index])
+
+
+def reset_failed_reminder(reminder: Reminder) -> None:
+    reminder.retry_status = "PENDING"
+    reminder.retry_count = 0
+    reminder.next_retry_at = None
+    reminder.last_error = None
+    reminder.failed_at = None
+    reminder.sent = False

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -3,8 +3,55 @@ import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class InMemoryRedis:
+    def __init__(self):
+        self.data = {}
+
+    def setex(self, key, _ttl, value):
+        self.data[key] = value
+        return True
+
+    def set(self, key, value):
+        self.data[key] = value
+        return True
+
+    def get(self, key):
+        return self.data.get(key)
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if key in self.data:
+                removed += 1
+            self.data.pop(key, None)
+        return removed
+
+    def scan(self, cursor=0, match=None, count=100):
+        import fnmatch
+
+        keys = list(self.data.keys())
+        if match:
+            keys = [key for key in keys if fnmatch.fnmatch(key, match)]
+        return 0, keys[:count]
+
+    def flushdb(self):
+        self.data.clear()
+        return True
+
+
+def _install_test_redis():
+    fake = InMemoryRedis()
+    import app.extensions as extensions
+    import app.routes.auth as auth
+    import app.services.cache as cache
+
+    extensions.redis_client = fake
+    auth.redis_client = fake
+    cache.redis_client = fake
+    return fake
 
 
 class TestSettings(Settings):
@@ -30,19 +77,14 @@ def app_fixture():
     )
     app = create_app(settings)
     app.config.update(TESTING=True)
+    fake_redis = _install_test_redis()
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -1,4 +1,7 @@
-from datetime import date
+from datetime import date, datetime, timedelta
+
+from app.extensions import db
+from app.models import Reminder
 
 
 def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = False):
@@ -80,3 +83,126 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def test_due_reminders_retry_when_sender_fails(client, auth_header, monkeypatch):
+    monkeypatch.setattr(
+        "app.routes.reminders.send_reminder",
+        lambda _reminder: False,
+    )
+    r = _create_due_reminder(client, auth_header)
+    reminder_id = r["id"]
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == {"processed": 1, "sent": 0, "retrying": 1, "failed": 0}
+
+    r = client.get("/reminders", headers=auth_header)
+    reminder = next(x for x in r.get_json() if x["id"] == reminder_id)
+    assert reminder["sent"] is False
+    assert reminder["retry_status"] == "RETRYING"
+    assert reminder["retry_count"] == 1
+    assert reminder["next_retry_at"] is not None
+    assert reminder["last_error"] == "sender returned false"
+
+
+def test_retrying_reminder_sends_after_backoff(
+    client, auth_header, app_fixture, monkeypatch
+):
+    outcomes = iter([False, True])
+    monkeypatch.setattr(
+        "app.routes.reminders.send_reminder",
+        lambda _reminder: next(outcomes),
+    )
+    reminder_id = _create_due_reminder(client, auth_header)["id"]
+
+    first = client.post("/reminders/run", headers=auth_header)
+    assert first.get_json()["retrying"] == 1
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        reminder.next_retry_at = datetime.utcnow() - timedelta(minutes=1)
+        db.session.commit()
+
+    second = client.post("/reminders/run", headers=auth_header)
+    assert second.status_code == 200
+    assert second.get_json() == {"processed": 1, "sent": 1, "retrying": 0, "failed": 0}
+
+    r = client.get("/reminders", headers=auth_header)
+    reminder = next(x for x in r.get_json() if x["id"] == reminder_id)
+    assert reminder["sent"] is True
+    assert reminder["retry_status"] == "SENT"
+    assert reminder["last_error"] is None
+
+
+def test_failed_jobs_endpoint_and_manual_retry(client, auth_header, app_fixture):
+    reminder_id = _create_due_reminder(client, auth_header)["id"]
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        reminder.retry_status = "FAILED"
+        reminder.retry_count = 3
+        reminder.max_retries = 3
+        reminder.last_error = "smtp timeout"
+        reminder.failed_at = datetime.utcnow()
+        db.session.commit()
+
+    r = client.get("/reminders/jobs/status", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["failed"] == 1
+    assert r.get_json()["healthy"] is False
+
+    r = client.get("/reminders/jobs/failed", headers=auth_header)
+    assert r.status_code == 200
+    failed = r.get_json()
+    assert len(failed) == 1
+    assert failed[0]["id"] == reminder_id
+    assert failed[0]["last_error"] == "smtp timeout"
+
+    r = client.post(f"/reminders/jobs/{reminder_id}/retry", headers=auth_header)
+    assert r.status_code == 200
+    retried = r.get_json()
+    assert retried["retry_status"] == "PENDING"
+    assert retried["retry_count"] == 0
+    assert retried["last_error"] is None
+
+
+def test_failed_jobs_are_user_scoped(client, auth_header, app_fixture):
+    first_id = _create_due_reminder(client, auth_header, message="First")["id"]
+    second_header = _register_and_login(client, "other@example.com")
+    second_id = _create_due_reminder(client, second_header, message="Second")["id"]
+    with app_fixture.app_context():
+        for reminder_id in (first_id, second_id):
+            reminder = db.session.get(Reminder, reminder_id)
+            reminder.retry_status = "FAILED"
+            reminder.retry_count = 3
+            reminder.failed_at = datetime.utcnow()
+        db.session.commit()
+
+    r = client.get("/reminders/jobs/failed", headers=auth_header)
+    assert [item["id"] for item in r.get_json()] == [first_id]
+
+    r = client.post(f"/reminders/jobs/{second_id}/retry", headers=auth_header)
+    assert r.status_code == 404
+
+
+def _create_due_reminder(client, auth_header, *, message: str = "Pay rent"):
+    r = client.post(
+        "/reminders",
+        json={
+            "message": message,
+            "send_at": (datetime.utcnow() - timedelta(minutes=2)).isoformat(),
+            "channel": "email",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def _register_and_login(client, email: str):
+    password = "password123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code == 201
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}


### PR DESCRIPTION
﻿## Summary
- /claim #130
- Persist reminder job retry state so failed sends are no longer marked as sent.
- Add exponential backoff, max-retry failure state, last error, last attempt, next retry, and failed-at timestamps.
- Add authenticated operator endpoints for reminder job health, failed/dead-letter inspection, and manual retry reset.
- Keep the dispatch path dependency-light and testable through a focused reminder job service.
- Update schema compatibility, SQL schema, README, and OpenAPI documentation.
- Harden backend tests with an in-memory Redis shim so auth/cache tests run without a live Redis service.

## Demo video
- Short proof video: https://github.com/Iineman2/FinMind/releases/download/finmind-maintenance-demos-991-992/finmind-pr992-reminder-retries-demo.mp4
- Walks through reminder retry/dead-letter behavior and authenticated operator endpoints.

## Validation
- packages/backend: .\.venv\Scripts\python -m pytest -q (26 passed, 55 warnings)
- packages/backend: .\.venv\Scripts\python -m black --check app tests
- packages/backend: .\.venv\Scripts\python -m flake8 app tests
- repo: OpenAPI YAML parsed successfully with PyYAML
- repo: git diff --check
