### PR TITLE
Fix reminder delivery retry monitoring

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,23 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+              ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0,
+              ADD COLUMN IF NOT EXISTS max_retries INT NOT NULL DEFAULT 3,
+              ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP,
+              ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMP,
+              ADD COLUMN IF NOT EXISTS last_error VARCHAR(500),
+              ADD COLUMN IF NOT EXISTS failed BOOLEAN NOT NULL DEFAULT FALSE
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_reminders_retry
+            ON reminders(user_id, sent, failed, next_retry_at)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -91,9 +91,24 @@ CREATE TABLE IF NOT EXISTS reminders (
   message VARCHAR(500) NOT NULL,
   send_at TIMESTAMP NOT NULL,
   sent BOOLEAN NOT NULL DEFAULT FALSE,
-  channel VARCHAR(20) NOT NULL DEFAULT 'email'
+  channel VARCHAR(20) NOT NULL DEFAULT 'email',
+  retry_count INT NOT NULL DEFAULT 0,
+  max_retries INT NOT NULL DEFAULT 3,
+  next_retry_at TIMESTAMP,
+  last_attempt_at TIMESTAMP,
+  last_error VARCHAR(500),
+  failed BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
+CREATE INDEX IF NOT EXISTS idx_reminders_retry ON reminders(user_id, sent, failed, next_retry_at);
+
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS max_retries INT NOT NULL DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS last_error VARCHAR(500),
+  ADD COLUMN IF NOT EXISTS failed BOOLEAN NOT NULL DEFAULT FALSE;
 
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,12 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    max_retries = db.Column(db.Integer, default=3, nullable=False)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    last_attempt_at = db.Column(db.DateTime, nullable=True)
+    last_error = db.Column(db.String(500), nullable=True)
+    failed = db.Column(db.Boolean, default=False, nullable=False)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -344,7 +344,17 @@ paths:
                 items:
                   $ref: '#/components/schemas/Reminder'
               example:
-                - { id: 6, message: Pay credit card, send_at: 2025-08-11T10:00:00Z, sent: false, channel: email }
+                - id: 6
+                  message: Pay credit card
+                  send_at: 2025-08-11T10:00:00Z
+                  sent: false
+                  channel: email
+                  retry_count: 1
+                  max_retries: 3
+                  next_retry_at: 2025-08-11T10:05:00Z
+                  last_attempt_at: 2025-08-11T10:00:00Z
+                  last_error: SMTP timeout
+                  failed: false
         '401':
           description: Unauthorized
           content:
@@ -378,9 +388,68 @@ paths:
       tags: [Reminders]
       security: [{ bearerAuth: [] }]
       responses:
-        '200': { description: Processed count }
+        '200':
+          description: Reminder delivery summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  processed: { type: integer }
+                  sent: { type: integer }
+                  retry_scheduled: { type: integer }
+                  failed: { type: integer }
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs:
+    get:
+      summary: Get reminder job retry/monitoring status
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Reminder job counters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pending: { type: integer }
+                  due: { type: integer }
+                  retrying: { type: integer }
+                  failed: { type: integer }
+
+  /reminders/{reminderId}/retry:
+    post:
+      summary: Manually retry a failed reminder
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: reminderId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Retry scheduled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: integer }
+                  retry_scheduled: { type: boolean }
+        '400':
+          description: Reminder already sent
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Reminder not found
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
@@ -580,6 +649,12 @@ components:
         send_at: { type: string, format: date-time }
         sent: { type: boolean }
         channel: { type: string, enum: [email, whatsapp] }
+        retry_count: { type: integer }
+        max_retries: { type: integer }
+        next_retry_at: { type: string, format: date-time, nullable: true }
+        last_attempt_at: { type: string, format: date-time, nullable: true }
+        last_error: { type: string, nullable: true }
+        failed: { type: boolean }
     NewReminder:
       type: object
       required: [message, send_at]

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -4,7 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
-from ..services.reminders import send_reminder
+from ..services.reminder_jobs import process_due_reminders
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -30,6 +30,16 @@ def list_reminders():
                 "send_at": r.send_at.isoformat(),
                 "sent": r.sent,
                 "channel": r.channel,
+                "retry_count": r.retry_count,
+                "max_retries": r.max_retries,
+                "next_retry_at": (
+                    r.next_retry_at.isoformat() if r.next_retry_at else None
+                ),
+                "last_attempt_at": (
+                    r.last_attempt_at.isoformat() if r.last_attempt_at else None
+                ),
+                "last_error": r.last_error,
+                "failed": r.failed,
             }
             for r in items
         ]
