### PR TITLE
Add weekly financial digest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ finmind/
 - Logs are emitted as JSON with `request_id` and shipped to Loki via Promtail.
 - Pre-provisioned Grafana dashboard: `FinMind Operations and KPI`.
 
+## Weekly Financial Digest
+- `GET /insights/weekly-digest?week_start=YYYY-MM-DD` returns a weekly summary
+  for the authenticated user.
+- The response includes income, expenses, net flow, prior-week comparison,
+  top spending categories, trend insights, and recommended next actions.
+- The digest is deterministic and works without paid AI API keys; it can be used
+  by schedulers, email jobs, or dashboard cards.
+
 ## Contribution Policy
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.
 

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,6 +1,7 @@
 from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..services.digests import weekly_financial_digest
 from ..services.ai import monthly_budget_suggestion
 import logging
 
@@ -23,3 +24,24 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-digest")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    week_start_arg = (request.args.get("week_start") or "").strip()
+    if week_start_arg:
+        try:
+            week_start = date.fromisoformat(week_start_arg)
+        except ValueError:
+            return jsonify(error="invalid week_start, expected YYYY-MM-DD"), 400
+    else:
+        week_start = None
+    digest = weekly_financial_digest(uid, week_start)
+    logger.info(
+        "Weekly digest served user=%s week_start=%s",
+        uid,
+        digest["period"]["week_start"],
+    )
+    return jsonify(digest)

