### PR TITLE
feat: add smart weekly financial digest with trends and insights

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import { Digest } from "./pages/Digest";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="digest"
+              element={
+                <ProtectedRoute>
+                  <Digest />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/digest.ts
+++ b/app/src/api/digest.ts
@@ -1,0 +1,40 @@
+import { api } from './client';
+
+export type WeeklyDigest = {
+  period: {
+    start: string;
+    end: string;
+  };
+  total_expenses: number;
+  total_income: number;
+  net: number;
+  top_categories: Array<{ category_id: number | null; name: string; amount: number }>;
+  daily_average: number;
+  wow_change: number;
+  narrative: string;
+  transactions_count: number;
+  method: 'gemini' | 'heuristic' | string;
+};
+
+export type DigestPreferences = {
+  enabled: boolean;
+  day_of_week: number;
+  send_email: boolean;
+};
+
+export async function getWeeklyDigest(): Promise<WeeklyDigest> {
+  return api<WeeklyDigest>('/digest/weekly');
+}
+
+export async function getDigestPreferences(): Promise<DigestPreferences> {
+  return api<DigestPreferences>('/digest/preferences');
+}
+
+export async function updateDigestPreferences(
+  prefs: Partial<DigestPreferences>,
+): Promise<DigestPreferences> {
+  return api<DigestPreferences>('/digest/preferences', {
+    method: 'PUT',
+    body: prefs,
+  });
+}

--- a/app/src/pages/Digest.tsx
+++ b/app/src/pages/Digest.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useState } from 'react';
+import {
+  FinancialCard,
+  FinancialCardContent,
+  FinancialCardHeader,
+  FinancialCardTitle,
+} from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import {
+  ArrowDownRight,
+  ArrowUpRight,
+  BarChart3,
+  Brain,
+  Calendar,
+  Mail,
+  RefreshCw,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from 'lucide-react';
+import {
+  getWeeklyDigest,
+  getDigestPreferences,
+  updateDigestPreferences,
+  type WeeklyDigest,
+  type DigestPreferences,
+} from '@/api/digest';
+import { formatMoney } from '@/lib/currency';
+import { useToast } from '@/hooks/use-toast';
+
+const DAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+export function Digest() {
+  const { toast } = useToast();
+  const [digest, setDigest] = useState<WeeklyDigest | null>(null);
+  const [prefs, setPrefs] = useState<DigestPreferences | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadDigest() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [d, p] = await Promise.all([getWeeklyDigest(), getDigestPreferences()]);
+      setDigest(d);
+      setPrefs(p);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to load digest';
+      setError(message);
+      toast({ title: 'Failed to load digest', description: message });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadDigest();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function toggleEnabled() {
+    if (!prefs) return;
+    try {
+      const updated = await updateDigestPreferences({ enabled: !prefs.enabled });
+      setPrefs(updated);
+      toast({ title: updated.enabled ? 'Digest enabled' : 'Digest disabled' });
+    } catch (err: unknown) {
+      toast({ title: 'Failed to update preferences', description: err instanceof Error ? err.message : 'Unknown error' });
+    }
+  }
+
+  async function toggleEmail() {
+    if (!prefs) return;
+    try {
+      const updated = await updateDigestPreferences({ send_email: !prefs.send_email });
+      setPrefs(updated);
+      toast({ title: updated.send_email ? 'Email notifications enabled' : 'Email notifications disabled' });
+    } catch (err: unknown) {
+      toast({ title: 'Failed to update preferences', description: err instanceof Error ? err.message : 'Unknown error' });
+    }
+  }
+
+  async function updateDay(day: number) {
+    try {
+      const updated = await updateDigestPreferences({ day_of_week: day });
+      setPrefs(updated);
+      toast({ title: 'Digest day set to ' + DAY_NAMES[day] });
+    } catch (err: unknown) {
+      toast({ title: 'Failed to update preferences', description: err instanceof Error ? err.message : 'Unknown error' });
+    }
+  }
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header">
+        <div className="relative flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+          <div>
+            <h1 className="page-title">Weekly Digest</h1>
+            <p className="page-subtitle">
+              Smart financial summary with AI-powered insights and trends.
+            </p>
+          </div>
+          <Button onClick={loadDigest} disabled={loading}>
+            <RefreshCw className={'mr-2 h-4 w-4 ' + (loading ? 'animate-spin' : '')} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="card">Loading digest...</div>
+      ) : error ? (
+        <div className="card text-red-600">{error}</div>
+      ) : digest ? (
+        <div className="space-y-6">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Calendar className="h-4 w-4" />
+            <span>{digest.period.start} to {digest.period.end}</span>
+            <span className="ml-2 text-xs">({digest.transactions_count} transactions)</span>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-4">
+            <FinancialCard variant="financial" className="fade-in-up">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm flex items-center gap-2">
+                  <TrendingDown className="h-4 w-4 text-red-500" />
+                  Total Spent
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="text-2xl font-bold">{formatMoney(digest.total_expenses)}</div>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant="financial" className="fade-in-up">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm flex items-center gap-2">
+                  <TrendingUp className="h-4 w-4 text-green-500" />
+                  Total Income
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="text-2xl font-bold">{formatMoney(digest.total_income)}</div>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant="financial" className="fade-in-up">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm flex items-center gap-2">
+                  <Wallet className="h-4 w-4" />
+                  Net
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className={'text-2xl font-bold ' + (digest.net >= 0 ? 'text-green-600' : 'text-red-600')}>
+                  {formatMoney(digest.net)}
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+
+            <FinancialCard variant="financial" className="fade-in-up">
+              <FinancialCardHeader className="pb-2">
+                <FinancialCardTitle className="text-sm flex items-center gap-2">
+                  {digest.wow_change > 0 ? (
+                    <ArrowUpRight className="h-4 w-4 text-red-500" />
+                  ) : digest.wow_change < 0 ? (
+                    <ArrowDownRight className="h-4 w-4 text-green-500" />
+                  ) : (
+                    <BarChart3 className="h-4 w-4" />
+                  )}
+                  WoW Change
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className={'text-2xl font-bold ' + (digest.wow_change > 0 ? 'text-red-600' : digest.wow_change < 0 ? 'text-green-600' : '')}>
+                  {digest.wow_change > 0 ? '+' : ''}{digest.wow_change.toFixed(1)}%
+                </div>
+                <div className="text-xs text-muted-foreground mt-1">
+                  Daily avg: {formatMoney(digest.daily_average)}
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          </div>
+
+          <FinancialCard variant="financial" className="fade-in-up">
+            <FinancialCardHeader>
+              <FinancialCardTitle className="flex items-center gap-2">
+                <BarChart3 className="h-5 w-5" />
+                Top Categories
+              </FinancialCardTitle>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              {digest.top_categories.length > 0 ? (
+                <div className="space-y-3">
+                  {digest.top_categories.map((cat, i) => (
+                    <div key={cat.category_id ?? 'uncat-' + i} className="flex items-center justify-between rounded-lg border p-3">
+                      <span className="font-medium">{cat.name}</span>
+                      <span className="font-semibold">{formatMoney(cat.amount)}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground">No spending categories this week.</div>
+              )}
+            </FinancialCardContent>
+          </FinancialCard>
+
+          <FinancialCard variant="financial" className="fade-in-up">
+            <FinancialCardHeader>
+              <FinancialCardTitle className="flex items-center gap-2">
+                <Brain className="h-5 w-5" />
+                AI Insight
+                <span className="text-xs font-normal text-muted-foreground">({digest.method})</span>
+              </FinancialCardTitle>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <p className="text-sm leading-relaxed">{digest.narrative}</p>
+            </FinancialCardContent>
+          </FinancialCard>
+
+          {prefs && (
+            <FinancialCard variant="financial" className="fade-in-up">
+              <FinancialCardHeader>
+                <FinancialCardTitle className="flex items-center gap-2">
+                  <Mail className="h-5 w-5" />
+                  Digest Preferences
+                </FinancialCardTitle>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="font-medium">Weekly Digest</div>
+                      <div className="text-sm text-muted-foreground">Receive a weekly financial summary</div>
+                    </div>
+                    <Button variant={prefs.enabled ? 'default' : 'outline'} size="sm" onClick={toggleEnabled}>
+                      {prefs.enabled ? 'Enabled' : 'Disabled'}
+                    </Button>
+                  </div>
+
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="font-medium">Email Notifications</div>
+                      <div className="text-sm text-muted-foreground">Send digest via email</div>
+                    </div>
+                    <Button variant={prefs.send_email ? 'default' : 'outline'} size="sm" onClick={toggleEmail}>
+                      {prefs.send_email ? 'On' : 'Off'}
+                    </Button>
+                  </div>
+
+                  <div>
+                    <div className="font-medium mb-2">Delivery Day</div>
+                    <div className="flex flex-wrap gap-2">
+                      {DAY_NAMES.map((name, i) => (
+                        <Button
+                          key={name}
+                          variant={prefs.day_of_week === i ? 'default' : 'outline'}
+                          size="sm"
+                          onClick={() => updateDay(i)}
+                        >
+                          {name.slice(0, 3)}
+                        </Button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default Digest;

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, func
 from .extensions import db
 
 
@@ -133,3 +133,13 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class DigestPreference(db.Model):
+    __tablename__ = "digest_preferences"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False, unique=True)
+    enabled = db.Column(db.Boolean, default=True)
+    day_of_week = db.Column(db.Integer, default=0)  # 0=Monday
+    send_email = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, server_default=func.now())

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,8 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +20,5 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,59 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import DigestPreference
+from ..services.digest import generate_weekly_digest
+import logging
+
+bp = Blueprint("digest", __name__)
+logger = logging.getLogger("finmind.digest")
+
+
+@bp.get("/weekly")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    digest = generate_weekly_digest(uid)
+    logger.info("Weekly digest served user=%s", uid)
+    return jsonify(digest)
+
+
+@bp.get("/preferences")
+@jwt_required()
+def get_preferences():
+    uid = int(get_jwt_identity())
+    pref = db.session.query(DigestPreference).filter_by(user_id=uid).first()
+    if not pref:
+        return jsonify(enabled=True, day_of_week=0, send_email=True)
+    return jsonify(
+        enabled=pref.enabled,
+        day_of_week=pref.day_of_week,
+        send_email=pref.send_email,
+    )
+
+
+@bp.put("/preferences")
+@jwt_required()
+def update_preferences():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    pref = db.session.query(DigestPreference).filter_by(user_id=uid).first()
+    if not pref:
+        pref = DigestPreference(user_id=uid)
+        db.session.add(pref)
+    if "enabled" in data:
+        pref.enabled = bool(data["enabled"])
+    if "day_of_week" in data:
+        dow = int(data["day_of_week"])
+        if dow < 0 or dow > 6:
+            return jsonify(error="day_of_week must be 0-6"), 400
+        pref.day_of_week = dow
+    if "send_email" in data:
+        pref.send_email = bool(data["send_email"])
+    db.session.commit()
+    logger.info("Digest preferences updated user=%s", uid)
+    return jsonify(
+        enabled=pref.enabled,
+        day_of_week=pref.day_of_week,
+        send_email=pref.send_email,
+    )

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,209 @@
+import json
+from datetime import date, timedelta
+from urllib import request as urllib_request
+
+from sqlalchemy import func
+
+from ..config import Settings
+from ..extensions import db
+from ..models import Expense, Category
+
+_settings = Settings()
+DIGEST_PERSONA = (
+    "You are FinMind's weekly digest narrator. Summarize the user's financial "
+    "week in 2-3 sentences. Be concise, data-driven, and encouraging. "
+    "Highlight the most important trend and one actionable suggestion."
+)
+
+
+def _week_totals(user_id: int, start: date, end: date) -> tuple[float, float]:
+    """Return (total_expenses, total_income) for the date range."""
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    return float(expenses or 0), float(income or 0)
+
+
+def _top_categories(user_id: int, start: date, end: date) -> list[dict]:
+    """Return top spending categories for the date range."""
+    rows = (
+        db.session.query(
+            Expense.category_id, func.coalesce(func.sum(Expense.amount), 0)
+        )
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id)
+        .order_by(func.sum(Expense.amount).desc())
+        .limit(5)
+        .all()
+    )
+    result = []
+    for cat_id, amount in rows:
+        name = "Uncategorized"
+        if cat_id:
+            cat = db.session.get(Category, cat_id)
+            if cat:
+                name = cat.name
+        result.append({"category_id": cat_id, "name": name, "amount": round(float(amount), 2)})
+    return result
+
+
+def _transaction_count(user_id: int, start: date, end: date) -> int:
+    return (
+        db.session.query(func.count(Expense.id))
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .scalar()
+    ) or 0
+
+
+def _gemini_narrative(
+    total_expenses: float,
+    total_income: float,
+    net: float,
+    wow_change: float,
+    top_categories: list[dict],
+    api_key: str,
+    model: str,
+) -> str:
+    prompt = (
+        f"{DIGEST_PERSONA}\n"
+        f"This week: spent={total_expenses:.2f}, earned={total_income:.2f}, "
+        f"net={net:.2f}, week-over-week change={wow_change:.1f}%.\n"
+        f"Top categories: {top_categories}\n"
+        "Return a plain text narrative summary (2-3 sentences, no JSON)."
+    )
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        f"{model}:generateContent?key={api_key}"
+    )
+    body = json.dumps(
+        {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {"temperature": 0.4},
+        }
+    ).encode("utf-8")
+    req = urllib_request.Request(
+        url=url,
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib_request.urlopen(req, timeout=10) as resp:  # nosec B310
+        payload = json.loads(resp.read().decode("utf-8"))
+    text = (
+        payload.get("candidates", [{}])[0]
+        .get("content", {})
+        .get("parts", [{}])[0]
+        .get("text", "")
+    )
+    return text.strip()
+
+
+def _heuristic_narrative(
+    total_expenses: float,
+    total_income: float,
+    net: float,
+    wow_change: float,
+    top_categories: list[dict],
+) -> str:
+    if not top_categories:
+        return "No transactions recorded this week. Start tracking to get insights!"
+    top_name = top_categories[0]["name"]
+    top_amount = top_categories[0]["amount"]
+    trend = "up" if wow_change > 0 else "down" if wow_change < 0 else "flat"
+    if trend == "up":
+        direction = f"Spending is up {abs(wow_change):.1f}% compared to last week."
+    elif trend == "down":
+        direction = f"Spending is down {abs(wow_change):.1f}% compared to last week."
+    else:
+        direction = "Spending is on par with last week."
+    return (
+        f"You spent a total of {total_expenses:.2f} this week, "
+        f"with {top_name} being your top category at {top_amount:.2f}. "
+        f"{direction}"
+    )
+
+
+def generate_weekly_digest(user_id: int) -> dict:
+    """Generate a weekly financial digest for the given user."""
+    today = date.today()
+    week_end = today
+    week_start = today - timedelta(days=6)
+    prev_week_end = week_start - timedelta(days=1)
+    prev_week_start = prev_week_end - timedelta(days=6)
+
+    total_expenses, total_income = _week_totals(user_id, week_start, week_end)
+    prev_expenses, _ = _week_totals(user_id, prev_week_start, prev_week_end)
+
+    net = round(total_income - total_expenses, 2)
+    daily_average = round(total_expenses / 7, 2)
+
+    if prev_expenses > 0:
+        wow_change = round(((total_expenses - prev_expenses) / prev_expenses) * 100, 2)
+    else:
+        wow_change = 0.0
+
+    top_cats = _top_categories(user_id, week_start, week_end)
+    tx_count = _transaction_count(user_id, week_start, week_end)
+
+    # Generate narrative
+    key = (_settings.gemini_api_key or "").strip()
+    model = _settings.gemini_model
+    method = "heuristic"
+    narrative = ""
+
+    if key:
+        try:
+            narrative = _gemini_narrative(
+                total_expenses, total_income, net, wow_change, top_cats, key, model
+            )
+            method = "gemini"
+        except Exception:
+            narrative = _heuristic_narrative(
+                total_expenses, total_income, net, wow_change, top_cats
+            )
+    else:
+        narrative = _heuristic_narrative(
+            total_expenses, total_income, net, wow_change, top_cats
+        )
+
+    return {
+        "period": {
+            "start": week_start.isoformat(),
+            "end": week_end.isoformat(),
+        },
+        "total_expenses": round(total_expenses, 2),
+        "total_income": round(total_income, 2),
+        "net": net,
+        "top_categories": top_cats,
+        "daily_average": daily_average,
+        "wow_change": wow_change,
+        "narrative": narrative,
+        "transactions_count": tx_count,
+        "method": method,
+    }

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,143 @@
+from datetime import date, timedelta
+
+
+def test_weekly_digest_with_expenses(client, auth_header):
+    today = date.today()
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 250,
+            "description": "Groceries",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 1000,
+            "description": "Salary",
+            "date": today.isoformat(),
+            "expense_type": "INCOME",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["total_expenses"] == 250.0
+    assert payload["total_income"] == 1000.0
+    assert payload["net"] == 750.0
+    assert payload["daily_average"] == round(250.0 / 7, 2)
+    assert payload["transactions_count"] == 2
+    assert "period" in payload
+    assert "narrative" in payload
+    assert len(payload["top_categories"]) >= 0
+
+
+def test_weekly_digest_empty_week(client, auth_header):
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["total_expenses"] == 0.0
+    assert payload["total_income"] == 0.0
+    assert payload["net"] == 0.0
+    assert payload["transactions_count"] == 0
+    assert payload["wow_change"] == 0.0
+    assert "narrative" in payload
+
+
+def test_weekly_digest_wow_comparison(client, auth_header):
+    today = date.today()
+    prev_date = today - timedelta(days=10)
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "Previous week spend",
+            "date": prev_date.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 300,
+            "description": "Current week spend",
+            "date": today.isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/digest/weekly", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert "wow_change" in payload
+    assert isinstance(payload["wow_change"], float)
+
+
+def test_preferences_default(client, auth_header):
+    r = client.get("/digest/preferences", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["enabled"] is True
+    assert payload["day_of_week"] == 0
+    assert payload["send_email"] is True
+
+
+def test_preferences_update(client, auth_header):
+    r = client.put(
+        "/digest/preferences",
+        json={"enabled": False, "day_of_week": 4, "send_email": False},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["enabled"] is False
+    assert payload["day_of_week"] == 4
+    assert payload["send_email"] is False
+
+    r = client.get("/digest/preferences", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["enabled"] is False
+    assert payload["day_of_week"] == 4
+
+
+def test_preferences_invalid_day(client, auth_header):
+    r = client.put(
+        "/digest/preferences",
+        json={"day_of_week": 7},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "day_of_week" in r.get_json()["error"]
+
+
+def test_preferences_partial_update(client, auth_header):
+    client.put(
+        "/digest/preferences",
+        json={"enabled": True, "day_of_week": 2, "send_email": True},
+        headers=auth_header,
+    )
+
+    r = client.put(
+        "/digest/preferences",
+        json={"day_of_week": 5},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["day_of_week"] == 5
+    assert payload["enabled"] is True
+    assert payload["send_email"] is True


### PR DESCRIPTION
## Summary

Implements a weekly financial digest with trend analysis and AI-powered narrative insights.

## Changes

### Backend
- New DigestPreference model for per-user settings
- New services/digest.py with weekly aggregation, WoW comparison, Gemini narrative
- New routes/digest.py with 3 endpoints (GET /digest/weekly, GET/PUT /digest/preferences)
- 7 tests covering generation, empty weeks, WoW comparison, preferences CRUD

### Frontend
- New Digest.tsx page with summary cards, top categories, AI narrative, preference toggles
- New api/digest.ts API client module
- Route at /digest

## Test plan
- [x] Digest with sample expenses returns correct totals
- [x] Empty week returns zero values gracefully
- [x] WoW comparison calculates correct percentage change
- [x] Preferences default creation on first access
- [x] Preferences update with validation
- [x] Gemini fallback to heuristic narrative