### PR TITLE
Add multi-account dashboard overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ finmind/
 - Logs are emitted as JSON with `request_id` and shipped to Loki via Promtail.
 - Pre-provisioned Grafana dashboard: `FinMind Operations and KPI`.
 
+## Multi-Account Dashboard
+- `POST /accounts` creates checking, savings, credit, cash, or wallet accounts
+  with balances and currencies.
+- `GET /accounts` lists all accounts for the authenticated user.
+- `GET /dashboard/summary` includes active account balances, account count, and
+  an account list so the dashboard can show a consolidated financial overview.
+
 ## Contribution Policy
 - See `CONTRIBUTING.md` for fork-first contribution flow and PR requirements.
 

--- a/app/src/api/dashboard.ts
+++ b/app/src/api/dashboard.ts
@@ -8,7 +8,16 @@ export type DashboardSummary = {
     monthly_expenses: number;
     upcoming_bills_total: number;
     upcoming_bills_count: number;
+    total_account_balance: number;
+    account_count: number;
   };
+  accounts: Array<{
+    id: number;
+    name: string;
+    account_type: string;
+    balance: number;
+    currency: string;
+  }>;
   recent_transactions: Array<{
     id: number;
     description: string;

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -57,6 +57,8 @@ export function Dashboard() {
         monthly_expenses: 0,
         upcoming_bills_total: 0,
         upcoming_bills_count: 0,
+        total_account_balance: 0,
+        account_count: 0,
       };
     }
     return data.summary;