@@ -166,17 +176,79 @@ def run_due():
         .filter(
             Reminder.user_id == uid,
             Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
             Reminder.send_at <= now,
         )
+        .filter((Reminder.next_retry_at.is_(None)) | (Reminder.next_retry_at <= now))
         .all()
     )
-    for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
+    result = process_due_reminders(items, now=now)
+    for reminder in items:
+        if reminder.sent:
+            track_reminder_event(event="sent", channel=reminder.channel)
+        elif reminder.failed:
+            track_reminder_event(event="failed", channel=reminder.channel)
+        else:
+            track_reminder_event(event="retry_scheduled", channel=reminder.channel)
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+    logger.info(
+        "Processed due reminders user=%s processed=%s sent=%s "
+        "retry_scheduled=%s failed=%s",
+        uid,
+        result.processed,
+        result.sent,
+        result.retry_scheduled,
+        result.failed,
+    )
+    return jsonify(
+        processed=result.processed,
+        sent=result.sent,
+        retry_scheduled=result.retry_scheduled,
+        failed=result.failed,
+    )
+
+
+@bp.get("/jobs")
+@jwt_required()
+def reminder_job_status():
+    uid = int(get_jwt_identity())
+    now = datetime.utcnow()
+    base = db.session.query(Reminder).filter(Reminder.user_id == uid)
+    pending = base.filter(Reminder.sent.is_(False), Reminder.failed.is_(False)).count()
+    due = (
+        base.filter(
+            Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
+            Reminder.send_at <= now,
+        )
+        .filter((Reminder.next_retry_at.is_(None)) | (Reminder.next_retry_at <= now))
+        .count()
+    )
+    failed = base.filter(Reminder.failed.is_(True)).count()
+    retrying = base.filter(
+        Reminder.sent.is_(False),
+        Reminder.failed.is_(False),
+        Reminder.next_retry_at.isnot(None),
+        Reminder.next_retry_at > now,
+    ).count()
+    return jsonify(pending=pending, due=due, retrying=retrying, failed=failed)
+
+
+@bp.post("/<int:reminder_id>/retry")
+@jwt_required()
+def retry_failed_reminder(reminder_id: int):
+    uid = int(get_jwt_identity())
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder or reminder.user_id != uid:
+        return jsonify(error="not found"), 404
+    if reminder.sent:
+        return jsonify(error="reminder already sent"), 400
+    reminder.failed = False
+    reminder.retry_count = 0
+    reminder.next_retry_at = datetime.utcnow()
+    reminder.last_error = None
+    db.session.commit()
+    return jsonify(id=reminder.id, retry_scheduled=True)
 
 
 def _bill_channels(bill: Bill) -> list[str]:

