### PR TITLE
feat: add weekly financial digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,25 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-summary`
+
+## Weekly Smart Digest
+
+`GET /insights/weekly-summary` returns an authenticated Monday-Sunday digest for
+the current week by default. Pass `week_start=YYYY-MM-DD` to inspect another
+week and `currency=USD` or another code to filter a multi-currency account.
+
+The response includes:
+
+- income, expense, net-flow, transaction count, previous-week expense total,
+  percentage delta, and trend direction;
+- seven daily buckets for the selected week;
+- category spending shares and top expenses;
+- bills due during the selected week;
+- deterministic insights and recommendations that work without an LLM key.
+
+This keeps the digest production-safe for free-tier users while still allowing
+the existing Gemini-powered budget suggestion flow to remain optional.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,58 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklySummary = {
+  period: {
+    week_start: string;
+    week_end: string;
+    previous_week_start: string;
+    previous_week_end: string;
+  };
+  currency: string | null;
+  summary: {
+    income: number;
+    expenses: number;
+    net: number;
+    transaction_count: number;
+    previous_expenses: number;
+    expense_change_pct: number | null;
+    expense_trend: 'up' | 'down' | 'flat' | 'new' | string;
+  };
+  daily: Array<{
+    date: string;
+    income: number;
+    expenses: number;
+    net: number;
+  }>;
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    share_pct: number;
+  }>;
+  top_expenses: Array<{
+    id: number;
+    description: string;
+    amount: number;
+    currency: string;
+    date: string;
+    category_id: number | null;
+    category_name: string;
+  }>;
+  upcoming_bills: Array<{
+    id: number;
+    name: string;
+    amount: number;
+    currency: string;
+    next_due_date: string;
+    cadence: string;
+    autopay_enabled: boolean;
+  }>;
+  insights: string[];
+  recommendations: string[];
+  method: string;
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +83,15 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklySummary(params?: {
+  weekStart?: string;
+  currency?: string;
+}): Promise<WeeklySummary> {
+  const query = new URLSearchParams();
+  if (params?.weekStart) query.set('week_start', params.weekStart);
+  if (params?.currency) query.set('currency', params.currency);
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+  return api<WeeklySummary>(`/insights/weekly-summary${suffix}`);
 }

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -10,7 +10,12 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
-import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
+import {
+  getBudgetSuggestion,
+  getWeeklySummary,
+  type BudgetSuggestion,
+  type WeeklySummary,
+} from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
 
 const PERSONAS = [
@@ -19,13 +24,23 @@ const PERSONAS = [
   'Debt-focused planner',
 ];
 
+function currentWeekStart() {
+  const now = new Date();
+  const day = now.getDay() || 7;
+  now.setDate(now.getDate() - day + 1);
+  return now.toISOString().slice(0, 10);
+}
+
 export function Analytics() {
   const { toast } = useToast();
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [weekStart, setWeekStart] = useState(currentWeekStart);
+  const [currency, setCurrency] = useState('');
   const [persona, setPersona] = useState(PERSONAS[0]);
   const [geminiKey, setGeminiKey] = useState('');
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BudgetSuggestion | null>(null);
+  const [weekly, setWeekly] = useState<WeeklySummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
@@ -37,7 +52,12 @@ export function Analytics() {
         persona,
         geminiApiKey: geminiKey.trim() || undefined,
       });
+      const weeklyPayload = await getWeeklySummary({
+        weekStart,
+        currency: currency.trim() || undefined,
+      });
       setData(payload);
+      setWeekly(weeklyPayload);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
@@ -71,7 +91,7 @@ export function Analytics() {
               Live spending analytics with Gemini-powered budget coaching.
             </p>
           </div>
-          <div className="grid gap-2 md:grid-cols-4">
+          <div className="grid gap-2 md:grid-cols-6">
             <div>
               <Label htmlFor="analytics-month">Month</Label>
               <Input
@@ -80,6 +100,27 @@ export function Analytics() {
                 type="month"
                 value={month}
                 onChange={(e) => setMonth(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-week">Week Start</Label>
+              <Input
+                id="analytics-week"
+                aria-label="analytics week start"
+                type="date"
+                value={weekStart}
+                onChange={(e) => setWeekStart(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-currency">Currency</Label>
+              <Input
+                id="analytics-currency"
+                aria-label="analytics currency"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+                placeholder="All"
+                maxLength={10}
               />
             </div>
             <div>
@@ -169,6 +210,150 @@ export function Analytics() {
               </div>
             </FinancialCardContent>
           </FinancialCard>
+
+          {weekly ? (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Weekly Smart Digest</FinancialCardTitle>
+                <FinancialCardDescription>
+                  {weekly.period.week_start} to {weekly.period.week_end}
+                </FinancialCardDescription>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid gap-3 md:grid-cols-4">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Income</div>
+                    <div className="font-semibold">
+                      {formatMoney(weekly.summary.income, weekly.currency || undefined)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expenses</div>
+                    <div className="font-semibold">
+                      {formatMoney(weekly.summary.expenses, weekly.currency || undefined)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Net Flow</div>
+                    <div className="font-semibold">
+                      {formatMoney(weekly.summary.net, weekly.currency || undefined)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expense Trend</div>
+                    <div className="font-semibold">
+                      {weekly.summary.expense_trend}
+                      {weekly.summary.expense_change_pct !== null
+                        ? ` (${weekly.summary.expense_change_pct.toFixed(2)}%)`
+                        : ''}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Top Categories</div>
+                    {weekly.category_breakdown.length ? (
+                      <div className="space-y-2">
+                        {weekly.category_breakdown.slice(0, 4).map((item) => (
+                          <div key={item.category_name} className="flex items-center justify-between rounded-lg border p-2 text-sm">
+                            <span>{item.category_name}</span>
+                            <span className="font-medium">
+                              {formatMoney(item.amount, weekly.currency || undefined)} · {item.share_pct.toFixed(2)}%
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-sm text-muted-foreground">No expenses in this week.</div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Insights</div>
+                    <ul className="list-disc space-y-1 pl-5 text-sm">
+                      {weekly.insights.map((insight) => (
+                        <li key={insight}>{insight}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Daily Flow</div>
+                    <div className="grid gap-2 sm:grid-cols-2">
+                      {weekly.daily.map((day) => (
+                        <div key={day.date} className="rounded-lg border p-2 text-sm">
+                          <div className="font-medium">{day.date}</div>
+                          <div className="text-muted-foreground">
+                            In {formatMoney(day.income, weekly.currency || undefined)} · Out{' '}
+                            {formatMoney(day.expenses, weekly.currency || undefined)}
+                          </div>
+                          <div className="font-medium">
+                            Net {formatMoney(day.net, weekly.currency || undefined)}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Top Expenses</div>
+                    {weekly.top_expenses.length ? (
+                      <div className="space-y-2">
+                        {weekly.top_expenses.map((expense) => (
+                          <div key={expense.id} className="rounded-lg border p-2 text-sm">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="font-medium">{expense.description}</span>
+                              <span>
+                                {formatMoney(expense.amount, expense.currency)}
+                              </span>
+                            </div>
+                            <div className="text-muted-foreground">
+                              {expense.category_name} · {expense.date}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-sm text-muted-foreground">No top expenses yet.</div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Upcoming Bills</div>
+                    {weekly.upcoming_bills.length ? (
+                      <div className="space-y-2">
+                        {weekly.upcoming_bills.map((bill) => (
+                          <div key={bill.id} className="rounded-lg border p-2 text-sm">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="font-medium">{bill.name}</span>
+                              <span>{formatMoney(bill.amount, bill.currency)}</span>
+                            </div>
+                            <div className="text-muted-foreground">
+                              Due {bill.next_due_date} · {bill.cadence.toLowerCase()}
+                              {bill.autopay_enabled ? ' · autopay' : ''}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-sm text-muted-foreground">No bills due this week.</div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Recommendations</div>
+                    <ul className="list-disc space-y-1 pl-5 text-sm">
+                      {weekly.recommendations.map((recommendation) => (
+                        <li key={recommendation}>{recommendation}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          ) : null}
 
           <FinancialCard variant="financial">
             <FinancialCardHeader>

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -480,6 +480,65 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
+  /insights/weekly-summary:
+    get:
+      summary: Get weekly financial digest
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          description: Any date in the requested week. The API normalizes it to Monday-Sunday.
+          schema: { type: string, format: date }
+        - in: query
+          name: currency
+          required: false
+          description: Optional currency filter, for example USD or EUR.
+          schema: { type: string }
+      responses:
+        '200':
+          description: Weekly digest with trends, categories, bills, and insights
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                period:
+                  week_start: 2026-05-11
+                  week_end: 2026-05-17
+                  previous_week_start: 2026-05-04
+                  previous_week_end: 2026-05-10
+                currency: USD
+                summary:
+                  income: 1200
+                  expenses: 300
+                  net: 900
+                  transaction_count: 2
+                  previous_expenses: 200
+                  expense_change_pct: 50
+                  expense_trend: up
+                category_breakdown:
+                  - category_id: 1
+                    category_name: Groceries
+                    amount: 300
+                    share_pct: 100
+                insights:
+                  - Expenses rose 50.00% versus last week.
+                recommendations:
+                  - Review the categories with the largest weekly increase.
+                method: deterministic
+        '400':
+          description: Invalid week_start
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
 components:
   securitySchemes:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,7 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.weekly_digest import weekly_financial_digest
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +24,27 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    raw_week = (
+        request.args.get("week_start") or request.args.get("date") or ""
+    ).strip()
+    currency = (request.args.get("currency") or "").strip().upper() or None
+    reference_date = None
+    if raw_week:
+        try:
+            reference_date = date.fromisoformat(raw_week)
+        except ValueError:
+            return jsonify(error="invalid week_start"), 400
+    payload = weekly_financial_digest(uid, reference_date, currency)
+    logger.info(
+        "Weekly summary served user=%s week_start=%s currency=%s",
+        uid,
+        payload["period"]["week_start"],
+        currency or "all",
+    )
+    return jsonify(payload)

--- a/packages/backend/app/services/weekly_digest.py
+++ b/packages/backend/app/services/weekly_digest.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Any
+
+from ..extensions import db
+from ..models import Bill, Category, Expense
+
+
+def _as_float(value: Decimal | int | float | None) -> float:
+    return round(float(value or 0), 2)
+
+
+def _week_bounds(reference: date | None = None) -> tuple[date, date]:
+    current = reference or date.today()
+    start = current - timedelta(days=current.weekday())
+    return start, start + timedelta(days=6)
+
+
+def _pct_change(current: float, previous: float) -> float | None:
+    if previous == 0:
+        return None if current else 0.0
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def _trend(current: float, previous: float) -> str:
+    if previous == 0 and current > 0:
+        return "new"
+    if current > previous:
+        return "up"
+    if current < previous:
+        return "down"
+    return "flat"
+
+
+def _expense_window(
+    uid: int,
+    start: date,
+    end: date,
+    currency: str | None = None,
+) -> list[Expense]:
+    query = db.session.query(Expense).filter(
+        Expense.user_id == uid,
+        Expense.spent_at >= start,
+        Expense.spent_at <= end,
+    )
+    if currency:
+        query = query.filter(Expense.currency == currency)
+    return query.order_by(Expense.spent_at.asc(), Expense.id.asc()).all()
+
+
+def _category_names(uid: int, category_ids: set[int]) -> dict[int, str]:
+    if not category_ids:
+        return {}
+    rows = (
+        db.session.query(Category)
+        .filter(Category.user_id == uid, Category.id.in_(category_ids))
+        .all()
+    )
+    return {row.id: row.name for row in rows}
+
+
+def _summarize_expenses(
+    uid: int,
+    expenses: list[Expense],
+    start: date,
+    end: date,
+) -> dict[str, Any]:
+    category_ids = {e.category_id for e in expenses if e.category_id is not None}
+    categories = _category_names(uid, category_ids)
+    days = {
+        (start + timedelta(days=i)).isoformat(): {
+            "date": (start + timedelta(days=i)).isoformat(),
+            "income": 0.0,
+            "expenses": 0.0,
+            "net": 0.0,
+        }
+        for i in range((end - start).days + 1)
+    }
+    category_totals: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"category_id": None, "category_name": "Uncategorized", "amount": 0.0}
+    )
+    income_total = 0.0
+    expense_total = 0.0
+    transactions = 0
+    top_expenses: list[dict[str, Any]] = []
+
+    for item in expenses:
+        amount = _as_float(item.amount)
+        day = days[item.spent_at.isoformat()]
+        if item.expense_type == "INCOME":
+            income_total += amount
+            day["income"] = round(day["income"] + amount, 2)
+        else:
+            expense_total += amount
+            day["expenses"] = round(day["expenses"] + amount, 2)
+            key = str(item.category_id or "uncategorized")
+            category_totals[key]["category_id"] = item.category_id
+            category_totals[key]["category_name"] = (
+                categories.get(item.category_id, "Uncategorized")
+                if item.category_id
+                else "Uncategorized"
+            )
+            category_totals[key]["amount"] = round(
+                category_totals[key]["amount"] + amount, 2
+            )
+            top_expenses.append(
+                {
+                    "id": item.id,
+                    "description": item.notes or "",
+                    "amount": amount,
+                    "currency": item.currency,
+                    "date": item.spent_at.isoformat(),
+                    "category_id": item.category_id,
+                    "category_name": category_totals[key]["category_name"],
+                }
+            )
+        day["net"] = round(day["income"] - day["expenses"], 2)
+        transactions += 1
+
+    breakdown = sorted(
+        category_totals.values(), key=lambda row: row["amount"], reverse=True
+    )
+    for row in breakdown:
+        row["share_pct"] = (
+            round((row["amount"] / expense_total) * 100, 2) if expense_total else 0.0
+        )
+
+    return {
+        "income": round(income_total, 2),
+        "expenses": round(expense_total, 2),
+        "net": round(income_total - expense_total, 2),
+        "transaction_count": transactions,
+        "daily": list(days.values()),
+        "category_breakdown": breakdown,
+        "top_expenses": sorted(
+            top_expenses, key=lambda row: row["amount"], reverse=True
+        )[:5],
+    }
+
+
+def _upcoming_bills(
+    uid: int,
+    start: date,
+    end: date,
+    currency: str | None = None,
+) -> list[dict[str, Any]]:
+    query = db.session.query(Bill).filter(
+        Bill.user_id == uid,
+        Bill.active.is_(True),
+        Bill.next_due_date >= start,
+        Bill.next_due_date <= end,
+    )
+    if currency:
+        query = query.filter(Bill.currency == currency)
+    bills = query.order_by(Bill.next_due_date.asc(), Bill.id.asc()).all()
+    return [
+        {
+            "id": bill.id,
+            "name": bill.name,
+            "amount": _as_float(bill.amount),
+            "currency": bill.currency,
+            "next_due_date": bill.next_due_date.isoformat(),
+            "cadence": (
+                bill.cadence.value if hasattr(bill.cadence, "value") else bill.cadence
+            ),
+            "autopay_enabled": bill.autopay_enabled,
+        }
+        for bill in bills
+    ]
+
+
+def _build_insights(
+    current: dict[str, Any],
+    previous: dict[str, Any],
+    upcoming_bills: list[dict[str, Any]],
+) -> tuple[list[str], list[str]]:
+    insights: list[str] = []
+    recommendations: list[str] = []
+
+    expense_delta = _pct_change(current["expenses"], previous["expenses"])
+    if expense_delta is None and current["expenses"]:
+        insights.append("This is the first week with tracked expenses in this view.")
+    elif expense_delta is not None:
+        if expense_delta > 10:
+            insights.append(f"Expenses rose {expense_delta:.2f}% versus last week.")
+            recommendations.append(
+                "Review the categories with the largest weekly increase."
+            )
+        elif expense_delta < -10:
+            insights.append(
+                f"Expenses fell {abs(expense_delta):.2f}% versus last week."
+            )
+            recommendations.append(
+                "Keep the constraints that reduced spending this week."
+            )
+        else:
+            insights.append("Expenses stayed within 10% of last week.")
+
+    if current["net"] >= 0:
+        insights.append("Net flow is positive for the selected week.")
+    else:
+        insights.append("Net flow is negative for the selected week.")
+        recommendations.append("Delay non-essential purchases until income catches up.")
+
+    if current["category_breakdown"]:
+        top = current["category_breakdown"][0]
+        insights.append(
+            f"{top['category_name']} is the top spending category at {top['share_pct']:.2f}%."
+        )
+        if top["share_pct"] >= 40:
+            recommendations.append(
+                f"Set a tighter weekly cap for {top['category_name']} before next week starts."
+            )
+
+    if upcoming_bills:
+        total_due = round(sum(bill["amount"] for bill in upcoming_bills), 2)
+        insights.append(
+            f"{len(upcoming_bills)} bills are due this week totaling {total_due:.2f}."
+        )
+        recommendations.append("Reserve bill cash before discretionary spend.")
+
+    if not insights:
+        insights.append("No weekly activity found for this period.")
+        recommendations.append(
+            "Add expenses or income to generate a useful weekly digest."
+        )
+
+    return insights, recommendations
+
+
+def weekly_financial_digest(
+    uid: int,
+    reference_date: date | None = None,
+    currency: str | None = None,
+) -> dict[str, Any]:
+    week_start, week_end = _week_bounds(reference_date)
+    previous_start = week_start - timedelta(days=7)
+    previous_end = week_end - timedelta(days=7)
+    currency_filter = (currency or "").strip().upper() or None
+
+    current = _summarize_expenses(
+        uid,
+        _expense_window(uid, week_start, week_end, currency_filter),
+        week_start,
+        week_end,
+    )
+    previous = _summarize_expenses(
+        uid,
+        _expense_window(uid, previous_start, previous_end, currency_filter),
+        previous_start,
+        previous_end,
+    )
+    upcoming = _upcoming_bills(uid, week_start, week_end, currency_filter)
+    insights, recommendations = _build_insights(current, previous, upcoming)
+
+    return {
+        "period": {
+            "week_start": week_start.isoformat(),
+            "week_end": week_end.isoformat(),
+            "previous_week_start": previous_start.isoformat(),
+            "previous_week_end": previous_end.isoformat(),
+        },
+        "currency": currency_filter,
+        "summary": {
+            "income": current["income"],
+            "expenses": current["expenses"],
+            "net": current["net"],
+            "transaction_count": current["transaction_count"],
+            "previous_expenses": previous["expenses"],
+            "expense_change_pct": _pct_change(
+                current["expenses"], previous["expenses"]
+            ),
+            "expense_trend": _trend(current["expenses"], previous["expenses"]),
+        },
+        "daily": current["daily"],
+        "category_breakdown": current["category_breakdown"],
+        "top_expenses": current["top_expenses"],
+        "upcoming_bills": upcoming,
+        "insights": insights,
+        "recommendations": recommendations,
+        "method": "deterministic",
+    }

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,5 +1,38 @@
 from datetime import date, timedelta
 
+import pytest
+from flask_jwt_extended import create_access_token
+from werkzeug.security import generate_password_hash
+
+from app.extensions import db
+from app.models import User
+
+
+@pytest.fixture()
+def auth_header(app_fixture):
+    with app_fixture.app_context():
+        user = User(
+            email="insights-test@example.com",
+            password_hash=generate_password_hash("password123"),
+            preferred_currency="INR",
+        )
+        db.session.add(user)
+        db.session.commit()
+        access = create_access_token(identity=str(user.id))
+    return {"Authorization": f"Bearer {access}"}
+
+
+@pytest.fixture(autouse=True)
+def disable_cache_invalidation(monkeypatch):
+    monkeypatch.setattr(
+        "app.routes.expenses.cache_delete_patterns",
+        lambda _patterns: None,
+    )
+    monkeypatch.setattr(
+        "app.routes.bills.cache_delete_patterns",
+        lambda _patterns: None,
+    )
+
 
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
@@ -90,3 +123,93 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_weekly_summary_returns_trends_categories_and_bills(client, auth_header):
+    monday = date.today() - timedelta(days=date.today().weekday())
+    previous_monday = monday - timedelta(days=7)
+
+    r = client.post("/categories", json={"name": "Groceries"}, headers=auth_header)
+    assert r.status_code == 201
+    groceries_id = r.get_json()["id"]
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 1200,
+            "description": "Salary",
+            "date": monday.isoformat(),
+            "expense_type": "INCOME",
+            "currency": "USD",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 300,
+            "description": "Weekly groceries",
+            "date": (monday + timedelta(days=1)).isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": groceries_id,
+            "currency": "USD",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 200,
+            "description": "Previous groceries",
+            "date": (previous_monday + timedelta(days=1)).isoformat(),
+            "expense_type": "EXPENSE",
+            "category_id": groceries_id,
+            "currency": "USD",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 49.99,
+            "currency": "USD",
+            "next_due_date": (monday + timedelta(days=4)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get(
+        f"/insights/weekly-summary?week_start={monday.isoformat()}&currency=USD",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["period"]["week_start"] == monday.isoformat()
+    assert payload["currency"] == "USD"
+    assert payload["summary"]["income"] == 1200.0
+    assert payload["summary"]["expenses"] == 300.0
+    assert payload["summary"]["previous_expenses"] == 200.0
+    assert payload["summary"]["expense_change_pct"] == 50.0
+    assert payload["summary"]["expense_trend"] == "up"
+    assert len(payload["daily"]) == 7
+    assert payload["category_breakdown"][0]["category_name"] == "Groceries"
+    assert payload["category_breakdown"][0]["amount"] == 300.0
+    assert payload["upcoming_bills"][0]["name"] == "Internet"
+    assert payload["insights"]
+    assert payload["recommendations"]
+
+
+def test_weekly_summary_rejects_invalid_date(client, auth_header):
+    r = client.get("/insights/weekly-summary?week_start=bad-date", headers=auth_header)
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid week_start"


### PR DESCRIPTION
## Summary

- Add a deterministic weekly smart digest service for FinMind.
- Expose `GET /insights/weekly-summary` with Monday-Sunday week normalization and optional currency filtering.
- Include income, expenses, net flow, previous-week delta, daily buckets, category shares, top expenses, upcoming bills, deterministic insights, and recommendations.
- Surface the digest in the existing Analytics page with weekly summary cards, daily flow, top expenses, upcoming bills, insights, and recommendations.
- Update OpenAPI docs and README.

## Validation

- `python3 -m compileall packages/backend/app packages/backend/tests`
- `PYTHONPATH=packages/backend uv run --python 3.12 --with-requirements packages/backend/requirements.txt black --check packages/backend/app/services/weekly_digest.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py`
- `PYTHONPATH=packages/backend uv run --python 3.12 --with-requirements packages/backend/requirements.txt pytest packages/backend/tests/test_insights.py -q`
- `git diff --check`
- direct Flask smoke test for `/insights/weekly-summary?week_start=<monday>&currency=USD`
- `npm --prefix app run lint`
- `npm --prefix app run build`

Targeted backend pytest result: `5 passed, 7 warnings in 0.35s`.

Note: I can add a short screen-recorded demo if the reviewer wants a separate media link; the endpoint and UI behavior are covered by the validation above.

For #121
/claim #121