### PR TITLE
Add retry monitoring for reminder jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,18 @@ finmind/
   - request count by endpoint/status
   - request duration histograms (latency, including dashboard p95 KPI)
   - reminder event counters (engagement KPI)
+  - background job counters for attempts, retries, successes, and failures
 - Logs are emitted as JSON with `request_id` and shipped to Loki via Promtail.
 - Pre-provisioned Grafana dashboard: `FinMind Operations and KPI`.
+
+## Background Job Retry
+- Due reminder delivery is retried before a reminder is marked as sent.
+- Configure retry behavior with `JOB_RETRY_MAX_ATTEMPTS` and
+  `JOB_RETRY_BASE_DELAY_SECONDS`.
+- `/reminders/run` returns `processed`, `sent`, `failed`, and `retries` so cron
+  runners and dashboards can detect degraded delivery.
+- Failed reminders stay unsent and keep `last_error` plus cumulative
+  `delivery_attempts` for operator follow-up.
 
 ## Contribution Policy
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -33,6 +33,8 @@ def create_app(settings: Settings | None = None) -> Flask:
         TWILIO_AUTH_TOKEN=cfg.twilio_auth_token,
         TWILIO_WHATSAPP_FROM=cfg.twilio_whatsapp_from,
         EMAIL_FROM=cfg.email_from,
+        JOB_RETRY_MAX_ATTEMPTS=cfg.job_retry_max_attempts,
+        JOB_RETRY_BASE_DELAY_SECONDS=cfg.job_retry_base_delay_seconds,
     )
 
     # Logging
