### PR TITLE
Add resilient reminder retry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,11 @@ finmind/
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.
 
 ## Notes on Free-Tier Reminders
-- Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
+- Primary: schedule via APScheduler in-process with persistence in Postgres and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).
+- Reminder dispatch is retry-aware: failed sends remain unsent, move to `RETRYING`, and use configurable backoff from `REMINDER_JOB_BACKOFF_SECONDS` (default `300,900,2700`) until `REMINDER_JOB_MAX_ATTEMPTS` is reached.
+- Operators can monitor reminder job health with `GET /reminders/jobs/stats`, inspect jobs with `GET /reminders/jobs?status=FAILED`, and reset a failed job with `POST /reminders/{id}/retry`.
+- Permanently failed reminders stay in `FAILED` state with `last_error` and `failed_at` for dead-letter review; they are not silently marked as sent.
 
 ## Security & Scalability
 - JWT access/refresh, secure cookies OR Authorization header.

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -33,6 +33,8 @@ def create_app(settings: Settings | None = None) -> Flask:
         TWILIO_AUTH_TOKEN=cfg.twilio_auth_token,
         TWILIO_WHATSAPP_FROM=cfg.twilio_whatsapp_from,
         EMAIL_FROM=cfg.email_from,
+        REMINDER_JOB_MAX_ATTEMPTS=cfg.reminder_job_max_attempts,
+        REMINDER_JOB_BACKOFF_SECONDS=cfg.reminder_job_backoff_seconds,
     )
 
     # Logging
@@ -110,10 +112,73 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS job_status VARCHAR(20)
+            NOT NULL DEFAULT 'PENDING'
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS max_attempts INT NOT NULL DEFAULT 3
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMP
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS sent_at TIMESTAMP
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS failed_at TIMESTAMP
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS last_error VARCHAR(1000)
+            """
+        )
+        cur.execute(
+            """
+            UPDATE reminders
+            SET job_status = 'SENT',
+                sent_at = COALESCE(sent_at, send_at)
+            WHERE sent IS TRUE AND job_status <> 'SENT'
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reminders_job_due
+            ON reminders(user_id, job_status, sent, send_at, next_retry_at)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(
-            "Schema compatibility patch failed for users.preferred_currency"
+            "Schema compatibility patch failed for users/reminder job columns"
         )
         conn.rollback()
     finally:

--- a/packages/backend/app/config.py
+++ b/packages/backend/app/config.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
 
     email_from: str | None = None
     smtp_url: str | None = None  # e.g. smtp+ssl://user:pass@mail:465
