### PR TITLE
Add resilient reminder retry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ finmind/
 ## Notes on Free-Tier Reminders
 - Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).
+- Due reminders are resilient to transient provider failures. Failed sends remain unsent, store `retry_count` and `last_error`, and are rescheduled with bounded exponential backoff until `max_attempts` is reached. `/reminders/jobs/health` exposes due and exhausted retry counts for monitoring.
 
 ## Security & Scalability
 - JWT access/refresh, secure cookies OR Authorization header.

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,14 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            ALTER TABLE reminders
+            ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS max_attempts INT NOT NULL DEFAULT 3,
+            ADD COLUMN IF NOT EXISTS last_error VARCHAR(500)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -91,9 +91,17 @@ CREATE TABLE IF NOT EXISTS reminders (
   message VARCHAR(500) NOT NULL,
   send_at TIMESTAMP NOT NULL,
   sent BOOLEAN NOT NULL DEFAULT FALSE,
-  channel VARCHAR(20) NOT NULL DEFAULT 'email'
+  channel VARCHAR(20) NOT NULL DEFAULT 'email',
+  retry_count INT NOT NULL DEFAULT 0,
+  max_attempts INT NOT NULL DEFAULT 3,
+  last_error VARCHAR(500)
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
+
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS max_attempts INT NOT NULL DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS last_error VARCHAR(500);
 
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,9 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    max_attempts = db.Column(db.Integer, default=3, nullable=False)
+    last_error = db.Column(db.String(500), nullable=True)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -378,7 +378,38 @@ paths:
       tags: [Reminders]
       security: [{ bearerAuth: [] }]
       responses:
-        '200': { description: Processed count }
+        '200':
+          description: Processed count with retry outcome counters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  processed: { type: integer }
+                  sent: { type: integer }
+                  failed: { type: integer }
+                  retried: { type: integer }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs/health:
+    get:
+      summary: Get reminder job backlog and exhausted retry counts
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Reminder job health
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  due: { type: integer }
+                  exhausted: { type: integer }
         '401':
           description: Unauthorized
           content:
@@ -580,6 +611,9 @@ components:
         send_at: { type: string, format: date-time }
         sent: { type: boolean }
         channel: { type: string, enum: [email, whatsapp] }
+        retry_count: { type: integer }
+        max_attempts: { type: integer }
+        last_error: { type: string, nullable: true }
     NewReminder:
       type: object
       required: [message, send_at]
@@ -587,3 +621,4 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+        max_attempts: { type: integer, default: 3, minimum: 1 }

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -30,6 +30,9 @@ def list_reminders():
                 "send_at": r.send_at.isoformat(),
                 "sent": r.sent,
                 "channel": r.channel,
+                "retry_count": r.retry_count,
+                "max_attempts": r.max_attempts,
+                "last_error": r.last_error,
             }
             for r in items
         ]
@@ -41,11 +44,18 @@ def list_reminders():
 def create_reminder():
     uid = int(get_jwt_identity())
     data = request.get_json() or {}
+    try:
+        max_attempts = int(data.get("max_attempts", 3))
+    except (TypeError, ValueError):
+        return jsonify(error="max_attempts must be an integer"), 400
+    if max_attempts < 1:
+        return jsonify(error="max_attempts must be >= 1"), 400
     r = Reminder(
         user_id=uid,
         message=data["message"],
         send_at=datetime.fromisoformat(data["send_at"]),
         channel=data.get("channel", "email"),
+        max_attempts=max_attempts,
     )
     db.session.add(r)
     db.session.commit()
@@ -167,16 +177,57 @@ def run_due():
             Reminder.user_id == uid,
             Reminder.sent.is_(False),
             Reminder.send_at <= now,
+            Reminder.retry_count < Reminder.max_attempts,
         )
         .all()
     )
+    sent = 0
+    failed = 0
+    retried = 0
     for r in items:
-        send_reminder(r)
-        r.sent = True
-        track_reminder_event(event="sent", channel=r.channel)
+        if _attempt_send(r):
+            sent += 1
+        else:
+            failed += 1
+            if r.retry_count < r.max_attempts:
+                retried += 1
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+    logger.info(
+        "Processed due reminders user=%s processed=%s sent=%s failed=%s retried=%s",
+        uid,
+        len(items),
+        sent,
+        failed,
+        retried,
+    )
+    return jsonify(processed=len(items), sent=sent, failed=failed, retried=retried)
+
+
+@bp.get("/jobs/health")
+@jwt_required()
+def reminder_jobs_health():
+    uid = int(get_jwt_identity())
+    now = datetime.utcnow()
+    due = (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.user_id == uid,
+            Reminder.sent.is_(False),
+            Reminder.send_at <= now,
+            Reminder.retry_count < Reminder.max_attempts,
+        )
+        .count()
+    )
+    exhausted = (
+        db.session.query(Reminder)
+        .filter(
+            Reminder.user_id == uid,
+            Reminder.sent.is_(False),
+            Reminder.retry_count >= Reminder.max_attempts,
+        )
+        .count()
+    )
+    return jsonify(due=due, exhausted=exhausted), 200
 
 
 def _bill_channels(bill: Bill) -> list[str]:
@@ -221,3 +272,34 @@ def _create_reminder_if_missing(
         )
     )
     return True
