### PR TITLE
Add weekly financial summary digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,15 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`,
+  `/insights/weekly-summary`
+
+### Weekly Financial Digest
+- `GET /insights/weekly-summary?week_start=YYYY-MM-DD`
+- Returns a seven-day summary with income, expenses, net flow, prior-week
+  comparisons, daily totals, category breakdown, largest expenses, highlights,
+  structured insights, and recommendations.
+- If `week_start` is omitted, the backend uses the Monday of the current week.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,64 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklySummary = {
+  period: {
+    week_start: string;
+    week_end: string;
+    previous_week_start: string;
+    previous_week_end: string;
+  };
+  summary: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+    income_transaction_count: number;
+    expense_transaction_count: number;
+    savings_rate_pct: number;
+  };
+  comparison: {
+    previous_income: number;
+    previous_expenses: number;
+    previous_net_flow: number;
+    income_change_pct: number;
+    expense_change_pct: number;
+    net_flow_change: number;
+  };
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    transaction_count: number;
+    share_pct: number;
+  }>;
+  daily_breakdown: Array<{
+    date: string;
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+  }>;
+  largest_expenses: Array<{
+    id: number;
+    description: string;
+    amount: number;
+    currency: string;
+    date: string;
+    category_id: number | null;
+    category_name: string;
+  }>;
+  highlights: string[];
+  insights: Array<{
+    type: string;
+    severity: string;
+    title: string;
+    detail: string;
+  }>;
+  recommendations: string[];
+  method: 'heuristic' | string;
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +89,13 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklySummary(params?: {
+  weekStart?: string;
+}): Promise<WeeklySummary> {
+  const query = params?.weekStart
+    ? `?week_start=${encodeURIComponent(params.weekStart)}`
+    : '';
+  return api<WeeklySummary>(`/insights/weekly-summary${query}`);
 }

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,66 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/weekly-summary:
+    get:
+      summary: Get weekly financial digest
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          description: Inclusive first day of the seven-day digest window.
+          schema: { type: string, format: date }
+      responses:
+        '200':
+          description: Weekly summary with trends and recommendations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklySummary'
+              example:
+                period:
+                  week_start: 2026-05-04
+                  week_end: 2026-05-10
+                  previous_week_start: 2026-04-27
+                  previous_week_end: 2026-05-03
+                summary:
+                  income: 1000
+                  expenses: 350
+                  net_flow: 650
+                  transaction_count: 3
+                  income_transaction_count: 1
+                  expense_transaction_count: 2
+                  savings_rate_pct: 65
+                comparison:
+                  previous_income: 1000
+                  previous_expenses: 200
+                  previous_net_flow: 800
+                  income_change_pct: 0
+                  expense_change_pct: 75
+                  net_flow_change: -150
+                highlights:
+                  - Weekly net flow was 650.0 from 1000.0 income and 350.0 expenses.
+                insights:
+                  - type: cash_flow
+                    severity: positive
+                    title: Positive weekly cash flow
+                    detail: Income exceeded expenses by 650.0.
+                recommendations:
+                  - Move part of the weekly surplus to savings.
+                method: heuristic
+        '400':
+          description: Invalid week_start
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -587,3 +647,76 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    WeeklySummary:
+      type: object
+      properties:
+        period:
+          type: object
+          properties:
+            week_start: { type: string, format: date }
+            week_end: { type: string, format: date }
+            previous_week_start: { type: string, format: date }
+            previous_week_end: { type: string, format: date }
+        summary:
+          type: object
+          properties:
+            income: { type: number, format: float }
+            expenses: { type: number, format: float }
+            net_flow: { type: number, format: float }
+            transaction_count: { type: integer }
+            income_transaction_count: { type: integer }
+            expense_transaction_count: { type: integer }
+            savings_rate_pct: { type: number, format: float }
+        comparison:
+          type: object
+          properties:
+            previous_income: { type: number, format: float }
+            previous_expenses: { type: number, format: float }
+            previous_net_flow: { type: number, format: float }
+            income_change_pct: { type: number, format: float }
+            expense_change_pct: { type: number, format: float }
+            net_flow_change: { type: number, format: float }
+        category_breakdown:
+          type: array
+          items:
+            type: object
+            properties:
+              category_id: { type: integer, nullable: true }
+              category_name: { type: string }
+              amount: { type: number, format: float }
+              transaction_count: { type: integer }
+              share_pct: { type: number, format: float }
+        daily_breakdown:
+          type: array
+          items:
+            type: object
+            properties:
+              date: { type: string, format: date }
+              income: { type: number, format: float }
+              expenses: { type: number, format: float }
+              net_flow: { type: number, format: float }
+              transaction_count: { type: integer }
+        largest_expenses:
+          type: array
+          items:
+            type: object
+            properties:
+              id: { type: integer }
+              description: { type: string }
+              amount: { type: number, format: float }
+              currency: { type: string }
+              date: { type: string, format: date }
+              category_id: { type: integer, nullable: true }
+              category_name: { type: string }
+        highlights:
+          type: array
+          items: { type: string }
+        insights:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        recommendations:
+          type: array
+          items: { type: string }
+        method: { type: string }

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,7 +1,7 @@
 from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from ..services.ai import monthly_budget_suggestion
+from ..services.ai import monthly_budget_suggestion, weekly_financial_summary
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +23,20 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    raw_week_start = (request.args.get("week_start") or "").strip() or None
+    try:
+        summary = weekly_financial_summary(uid, raw_week_start)
+    except ValueError:
+        return jsonify(error="invalid week_start, expected YYYY-MM-DD"), 400
+    logger.info(
+        "Weekly financial summary served user=%s week_start=%s",
+        uid,
+        summary["period"]["week_start"],
+    )
+    return jsonify(summary)

--- a/packages/backend/app/services/ai.py
+++ b/packages/backend/app/services/ai.py
@@ -1,11 +1,12 @@
 import json
+from datetime import date, timedelta
 from urllib import request
 
 from sqlalchemy import extract, func
 
 from ..config import Settings
 from ..extensions import db
-from ..models import Expense
+from ..models import Category, Expense
 
 _settings = Settings()
 DEFAULT_PERSONA = (
@@ -62,6 +63,313 @@ def _previous_month(ym: str) -> str:
     if month == 1:
         return f"{year - 1:04d}-12"
     return f"{year:04d}-{month - 1:02d}"
+
+
+def _round_money(value: float) -> float:
+    return round(float(value or 0), 2)
+
+
+def _pct_change(current: float, previous: float) -> float:
+    if previous == 0:
+        return 0.0 if current == 0 else 100.0
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def _parse_week_start(week_start: str | None) -> date:
+    if not week_start:
+        today = date.today()
+        return today - timedelta(days=today.weekday())
+    return date.fromisoformat(week_start)
+
+
+def _weekly_rows(uid: int, start: date, end: date) -> list[Expense]:
+    return (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .order_by(Expense.spent_at.asc(), Expense.id.asc())
+        .all()
+    )
+
+
+def _category_names(uid: int) -> dict[int, str]:
+    rows = db.session.query(Category.id, Category.name).filter_by(user_id=uid).all()
+    return {int(category_id): name for category_id, name in rows}
+
+
+def _sum_rows(rows: list[Expense]) -> tuple[float, float]:
+    income = 0.0
+    expenses = 0.0
+    for row in rows:
+        amount = float(row.amount or 0)
+        if row.expense_type == "INCOME":
+            income += amount
+        else:
+            expenses += amount
+    return income, expenses
+
+
+def _daily_breakdown(rows: list[Expense], start: date) -> list[dict]:
+    daily = {
+        start
+        + timedelta(days=offset): {
+            "date": (start + timedelta(days=offset)).isoformat(),
+            "income": 0.0,
+            "expenses": 0.0,
+            "net_flow": 0.0,
+            "transaction_count": 0,
+        }
+        for offset in range(7)
+    }
+    for row in rows:
+        day = daily[row.spent_at]
+        amount = float(row.amount or 0)
+        if row.expense_type == "INCOME":
+            day["income"] += amount
+        else:
+            day["expenses"] += amount
+        day["transaction_count"] += 1
+        day["net_flow"] = day["income"] - day["expenses"]
+
+    return [
+        {
+            **values,
+            "income": _round_money(values["income"]),
+            "expenses": _round_money(values["expenses"]),
+            "net_flow": _round_money(values["net_flow"]),
+        }
+        for values in daily.values()
+    ]
+
+
+def _category_breakdown(
+    rows: list[Expense], category_names: dict[int, str], total_expenses: float
+) -> list[dict]:
+    totals: dict[str, dict] = {}
+    for row in rows:
+        if row.expense_type == "INCOME":
+            continue
+        key = str(row.category_id or "uncategorized")
+        label = category_names.get(row.category_id, "Uncategorized")
+        item = totals.setdefault(
+            key,
+            {
+                "category_id": row.category_id,
+                "category_name": label,
+                "amount": 0.0,
+                "transaction_count": 0,
+                "share_pct": 0.0,
+            },
+        )
+        item["amount"] += float(row.amount or 0)
+        item["transaction_count"] += 1
+
+    breakdown = []
+    for item in totals.values():
+        amount = _round_money(item["amount"])
+        item["amount"] = amount
+        item["share_pct"] = (
+            round((amount / total_expenses) * 100, 2) if total_expenses > 0 else 0.0
+        )
+        breakdown.append(item)
+    return sorted(breakdown, key=lambda item: item["amount"], reverse=True)
+
+
+def _largest_expenses(
+    rows: list[Expense], category_names: dict[int, str], limit: int = 5
+) -> list[dict]:
+    expense_rows = [row for row in rows if row.expense_type != "INCOME"]
+    top_rows = sorted(
+        expense_rows, key=lambda row: float(row.amount or 0), reverse=True
+    )
+    return [
+        {
+            "id": row.id,
+            "description": row.notes or "Transaction",
+            "amount": _round_money(float(row.amount or 0)),
+            "currency": row.currency,
+            "date": row.spent_at.isoformat(),
+            "category_id": row.category_id,
+            "category_name": category_names.get(row.category_id, "Uncategorized"),
+        }
+        for row in top_rows[:limit]
+    ]
+
+
+def _build_weekly_narrative(
+    current_income: float,
+    current_expenses: float,
+    previous_expenses: float,
+    category_breakdown: list[dict],
+    daily_breakdown: list[dict],
+    transaction_count: int,
+) -> tuple[list[str], list[dict], list[str]]:
+    net_flow = current_income - current_expenses
+    highlights: list[str] = []
+    insights: list[dict] = []
+    recommendations: list[str] = []
+
+    if transaction_count == 0:
+        highlights.append("No transactions were recorded for this week.")
+        insights.append(
+            {
+                "type": "activity",
+                "severity": "info",
+                "title": "No weekly activity",
+                "detail": "Add income and expense transactions to generate trends.",
+            }
+        )
+        recommendations.append("Log this week's transactions to unlock the digest.")
+        return highlights, insights, recommendations
+
+    highlights.append(
+        "Weekly net flow was "
+        f"{_round_money(net_flow)} from {_round_money(current_income)} income and "
+        f"{_round_money(current_expenses)} expenses."
+    )
+
+    expense_change = _pct_change(current_expenses, previous_expenses)
+    if previous_expenses > 0:
+        direction = "higher" if expense_change >= 0 else "lower"
+        highlights.append(
+            f"Expenses were {abs(expense_change):.2f}% {direction} than last week."
+        )
+
+    if net_flow < 0:
+        insights.append(
+            {
+                "type": "cash_flow",
+                "severity": "warning",
+                "title": "Negative weekly cash flow",
+                "detail": (
+                    "Expenses exceeded income by "
+                    f"{_round_money(abs(net_flow))} this week."
+                ),
+            }
+        )
+        recommendations.append("Review discretionary purchases before next week.")
+    else:
+        insights.append(
+            {
+                "type": "cash_flow",
+                "severity": "positive",
+                "title": "Positive weekly cash flow",
+                "detail": f"Income exceeded expenses by {_round_money(net_flow)}.",
+            }
+        )
+        recommendations.append("Move part of the weekly surplus to savings.")
+
+    if category_breakdown:
+        top_category = category_breakdown[0]
+        insights.append(
+            {
+                "type": "category",
+                "severity": "info",
+                "title": f"{top_category['category_name']} led spending",
+                "detail": (
+                    f"{top_category['category_name']} represented "
+                    f"{top_category['share_pct']:.2f}% of weekly expenses."
+                ),
+            }
+        )
+        if top_category["share_pct"] >= 40:
+            recommendations.append(
+                f"Set a cap for {top_category['category_name']} next week."
+            )
+
+    expense_days = [day for day in daily_breakdown if day["expenses"] > 0]
+    if expense_days:
+        busiest_day = max(expense_days, key=lambda day: day["expenses"])
+        share = (
+            round((busiest_day["expenses"] / current_expenses) * 100, 2)
+            if current_expenses > 0
+            else 0.0
+        )
+        insights.append(
+            {
+                "type": "daily_trend",
+                "severity": "info",
+                "title": "Highest spend day",
+                "detail": (
+                    f"{busiest_day['date']} accounted for {share:.2f}% "
+                    "of weekly expenses."
+                ),
+            }
+        )
+
+    if current_income == 0 and current_expenses > 0:
+        recommendations.append("Record income deposits to track true cash flow.")
+
+    return highlights, insights, recommendations
+
+
+def weekly_financial_summary(uid: int, week_start: str | None = None) -> dict:
+    start = _parse_week_start(week_start)
+    end = start + timedelta(days=6)
+    previous_start = start - timedelta(days=7)
+    previous_end = start - timedelta(days=1)
+
+    rows = _weekly_rows(uid, start, end)
+    previous_rows = _weekly_rows(uid, previous_start, previous_end)
+    category_names = _category_names(uid)
+
+    current_income, current_expenses = _sum_rows(rows)
+    previous_income, previous_expenses = _sum_rows(previous_rows)
+    net_flow = current_income - current_expenses
+    previous_net_flow = previous_income - previous_expenses
+
+    daily = _daily_breakdown(rows, start)
+    categories = _category_breakdown(rows, category_names, current_expenses)
+    highlights, insights, recommendations = _build_weekly_narrative(
+        current_income,
+        current_expenses,
+        previous_expenses,
+        categories,
+        daily,
+        len(rows),
+    )
+
+    income_count = len([row for row in rows if row.expense_type == "INCOME"])
+    expense_count = len(rows) - income_count
+    savings_rate = (
+        round((net_flow / current_income) * 100, 2) if current_income > 0 else 0.0
+    )
+
+    return {
+        "period": {
+            "week_start": start.isoformat(),
+            "week_end": end.isoformat(),
+            "previous_week_start": previous_start.isoformat(),
+            "previous_week_end": previous_end.isoformat(),
+        },
+        "summary": {
+            "income": _round_money(current_income),
+            "expenses": _round_money(current_expenses),
+            "net_flow": _round_money(net_flow),
+            "transaction_count": len(rows),
+            "income_transaction_count": income_count,
+            "expense_transaction_count": expense_count,
+            "savings_rate_pct": savings_rate,
+        },
+        "comparison": {
+            "previous_income": _round_money(previous_income),
+            "previous_expenses": _round_money(previous_expenses),
+            "previous_net_flow": _round_money(previous_net_flow),
+            "income_change_pct": _pct_change(current_income, previous_income),
+            "expense_change_pct": _pct_change(current_expenses, previous_expenses),
+            "net_flow_change": _round_money(net_flow - previous_net_flow),
+        },
+        "category_breakdown": categories,
+        "daily_breakdown": daily,
+        "largest_expenses": _largest_expenses(rows, category_names),
+        "highlights": highlights,
+        "insights": insights,
+        "recommendations": recommendations,
+        "method": "heuristic",
+    }
 
 
 def _build_analytics(uid: int, ym: str) -> dict:

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,6 +1,124 @@
 from datetime import date, timedelta
 
 
+def _create_category(client, auth_header, name: str) -> int:
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+def _create_transaction(
+    client,
+    auth_header,
+    amount: float,
+    description: str,
+    spent_at: date,
+    expense_type: str = "EXPENSE",
+    category_id: int | None = None,
+):
+    payload = {
+        "amount": amount,
+        "description": description,
+        "date": spent_at.isoformat(),
+        "expense_type": expense_type,
+    }
+    if category_id is not None:
+        payload["category_id"] = category_id
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def test_weekly_summary_returns_digest_trends_and_breakdowns(client, auth_header):
+    week_start = date(2026, 5, 4)
+    previous_week_start = week_start - timedelta(days=7)
+    groceries = _create_category(client, auth_header, "Groceries")
+    travel = _create_category(client, auth_header, "Travel")
+
+    _create_transaction(
+        client,
+        auth_header,
+        1000,
+        "Paycheck",
+        week_start,
+        expense_type="INCOME",
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        250,
+        "Weekly groceries",
+        week_start + timedelta(days=1),
+        category_id=groceries,
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        100,
+        "Transit pass",
+        week_start + timedelta(days=2),
+        category_id=travel,
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        200,
+        "Previous week groceries",
+        previous_week_start + timedelta(days=1),
+        category_id=groceries,
+    )
+
+    r = client.get(
+        f"/insights/weekly-summary?week_start={week_start.isoformat()}",
+        headers=auth_header,
+    )
+
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period"]["week_start"] == "2026-05-04"
+    assert payload["period"]["week_end"] == "2026-05-10"
+    assert payload["summary"]["income"] == 1000.0
+    assert payload["summary"]["expenses"] == 350.0
+    assert payload["summary"]["net_flow"] == 650.0
+    assert payload["summary"]["transaction_count"] == 3
+    assert payload["comparison"]["previous_expenses"] == 200.0
+    assert payload["comparison"]["expense_change_pct"] == 75.0
+    assert len(payload["daily_breakdown"]) == 7
+    assert payload["daily_breakdown"][1]["expenses"] == 250.0
+    assert payload["category_breakdown"][0]["category_name"] == "Groceries"
+    assert payload["category_breakdown"][0]["amount"] == 250.0
+    assert payload["largest_expenses"][0]["description"] == "Weekly groceries"
+    assert payload["highlights"]
+    assert payload["insights"]
+    assert payload["recommendations"]
+    assert payload["method"] == "heuristic"
+
+
+def test_weekly_summary_empty_week_returns_zero_activity_digest(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-04",
+        headers=auth_header,
+    )
+
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["summary"]["transaction_count"] == 0
+    assert payload["summary"]["income"] == 0.0
+    assert payload["summary"]["expenses"] == 0.0
+    assert payload["category_breakdown"] == []
+    assert payload["largest_expenses"] == []
+    assert payload["insights"][0]["type"] == "activity"
+
+
+def test_weekly_summary_rejects_invalid_week_start(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-99-99", headers=auth_header
+    )
+
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid week_start, expected YYYY-MM-DD"
+
+
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
     previous = (current.replace(day=1) - timedelta(days=1)).replace(day=10)


### PR DESCRIPTION
/claim #121

## Summary
- Add `GET /insights/weekly-summary` for a seven-day financial digest.
- Include income, expenses, net flow, previous-week comparison, daily totals, category breakdown, largest expenses, highlights, insights, and recommendations.
- Add typed frontend API helper plus OpenAPI and README documentation.

Closes #121.

## Demo / proof
The endpoint returns a structured weekly digest with:
- `period`, `summary`, `comparison`, `category_breakdown`, `daily_breakdown`, `largest_expenses`, `highlights`, `insights`, and `recommendations`.
- Focused test fixture covers income, expenses, previous-week comparison, daily/category breakdown, empty-state handling, and invalid `week_start` validation.

## Test plan
- `python -m black --check packages/backend/app/services/ai.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py`
- `python -m pyflakes packages/backend/app/services/ai.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py`
- `python -m pycodestyle --max-line-length=88 --ignore=E203,W503 packages/backend/app/services/ai.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py`
- `python -m pytest -q tests/test_insights.py` with Redis stub for local focused verification: 6 passed
- `npm ci && npm run build`