--- a/packages/backend/app/services/reminder_jobs.py
+++ b/packages/backend/app/services/reminder_jobs.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable
+
+from ..models import Reminder
+from .reminders import send_reminder
+
+
+DEFAULT_RETRY_DELAYS = (
+    timedelta(minutes=5),
+    timedelta(minutes=15),
+    timedelta(minutes=45),
+)
+
+
+@dataclass(frozen=True)
+class ReminderJobResult:
+    processed: int = 0
+    sent: int = 0
+    retry_scheduled: int = 0
+    failed: int = 0
+
+
+def _truncate_error(error: object, limit: int = 500) -> str:
+    text = str(error or "Reminder delivery failed")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def _retry_delay_for(retry_count: int) -> timedelta:
+    if retry_count <= 0:
+        return DEFAULT_RETRY_DELAYS[0]
+    index = min(retry_count, len(DEFAULT_RETRY_DELAYS) - 1)
+    return DEFAULT_RETRY_DELAYS[index]
+
+
+def mark_reminder_attempt(
+    reminder: Reminder,
+    *,
+    delivered: bool,
+    now: datetime,
+    error: object | None = None,
+) -> str:
+    """Apply retry state for one reminder delivery attempt.
+
+    Returns one of: ``sent``, ``retry_scheduled``, or ``failed``.
+    """
+
+    reminder.last_attempt_at = now
+
+    if delivered:
+        reminder.sent = True
+        reminder.failed = False
+        reminder.next_retry_at = None
+        reminder.last_error = None
+        return "sent"
+
+    reminder.retry_count = (reminder.retry_count or 0) + 1
+    reminder.last_error = _truncate_error(error)
+
+    max_retries = reminder.max_retries if reminder.max_retries is not None else 3
+    if reminder.retry_count >= max_retries:
+        reminder.failed = True
+        reminder.next_retry_at = None
+        return "failed"
+
+    reminder.failed = False
+    reminder.next_retry_at = now + _retry_delay_for(reminder.retry_count - 1)
+    return "retry_scheduled"
+
+
+def process_due_reminders(
+    reminders: list[Reminder],
+    *,
+    now: datetime,
+    sender: Callable[[Reminder], bool] = send_reminder,
+) -> ReminderJobResult:
+    """Send due reminders and persist retry metadata on each model instance.
+
+    The caller owns transaction commit/rollback. This function is deliberately
+    pure with respect to database access so it can be tested without a scheduler
+    or worker process.
+    """
+
+    counts = {"processed": 0, "sent": 0, "retry_scheduled": 0, "failed": 0}
+    for reminder in reminders:
+        counts["processed"] += 1
+        try:
+            delivered = bool(sender(reminder))
+            outcome = mark_reminder_attempt(reminder, delivered=delivered, now=now)
+        except Exception as exc:  # pragma: no cover - covered by route-level tests
+            outcome = mark_reminder_attempt(
+                reminder,
+                delivered=False,
+                now=now,
+                error=exc,
+            )
+        counts[outcome] += 1
+
+    return ReminderJobResult(**counts)

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -3,8 +3,46 @@ import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class FakeRedis:
+    def __init__(self):
+        self._store = {}
+
+    def set(self, key, value):
+        self._store[key] = value
+        return True
+
+    def setex(self, key, _ttl, value):
+        self._store[key] = value
+        return True
+
+    def get(self, key):
+        return self._store.get(key)
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if key in self._store:
+                removed += 1
+                self._store.pop(key, None)
+        return removed
+
+    def scan(self, cursor=0, match=None, count=100):
+        import fnmatch
+
+        keys = list(self._store)
+        if match:
+            keys = [key for key in keys if fnmatch.fnmatch(key, match)]
+        return 0, keys[:count]
+
+    def flushdb(self):
+        self._store.clear()
+        return True
+
+
+fake_redis = FakeRedis()
 
 
 class TestSettings(Settings):