@@ -108,6 +110,18 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             ALTER TABLE users
             ADD COLUMN IF NOT EXISTS preferred_currency VARCHAR(10)
             NOT NULL DEFAULT 'INR'
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS delivery_attempts INT NOT NULL DEFAULT 0
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS last_error VARCHAR(500)
             """
         )
         conn.commit()

--- a/packages/backend/app/config.py
+++ b/packages/backend/app/config.py
@@ -23,6 +23,9 @@ class Settings(BaseSettings):
     email_from: str | None = None
     smtp_url: str | None = None  # e.g. smtp+ssl://user:pass@mail:465
 
+    job_retry_max_attempts: int = 3
+    job_retry_base_delay_seconds: float = 0.0
+
     # pydantic-settings v2 configuration
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -91,9 +91,17 @@ CREATE TABLE IF NOT EXISTS reminders (
   message VARCHAR(500) NOT NULL,
   send_at TIMESTAMP NOT NULL,
   sent BOOLEAN NOT NULL DEFAULT FALSE,
-  channel VARCHAR(20) NOT NULL DEFAULT 'email'
+  channel VARCHAR(20) NOT NULL DEFAULT 'email',
+  delivery_attempts INT NOT NULL DEFAULT 0,
+  last_error VARCHAR(500)
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
+
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS delivery_attempts INT NOT NULL DEFAULT 0;
+
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS last_error VARCHAR(500);
 
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,8 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    delivery_attempts = db.Column(db.Integer, default=0, nullable=False)
+    last_error = db.Column(db.String(500), nullable=True)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/observability.py
+++ b/packages/backend/app/observability.py
@@ -60,6 +60,12 @@ class Observability:
             ["event", "channel", "status"],
             registry=self.registry,
         )
+        self.background_job_events_total = Counter(
+            "finmind_background_job_events_total",
+            "Background job attempts, retries, successes, and failures.",
+            ["job", "event"],
+            registry=self.registry,
+        )
 
     def observe_http_request(
         self, method: str, endpoint: str, status_code: int, duration_seconds: float
@@ -78,6 +84,9 @@ class Observability:
         self.reminder_events_total.labels(
             event=event, channel=channel, status=status
         ).inc()
+
+    def record_background_job_event(self, job: str, event: str) -> None:
+        self.background_job_events_total.labels(job=job, event=event).inc()
 
     def metrics_response(self) -> Response:
         if self.multiprocess_enabled:
@@ -137,3 +146,9 @@ def track_reminder_event(event: str, channel: str, status: str = "ok") -> None:
     obs = current_app.extensions.get("observability")
     if obs:
         obs.record_reminder_event(event=event, channel=channel, status=status)
+
+
+def track_background_job_event(job: str, event: str) -> None:
+    obs = current_app.extensions.get("observability")
+    if obs:
+        obs.record_background_job_event(job=job, event=event)

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
+from ..services.jobs import run_with_retry
 from ..services.reminders import send_reminder
 import logging
 
@@ -30,6 +31,8 @@ def list_reminders():
                 "send_at": r.send_at.isoformat(),
                 "sent": r.sent,
                 "channel": r.channel,
+                "delivery_attempts": r.delivery_attempts,
+                "last_error": r.last_error,
             }
             for r in items
         ]
@@ -170,13 +173,38 @@ def run_due():
         )
         .all()
     )
+    sent = 0
+    failed = 0
+    retries = 0
     for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
+        result = run_with_retry(
+            job_name="send_reminder",
+            operation=lambda reminder=r: send_reminder(reminder),
+            logger=logger,
+        )
+        r.delivery_attempts += result.attempts
+        retries += max(0, result.attempts - 1)
+        if result.success:
+            r.sent = True
+            r.last_error = None
+            sent += 1
+            track_reminder_event(event="sent", channel=r.channel)
+        else:
+            failed += 1
+            r.last_error = (result.error or "delivery failed")[:500]
+            track_reminder_event(
+                event="send_failed", channel=r.channel, status="failed"
+            )
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+    logger.info(
+        "Processed due reminders user=%s count=%s sent=%s failed=%s retries=%s",
+        uid,
+        len(items),
+        sent,
+        failed,
+        retries,
+    )
+    return jsonify(processed=len(items), sent=sent, failed=failed, retries=retries)
 
 
 def _bill_channels(bill: Bill) -> list[str]:

--- a/packages/backend/app/services/jobs.py
+++ b/packages/backend/app/services/jobs.py
@@ -1,0 +1,60 @@
+import logging
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+from flask import current_app
+
+from ..observability import track_background_job_event
+
+
+@dataclass(frozen=True)
+class JobResult:
+    success: bool
+    attempts: int
+    error: str | None = None
+
+
+def run_with_retry(
+    *,
+    job_name: str,
+    operation: Callable[[], bool],
+    max_attempts: int | None = None,
+    base_delay_seconds: float | None = None,
+    logger: logging.Logger | None = None,
+) -> JobResult:
+    """Run a boolean job operation with bounded retry and metrics."""
+    attempts_limit = max(
+        1, int(max_attempts or current_app.config["JOB_RETRY_MAX_ATTEMPTS"])
+    )
+    delay = float(
+        current_app.config["JOB_RETRY_BASE_DELAY_SECONDS"]
+        if base_delay_seconds is None
+        else base_delay_seconds
+    )
+    log = logger or logging.getLogger("finmind.jobs")
+    last_error = None
+
+    for attempt in range(1, attempts_limit + 1):
+        track_background_job_event(job_name, "attempt")
+        try:
+            if operation():
+                track_background_job_event(job_name, "success")
+                return JobResult(success=True, attempts=attempt)
+            raise RuntimeError("operation returned false")
+        except Exception as exc:  # noqa: BLE001 - job runner must isolate failures
+            last_error = str(exc) or exc.__class__.__name__
+            log.warning(
+                "Background job failed job=%s attempt=%s/%s error=%s",
+                job_name,
+                attempt,
+                attempts_limit,
+                last_error,
+            )
+            if attempt < attempts_limit:
+                track_background_job_event(job_name, "retry")
+                if delay > 0:
+                    time.sleep(delay * (2 ** (attempt - 1)))
+
+    track_background_job_event(job_name, "failure")
+    return JobResult(success=False, attempts=attempts_limit, error=last_error)

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -1,4 +1,9 @@
-from datetime import date
+from datetime import date, datetime, timedelta
+
+from flask_jwt_extended import create_access_token
+
+from app.extensions import db
+from app.models import User
 
 
 def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = False):
@@ -80,3 +85,68 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def _auth_header_without_redis(app_fixture):
+    with app_fixture.app_context():
+        user = User(email="retry@example.com", password_hash="unused")
+        db.session.add(user)
+        db.session.commit()
+        token = create_access_token(identity=str(user.id))
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_run_due_retries_transient_delivery_failures(client, app_fixture, monkeypatch):
+    attempts = {"count": 0}
+
+    def flaky_send(_reminder):
+        attempts["count"] += 1
+        return attempts["count"] >= 3
+
+    monkeypatch.setattr("app.routes.reminders.send_reminder", flaky_send)
+    auth_header = _auth_header_without_redis(app_fixture)
+    send_at = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    r = client.post(
+        "/reminders",
+        json={"message": "Retry me", "send_at": send_at, "channel": "email"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload == {"processed": 1, "sent": 1, "failed": 0, "retries": 2}
+    assert attempts["count"] == 3
+
+    r = client.get("/reminders", headers=auth_header)
+    reminder = r.get_json()[0]
+    assert reminder["sent"] is True
+    assert reminder["delivery_attempts"] == 3
+    assert reminder["last_error"] is None
+
+
+def test_run_due_keeps_failed_reminders_unsent(client, app_fixture, monkeypatch):
+    def failed_send(_reminder):
+        raise RuntimeError("smtp timeout")
+
+    monkeypatch.setattr("app.routes.reminders.send_reminder", failed_send)
+    auth_header = _auth_header_without_redis(app_fixture)
+    send_at = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    r = client.post(
+        "/reminders",
+        json={"message": "Do not mark sent", "send_at": send_at, "channel": "email"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload == {"processed": 1, "sent": 0, "failed": 1, "retries": 2}
+
+    r = client.get("/reminders", headers=auth_header)
+    reminder = r.get_json()[0]
+    assert reminder["sent"] is False
+    assert reminder["delivery_attempts"] == 3
+    assert reminder["last_error"] == "smtp timeout"


### PR DESCRIPTION
## Summary
- Add bounded retry handling for due reminder delivery jobs
- Keep failed reminders unsent, track cumulative delivery attempts, and store `last_error`
- Add Prometheus background job counters for attempts, retries, successes, and failures
- Return `processed`, `sent`, `failed`, and `retries` from `/reminders/run`
- Document retry configuration and monitoring behavior

Closes #130

## Validation
- `py -3.11 -m venv .venv-backend-test`
- `.\.venv-backend-test\Scripts\python.exe -m pip install -r packages\backend\requirements.txt`
- From `packages/backend`: `..\..\.venv-backend-test\Scripts\python.exe -m pytest tests\test_reminders.py -q -k run_due` -> `2 passed, 2 deselected`
- From `packages/backend`: `..\..\.venv-backend-test\Scripts\python.exe -m black --check app\config.py app\__init__.py app\models.py app\observability.py app\services\jobs.py app\routes\reminders.py tests\test_reminders.py`
- From `packages/backend`: `..\..\.venv-backend-test\Scripts\python.exe -m flake8 app\config.py app\__init__.py app\models.py app\observability.py app\services\jobs.py app\routes\reminders.py tests\test_reminders.py`
- `python -m py_compile packages\backend\app\config.py packages\backend\app\__init__.py packages\backend\app\models.py packages\backend\app\observability.py packages\backend\app\services\jobs.py packages\backend\app\routes\reminders.py packages\backend\tests\test_reminders.py`
- `git diff --check`

Note: running the entire existing `tests/test_reminders.py` module locally requires Redis for the pre-existing `auth_header` fixture; the new retry tests avoid Redis by minting JWTs directly and passed in the local environment.

/claim #130
