### PR TITLE
feat: add multi-account financial overview dashboard

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -16,6 +16,7 @@ import NotFound from "./pages/NotFound";
 import { Landing } from "./pages/Landing";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
 import Account from "./pages/Account";
+import Accounts from "./pages/Accounts";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="accounts"
+              element={
+                <ProtectedRoute>
+                  <Accounts />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/accounts.ts
+++ b/app/src/api/accounts.ts
@@ -1,0 +1,74 @@
+import { api } from './client';
+
+export type Account = {
+  id: number;
+  name: string;
+  account_type: string;
+  currency: string;
+  initial_balance: number;
+  is_default: boolean;
+  active: boolean;
+  created_at: string | null;
+};
+
+export type AccountCreate = {
+  name: string;
+  account_type?: string;
+  currency?: string;
+  initial_balance?: number;
+  is_default?: boolean;
+};
+
+export type AccountUpdate = Partial<AccountCreate>;
+
+export type AccountSummary = {
+  account: Account;
+  balance: number;
+  total_income: number;
+  total_expenses: number;
+  monthly_spend: number;
+  recent_transactions: {
+    id: number;
+    description: string;
+    amount: number;
+    date: string;
+    type: string;
+    category_id: number | null;
+    currency: string;
+  }[];
+};
+
+export type AccountOverview = {
+  total_net_worth: number;
+  accounts: {
+    account: Account;
+    balance: number;
+    total_income: number;
+    total_expenses: number;
+    monthly_spend: number;
+  }[];
+};
+
+export async function listAccounts(): Promise<Account[]> {
+  return api<Account[]>('/accounts');
+}
+
+export async function createAccount(payload: AccountCreate): Promise<Account> {
+  return api<Account>('/accounts', { method: 'POST', body: payload });
+}
+
+export async function updateAccount(id: number, payload: AccountUpdate): Promise<Account> {
+  return api<Account>(`/accounts/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function deleteAccount(id: number): Promise<{ message: string }> {
+  return api<{ message: string }>(`/accounts/${id}`, { method: 'DELETE' });
+}
+
+export async function getAccountSummary(id: number): Promise<AccountSummary> {
+  return api<AccountSummary>(`/accounts/${id}/summary`);
+}
+
+export async function getAccountsOverview(): Promise<AccountOverview> {
+  return api<AccountOverview>('/accounts/overview');
+}

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -1,0 +1,342 @@
+import { useState, useEffect, useCallback } from 'react';
+import { FinancialCard, FinancialCardContent, FinancialCardDescription, FinancialCardFooter, FinancialCardHeader, FinancialCardTitle } from '@/components/ui/financial-card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Wallet, Plus, Landmark, CreditCard, Banknote, PiggyBank, TrendingUp, ArrowUpRight, ArrowDownRight, DollarSign } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { createAccount, deleteAccount, getAccountSummary, getAccountsOverview, type AccountSummary, type AccountOverview } from '@/api/accounts';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { formatMoney } from '@/lib/currency';
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  checking: 'Checking',
+  savings: 'Savings',
+  credit_card: 'Credit Card',
+  cash: 'Cash',
+  investment: 'Investment',
+};
+
+function AccountTypeIcon({ type, className }: { type: string; className?: string }) {
+  const cn = className || 'w-6 h-6';
+  switch (type) {
+    case 'checking':
+      return <Landmark className={cn} />;
+    case 'savings':
+      return <PiggyBank className={cn} />;
+    case 'credit_card':
+      return <CreditCard className={cn} />;
+    case 'cash':
+      return <Banknote className={cn} />;
+    case 'investment':
+      return <TrendingUp className={cn} />;
+    default:
+      return <Wallet className={cn} />;
+  }
+}
+
+export default function Accounts() {
+  const { toast } = useToast();
+  const [overview, setOverview] = useState<AccountOverview | null>(null);
+  const [selectedAccount, setSelectedAccount] = useState<AccountSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [accountType, setAccountType] = useState('checking');
+  const [currency, setCurrency] = useState('INR');
+  const [initialBalance, setInitialBalance] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const getErrorMessage = (error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback;
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await getAccountsOverview();
+      setOverview(data);
+    } catch (error: unknown) {
+      toast({ title: 'Failed to load accounts', description: getErrorMessage(error, 'Please try again.') });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function onSelectAccount(accountId: number) {
+    setSummaryLoading(true);
+    try {
+      const data = await getAccountSummary(accountId);
+      setSelectedAccount(data);
+    } catch (error: unknown) {
+      toast({ title: 'Failed to load account details', description: getErrorMessage(error, 'Please try again.') });
+    } finally {
+      setSummaryLoading(false);
+    }
+  }
+
+  async function onCreate() {
+    if (!name.trim()) return;
+    setSaving(true);
+    try {
+      await createAccount({
+        name: name.trim(),
+        account_type: accountType,
+        currency: currency.toUpperCase(),
+        initial_balance: initialBalance ? Number(initialBalance) : 0,
+      });
+      await refresh();
+      setOpen(false);
+      setName('');
+      setAccountType('checking');
+      setCurrency('INR');
+      setInitialBalance('');
+      toast({ title: 'Account created' });
+    } catch (error: unknown) {
+      toast({ title: 'Failed to create account', description: getErrorMessage(error, 'Please try again.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onDelete(id: number) {
+    try {
+      await deleteAccount(id);
+      toast({ title: 'Account deleted' });
+      if (selectedAccount?.account.id === id) {
+        setSelectedAccount(null);
+      }
+      await refresh();
+    } catch (error: unknown) {
+      toast({ title: 'Failed to delete account', description: getErrorMessage(error, 'Please try again.') });
+    }
+  }
+
+  return (
+    <div className="page-wrap">
+      <div className="page-header">
+        <div className="relative flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+          <div>
+            <h1 className="page-title">Accounts</h1>
+            <p className="page-subtitle">
+              Manage your financial accounts and track balances
+            </p>
+          </div>
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <Button variant="financial" size="sm">
+                <Plus className="w-4 h-4" />
+                Add Account
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>New Account</DialogTitle>
+                <DialogDescription>Add a financial account to track.</DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-sm mb-1">Name</label>
+                  <input className="input w-full" value={name} onChange={(e) => setName(e.target.value)} placeholder="Main Checking" />
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm mb-1">Account Type</label>
+                    <select className="input w-full" value={accountType} onChange={(e) => setAccountType(e.target.value)}>
+                      <option value="checking">Checking</option>
+                      <option value="savings">Savings</option>
+                      <option value="credit_card">Credit Card</option>
+                      <option value="cash">Cash</option>
+                      <option value="investment">Investment</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm mb-1">Currency</label>
+                    <input className="input w-full" value={currency} onChange={(e) => setCurrency(e.target.value)} placeholder="INR" maxLength={3} />
+                  </div>
+                </div>
+                <div>
+                  <label className="block text-sm mb-1">Initial Balance</label>
+                  <input className="input w-full" type="number" min="0" step="0.01" value={initialBalance} onChange={(e) => setInitialBalance(e.target.value)} placeholder="0.00" />
+                </div>
+              </div>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setOpen(false)} disabled={saving}>Cancel</Button>
+                <Button onClick={onCreate} disabled={saving || !name.trim()}>Create</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      {loading ? (
+        <div>Loading...</div>
+      ) : (
+        <>
+          {overview && (
+            <div className="mb-8">
+              <FinancialCard variant="financial" className="fade-in-up">
+                <FinancialCardHeader className="pb-3">
+                  <div className="flex items-center justify-between">
+                    <FinancialCardTitle className="text-sm font-medium text-muted-foreground">
+                      Total Net Worth
+                    </FinancialCardTitle>
+                    <DollarSign className="w-5 h-5 text-muted-foreground" />
+                  </div>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  <div className="metric-value text-foreground mb-1">
+                    {formatMoney(overview.total_net_worth)}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    Across {overview.accounts.length} account{overview.accounts.length !== 1 ? 's' : ''}
+                  </div>
+                </FinancialCardContent>
+              </FinancialCard>
+            </div>
+          )}
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 mb-8">
+            {overview?.accounts.map((item) => (
+              <FinancialCard
+                key={item.account.id}
+                variant="financial"
+                className="fade-in-up cursor-pointer hover:ring-2 hover:ring-primary/30 transition-all"
+                onClick={() => onSelectAccount(item.account.id)}
+              >
+                <FinancialCardHeader className="pb-3">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center space-x-3">
+                      <div className="w-10 h-10 rounded-xl bg-primary/10 text-primary flex items-center justify-center">
+                        <AccountTypeIcon type={item.account.account_type} className="w-5 h-5" />
+                      </div>
+                      <div>
+                        <FinancialCardTitle className="text-sm font-medium">
+                          {item.account.name}
+                        </FinancialCardTitle>
+                        <div className="text-xs text-muted-foreground">
+                          {ACCOUNT_TYPE_LABELS[item.account.account_type] || item.account.account_type}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      {item.account.is_default && (
+                        <Badge variant="secondary" className="text-xs">Default</Badge>
+                      )}
+                      <Badge variant="outline" className="text-xs">{item.account.currency}</Badge>
+                    </div>
+                  </div>
+                </FinancialCardHeader>
+                <FinancialCardContent>
+                  <div className="metric-value text-foreground mb-2">
+                    {formatMoney(item.balance, item.account.currency)}
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <div className="flex items-center text-success">
+                      <ArrowUpRight className="w-3 h-3 mr-1" />
+                      {formatMoney(item.total_income, item.account.currency)}
+                    </div>
+                    <div className="flex items-center text-destructive">
+                      <ArrowDownRight className="w-3 h-3 mr-1" />
+                      {formatMoney(item.total_expenses, item.account.currency)}
+                    </div>
+                  </div>
+                  {item.monthly_spend > 0 && (
+                    <div className="text-xs text-muted-foreground mt-2">
+                      This month: {formatMoney(item.monthly_spend, item.account.currency)} spent
+                    </div>
+                  )}
+                </FinancialCardContent>
+                <FinancialCardFooter className="flex justify-end pt-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onDelete(item.account.id);
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </FinancialCardFooter>
+              </FinancialCard>
+            ))}
+          </div>
+
+          {overview?.accounts.length === 0 && (
+            <div className="text-center py-12 text-muted-foreground">
+              <Wallet className="w-12 h-12 mx-auto mb-4 opacity-50" />
+              <p className="text-lg font-medium mb-1">No accounts yet</p>
+              <p className="text-sm">Add your first financial account to get started.</p>
+            </div>
+          )}
+
+          {summaryLoading && (
+            <div className="card fade-in-up p-6">Loading account details...</div>
+          )}
+
+          {selectedAccount && !summaryLoading && (
+            <FinancialCard variant="financial" className="fade-in-up">
+              <FinancialCardHeader>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center space-x-3">
+                    <AccountTypeIcon type={selectedAccount.account.account_type} className="w-6 h-6" />
+                    <div>
+                      <FinancialCardTitle className="section-title">{selectedAccount.account.name}</FinancialCardTitle>
+                      <FinancialCardDescription>
+                        Recent transactions
+                      </FinancialCardDescription>
+                    </div>
+                  </div>
+                  <div className="text-right">
+                    <div className="text-lg font-semibold">{formatMoney(selectedAccount.balance, selectedAccount.account.currency)}</div>
+                    <div className="text-xs text-muted-foreground">Current balance</div>
+                  </div>
+                </div>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid grid-cols-3 gap-4 mb-6">
+                  <div className="text-center p-3 rounded-lg bg-muted/50">
+                    <div className="text-xs text-muted-foreground mb-1">Income</div>
+                    <div className="font-semibold text-success">{formatMoney(selectedAccount.total_income, selectedAccount.account.currency)}</div>
+                  </div>
+                  <div className="text-center p-3 rounded-lg bg-muted/50">
+                    <div className="text-xs text-muted-foreground mb-1">Expenses</div>
+                    <div className="font-semibold text-destructive">{formatMoney(selectedAccount.total_expenses, selectedAccount.account.currency)}</div>
+                  </div>
+                  <div className="text-center p-3 rounded-lg bg-muted/50">
+                    <div className="text-xs text-muted-foreground mb-1">This Month</div>
+                    <div className="font-semibold">{formatMoney(selectedAccount.monthly_spend, selectedAccount.account.currency)}</div>
+                  </div>
+                </div>
+
+                {selectedAccount.recent_transactions.length === 0 ? (
+                  <div className="text-sm text-muted-foreground text-center py-4">No transactions yet for this account.</div>
+                ) : (
+                  <div className="space-y-2">
+                    {selectedAccount.recent_transactions.map((txn) => (
+                      <div key={txn.id} className="interactive-row flex items-center justify-between border-b py-2">
+                        <div>
+                          <div className="font-medium text-sm">{txn.description}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {new Date(txn.date).toLocaleDateString()}
+                          </div>
+                        </div>
+                        <div className={`font-semibold text-sm ${txn.type === 'INCOME' ? 'text-success' : 'text-destructive'}`}>
+                          {txn.type === 'INCOME' ? '+' : '-'}{formatMoney(txn.amount, txn.currency)}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </FinancialCardContent>
+            </FinancialCard>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime, date
 from enum import Enum
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Enum as SAEnum, func
 from .extensions import db
 
 
@@ -27,11 +27,25 @@ class Category(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class Account(db.Model):
+    __tablename__ = "accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(100), nullable=False)
+    account_type = db.Column(db.String(30), default="checking")  # checking, savings, credit_card, cash, investment
+    currency = db.Column(db.String(3), default="INR")
+    initial_balance = db.Column(db.Numeric(12, 2), default=0)
+    is_default = db.Column(db.Boolean, default=False)
+    active = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, server_default=func.now())
+
+
 class Expense(db.Model):
     __tablename__ = "expenses"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    account_id = db.Column(db.Integer, db.ForeignKey("accounts.id"), nullable=True)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
     expense_type = db.Column(db.String(20), default="EXPENSE", nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,282 @@
+from datetime import date
+from decimal import Decimal, InvalidOperation
+
+from sqlalchemy import extract, func
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..extensions import db
+from ..models import Account, Expense
+
+bp = Blueprint("accounts", __name__)
+
+VALID_ACCOUNT_TYPES = {"checking", "savings", "credit_card", "cash", "investment"}
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    items = (
+        db.session.query(Account)
+        .filter_by(user_id=uid, active=True)
+        .order_by(Account.created_at.desc())
+        .all()
+    )
+    return jsonify([_account_to_dict(a) for a in items])
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    account_type = (data.get("account_type") or "checking").lower()
+    if account_type not in VALID_ACCOUNT_TYPES:
+        return jsonify(error="invalid account_type"), 400
+    currency = (data.get("currency") or "INR").upper()[:3]
+    initial_balance = _parse_amount(data.get("initial_balance", 0))
+    if initial_balance is None:
+        return jsonify(error="invalid initial_balance"), 400
+    is_default = bool(data.get("is_default", False))
+
+    # If this is set as default, unset any existing default
+    if is_default:
+        db.session.query(Account).filter_by(user_id=uid, is_default=True).update(
+            {"is_default": False}
+        )
+
+    # If user has no active accounts, make this the default
+    existing_count = (
+        db.session.query(func.count(Account.id))
+        .filter_by(user_id=uid, active=True)
+        .scalar()
+    )
+    if existing_count == 0:
+        is_default = True
+
+    account = Account(
+        user_id=uid,
+        name=name,
+        account_type=account_type,
+        currency=currency,
+        initial_balance=initial_balance,
+        is_default=is_default,
+    )
+    db.session.add(account)
+    db.session.commit()
+    return jsonify(_account_to_dict(account)), 201
+
+
+@bp.patch("/<int:id>")
+@jwt_required()
+def update_account(id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, id)
+    if not account or account.user_id != uid or not account.active:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = (data.get("name") or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        account.name = name
+    if "account_type" in data:
+        account_type = (data.get("account_type") or "").lower()
+        if account_type not in VALID_ACCOUNT_TYPES:
+            return jsonify(error="invalid account_type"), 400
+        account.account_type = account_type
+    if "currency" in data:
+        account.currency = (data.get("currency") or "INR").upper()[:3]
+    if "initial_balance" in data:
+        initial_balance = _parse_amount(data.get("initial_balance"))
+        if initial_balance is None:
+            return jsonify(error="invalid initial_balance"), 400
+        account.initial_balance = initial_balance
+    if "is_default" in data and data["is_default"]:
+        db.session.query(Account).filter(
+            Account.user_id == uid, Account.id != id, Account.is_default.is_(True)
+        ).update({"is_default": False})
+        account.is_default = True
+    db.session.commit()
+    return jsonify(_account_to_dict(account))
+
+
+@bp.delete("/<int:id>")
+@jwt_required()
+def delete_account(id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, id)
+    if not account or account.user_id != uid or not account.active:
+        return jsonify(error="not found"), 404
+    account.active = False
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+@bp.get("/<int:id>/summary")
+@jwt_required()
+def account_summary(id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, id)
+    if not account or account.user_id != uid or not account.active:
+        return jsonify(error="not found"), 404
+
+    today = date.today()
+    year, month = today.year, today.month
+
+    total_income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.account_id == id,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+
+    total_expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.account_id == id,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+
+    monthly_spend = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.account_id == id,
+            Expense.expense_type != "INCOME",
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+        )
+        .scalar()
+    )
+
+    recent = (
+        db.session.query(Expense)
+        .filter(Expense.user_id == uid, Expense.account_id == id)
+        .order_by(Expense.spent_at.desc(), Expense.id.desc())
+        .limit(10)
+        .all()
+    )
+
+    balance = float(account.initial_balance or 0) + float(total_income or 0) - float(total_expenses or 0)
+
+    return jsonify(
+        {
+            "account": _account_to_dict(account),
+            "balance": round(balance, 2),
+            "total_income": float(total_income or 0),
+            "total_expenses": float(total_expenses or 0),
+            "monthly_spend": float(monthly_spend or 0),
+            "recent_transactions": [
+                {
+                    "id": e.id,
+                    "description": e.notes or "Transaction",
+                    "amount": float(e.amount),
+                    "date": e.spent_at.isoformat(),
+                    "type": e.expense_type,
+                    "category_id": e.category_id,
+                    "currency": e.currency,
+                }
+                for e in recent
+            ],
+        }
+    )
+
+
+@bp.get("/overview")
+@jwt_required()
+def accounts_overview():
+    uid = int(get_jwt_identity())
+    accounts = (
+        db.session.query(Account)
+        .filter_by(user_id=uid, active=True)
+        .order_by(Account.created_at.asc())
+        .all()
+    )
+
+    today = date.today()
+    year, month = today.year, today.month
+    account_details = []
+    total_net_worth = 0.0
+
+    for acct in accounts:
+        total_income = float(
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                Expense.account_id == acct.id,
+                Expense.expense_type == "INCOME",
+            )
+            .scalar()
+            or 0
+        )
+        total_expenses = float(
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                Expense.account_id == acct.id,
+                Expense.expense_type != "INCOME",
+            )
+            .scalar()
+            or 0
+        )
+        monthly_spend = float(
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                Expense.account_id == acct.id,
+                Expense.expense_type != "INCOME",
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+            )
+            .scalar()
+            or 0
+        )
+        balance = float(acct.initial_balance or 0) + total_income - total_expenses
+        total_net_worth += balance
+        account_details.append(
+            {
+                "account": _account_to_dict(acct),
+                "balance": round(balance, 2),
+                "total_income": total_income,
+                "total_expenses": total_expenses,
+                "monthly_spend": monthly_spend,
+            }
+        )
+
+    return jsonify(
+        {
+            "total_net_worth": round(total_net_worth, 2),
+            "accounts": account_details,
+        }
+    )
+
+
+def _account_to_dict(a: Account) -> dict:
+    return {
+        "id": a.id,
+        "name": a.name,
+        "account_type": a.account_type,
+        "currency": a.currency,
+        "initial_balance": float(a.initial_balance or 0),
+        "is_default": a.is_default,
+        "active": a.active,
+        "created_at": a.created_at.isoformat() if a.created_at else None,
+    }
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -17,7 +17,15 @@ def dashboard_summary():
     ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
     if not _is_valid_month(ym):
         return jsonify(error="invalid month, expected YYYY-MM"), 400
-    key = dashboard_summary_key(uid, ym)
+    account_id = request.args.get("account_id")
+    if account_id:
+        try:
+            account_id = int(account_id)
+        except ValueError:
+            return jsonify(error="invalid account_id"), 400
+
+    cache_suffix = f":acct{account_id}" if account_id else ""
+    key = dashboard_summary_key(uid, ym) + cache_suffix
     cached = cache_get(key)
     if cached:
         return jsonify(cached)
@@ -41,26 +49,29 @@ def dashboard_summary():
     today = date.today()
 
     try:
-        income = (
-            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
-            .filter(
-                Expense.user_id == uid,
-                extract("year", Expense.spent_at) == year,
-                extract("month", Expense.spent_at) == month,
-                Expense.expense_type == "INCOME",
-            )
-            .scalar()
+        income_q = db.session.query(
+            func.coalesce(func.sum(Expense.amount), 0)
+        ).filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
         )
-        expenses = (
-            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
-            .filter(
-                Expense.user_id == uid,
-                extract("year", Expense.spent_at) == year,
-                extract("month", Expense.spent_at) == month,
-                Expense.expense_type != "INCOME",
-            )
-            .scalar()
+        if account_id:
+            income_q = income_q.filter(Expense.account_id == account_id)
+        income = income_q.scalar()
+
+        expenses_q = db.session.query(
+            func.coalesce(func.sum(Expense.amount), 0)
+        ).filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
         )
+        if account_id:
+            expenses_q = expenses_q.filter(Expense.account_id == account_id)
+        expenses = expenses_q.scalar()
         payload["summary"]["monthly_income"] = float(income or 0)
         payload["summary"]["monthly_expenses"] = float(expenses or 0)
         payload["summary"]["net_flow"] = round(
@@ -72,10 +83,11 @@ def dashboard_summary():
         payload["errors"].append("summary_unavailable")
 
     try:
+        recent_q = db.session.query(Expense).filter(Expense.user_id == uid)
+        if account_id:
+            recent_q = recent_q.filter(Expense.account_id == account_id)
         rows = (
-            db.session.query(Expense)
-            .filter(Expense.user_id == uid)
-            .order_by(Expense.spent_at.desc(), Expense.id.desc())
+            recent_q.order_by(Expense.spent_at.desc(), Expense.id.desc())
             .limit(10)
             .all()
         )
@@ -127,7 +139,7 @@ def dashboard_summary():
         payload["errors"].append("upcoming_bills_unavailable")
 
     try:
-        category_rows = (
+        cat_q = (
             db.session.query(
                 Expense.category_id,
                 func.coalesce(Category.name, "Uncategorized").label("category_name"),
@@ -143,7 +155,11 @@ def dashboard_summary():
                 extract("month", Expense.spent_at) == month,
                 Expense.expense_type != "INCOME",
             )
-            .group_by(Expense.category_id, Category.name)
+        )
+        if account_id:
+            cat_q = cat_q.filter(Expense.account_id == account_id)
+        category_rows = (
+            cat_q.group_by(Expense.category_id, Category.name)
             .order_by(func.sum(Expense.amount).desc())
             .all()
         )

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -29,6 +29,7 @@ def list_expenses():
     except ValueError:
         return jsonify(error="invalid pagination"), 400
 
+    account_id = request.args.get("account_id")
     try:
         if from_date:
             q = q.filter(Expense.spent_at >= date.fromisoformat(from_date))
@@ -36,6 +37,8 @@ def list_expenses():
             q = q.filter(Expense.spent_at <= date.fromisoformat(to_date))
         if category_id:
             q = q.filter(Expense.category_id == int(category_id))
+        if account_id:
+            q = q.filter(Expense.account_id == int(account_id))
     except ValueError:
         return jsonify(error="invalid filter values"), 400
     if search:
@@ -71,6 +74,7 @@ def create_expense():
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
         category_id=data.get("category_id"),
+        account_id=data.get("account_id"),
         notes=description,
         spent_at=date.fromisoformat(raw_date) if raw_date else date.today(),
     )
@@ -221,6 +225,8 @@ def update_expense(expense_id: int):
         e.expense_type = str(data.get("expense_type") or "EXPENSE").upper()
     if "category_id" in data:
         e.category_id = data.get("category_id")
+    if "account_id" in data:
+        e.account_id = data.get("account_id")
     if "description" in data or "notes" in data:
         description = (data.get("description") or data.get("notes") or "").strip()
         if not description:
@@ -317,6 +323,7 @@ def _expense_to_dict(e: Expense) -> dict:
         "amount": float(e.amount),
         "currency": e.currency,
         "category_id": e.category_id,
+        "account_id": e.account_id,
         "expense_type": e.expense_type,
         "description": e.notes or "",
         "date": e.spent_at.isoformat(),

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,267 @@
+def test_account_crud(client, auth_header):
+    # List empty
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+    # Create
+    r = client.post(
+        "/accounts",
+        json={"name": "Main Checking", "account_type": "checking", "currency": "INR", "initial_balance": 5000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    acct = r.get_json()
+    acct_id = acct["id"]
+    assert acct["name"] == "Main Checking"
+    assert acct["account_type"] == "checking"
+    assert acct["currency"] == "INR"
+    assert acct["initial_balance"] == 5000.0
+    assert acct["is_default"] is True  # first account becomes default
+    assert acct["active"] is True
+
+    # List returns one
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 1
+
+    # Update
+    r = client.patch(
+        f"/accounts/{acct_id}",
+        json={"name": "Updated Checking", "account_type": "savings"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    updated = r.get_json()
+    assert updated["name"] == "Updated Checking"
+    assert updated["account_type"] == "savings"
+
+    # Soft delete
+    r = client.delete(f"/accounts/{acct_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "deleted"
+
+    # List returns empty (soft deleted)
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_create_account_validation(client, auth_header):
+    # Missing name
+    r = client.post("/accounts", json={"account_type": "checking"}, headers=auth_header)
+    assert r.status_code == 400
+    assert "name" in r.get_json()["error"]
+
+    # Invalid account_type
+    r = client.post(
+        "/accounts",
+        json={"name": "Bad Type", "account_type": "invalid_type"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "account_type" in r.get_json()["error"]
+
+    # Invalid initial_balance
+    r = client.post(
+        "/accounts",
+        json={"name": "Bad Balance", "initial_balance": "not_a_number"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "initial_balance" in r.get_json()["error"]
+
+
+def test_account_not_found(client, auth_header):
+    r = client.patch("/accounts/9999", json={"name": "X"}, headers=auth_header)
+    assert r.status_code == 404
+
+    r = client.delete("/accounts/9999", headers=auth_header)
+    assert r.status_code == 404
+
+    r = client.get("/accounts/9999/summary", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_account_summary_calculation(client, auth_header):
+    # Create account
+    r = client.post(
+        "/accounts",
+        json={"name": "Savings", "account_type": "savings", "initial_balance": 10000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    acct_id = r.get_json()["id"]
+
+    # Add income to this account
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 500,
+            "description": "Salary",
+            "expense_type": "INCOME",
+            "date": "2026-05-01",
+            "account_id": acct_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Add expense to this account
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "Groceries",
+            "date": "2026-05-02",
+            "account_id": acct_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Get summary
+    r = client.get(f"/accounts/{acct_id}/summary", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["balance"] == 10300.0  # 10000 + 500 - 200
+    assert data["total_income"] == 500.0
+    assert data["total_expenses"] == 200.0
+    assert len(data["recent_transactions"]) == 2
+    assert data["account"]["id"] == acct_id
+
+
+def test_multi_account_overview(client, auth_header):
+    # Create two accounts
+    r = client.post(
+        "/accounts",
+        json={"name": "Checking", "account_type": "checking", "initial_balance": 5000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    acct1_id = r.get_json()["id"]
+
+    r = client.post(
+        "/accounts",
+        json={"name": "Savings", "account_type": "savings", "initial_balance": 20000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    acct2_id = r.get_json()["id"]
+
+    # Add expense to first account
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 100,
+            "description": "Coffee",
+            "date": "2026-05-10",
+            "account_id": acct1_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Get overview
+    r = client.get("/accounts/overview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_net_worth"] == 24900.0  # 5000 - 100 + 20000
+    assert len(data["accounts"]) == 2
+
+    # Verify per-account breakdown
+    acct1_data = next(a for a in data["accounts"] if a["account"]["id"] == acct1_id)
+    assert acct1_data["balance"] == 4900.0
+    assert acct1_data["total_expenses"] == 100.0
+
+    acct2_data = next(a for a in data["accounts"] if a["account"]["id"] == acct2_id)
+    assert acct2_data["balance"] == 20000.0
+
+
+def test_expense_filtering_by_account(client, auth_header):
+    # Create two accounts
+    r = client.post(
+        "/accounts",
+        json={"name": "Account A", "initial_balance": 1000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    acct_a = r.get_json()["id"]
+
+    r = client.post(
+        "/accounts",
+        json={"name": "Account B", "initial_balance": 2000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    acct_b = r.get_json()["id"]
+
+    # Add expenses to different accounts
+    r = client.post(
+        "/expenses",
+        json={"amount": 50, "description": "A expense", "date": "2026-05-01", "account_id": acct_a},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={"amount": 75, "description": "B expense", "date": "2026-05-01", "account_id": acct_b},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Filter by account A
+    r = client.get(f"/expenses?account_id={acct_a}", headers=auth_header)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert len(items) == 1
+    assert items[0]["description"] == "A expense"
+    assert items[0]["account_id"] == acct_a
+
+    # Filter by account B
+    r = client.get(f"/expenses?account_id={acct_b}", headers=auth_header)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert len(items) == 1
+    assert items[0]["description"] == "B expense"
+
+
+def test_default_account_logic(client, auth_header):
+    # First account automatically becomes default
+    r = client.post(
+        "/accounts",
+        json={"name": "First"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    first_id = r.get_json()["id"]
+    assert r.get_json()["is_default"] is True
+
+    # Second account is NOT default by default
+    r = client.post(
+        "/accounts",
+        json={"name": "Second"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    second_id = r.get_json()["id"]
+    assert r.get_json()["is_default"] is False
+
+    # Make second account the default
+    r = client.patch(
+        f"/accounts/{second_id}",
+        json={"is_default": True},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["is_default"] is True
+
+    # First account should no longer be default
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    accounts = r.get_json()
+    first = next(a for a in accounts if a["id"] == first_id)
+    second = next(a for a in accounts if a["id"] == second_id)
+    assert first["is_default"] is False
+    assert second["is_default"] is True


### PR DESCRIPTION
## Summary

Adds multi-account support allowing users to manage multiple financial accounts (checking, savings, credit card, cash, investment) and view a unified overview.

## Changes

### Backend
- New Account model with type, currency, initial_balance, default flag
- Added account_id FK on Expense model (nullable, backward compatible)
- New routes/accounts.py with 6 endpoints: CRUD + summary + overview
- Updated dashboard.py to support optional account_id filtering
- Updated expenses.py to support account_id on create/list
- 6 test functions covering CRUD, summary, overview, expense filtering

### Frontend
- New Accounts.tsx page with net worth card, account cards grid, account detail panel, add account dialog
- New api/accounts.ts API client module
- Route at /accounts

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | /accounts | List all accounts |
| POST | /accounts | Create account |
| PATCH | /accounts/:id | Update account |
| DELETE | /accounts/:id | Soft delete |
| GET | /accounts/:id/summary | Account balance and stats |
| GET | /accounts/overview | Multi-account net worth overview |

## Test plan
- [x] Account CRUD operations
- [x] Account summary with balance calculation
- [x] Multi-account overview with net worth
- [x] Expense filtering by account_id
- [x] Default account logic
- [x] Backward compatible (account_id is nullable)