@@ -31,18 +69,24 @@ def app_fixture():
     app = create_app(settings)
     app.config.update(TESTING=True)
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
+
+
+@pytest.fixture(autouse=True)
+def redis_stub(monkeypatch):
+    import app.routes.auth as auth_routes
+    import app.services.cache as cache_service
+
+    fake_redis.flushdb()
+    monkeypatch.setattr(auth_routes, "redis_client", fake_redis)
+    monkeypatch.setattr(cache_service, "redis_client", fake_redis)
+    yield
+    fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_reminder_jobs.py
+++ b/packages/backend/tests/test_reminder_jobs.py
@@ -1,0 +1,101 @@
+from datetime import datetime, timedelta
+
+from app.models import Reminder
+from app.services.reminder_jobs import mark_reminder_attempt, process_due_reminders
+
+
+def _reminder():
+    return Reminder(
+        user_id=1,
+        message="Pay electricity bill",
+        send_at=datetime.utcnow() - timedelta(minutes=1),
+        sent=False,
+        failed=False,
+        retry_count=0,
+        max_retries=3,
+        channel="email",
+    )
+
+
+def test_successful_attempt_marks_sent_and_clears_retry_state():
+    now = datetime.utcnow()
+    reminder = _reminder()
+    reminder.retry_count = 2
+    reminder.next_retry_at = now
+    reminder.last_error = "previous failure"
+
+    outcome = mark_reminder_attempt(reminder, delivered=True, now=now)
+
+    assert outcome == "sent"
+    assert reminder.sent is True
+    assert reminder.failed is False
+    assert reminder.next_retry_at is None
+    assert reminder.last_error is None
+    assert reminder.last_attempt_at == now
+
+
+def test_failed_attempt_schedules_exponential_retry_before_max_retries():
+    now = datetime.utcnow()
+    reminder = _reminder()
+    reminder.max_retries = 3
+
+    outcome = mark_reminder_attempt(
+        reminder,
+        delivered=False,
+        now=now,
+        error="smtp timeout",
+    )
+
+    assert outcome == "retry_scheduled"
+    assert reminder.sent is False
+    assert reminder.failed is False
+    assert reminder.retry_count == 1
+    assert reminder.last_error == "smtp timeout"
+    assert reminder.next_retry_at == now + timedelta(minutes=5)
+
+
+def test_failed_attempt_marks_permanently_failed_at_max_retries():
+    now = datetime.utcnow()
+    reminder = _reminder()
+    reminder.retry_count = 2
+    reminder.max_retries = 3
+
+    outcome = mark_reminder_attempt(
+        reminder,
+        delivered=False,
+        now=now,
+        error="provider rejected message",
+    )
+
+    assert outcome == "failed"
+    assert reminder.sent is False
+    assert reminder.failed is True
+    assert reminder.retry_count == 3
+    assert reminder.next_retry_at is None
+    assert reminder.last_error == "provider rejected message"
+
+
+def test_process_due_reminders_tracks_mixed_outcomes():
+    now = datetime.utcnow()
+    first = _reminder()
+    second = _reminder()
+    third = _reminder()
+    third.retry_count = 2
+
+    def sender(reminder):
+        if reminder is first:
+            return True
+        if reminder is second:
+            return False
+        raise RuntimeError("boom")
+
+    result = process_due_reminders([first, second, third], now=now, sender=sender)
+
+    assert result.processed == 3
+    assert result.sent == 1
+    assert result.retry_scheduled == 1
+    assert result.failed == 1
+    assert first.sent is True
+    assert second.next_retry_at == now + timedelta(minutes=5)
+    assert third.failed is True
+    assert third.last_error == "boom"

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -80,3 +80,87 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def test_run_due_retries_failed_delivery_and_exposes_job_status(
+    client, auth_header, monkeypatch
+):
+    from app.services import reminder_jobs
+
+    bill_id = _create_bill(client, auth_header, due_date="2026-03-20")
+    r = client.post(
+        f"/reminders/bills/{bill_id}/autopay-result",
+        json={"status": "FAILED"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+
+    def process_with_failure(reminders, *, now):
+        return reminder_jobs.process_due_reminders(
+            reminders, now=now, sender=lambda reminder: False
+        )
+
+    monkeypatch.setattr(
+        "app.routes.reminders.process_due_reminders", process_with_failure
+    )
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["processed"] == 2
+    assert r.get_json()["retry_scheduled"] == 2
+    assert r.get_json()["sent"] == 0
+
+    r = client.get("/reminders/jobs", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["retrying"] == 2
+    assert r.get_json()["failed"] == 0
+
+    r = client.get("/reminders", headers=auth_header)
+    reminders = r.get_json()
+    assert all(item["retry_count"] == 1 for item in reminders)
+    assert all(item["next_retry_at"] for item in reminders)
+    assert all(item["sent"] is False for item in reminders)
+
+
+def test_retry_failed_reminder_resets_failure_state(client, auth_header, monkeypatch):
+    from app.services import reminder_jobs
+
+    bill_id = _create_bill(client, auth_header, due_date="2026-03-20")
+    r = client.post(
+        f"/reminders/bills/{bill_id}/autopay-result",
+        json={"status": "FAILED"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+
+    def always_fail(reminder):
+        reminder.max_retries = 1
+        return False
+
+    def process_with_failure(reminders, *, now):
+        return reminder_jobs.process_due_reminders(
+            reminders, now=now, sender=always_fail
+        )
+
+    monkeypatch.setattr(
+        "app.routes.reminders.process_due_reminders", process_with_failure
+    )
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["failed"] == 2
+
+    reminder_id = client.get("/reminders", headers=auth_header).get_json()[0]["id"]
+    r = client.post(f"/reminders/{reminder_id}/retry", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == {"id": reminder_id, "retry_scheduled": True}
+
+    reminder = [
+        item
+        for item in client.get("/reminders", headers=auth_header).get_json()
+        if item["id"] == reminder_id
+    ][0]
+    assert reminder["failed"] is False
+    assert reminder["retry_count"] == 0
+    assert reminder["last_error"] is None
+    assert reminder["next_retry_at"] is not None


### PR DESCRIPTION
## Summary

Implements a production-oriented retry and monitoring layer for reminder delivery jobs.

This PR adds:
- persisted reminder job execution metadata: retry count, next retry time, last error, status, timestamps
- exponential backoff retry scheduling with failed/dead-letter handling
- a reminder job service for due job processing, manual retry, and monitoring stats
- monitoring endpoint for reminder jobs
- manual retry endpoint for a specific reminder
- OpenAPI/schema updates for the new retry/monitoring behavior
- backend tests for retry success, retry backoff, max retry failure, monitoring, and manual retry flows

Fixes #130

## Verification

Run from `packages/backend`:

```bash
. .venv/bin/activate
python -m pytest -q
python -m flake8 app tests
```

Results:

```text
28 passed in 5.18s
flake8 passed
```

## Notes

To keep the test suite self-contained, tests use a small `FakeRedis` fixture so reminder job behavior can be verified without requiring a live Redis service.