+    reminder_job_max_attempts: int = 3
+    reminder_job_backoff_seconds: str = "300,900,2700"
 
     # pydantic-settings v2 configuration
     model_config = SettingsConfigDict(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -91,9 +91,42 @@ CREATE TABLE IF NOT EXISTS reminders (
   message VARCHAR(500) NOT NULL,
   send_at TIMESTAMP NOT NULL,
   sent BOOLEAN NOT NULL DEFAULT FALSE,
-  channel VARCHAR(20) NOT NULL DEFAULT 'email'
+  channel VARCHAR(20) NOT NULL DEFAULT 'email',
+  job_status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+  retry_count INT NOT NULL DEFAULT 0,
+  max_attempts INT NOT NULL DEFAULT 3,
+  next_retry_at TIMESTAMP,
+  last_attempt_at TIMESTAMP,
+  sent_at TIMESTAMP,
+  failed_at TIMESTAMP,
+  last_error VARCHAR(1000)
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
+
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS job_status VARCHAR(20) NOT NULL DEFAULT 'PENDING';
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0;
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS max_attempts INT NOT NULL DEFAULT 3;
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP;
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMP;
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS sent_at TIMESTAMP;
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS failed_at TIMESTAMP;
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS last_error VARCHAR(1000);
+
+UPDATE reminders
+SET job_status = 'SENT',
+    sent_at = COALESCE(sent_at, send_at)
+WHERE sent IS TRUE AND job_status <> 'SENT';
+
+CREATE INDEX IF NOT EXISTS idx_reminders_job_due
+  ON reminders(user_id, job_status, sent, send_at, next_retry_at);
 
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,14 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    job_status = db.Column(db.String(20), default="PENDING", nullable=False)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    max_attempts = db.Column(db.Integer, default=3, nullable=False)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    last_attempt_at = db.Column(db.DateTime, nullable=True)
+    sent_at = db.Column(db.DateTime, nullable=True)
+    failed_at = db.Column(db.DateTime, nullable=True)
+    last_error = db.Column(db.String(1000), nullable=True)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -374,13 +374,111 @@ paths:
 
   /reminders/run:
     post:
-      summary: Process due reminders
+      summary: Process due reminder jobs with retry handling
       tags: [Reminders]
       security: [{ bearerAuth: [] }]
       responses:
-        '200': { description: Processed count }
+        '200':
+          description: Processed job counts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  processed: { type: integer }
+                  sent: { type: integer }
+                  retrying: { type: integer }
+                  failed: { type: integer }
+              example:
+                processed: 2
+                sent: 1
+                retrying: 1
+                failed: 0
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs/stats:
+    get:
+      summary: Get reminder job retry and monitoring statistics
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Aggregated reminder job health for the authenticated user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  pending: { type: integer }
+                  retrying: { type: integer }
+                  sent: { type: integer }
+                  failed: { type: integer }
+                  due_now: { type: integer }
+                  next_retry_at: { type: string, format: date-time, nullable: true }
+                  last_failure_at: { type: string, format: date-time, nullable: true }
+              example:
+                total: 8
+                pending: 3
+                retrying: 1
+                sent: 3
+                failed: 1
+                due_now: 1
+                next_retry_at: 2026-05-12T10:15:00
+                last_failure_at: 2026-05-12T10:10:00
+
+  /reminders/jobs:
+    get:
+      summary: List reminder jobs, optionally filtered by retry status
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema: { type: string, enum: [PENDING, RETRYING, SENT, FAILED] }
+        - in: query
+          name: limit
+          required: false
+          schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+      responses:
+        '200':
+          description: Reminder jobs for the authenticated user
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Reminder'
+        '400':
+          description: Invalid filter
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/{reminderId}/retry:
+    post:
+      summary: Reset a failed or retrying reminder job for manual retry
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: reminderId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Reset reminder job
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reminder'
+        '404':
+          description: Reminder not found for the authenticated user
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
@@ -579,7 +677,15 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         sent: { type: boolean }
-        channel: { type: string, enum: [email, whatsapp] }
+        channel: { type: string }
+        job_status: { type: string, enum: [PENDING, RETRYING, SENT, FAILED] }
+        retry_count: { type: integer }
+        max_attempts: { type: integer }
+        next_retry_at: { type: string, format: date-time, nullable: true }
+        last_attempt_at: { type: string, format: date-time, nullable: true }
+        sent_at: { type: string, format: date-time, nullable: true }
+        failed_at: { type: string, format: date-time, nullable: true }
+        last_error: { type: string, nullable: true }
     NewReminder:
       type: object
       required: [message, send_at]

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -4,7 +4,15 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
-from ..services.reminders import send_reminder
+from ..services.reminder_jobs import (
+    VALID_STATUSES,
+    configured_max_attempts,
+    process_due_reminders,
+    reminder_job_stats,
+    reminder_jobs_query,
+    reset_reminder_for_retry,
+    serialize_reminder_job,
+)
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -22,18 +30,7 @@ def list_reminders():
         .all()
     )
     logger.info("List reminders user=%s count=%s", uid, len(items))
-    return jsonify(
-        [
-            {
-                "id": r.id,
-                "message": r.message,
-                "send_at": r.send_at.isoformat(),
-                "sent": r.sent,
-                "channel": r.channel,
-            }
-            for r in items
-        ]
-    )
+    return jsonify([serialize_reminder_job(r) for r in items])
 
 
 @bp.post("")
@@ -46,6 +43,7 @@ def create_reminder():
         message=data["message"],
         send_at=datetime.fromisoformat(data["send_at"]),
         channel=data.get("channel", "email"),
+        max_attempts=configured_max_attempts(),
     )
     db.session.add(r)
     db.session.commit()
@@ -148,6 +146,7 @@ def autopay_result_followup(bill_id: int):
                 message=message,
                 send_at=now,
                 channel=channel,
+                max_attempts=configured_max_attempts(),
             )
         )
         created += 1
@@ -160,23 +159,47 @@ def autopay_result_followup(bill_id: int):
 @jwt_required()
 def run_due():
     uid = int(get_jwt_identity())
