### PR TITLE
feat: add weekly financial digest insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-digest`
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,41 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklyDigest = {
+  week_start: string;
+  week_end: string;
+  total_income: number;
+  total_expenses: number;
+  net_flow: number;
+  average_daily_expense: number;
+  previous_week: {
+    week_start: string;
+    week_end: string;
+    total_income: number;
+    total_expenses: number;
+    net_flow: number;
+  };
+  trend: {
+    income_change_pct: number;
+    expense_change_pct: number;
+    net_flow_change: number;
+  };
+  daily_totals: Array<{
+    date: string;
+    income: number;
+    expenses: number;
+    net_flow: number;
+  }>;
+  top_categories: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+  }>;
+  insights: string[];
+  recommended_actions: string[];
+  method: 'heuristic' | string;
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +66,11 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklyDigest(params?: {
+  weekStart?: string;
+}): Promise<WeeklyDigest> {
+  const query = params?.weekStart ? `?week_start=${encodeURIComponent(params.weekStart)}` : '';
+  return api<WeeklyDigest>(`/insights/weekly-digest${query}`);
 }

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,62 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/weekly-digest:
+    get:
+      summary: Get weekly financial digest
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          description: Any date in the requested week. The response normalizes to Monday.
+          schema: { type: string, format: date }
+      responses:
+        '200':
+          description: Weekly digest with totals, trend and recommendations
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                week_start: 2025-08-04
+                week_end: 2025-08-10
+                total_income: 1200
+                total_expenses: 250
+                net_flow: 950
+                average_daily_expense: 35.71
+                previous_week:
+                  week_start: 2025-07-28
+                  week_end: 2025-08-03
+                  total_income: 1000
+                  total_expenses: 200
+                  net_flow: 800
+                trend:
+                  income_change_pct: 20
+                  expense_change_pct: 25
+                  net_flow_change: 150
+                top_categories:
+                  - category_id: null
+                    category_name: Uncategorized
+                    amount: 250
+                insights:
+                  - This week is cash-flow positive based on recorded activity.
+                recommended_actions:
+                  - Move part of the positive weekly balance into savings.
+                method: heuristic
+        '400':
+          description: Invalid week_start
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,7 +1,7 @@
 from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from ..services.ai import monthly_budget_suggestion
+from ..services.ai import monthly_budget_suggestion, weekly_financial_digest
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +23,16 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-digest")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    week_start = (request.args.get("week_start") or "").strip() or None
+    try:
+        digest = weekly_financial_digest(uid, week_start=week_start)
+    except ValueError:
+        return jsonify(error="invalid week_start"), 400
+    logger.info("Weekly digest served user=%s week_start=%s", uid, digest["week_start"])
+    return jsonify(digest)

--- a/packages/backend/app/services/ai.py
+++ b/packages/backend/app/services/ai.py
@@ -1,11 +1,12 @@
 import json
+from datetime import date, timedelta
 from urllib import request
 
 from sqlalchemy import extract, func
 
 from ..config import Settings
 from ..extensions import db
-from ..models import Expense
+from ..models import Category, Expense
 
 _settings = Settings()
 DEFAULT_PERSONA = (
@@ -78,6 +79,208 @@ def _build_analytics(uid: int, ym: str) -> dict:
         "current_month_expenses": round(current_expenses, 2),
         "previous_month_expenses": round(prev_expenses, 2),
         "top_categories": [{"category_id": k, "amount": round(v, 2)} for k, v in top],
+    }
+
+
+def _money(value) -> float:
+    return round(float(value or 0), 2)
+
+
+def _week_start(raw: str | None = None) -> date:
+    if raw:
+        parsed = date.fromisoformat(raw)
+        return parsed - timedelta(days=parsed.weekday())
+    today = date.today()
+    return today - timedelta(days=today.weekday())
+
+
+def _week_totals(uid: int, start: date) -> tuple[float, float]:
+    end = start + timedelta(days=6)
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type == "INCOME",
+        )
+        .scalar()
+    )
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .scalar()
+    )
+    return _money(income), _money(expenses)
+
+
+def _daily_week_totals(uid: int, start: date) -> list[dict]:
+    end = start + timedelta(days=6)
+    rows = (
+        db.session.query(
+            Expense.spent_at,
+            Expense.expense_type,
+            func.coalesce(func.sum(Expense.amount), 0),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .group_by(Expense.spent_at, Expense.expense_type)
+        .all()
+    )
+    by_day = {
+        (start + timedelta(days=offset)): {"income": 0.0, "expenses": 0.0}
+        for offset in range(7)
+    }
+    for spent_at, expense_type, amount in rows:
+        bucket = by_day[spent_at]
+        if expense_type == "INCOME":
+            bucket["income"] += float(amount or 0)
+        else:
+            bucket["expenses"] += float(amount or 0)
+    return [
+        {
+            "date": day.isoformat(),
+            "income": _money(values["income"]),
+            "expenses": _money(values["expenses"]),
+            "net_flow": _money(values["income"] - values["expenses"]),
+        }
+        for day, values in by_day.items()
+    ]
+
+
+def _weekly_category_spend(uid: int, start: date) -> list[dict]:
+    end = start + timedelta(days=6)
+    rows = (
+        db.session.query(
+            Expense.category_id,
+            func.coalesce(Category.name, "Uncategorized"),
+            func.coalesce(func.sum(Expense.amount), 0),
+        )
+        .outerjoin(
+            Category,
+            (Category.id == Expense.category_id) & (Category.user_id == uid),
+        )
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            Expense.expense_type != "INCOME",
+        )
+        .group_by(Expense.category_id, Category.name)
+        .order_by(func.sum(Expense.amount).desc())
+        .limit(5)
+        .all()
+    )
+    return [
+        {
+            "category_id": category_id,
+            "category_name": category_name,
+            "amount": _money(amount),
+        }
+        for category_id, category_name, amount in rows
+    ]
+
+
+def _percentage_change(current: float, previous: float) -> float:
+    if previous <= 0:
+        return 0.0
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def _weekly_digest_insights(
+    income: float,
+    expenses: float,
+    previous_expenses: float,
+    top_categories: list[dict],
+) -> tuple[list[str], list[str]]:
+    insights: list[str] = []
+    actions: list[str] = []
+    if income == 0 and expenses == 0:
+        insights.append("No activity was recorded for this week yet.")
+        actions.append("Add this week's income and expenses to unlock a useful digest.")
+        return insights, actions
+
+    net_flow = income - expenses
+    if net_flow >= 0:
+        insights.append("This week is cash-flow positive based on recorded activity.")
+        actions.append("Move part of the positive weekly balance into savings.")
+    else:
+        insights.append("This week is cash-flow negative based on recorded activity.")
+        actions.append(
+            "Review flexible spending before adding new non-essential expenses."
+        )
+
+    change = _percentage_change(expenses, previous_expenses)
+    if change > 10:
+        insights.append(f"Weekly spending is up {change}% from the previous week.")
+        actions.append(
+            "Audit the highest category and set a short-term cap for next week."
+        )
+    elif change < -10:
+        insights.append(
+            f"Weekly spending is down {abs(change)}% from the previous week."
+        )
+        actions.append("Keep the same controls that reduced spending this week.")
+    elif previous_expenses:
+        insights.append("Weekly spending is broadly in line with the previous week.")
+
+    if top_categories and expenses > 0:
+        top = top_categories[0]
+        share = round((top["amount"] / expenses) * 100, 2)
+        insights.append(
+            f"{top['category_name']} is the largest spend area at {share}% of expenses."
+        )
+        actions.append(
+            f"Check whether {top['category_name']} has avoidable repeat costs."
+        )
+
+    return insights[:4], actions[:4]
+
+
+def weekly_financial_digest(uid: int, week_start: str | None = None) -> dict:
+    start = _week_start(week_start)
+    end = start + timedelta(days=6)
+    previous_start = start - timedelta(days=7)
+    income, expenses = _week_totals(uid, start)
+    previous_income, previous_expenses = _week_totals(uid, previous_start)
+    top_categories = _weekly_category_spend(uid, start)
+    insights, actions = _weekly_digest_insights(
+        income, expenses, previous_expenses, top_categories
+    )
+    return {
+        "week_start": start.isoformat(),
+        "week_end": end.isoformat(),
+        "total_income": income,
+        "total_expenses": expenses,
+        "net_flow": _money(income - expenses),
+        "average_daily_expense": _money(expenses / 7),
+        "previous_week": {
+            "week_start": previous_start.isoformat(),
+            "week_end": (previous_start + timedelta(days=6)).isoformat(),
+            "total_income": previous_income,
+            "total_expenses": previous_expenses,
+            "net_flow": _money(previous_income - previous_expenses),
+        },
+        "trend": {
+            "income_change_pct": _percentage_change(income, previous_income),
+            "expense_change_pct": _percentage_change(expenses, previous_expenses),
+            "net_flow_change": _money(
+                (income - expenses) - (previous_income - previous_expenses)
+            ),
+        },
+        "daily_totals": _daily_week_totals(uid, start),
+        "top_categories": top_categories,
+        "insights": insights,
+        "recommended_actions": actions,
+        "method": "heuristic",
     }
 
 

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -3,8 +3,31 @@ import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    def flushdb(self):
+        self.data.clear()
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def setex(self, key, _ttl, value):
+        self.data[key] = value
+
+    def get(self, key):
+        return self.data.get(key)
+
+    def delete(self, *keys):
+        for key in keys:
+            self.data.pop(key, None)
+
+    def scan(self, cursor=0, match=None, count=100):
+        return 0, []
 
 
 class TestSettings(Settings):
@@ -20,9 +43,13 @@ def _setup_db(app):
 
 
 @pytest.fixture()
-def app_fixture():
+def app_fixture(monkeypatch):
     # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
+    fake_redis = FakeRedis()
+    monkeypatch.setattr("app.extensions.redis_client", fake_redis)
+    monkeypatch.setattr("app.routes.auth.redis_client", fake_redis)
+    monkeypatch.setattr("app.services.cache.redis_client", fake_redis)
     settings = TestSettings(
         database_url="sqlite+pysqlite:///:memory:",
         redis_url="redis://localhost:6379/15",
@@ -32,7 +59,7 @@ def app_fixture():
     app.config.update(TESTING=True)
     _setup_db(app)
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
     yield app
@@ -40,7 +67,7 @@ def app_fixture():
         db.session.remove()
         db.drop_all()
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
 

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -90,3 +90,50 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_weekly_digest_returns_financial_summary(client, auth_header):
+    week_start = date.today() - timedelta(days=date.today().weekday())
+    previous_week = week_start - timedelta(days=7)
+
+    for amount, description, spent_at, expense_type in [
+        (1200, "Paycheck", week_start, "INCOME"),
+        (180, "Groceries", week_start + timedelta(days=1), "EXPENSE"),
+        (70, "Transport", week_start + timedelta(days=2), "EXPENSE"),
+        (200, "Previous week groceries", previous_week, "EXPENSE"),
+    ]:
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": amount,
+                "description": description,
+                "date": spent_at.isoformat(),
+                "expense_type": expense_type,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get(
+        f"/insights/weekly-digest?week_start={week_start.isoformat()}",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["week_start"] == week_start.isoformat()
+    assert payload["week_end"] == (week_start + timedelta(days=6)).isoformat()
+    assert payload["total_income"] == 1200
+    assert payload["total_expenses"] == 250
+    assert payload["net_flow"] == 950
+    assert len(payload["daily_totals"]) == 7
+    assert payload["previous_week"]["total_expenses"] == 200
+    assert payload["trend"]["expense_change_pct"] == 25
+    assert payload["top_categories"][0]["category_name"] == "Uncategorized"
+    assert payload["insights"]
+    assert payload["recommended_actions"]
+
+
+def test_weekly_digest_rejects_invalid_week_start(client, auth_header):
+    r = client.get("/insights/weekly-digest?week_start=not-a-date", headers=auth_header)
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid week_start"


### PR DESCRIPTION
## Summary
- Adds a new authenticated `/insights/weekly-digest` endpoint for weekly income, expense, net-flow, previous-week comparison, daily totals, top categories, insights, and recommended actions.
- Exposes a frontend `getWeeklyDigest` API client and TypeScript response type.
- Documents the endpoint in OpenAPI and README.
- Adds focused tests for weekly digest success and invalid `week_start`, plus a fake Redis test client so auth/cache tests run without a live Redis container.

## Verification
- `python -m black --check packages/backend/app/services/ai.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py packages/backend/tests/conftest.py`
- `python -m flake8 packages/backend/app/services/ai.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py packages/backend/tests/conftest.py`
- `python -m pytest tests/test_insights.py -q` from `packages/backend`

Closes #121