+
+
+def _attempt_send(reminder: Reminder) -> bool:
+    try:
+        ok = bool(send_reminder(reminder))
+    except Exception as error:  # pragma: no cover - defensive around providers
+        ok = False
+        reminder.last_error = str(error)[:500]
+        logger.exception("Reminder send raised id=%s", reminder.id)
+
+    if ok:
+        reminder.sent = True
+        reminder.last_error = None
+        track_reminder_event(event="sent", channel=reminder.channel)
+        return True
+
+    reminder.retry_count += 1
+    reminder.last_error = reminder.last_error or "provider returned false"
+    if reminder.retry_count < reminder.max_attempts:
+        reminder.send_at = datetime.utcnow() + _retry_delay(reminder.retry_count)
+        track_reminder_event(event="retry_scheduled", channel=reminder.channel)
+    else:
+        track_reminder_event(
+            event="failed", channel=reminder.channel, status="exhausted"
+        )
+    return False
+
+
+def _retry_delay(retry_count: int) -> timedelta:
+    minutes = min(60, 2 ** max(0, retry_count - 1))
+    return timedelta(minutes=minutes)

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -1,4 +1,5 @@
 from datetime import date
+from datetime import datetime, timedelta
 
 
 def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = False):
@@ -80,3 +81,91 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def test_due_reminders_retry_failed_send_and_expose_health(
+    client, auth_header, monkeypatch
+):
+    attempts = {"count": 0}
+
+    def fake_send(_reminder):
+        attempts["count"] += 1
+        return False
+
+    monkeypatch.setattr("app.routes.reminders.send_reminder", fake_send)
+    send_at = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    created = client.post(
+        "/reminders",
+        json={
+            "message": "Retry me",
+            "send_at": send_at,
+            "channel": "email",
+            "max_attempts": 2,
+        },
+        headers=auth_header,
+    )
+    assert created.status_code == 201
+
+    run = client.post("/reminders/run", headers=auth_header)
+    assert run.status_code == 200
+    assert run.get_json() == {"processed": 1, "sent": 0, "failed": 1, "retried": 1}
+    assert attempts["count"] == 1
+
+    listed = client.get("/reminders", headers=auth_header)
+    reminder = listed.get_json()[0]
+    assert reminder["sent"] is False
+    assert reminder["retry_count"] == 1
+    assert reminder["max_attempts"] == 2
+    assert reminder["last_error"] == "provider returned false"
+    assert datetime.fromisoformat(reminder["send_at"]) > datetime.utcnow()
+
+    health = client.get("/reminders/jobs/health", headers=auth_header)
+    assert health.status_code == 200
+    assert health.get_json() == {"due": 0, "exhausted": 0}
+
+
+def test_due_reminders_mark_exhausted_after_max_attempts(
+    client, auth_header, monkeypatch
+):
+    monkeypatch.setattr("app.routes.reminders.send_reminder", lambda _reminder: False)
+    send_at = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    created = client.post(
+        "/reminders",
+        json={
+            "message": "Do not retry",
+            "send_at": send_at,
+            "channel": "email",
+            "max_attempts": 1,
+        },
+        headers=auth_header,
+    )
+    assert created.status_code == 201
+
+    run = client.post("/reminders/run", headers=auth_header)
+    assert run.status_code == 200
+    assert run.get_json() == {"processed": 1, "sent": 0, "failed": 1, "retried": 0}
+
+    health = client.get("/reminders/jobs/health", headers=auth_header)
+    assert health.status_code == 200
+    assert health.get_json() == {"due": 0, "exhausted": 1}
+
+
+def test_due_reminders_clear_retry_state_on_success(client, auth_header, monkeypatch):
+    monkeypatch.setattr("app.routes.reminders.send_reminder", lambda _reminder: True)
+    send_at = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    created = client.post(
+        "/reminders",
+        json={"message": "Send me", "send_at": send_at, "channel": "email"},
+        headers=auth_header,
+    )
+    assert created.status_code == 201
+
+    run = client.post("/reminders/run", headers=auth_header)
+    assert run.status_code == 200
+    assert run.get_json() == {"processed": 1, "sent": 1, "failed": 0, "retried": 0}
+
+    listed = client.get("/reminders", headers=auth_header)
+    reminder = listed.get_json()[0]
+    assert reminder["sent"] is True
+    assert reminder["retry_count"] == 0
+    assert reminder["last_error"] is None


### PR DESCRIPTION
## Summary
- Adds retry metadata to reminders (`retry_count`, `max_attempts`, `last_error`).
- Keeps failed reminder sends unsent, schedules bounded exponential backoff, and marks exhausted jobs when attempts are used up.
- Adds `/reminders/jobs/health` so operators can monitor due and exhausted reminder jobs.
- Updates schema, OpenAPI docs, README, and backend tests.

## Verification
- `python -m black --check packages\backend\app\routes\reminders.py packages\backend\app\models.py packages\backend\app\__init__.py packages\backend\tests\test_reminders.py`
- `python -m flake8 packages\backend\app\routes\reminders.py packages\backend\app\models.py packages\backend\app\__init__.py packages\backend\tests\test_reminders.py`

Note: local pytest execution is blocked in this Windows environment because the existing auth test fixture attempts to reach Redis at `redis:6379` without Docker/Redis available. The new retry behavior is covered by tests added in `tests/test_reminders.py`.

Closes #130