-    now = datetime.utcnow() + timedelta(minutes=1)
-    items = (
-        db.session.query(Reminder)
-        .filter(
-            Reminder.user_id == uid,
-            Reminder.sent.is_(False),
-            Reminder.send_at <= now,
-        )
-        .all()
-    )
-    for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
+    summary = process_due_reminders(uid)
+    logger.info("Processed due reminders user=%s result=%s", uid, summary)
+    return jsonify(summary)
+
+
+@bp.get("/jobs/stats")
+@jwt_required()
+def job_stats():
+    uid = int(get_jwt_identity())
+    return jsonify(reminder_job_stats(uid))
+
+
+@bp.get("/jobs")
+@jwt_required()
+def list_jobs():
+    uid = int(get_jwt_identity())
+    status = request.args.get("status")
+    if status:
+        status = status.upper().strip()
+        if status not in VALID_STATUSES:
+            return jsonify(error="unsupported status"), 400
+    try:
+        limit = min(max(int(request.args.get("limit", 50)), 1), 100)
+    except ValueError:
+        return jsonify(error="limit must be an integer"), 400
+
+    jobs = reminder_jobs_query(uid, status=status).limit(limit).all()
+    return jsonify([serialize_reminder_job(job) for job in jobs])
+
+
+@bp.post("/<int:reminder_id>/retry")
+@jwt_required()
+def retry_reminder(reminder_id: int):
+    uid = int(get_jwt_identity())
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder or reminder.user_id != uid:
+        return jsonify(error="not found"), 404
+    reset_reminder_for_retry(reminder)
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+    logger.info("Reset reminder job for retry id=%s user=%s", reminder.id, uid)
+    return jsonify(serialize_reminder_job(reminder)), 200
 
 
 def _bill_channels(bill: Bill) -> list[str]:
@@ -218,6 +241,7 @@ def _create_reminder_if_missing(
             channel=channel,
             send_at=send_at,
             message=message,
+            max_attempts=configured_max_attempts(),
         )
     )
     return True

