### PR TITLE
feat: API response compression & payload optimization

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -52,6 +52,10 @@ def create_app(settings: Settings | None = None) -> Flask:
     # Blueprint routes
     register_routes(app)
 
+    # Response compression
+    from .middleware.compression import init_compression
+    init_compression(app)
+
     # Backward-compatible schema patch for existing databases.
     with app.app_context():
         _ensure_schema_compatibility(app)

--- a/packages/backend/app/middleware/compression.py
+++ b/packages/backend/app/middleware/compression.py
@@ -1,0 +1,47 @@
+"""API response compression and payload optimization middleware."""
+
+import gzip
+from flask import Flask, request
+
+
+def init_compression(app: Flask, min_size: int = 500):
+    """Add gzip compression to responses larger than min_size bytes.
+
+    Compresses JSON responses when client sends Accept-Encoding: gzip.
+    """
+
+    @app.after_request
+    def compress_response(response):
+        # Skip if client doesn't accept gzip
+        if "gzip" not in request.headers.get("Accept-Encoding", ""):
+            return response
+
+        # Skip small responses
+        if response.content_length and response.content_length < min_size:
+            return response
+
+        # Skip non-JSON or already encoded
+        if (
+            response.status_code < 200
+            or response.status_code >= 300
+            or "Content-Encoding" in response.headers
+            or not response.content_type.startswith("application/json")
+        ):
+            return response
+
+        data = response.get_data()
+        if len(data) < min_size:
+            return response
+
+        compressed = gzip.compress(data, compresslevel=6)
+
+        # Only use compression if it actually reduces size
+        if len(compressed) >= len(data):
+            return response
+
+        response.set_data(compressed)
+        response.headers["Content-Encoding"] = "gzip"
+        response.headers["Content-Length"] = len(compressed)
+        response.headers["Vary"] = "Accept-Encoding"
+
+        return response

--- a/packages/backend/tests/test_compression.py
+++ b/packages/backend/tests/test_compression.py
@@ -1,0 +1,33 @@
+"""Tests for API response compression."""
+
+
+def test_compression_with_gzip_header(client):
+    """Large JSON responses should be compressed when client accepts gzip."""
+    email = "compress@test.com"
+    password = "secret123"
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    token = r.get_json()["access_token"]
+
+    # Request with gzip accept header
+    r = client.get(
+        "/expenses/",
+        headers={"Authorization": f"Bearer {token}", "Accept-Encoding": "gzip"},
+    )
+    assert r.status_code == 200
+
+
+def test_no_compression_without_header(client):
+    """Responses should not be compressed without Accept-Encoding: gzip."""
+    email = "nocompress@test.com"
+    password = "secret123"
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    token = r.get_json()["access_token"]
+
+    r = client.get(
+        "/expenses/",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    assert "Content-Encoding" not in r.headers


### PR DESCRIPTION
Adds gzip compression middleware for JSON responses.

- Compresses responses > 500 bytes when client accepts gzip
- Adds Vary: Accept-Encoding for CDN compatibility
- Tests included

Closes #129