@@ -88,6 +90,14 @@ export function Dashboard() {
       description: 'Current month',
     },
     {
+      title: 'Account Balance',
+      amount: currency(summary.total_account_balance),
+      change: `${summary.account_count} account(s)`,
+      trend: summary.total_account_balance >= 0 ? 'up' : 'down',
+      icon: Wallet,
+      description: 'Active accounts',
+    },
+    {
       title: 'Upcoming Bills',
       amount: currency(summary.upcoming_bills_total),
       change: `${summary.upcoming_bills_count} bill(s)`,
@@ -98,6 +108,7 @@ export function Dashboard() {
   ] as const;
 
   const transactions = data?.recent_transactions ?? [];
+  const accounts = data?.accounts ?? [];
   const upcomingBills = data?.upcoming_bills ?? [];
   const categoryBreakdown = data?.category_breakdown ?? [];
 
@@ -141,7 +152,7 @@ export function Dashboard() {
         </div>
       )}
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-8">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5 mb-8">
         {summaryCards.map((card, index) => (
           <FinancialCard key={index} variant="financial" className="group card-interactive fade-in-up">
             <FinancialCardHeader className="pb-3">
@@ -210,6 +221,32 @@ export function Dashboard() {
         </div>
 
         <div className="space-y-6">
+          <FinancialCard variant="financial" className="fade-in-up">
+            <FinancialCardHeader>
+              <FinancialCardTitle className="section-title">Accounts</FinancialCardTitle>
+              <FinancialCardDescription>Active balances across accounts</FinancialCardDescription>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              {accounts.length === 0 ? (
+                <div className="text-sm text-muted-foreground">No accounts added.</div>
+              ) : (
+                <div className="space-y-3">
+                  {accounts.map((account) => (
+                    <div key={account.id} className="interactive-row flex items-center justify-between">
+                      <div>
+                        <div className="font-medium text-foreground text-sm">{account.name}</div>
+                        <div className="text-xs text-muted-foreground capitalize">{account.account_type}</div>
+                      </div>
+                      <div className="text-sm font-semibold text-foreground">
+                        {currency(account.balance, account.currency)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </FinancialCardContent>
+          </FinancialCard>
+
           <FinancialCard variant="financial" className="fade-in-up">
             <FinancialCardHeader>
               <div className="flex items-center justify-between">

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,27 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS accounts (
+              id SERIAL PRIMARY KEY,
+              user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              name VARCHAR(120) NOT NULL,
+              account_type VARCHAR(40) NOT NULL DEFAULT 'checking',
+              balance NUMERIC(12,2) NOT NULL DEFAULT 0,
+              currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+              active BOOLEAN NOT NULL DEFAULT TRUE,
+              created_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE expenses
+            ADD COLUMN IF NOT EXISTS account_id INT REFERENCES accounts(id)
+            ON DELETE SET NULL
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -18,9 +18,22 @@ CREATE TABLE IF NOT EXISTS categories (
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS accounts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(120) NOT NULL,
+  account_type VARCHAR(40) NOT NULL DEFAULT 'checking',
+  balance NUMERIC(12,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_accounts_user_active ON accounts(user_id, active);
+
 CREATE TABLE IF NOT EXISTS expenses (
   id SERIAL PRIMARY KEY,
   user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
   category_id INT REFERENCES categories(id) ON DELETE SET NULL,
   amount NUMERIC(12,2) NOT NULL,
   currency VARCHAR(10) NOT NULL DEFAULT 'INR',
@@ -33,6 +46,9 @@ CREATE INDEX IF NOT EXISTS idx_expenses_user_spent_at ON expenses(user_id, spent
 
 ALTER TABLE expenses
   ADD COLUMN IF NOT EXISTS expense_type VARCHAR(20) NOT NULL DEFAULT 'EXPENSE';
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS account_id INT REFERENCES accounts(id) ON DELETE SET NULL;
 
 DO $$ BEGIN
   CREATE TYPE recurring_cadence AS ENUM ('DAILY','WEEKLY','MONTHLY','YEARLY');

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -31,6 +31,7 @@ class Expense(db.Model):
     __tablename__ = "expenses"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    account_id = db.Column(db.Integer, db.ForeignKey("accounts.id"), nullable=True)
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
@@ -132,4 +133,16 @@ class AuditLog(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Account(db.Model):
+    __tablename__ = "accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    account_type = db.Column(db.String(40), default="checking", nullable=False)
+    balance = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .accounts import bp as accounts_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,102 @@
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import Account, User
+from ..services.cache import cache_delete_patterns
+
+bp = Blueprint("accounts", __name__)
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    accounts = (
+        db.session.query(Account)
+        .filter_by(user_id=uid)
+        .order_by(Account.active.desc(), Account.name.asc())
+        .all()
+    )
+    return jsonify([_account_to_dict(account) for account in accounts])
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+    name = str(data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    balance = _parse_amount(data.get("balance", 0))
+    if balance is None:
+        return jsonify(error="invalid balance"), 400
+    account = Account(
+        user_id=uid,
+        name=name[:120],
+        account_type=str(data.get("account_type") or "checking").strip()[:40],
+        balance=balance,
+        currency=str(
+            data.get("currency") or (user.preferred_currency if user else "INR")
+        )[:10],
+        active=bool(data.get("active", True)),
+    )
+    db.session.add(account)
+    db.session.commit()
+    _invalidate_dashboard(uid)
+    return jsonify(_account_to_dict(account)), 201
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(Account, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = str(data.get("name") or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        account.name = name[:120]
+    if "account_type" in data:
+        account.account_type = str(data.get("account_type") or "checking").strip()[:40]
+    if "currency" in data:
+        account.currency = str(data.get("currency") or "INR")[:10]
+    if "balance" in data:
+        balance = _parse_amount(data.get("balance"))
+        if balance is None:
+            return jsonify(error="invalid balance"), 400
+        account.balance = balance
+    if "active" in data:
+        account.active = bool(data.get("active"))
+    db.session.commit()
+    _invalidate_dashboard(uid)
+    return jsonify(_account_to_dict(account))
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _account_to_dict(account: Account) -> dict:
+    return {
+        "id": account.id,
+        "name": account.name,
+        "account_type": account.account_type,
+        "balance": float(account.balance),
+        "currency": account.currency,
+        "active": account.active,
+    }
+
+
+def _invalidate_dashboard(uid: int) -> None:
+    cache_delete_patterns([f"user:{uid}:dashboard_summary:*"])

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -4,7 +4,7 @@ from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..extensions import db
-from ..models import Bill, Expense, Category
+from ..models import Account, Bill, Expense, Category
 from ..services.cache import cache_get, cache_set, dashboard_summary_key
 
 bp = Blueprint("dashboard", __name__)
@@ -30,7 +30,10 @@ def dashboard_summary():
             "monthly_expenses": 0.0,
             "upcoming_bills_total": 0.0,
             "upcoming_bills_count": 0,
+            "total_account_balance": 0.0,
+            "account_count": 0,
         },
+        "accounts": [],
         "recent_transactions": [],
         "upcoming_bills": [],
         "category_breakdown": [],
@@ -39,6 +42,30 @@ def dashboard_summary():
 
     year, month = map(int, ym.split("-"))
     today = date.today()
+
+    try:
+        accounts = (
+            db.session.query(Account)
+            .filter(Account.user_id == uid, Account.active.is_(True))
+            .order_by(Account.name.asc())
+            .all()
+        )
+        payload["accounts"] = [
+            {
+                "id": account.id,
+                "name": account.name,
+                "account_type": account.account_type,
+                "balance": float(account.balance),
+                "currency": account.currency,
+            }
+            for account in accounts
+        ]
+        payload["summary"]["total_account_balance"] = round(
+            sum(float(account.balance) for account in accounts), 2
+        )
+        payload["summary"]["account_count"] = len(accounts)
+    except Exception:
+        payload["errors"].append("accounts_unavailable")
 
     try:
         income = (

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -5,7 +5,7 @@ from decimal import Decimal, InvalidOperation
 from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
-from ..models import Expense, RecurringCadence, RecurringExpense, User
+from ..models import Account, Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
 import logging
@@ -65,8 +65,13 @@ def create_expense():
     description = (data.get("description") or data.get("notes") or "").strip()
     if not description:
         return jsonify(error="description required"), 400
+    try:
+        account_id = _validated_account_id(uid, data.get("account_id"))
+    except (TypeError, ValueError):
+        return jsonify(error="invalid account_id"), 400
     e = Expense(
         user_id=uid,
+        account_id=account_id,
         amount=amount,
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
@@ -221,6 +226,11 @@ def update_expense(expense_id: int):
         e.expense_type = str(data.get("expense_type") or "EXPENSE").upper()
     if "category_id" in data:
         e.category_id = data.get("category_id")
+    if "account_id" in data:
+        try:
+            e.account_id = _validated_account_id(uid, data.get("account_id"))
+        except (TypeError, ValueError):
+            return jsonify(error="invalid account_id"), 400
     if "description" in data or "notes" in data:
         description = (data.get("description") or data.get("notes") or "").strip()
         if not description:
@@ -316,6 +326,7 @@ def _expense_to_dict(e: Expense) -> dict:
         "id": e.id,
         "amount": float(e.amount),
         "currency": e.currency,
+        "account_id": e.account_id,
         "category_id": e.category_id,
         "expense_type": e.expense_type,
         "description": e.notes or "",
@@ -343,6 +354,16 @@ def _parse_amount(raw) -> Decimal | None:
         return Decimal(str(raw)).quantize(Decimal("0.01"))
     except (InvalidOperation, ValueError, TypeError):
         return None
+
+
+def _validated_account_id(uid: int, raw) -> int | None:
+    if raw in (None, ""):
+        return None
+    account_id = int(raw)
+    account = db.session.get(Account, account_id)
+    if not account or account.user_id != uid:
+        raise ValueError("invalid account_id")
+    return account_id
 
 
 def _parse_recurring_cadence(raw: str | None) -> str | None:

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,100 @@
+from datetime import date
+
+from flask_jwt_extended import create_access_token
+
+from app.extensions import db
+from app.models import Account, Expense, User
+
+
+def _auth_header_without_redis(app_fixture, email="accounts@example.com"):
+    with app_fixture.app_context():
+        user = User(email=email, password_hash="unused")
+        db.session.add(user)
+        db.session.commit()
+        token = create_access_token(identity=str(user.id))
+    return user.id, {"Authorization": f"Bearer {token}"}
+
+
+def test_accounts_can_be_created_listed_and_updated(client, app_fixture, monkeypatch):
+    monkeypatch.setattr(
+        "app.routes.accounts.cache_delete_patterns", lambda *_args: None
+    )
+    _, auth_header = _auth_header_without_redis(app_fixture)
+
+    r = client.post(
+        "/accounts",
+        json={
+            "name": "Main Checking",
+            "account_type": "checking",
+            "balance": 1250.75,
+            "currency": "USD",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    account = r.get_json()
+    assert account["name"] == "Main Checking"
+    assert account["balance"] == 1250.75
+
+    r = client.patch(
+        f"/accounts/{account['id']}",
+        json={"balance": 1500, "account_type": "savings"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["account_type"] == "savings"
+
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    accounts = r.get_json()
+    assert len(accounts) == 1
+    assert accounts[0]["balance"] == 1500.0
+
+
+def test_dashboard_includes_multi_account_overview(client, app_fixture, monkeypatch):
+    monkeypatch.setattr("app.routes.dashboard.cache_get", lambda *_args: None)
+    monkeypatch.setattr(
+        "app.routes.dashboard.cache_set", lambda *_args, **_kwargs: None
+    )
+    uid, auth_header = _auth_header_without_redis(
+        app_fixture, email="dashboard-accounts@example.com"
+    )
+    with app_fixture.app_context():
+        checking = Account(
+            user_id=uid,
+            name="Checking",
+            account_type="checking",
+            balance=1000,
+            currency="USD",
+        )
+        savings = Account(
+            user_id=uid,
+            name="Savings",
+            account_type="savings",
+            balance=2500,
+            currency="USD",
+        )
+        db.session.add_all([checking, savings])
+        db.session.flush()
+        db.session.add(
+            Expense(
+                user_id=uid,
+                account_id=checking.id,
+                amount=100,
+                currency="USD",
+                expense_type="EXPENSE",
+                notes="Groceries",
+                spent_at=date.today(),
+            )
+        )
+        db.session.commit()
+
+    r = client.get("/dashboard/summary", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["summary"]["account_count"] == 2
+    assert payload["summary"]["total_account_balance"] == 3500.0
+    assert [account["name"] for account in payload["accounts"]] == [
+        "Checking",
+        "Savings",
+    ]


### PR DESCRIPTION
## Summary
- Add account records with create/list/update API support
- Allow transactions to be associated with accounts
- Extend `/dashboard/summary` with active accounts, account count, and total account balance
- Show account balances in the dashboard UI
- Add focused backend tests and README documentation

Closes #132

## Validation
- From `packages/backend`: `.\.venv-backend-test\Scripts\python.exe -m pytest tests\test_accounts.py -q` -> `2 passed`
- From `packages/backend`: `.\.venv-backend-test\Scripts\python.exe -m black --check app\models.py app\__init__.py app\routes\accounts.py app\routes\__init__.py app\routes\expenses.py app\routes\dashboard.py tests\test_accounts.py`
- From `packages/backend`: `.\.venv-backend-test\Scripts\python.exe -m flake8 app\models.py app\__init__.py app\routes\accounts.py app\routes\__init__.py app\routes\expenses.py app\routes\dashboard.py tests\test_accounts.py`
- `python -m py_compile packages\backend\app\__init__.py packages\backend\app\models.py packages\backend\app\routes\__init__.py packages\backend\app\routes\accounts.py packages\backend\app\routes\dashboard.py packages\backend\app\routes\expenses.py packages\backend\tests\test_accounts.py`
- From `app`: `npm ci && npm run build`
- `git diff --check`

Note: `npm ci` reported existing dependency audit findings in the frontend dependency tree; the production build still completed successfully.

/claim #132