--- a/packages/backend/app/services/reminder_jobs.py
+++ b/packages/backend/app/services/reminder_jobs.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from flask import current_app
+from sqlalchemy import func, or_
+
+from ..extensions import db
+from ..models import Reminder
+from ..observability import track_reminder_event
+from .reminders import send_reminder
+
+PENDING = "PENDING"
+RETRYING = "RETRYING"
+SENT = "SENT"
+FAILED = "FAILED"
+ACTIVE_STATUSES = {PENDING, RETRYING}
+VALID_STATUSES = {PENDING, RETRYING, SENT, FAILED}
+DEFAULT_RETRY_DELAYS = (300, 900, 2700)
+MAX_ERROR_LENGTH = 1000
+
+
+def configured_max_attempts() -> int:
+    raw = current_app.config.get("REMINDER_JOB_MAX_ATTEMPTS", 3)
+    try:
+        return max(int(raw), 1)
+    except (TypeError, ValueError):
+        return 3
+
+
+def configured_retry_delays() -> tuple[int, ...]:
+    raw = current_app.config.get("REMINDER_JOB_BACKOFF_SECONDS")
+    if not raw:
+        return DEFAULT_RETRY_DELAYS
+    if isinstance(raw, str):
+        pieces = raw.split(",")
+    else:
+        pieces = list(raw)
+
+    delays: list[int] = []
+    for piece in pieces:
+        try:
+            delay = int(str(piece).strip())
+        except (TypeError, ValueError):
+            continue
+        if delay > 0:
+            delays.append(delay)
+    return tuple(delays) or DEFAULT_RETRY_DELAYS
+
+
+def serialize_reminder_job(reminder: Reminder) -> dict:
+    return {
+        "id": reminder.id,
+        "message": reminder.message,
+        "send_at": _iso(reminder.send_at),
+        "sent": reminder.sent,
+        "channel": reminder.channel,
+        "job_status": reminder.job_status,
+        "retry_count": reminder.retry_count,
+        "max_attempts": reminder.max_attempts,
+        "next_retry_at": _iso(reminder.next_retry_at),
+        "last_attempt_at": _iso(reminder.last_attempt_at),
+        "sent_at": _iso(reminder.sent_at),
+        "failed_at": _iso(reminder.failed_at),
+        "last_error": reminder.last_error,
+    }
+
+
+def process_due_reminders(user_id: int, now: datetime | None = None) -> dict:
+    now = now or datetime.utcnow()
+    reminders = (
+        _due_reminders_query(user_id=user_id, now=now)
+        .order_by(Reminder.send_at.asc(), Reminder.id.asc())
+        .all()
+    )
+    summary = {
+        "processed": len(reminders),
+        "sent": 0,
+        "retrying": 0,
+        "failed": 0,
+    }
+    for reminder in reminders:
+        result = attempt_reminder_delivery(reminder, now=now)
+        if result["job_status"] == SENT:
+            summary["sent"] += 1
+        elif result["job_status"] == RETRYING:
+            summary["retrying"] += 1
+        elif result["job_status"] == FAILED:
+            summary["failed"] += 1
+    db.session.commit()
+    return summary
+
+
+def attempt_reminder_delivery(reminder: Reminder, now: datetime | None = None) -> dict:
+    now = now or datetime.utcnow()
+    _ensure_retry_defaults(reminder)
+    reminder.last_attempt_at = now
+
+    try:
+        delivered = bool(send_reminder(reminder))
+        error = None if delivered else "send_reminder returned false"
+    except Exception as exc:  # pragma: no cover - explicit tests monkeypatch this
+        delivered = False
+        error = str(exc) or exc.__class__.__name__
+
+    if delivered:
+        reminder.sent = True
+        reminder.job_status = SENT
+        reminder.sent_at = now
+        reminder.failed_at = None
+        reminder.next_retry_at = None
+        reminder.last_error = None
+        track_reminder_event(event="sent", channel=reminder.channel)
+        return {"job_status": SENT, "error": None}
+
+    reminder.sent = False
+    reminder.retry_count = (reminder.retry_count or 0) + 1
+    reminder.last_error = _truncate_error(error)
+
+    if reminder.retry_count >= reminder.max_attempts:
+        reminder.job_status = FAILED
+        reminder.failed_at = now
+        reminder.next_retry_at = None
+        track_reminder_event(
+            event="failed", channel=reminder.channel, status="delivery_error"
+        )
+        return {"job_status": FAILED, "error": reminder.last_error}
+
+    reminder.job_status = RETRYING
+    reminder.failed_at = None
+    reminder.next_retry_at = now + timedelta(
+        seconds=_delay_for_failure(reminder.retry_count)
+    )
+    track_reminder_event(
+        event="retry_scheduled", channel=reminder.channel, status="delivery_error"
+    )
+    return {"job_status": RETRYING, "error": reminder.last_error}
+
+
+def reset_reminder_for_retry(reminder: Reminder) -> None:
+    _ensure_retry_defaults(reminder)
+    reminder.sent = False
+    reminder.job_status = PENDING
+    reminder.retry_count = 0
+    reminder.next_retry_at = None
+    reminder.sent_at = None
+    reminder.failed_at = None
+    reminder.last_error = None
+    track_reminder_event(event="manual_retry", channel=reminder.channel)
+
+
+def reminder_job_stats(user_id: int, now: datetime | None = None) -> dict:
+    now = now or datetime.utcnow()
+    counts = dict(
+        db.session.query(Reminder.job_status, func.count(Reminder.id))
+        .filter(Reminder.user_id == user_id)
+        .group_by(Reminder.job_status)
+        .all()
+    )
+    next_retry_at = (
+        db.session.query(func.min(Reminder.next_retry_at))
+        .filter(
+            Reminder.user_id == user_id,
+            Reminder.job_status == RETRYING,
+            Reminder.next_retry_at.isnot(None),
+        )
+        .scalar()
+    )
+    last_failure_at = (
+        db.session.query(func.max(Reminder.failed_at))
+        .filter(Reminder.user_id == user_id, Reminder.failed_at.isnot(None))
+        .scalar()
+    )
+    return {
+        "total": sum(counts.values()),
+        "pending": counts.get(PENDING, 0),
+        "retrying": counts.get(RETRYING, 0),
+        "sent": counts.get(SENT, 0),
+        "failed": counts.get(FAILED, 0),
+        "due_now": _due_reminders_query(user_id=user_id, now=now).count(),
+        "next_retry_at": _iso(next_retry_at),
+        "last_failure_at": _iso(last_failure_at),
+    }
+
+
+def reminder_jobs_query(user_id: int, status: str | None = None):
+    query = db.session.query(Reminder).filter(Reminder.user_id == user_id)
+    if status:
+        query = query.filter(Reminder.job_status == status)
+    return query.order_by(Reminder.send_at.desc(), Reminder.id.desc())
+
+
+def _due_reminders_query(user_id: int, now: datetime):
+    due_cutoff = now + timedelta(minutes=1)
+    return db.session.query(Reminder).filter(
+        Reminder.user_id == user_id,
+        Reminder.sent.is_(False),
+        Reminder.send_at <= due_cutoff,
+        Reminder.job_status.in_(ACTIVE_STATUSES),
+        or_(Reminder.next_retry_at.is_(None), Reminder.next_retry_at <= now),
+    )
+
+
+def _ensure_retry_defaults(reminder: Reminder) -> None:
+    if not reminder.job_status:
+        reminder.job_status = PENDING
+    if reminder.retry_count is None:
+        reminder.retry_count = 0
+    if not reminder.max_attempts:
+        reminder.max_attempts = configured_max_attempts()
+
+
+def _delay_for_failure(failure_count: int) -> int:
+    delays = configured_retry_delays()
+    index = min(max(failure_count - 1, 0), len(delays) - 1)
+    return delays[index]
+
+
+def _truncate_error(error: str | None) -> str:
+    text = error or "delivery failed"
+    return text[:MAX_ERROR_LENGTH]
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -2,9 +2,46 @@ import os
 import pytest
 from app import create_app
 from app.config import Settings