--- a/packages/backend/app/services/digests.py
+++ b/packages/backend/app/services/digests.py
@@ -1,0 +1,168 @@
+from datetime import date, timedelta
+
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Category, Expense
+
+
+def _week_start(value: date | None = None) -> date:
+    anchor = value or date.today()
+    return anchor - timedelta(days=anchor.weekday())
+
+
+def _pct_change(current: float, previous: float) -> float:
+    if previous == 0:
+        return 0.0
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def _totals(uid: int, start: date, end: date) -> dict[str, float]:
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+    income_value = round(float(income or 0), 2)
+    expense_value = round(float(expenses or 0), 2)
+    return {
+        "income": income_value,
+        "expenses": expense_value,
+        "net_flow": round(income_value - expense_value, 2),
+    }
+
+
+def _category_totals(uid: int, start: date, end: date) -> list[dict]:
+    rows = (
+        db.session.query(
+            func.coalesce(Category.name, "Uncategorized").label("category_name"),
+            func.coalesce(func.sum(Expense.amount), 0).label("amount"),
+        )
+        .outerjoin(
+            Category,
+            (Category.id == Expense.category_id) & (Category.user_id == uid),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .limit(5)
+        .all()
+    )
+    total = sum(float(row.amount or 0) for row in rows)
+    return [
+        {
+            "category_name": row.category_name,
+            "amount": round(float(row.amount or 0), 2),
+            "share_pct": (
+                round((float(row.amount or 0) / total) * 100, 2) if total > 0 else 0
+            ),
+        }
+        for row in rows
+    ]
+
+
+def _insights(
+    *,
+    totals: dict[str, float],
+    previous_totals: dict[str, float],
+    top_categories: list[dict],
+) -> list[str]:
+    items: list[str] = []
+    change = _pct_change(totals["expenses"], previous_totals["expenses"])
+    if totals["net_flow"] >= 0:
+        items.append(
+            f"Positive weekly cash flow of {totals['net_flow']:.2f}; "
+            "keep the surplus assigned."
+        )
+    else:
+        items.append(
+            f"Negative weekly cash flow of {abs(totals['net_flow']):.2f}; "
+            "review upcoming discretionary spend."
+        )
+    if change > 0:
+        items.append(f"Spending increased {change:.2f}% compared with the prior week.")
+    elif change < 0:
+        items.append(
+            f"Spending decreased {abs(change):.2f}% compared with the prior week."
+        )
+    else:
+        items.append("Spending was flat compared with the prior week.")
+    if top_categories:
+        top = top_categories[0]
+        items.append(
+            f"{top['category_name']} was the largest category at "
+            f"{top['share_pct']:.2f}% of spend."
+        )
+    return items
+
+
+def _actions(totals: dict[str, float], top_categories: list[dict]) -> list[str]:
+    actions = []
+    if totals["net_flow"] > 0:
+        actions.append("Move part of this week's surplus into savings or debt payoff.")
+    else:
+        actions.append(
+            "Pause one non-essential purchase next week to restore positive cash flow."
+        )
+    if top_categories:
+        actions.append(
+            f"Set a specific cap for {top_categories[0]['category_name']} "
+            "before the next week starts."
+        )
+    actions.append(
+        "Review recurring bills due in the next 7 days before adding new commitments."
+    )
+    return actions
+
+
+def weekly_financial_digest(uid: int, week_start: date | None = None) -> dict:
+    start = _week_start(week_start)
+    end = start + timedelta(days=6)
+    previous_start = start - timedelta(days=7)
+    previous_end = start - timedelta(days=1)
+    totals = _totals(uid, start, end)
+    previous_totals = _totals(uid, previous_start, previous_end)
+    top_categories = _category_totals(uid, start, end)
+    return {
+        "period": {
+            "week_start": start.isoformat(),
+            "week_end": end.isoformat(),
+            "previous_week_start": previous_start.isoformat(),
+            "previous_week_end": previous_end.isoformat(),
+        },
+        "summary": {
+            **totals,
+            "previous_week_expenses": previous_totals["expenses"],
+            "spending_change_pct": _pct_change(
+                totals["expenses"], previous_totals["expenses"]
+            ),
+        },
+        "top_categories": top_categories,
+        "insights": _insights(
+            totals=totals,
+            previous_totals=previous_totals,
+            top_categories=top_categories,
+        ),
+        "recommended_actions": _actions(totals, top_categories),
+        "method": "heuristic",
+    }

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,5 +1,10 @@
 from datetime import date, timedelta
 
+from flask_jwt_extended import create_access_token
+
+from app.extensions import db
+from app.models import Category, Expense, User
+
 
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
@@ -90,3 +95,80 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def _auth_header_without_redis(app_fixture):
+    with app_fixture.app_context():
+        user = User(email="digest@example.com", password_hash="unused")
+        db.session.add(user)
+        db.session.commit()
+        token = create_access_token(identity=str(user.id))
+    return user.id, {"Authorization": f"Bearer {token}"}
+
+
+def test_weekly_digest_returns_summary_trends_and_actions(client, app_fixture):
+    uid, auth_header = _auth_header_without_redis(app_fixture)
+    week_start = date(2026, 5, 11)
+    previous_week = week_start - timedelta(days=7)
+    with app_fixture.app_context():
+        groceries = Category(user_id=uid, name="Groceries")
+        db.session.add(groceries)
+        db.session.flush()
+        db.session.add_all(
+            [
+                Expense(
+                    user_id=uid,
+                    category_id=groceries.id,
+                    amount=100,
+                    expense_type="EXPENSE",
+                    notes="Groceries",
+                    spent_at=week_start,
+                ),
+                Expense(
+                    user_id=uid,
+                    amount=50,
+                    expense_type="EXPENSE",
+                    notes="Transport",
+                    spent_at=week_start + timedelta(days=1),
+                ),
+                Expense(
+                    user_id=uid,
+                    amount=300,
+                    expense_type="INCOME",
+                    notes="Freelance",
+                    spent_at=week_start + timedelta(days=2),
+                ),
+                Expense(
+                    user_id=uid,
+                    amount=100,
+                    expense_type="EXPENSE",
+                    notes="Prior week",
+                    spent_at=previous_week,
+                ),
+            ]
+        )
+        db.session.commit()
+
+    r = client.get(
+        f"/insights/weekly-digest?week_start={week_start.isoformat()}",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period"]["week_start"] == week_start.isoformat()
+    assert payload["summary"]["income"] == 300.0
+    assert payload["summary"]["expenses"] == 150.0
+    assert payload["summary"]["net_flow"] == 150.0
+    assert payload["summary"]["previous_week_expenses"] == 100.0
+    assert payload["summary"]["spending_change_pct"] == 50.0
+    assert payload["top_categories"][0]["category_name"] == "Groceries"
+    assert payload["insights"]
+    assert payload["recommended_actions"]
+
+
+def test_weekly_digest_rejects_invalid_week_start(client, app_fixture):
+    _, auth_header = _auth_header_without_redis(app_fixture)
+
+    r = client.get("/insights/weekly-digest?week_start=not-a-date", headers=auth_header)
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid week_start, expected YYYY-MM-DD"


### PR DESCRIPTION
## Summary
- Add `GET /insights/weekly-digest` for authenticated users
- Summarize weekly income, expenses, net flow, prior-week comparison, top categories, trend insights, and recommended actions
- Keep the digest deterministic and usable without paid AI API keys
- Add focused tests and README documentation

Closes #121

## Validation
- From `packages/backend`: `.\.venv-backend-test\Scripts\python.exe -m pytest tests\test_insights.py -q -k weekly_digest` -> `2 passed, 3 deselected`
- From `packages/backend`: `.\.venv-backend-test\Scripts\python.exe -m black --check app\services\digests.py app\routes\insights.py tests\test_insights.py`
- From `packages/backend`: `.\.venv-backend-test\Scripts\python.exe -m flake8 app\services\digests.py app\routes\insights.py tests\test_insights.py`
- `python -m py_compile packages\backend\app\services\digests.py packages\backend\app\routes\insights.py packages\backend\tests\test_insights.py`
- `git diff --check`

Note: the new digest tests mint JWTs directly so they can run locally without Redis; the existing auth fixture in this repo still requires Redis for full-module runs.

/claim #121