+from app import extensions as app_extensions
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+from app.routes import auth as auth_routes
+from app.services import cache as cache_service
+
+
+class InMemoryRedis:
+    def __init__(self):
+        self.store = {}
+
+    def flushdb(self):
+        self.store.clear()
+
+    def set(self, key, value):
+        self.store[key] = value
+        return True
+
+    def setex(self, key, _ttl, value):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            if key in self.store:
+                deleted += 1
+                del self.store[key]
+        return deleted
+
+    def scan(self, cursor=0, match=None, count=None):
+        keys = list(self.store)
+        if match:
+            import fnmatch
+
+            keys = [key for key in keys if fnmatch.fnmatch(key, match)]
+        return 0, keys[: count or len(keys)]
 
 
 class TestSettings(Settings):
@@ -30,19 +67,17 @@ def app_fixture():
     )
     app = create_app(settings)
     app.config.update(TESTING=True)
+    fake_redis = InMemoryRedis()
+    app_extensions.redis_client = fake_redis
+    auth_routes.redis_client = fake_redis
+    cache_service.redis_client = fake_redis
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -1,4 +1,7 @@
-from datetime import date
+from datetime import date, datetime, timedelta
+
+from app.extensions import db
+from app.models import Reminder
 
 
 def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = False):
@@ -14,6 +17,26 @@ def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = 
     r = client.post("/bills", json=payload, headers=auth_header)
     assert r.status_code == 201
     return r.get_json()["id"]
+
+
+def _create_reminder(client, auth_header, *, send_at=None, channel="email"):
+    payload = {
+        "message": "Pay card",
+        "send_at": (send_at or datetime.utcnow() - timedelta(minutes=5)).isoformat(),
+        "channel": channel,
+    }
+    r = client.post("/reminders", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+def _login(client, email: str):
+    password = "password123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code == 201
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
 
 
 def test_bill_reminders_schedule_supports_default_and_override_offsets(
@@ -80,3 +103,120 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def test_run_due_retries_failed_reminders_without_marking_sent(
+    app_fixture, client, auth_header, monkeypatch
+):
+    reminder_id = _create_reminder(client, auth_header)
+    monkeypatch.setattr("app.services.reminder_jobs.send_reminder", lambda _r: False)
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == {"processed": 1, "sent": 0, "retrying": 1, "failed": 0}
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        assert reminder.sent is False
+        assert reminder.job_status == "RETRYING"
+        assert reminder.retry_count == 1
+        assert reminder.next_retry_at is not None
+        assert reminder.last_error == "send_reminder returned false"
+
+    stats = client.get("/reminders/jobs/stats", headers=auth_header).get_json()
+    assert stats["retrying"] == 1
+    assert stats["due_now"] == 0
+    assert stats["next_retry_at"] is not None
+
+    jobs = client.get("/reminders/jobs?status=RETRYING", headers=auth_header).get_json()
+    assert [job["id"] for job in jobs] == [reminder_id]
+
+
+def test_retry_backoff_waits_until_next_retry_window(
+    app_fixture, client, auth_header, monkeypatch
+):
+    reminder_id = _create_reminder(client, auth_header)
+    monkeypatch.setattr("app.services.reminder_jobs.send_reminder", lambda _r: False)
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["retrying"] == 1
+
+    monkeypatch.setattr("app.services.reminder_jobs.send_reminder", lambda _r: True)
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["processed"] == 0
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        reminder.next_retry_at = datetime.utcnow() - timedelta(seconds=1)
+        db.session.commit()
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["sent"] == 1
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        assert reminder.sent is True
+        assert reminder.job_status == "SENT"
+        assert reminder.sent_at is not None
+        assert reminder.next_retry_at is None
+        assert reminder.last_error is None
+
+
+def test_max_attempts_failure_can_be_manually_retried(
+    app_fixture, client, auth_header, monkeypatch
+):
+    reminder_id = _create_reminder(client, auth_header)
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        reminder.max_attempts = 1
+        db.session.commit()
+    monkeypatch.setattr(
+        "app.services.reminder_jobs.send_reminder",
+        lambda _r: (_ for _ in ()).throw(RuntimeError("provider down")),
+    )
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == {"processed": 1, "sent": 0, "retrying": 0, "failed": 1}
+
+    with app_fixture.app_context():
+        reminder = db.session.get(Reminder, reminder_id)
+        assert reminder.job_status == "FAILED"
+        assert reminder.failed_at is not None
+        assert reminder.last_error == "provider down"
+
+    failed = client.get("/reminders/jobs?status=FAILED", headers=auth_header)
+    assert failed.status_code == 200
+    assert failed.get_json()[0]["id"] == reminder_id
+
+    r = client.post(f"/reminders/{reminder_id}/retry", headers=auth_header)
+    assert r.status_code == 200
+    retry_payload = r.get_json()
+    assert retry_payload["job_status"] == "PENDING"
+    assert retry_payload["retry_count"] == 0
+    assert retry_payload["last_error"] is None
+
+    monkeypatch.setattr("app.services.reminder_jobs.send_reminder", lambda _r: True)
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["sent"] == 1
+
+
+def test_reminder_job_monitoring_is_user_scoped(client, auth_header):
+    first_id = _create_reminder(client, auth_header)
+    other_header = _login(client, "other@example.com")
+    other_id = _create_reminder(client, other_header)
+
+    first_jobs = client.get("/reminders/jobs", headers=auth_header)
+    assert first_jobs.status_code == 200
+    assert [job["id"] for job in first_jobs.get_json()] == [first_id]
+
+    other_jobs = client.get("/reminders/jobs", headers=other_header)
+    assert other_jobs.status_code == 200
+    assert [job["id"] for job in other_jobs.get_json()] == [other_id]
+
+    r = client.post(f"/reminders/{other_id}/retry", headers=auth_header)
+    assert r.status_code == 404


### PR DESCRIPTION
/claim #130

## Summary

- Persist reminder delivery job state on the existing reminders table: status, retry count, max attempts, next retry, last attempt, sent/failed timestamps, and last error.
- Route `/reminders/run` through retry-aware processing so failed deliveries are not marked sent; failures schedule configurable backoff and eventually move to a dead-letter `FAILED` state.
- Add authenticated monitoring and manual recovery APIs: `GET /reminders/jobs/stats`, `GET /reminders/jobs?status=...`, and `POST /reminders/{id}/retry`.
- Add Postgres schema compatibility updates, OpenAPI docs, README operator notes, and tests for retry, max attempts, manual retry, backoff windows, and user isolation.

## Assumption

This is scoped to the current persisted reminder/background dispatch path rather than introducing a separate generic queue dependency. That keeps the patch aligned with the app's existing cron/APScheduler-style `/reminders/run` workflow.

## Validation

- `black --check .` from `packages/backend`: passed
- `flake8 .` from `packages/backend`: passed
- `python -m pytest -q` from `packages/backend`: 26 passed
- `bandit -r app -ll` from `packages/backend`: no issues identified
- Backend Docker image build: passed via tar-stream context
- API smoke: register/login, create due reminder, failed run -> RETRYING, monitoring stats/list, manual retry, simulated provider recovery -> SENT
