### PR TITLE
feat: add multi-account dashboard overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See `backend/app/db/schema.sql`. Key tables:
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
+- Accounts: CRUD `/accounts`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
@@ -71,6 +72,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Auth screens: register/login.
 - Dashboard:
   - Monthly spend chart, category breakdown donut.
+  - Multi-account overview with income, expenses, net flow, and projected balances.
   - Upcoming bills list with due dates and pay status.
   - AI budget suggestion card.
 - Expenses page: add expense (amount, category, notes, date), list & filter.

--- a/app/src/api/accounts.ts
+++ b/app/src/api/accounts.ts
@@ -1,0 +1,26 @@
+import { api } from './client';
+
+export type FinancialAccount = {
+  id: number;
+  name: string;
+  account_type: string;
+  currency: string;
+  opening_balance: number;
+  active: boolean;
+};
+
+export async function listAccounts(): Promise<FinancialAccount[]> {
+  return api<FinancialAccount[]>('/accounts');
+}
+
+export async function createAccount(payload: {
+  name: string;
+  account_type?: string;
+  currency?: string;
+  opening_balance?: number;
+}): Promise<FinancialAccount> {
+  return api<FinancialAccount>('/accounts', {
+    method: 'POST',
+    body: payload,
+  });
+}

--- a/app/src/api/dashboard.ts
+++ b/app/src/api/dashboard.ts
@@ -15,6 +15,7 @@ export type DashboardSummary = {
     amount: number;
     date: string;
     type: 'INCOME' | 'EXPENSE' | string;
+    account_id: number | null;
     category_id: number | null;
     currency: string;
   }>;
@@ -33,6 +34,17 @@ export type DashboardSummary = {
     category_name: string;
     amount: number;
     share_pct: number;
+  }>;
+  account_overview: Array<{
+    account_id: number | null;
+    name: string;
+    account_type: string;
+    currency: string | null;
+    opening_balance: number;
+    monthly_income: number;
+    monthly_expenses: number;
+    net_flow: number;
+    projected_balance: number;
   }>;
   errors?: string[];
 };

--- a/app/src/api/expenses.ts
+++ b/app/src/api/expenses.ts
@@ -5,6 +5,7 @@ export type Expense = {
   amount: number;
   currency?: string;
   description: string;
+  account_id: number | null;
   category_id: number | null;
   date: string; // ISO date
 };
@@ -12,6 +13,7 @@ export type Expense = {
 export type ExpenseCreate = {
   amount: number;
   description: string;
+  account_id?: number | null;
   category_id?: number | null;
   date: string; // ISO date
 };

--- a/app/src/pages/Account.tsx
+++ b/app/src/pages/Account.tsx
@@ -3,7 +3,9 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { me, updateMe } from '@/api/auth';
+import { createAccount, listAccounts, type FinancialAccount } from '@/api/accounts';
 import { setCurrency } from '@/lib/auth';
+import { formatMoney } from '@/lib/currency';
 
 const SUPPORTED_CURRENCIES = [
   { code: 'INR', label: 'Indian Rupee (INR)' },
@@ -23,14 +25,20 @@ export default function Account() {
   const [currency, setCurrencyState] = useState('INR');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
+  const [accountName, setAccountName] = useState('');
+  const [accountType, setAccountType] = useState('CHECKING');
+  const [openingBalance, setOpeningBalance] = useState('0');
 
   useEffect(() => {
     const load = async () => {
       setLoading(true);
       try {
         const data = await me();
+        const accountData = await listAccounts();
         setEmail(data.email);
         setCurrencyState(data.preferred_currency || 'INR');
+        setAccounts(accountData);
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.message : 'Failed to load account';
@@ -55,6 +63,33 @@ export default function Account() {
       const message =
         error instanceof Error ? error.message : 'Failed to update account';
       toast({ title: 'Failed to update account', description: message });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onCreateAccount = async () => {
+    const name = accountName.trim();
+    if (!name) {
+      toast({ title: 'Account name required' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const account = await createAccount({
+        name,
+        account_type: accountType,
+        currency,
+        opening_balance: Number(openingBalance || 0),
+      });
+      setAccounts((items) => [...items, account].sort((a, b) => a.name.localeCompare(b.name)));
+      setAccountName('');
+      setOpeningBalance('0');
+      toast({ title: 'Financial account added' });
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to create account';
+      toast({ title: 'Failed to create account', description: message });
     } finally {
       setSaving(false);
     }
@@ -105,6 +140,71 @@ export default function Account() {
                 {saving ? 'Saving...' : 'Save Preferences'}
               </Button>
             </div>
+          </>
+        )}
+      </div>
+
+      <div className="card card-interactive space-y-5 fade-in-up">
+        <div>
+          <h2 className="section-title">Financial Accounts</h2>
+          <p className="text-sm text-muted-foreground">
+            Add accounts to compare income, spending, and projected balances on the dashboard.
+          </p>
+        </div>
+        {loading ? (
+          <div className="text-sm text-muted-foreground">Loading accounts...</div>
+        ) : (
+          <>
+            <div className="grid gap-3 md:grid-cols-4">
+              <input
+                aria-label="Account name"
+                className="input"
+                placeholder="Account name"
+                value={accountName}
+                onChange={(e) => setAccountName(e.target.value)}
+              />
+              <select
+                aria-label="Account type"
+                className="input"
+                value={accountType}
+                onChange={(e) => setAccountType(e.target.value)}
+              >
+                <option value="CHECKING">Checking</option>
+                <option value="SAVINGS">Savings</option>
+                <option value="CREDIT">Credit</option>
+                <option value="CASH">Cash</option>
+                <option value="INVESTMENT">Investment</option>
+                <option value="OTHER">Other</option>
+              </select>
+              <input
+                aria-label="Opening balance"
+                className="input"
+                inputMode="decimal"
+                placeholder="Opening balance"
+                value={openingBalance}
+                onChange={(e) => setOpeningBalance(e.target.value)}
+              />
+              <Button variant="financial" onClick={onCreateAccount} disabled={saving}>
+                Add Account
+              </Button>
+            </div>
+            {accounts.length === 0 ? (
+              <div className="text-sm text-muted-foreground">No financial accounts yet.</div>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2">
+                {accounts.map((account) => (
+                  <div key={account.id} className="interactive-row flex items-center justify-between">
+                    <div>
+                      <div className="font-medium text-foreground">{account.name}</div>
+                      <div className="text-xs text-muted-foreground">{account.account_type}</div>
+                    </div>
+                    <div className="text-sm font-semibold text-foreground">
+                      {formatMoney(account.opening_balance, account.currency)}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -100,6 +100,7 @@ export function Dashboard() {
   const transactions = data?.recent_transactions ?? [];
   const upcomingBills = data?.upcoming_bills ?? [];
   const categoryBreakdown = data?.category_breakdown ?? [];
+  const accountOverview = data?.account_overview ?? [];
 
   return (
     <div className="page-wrap">
@@ -165,6 +166,55 @@ export function Dashboard() {
           </FinancialCard>
         ))}
       </div>
+
+      <FinancialCard variant="financial" className="mb-8 fade-in-up">
+        <FinancialCardHeader>
+          <div className="flex items-center justify-between">
+            <FinancialCardTitle className="section-title">Account Overview</FinancialCardTitle>
+            <Button variant="ghost" size="sm" onClick={() => navigate('/account')}>Manage</Button>
+          </div>
+          <FinancialCardDescription>Monthly movement across all active accounts</FinancialCardDescription>
+        </FinancialCardHeader>
+        <FinancialCardContent>
+          {accountOverview.length === 0 ? (
+            <div className="text-sm text-muted-foreground">Create accounts to compare balances in one view.</div>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+              {accountOverview.map((account) => {
+                const positive = account.net_flow >= 0;
+                return (
+                  <div key={account.account_id ?? 'unassigned'} className="interactive-row">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="font-medium text-foreground">{account.name}</div>
+                        <div className="text-xs text-muted-foreground">{account.account_type}</div>
+                      </div>
+                      <div className={`text-sm font-semibold ${positive ? 'text-success' : 'text-destructive'}`}>
+                        {positive ? '+' : ''}
+                        {currency(account.net_flow, account.currency || undefined)}
+                      </div>
+                    </div>
+                    <div className="mt-3 grid grid-cols-2 gap-2 text-xs text-muted-foreground">
+                      <div>
+                        <div>Income</div>
+                        <div className="font-medium text-success">{currency(account.monthly_income, account.currency || undefined)}</div>
+                      </div>
+                      <div>
+                        <div>Expenses</div>
+                        <div className="font-medium text-foreground">{currency(account.monthly_expenses, account.currency || undefined)}</div>
+                      </div>
+                      <div className="col-span-2">
+                        <div>Projected balance</div>
+                        <div className="font-medium text-foreground">{currency(account.projected_balance, account.currency || undefined)}</div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </FinancialCardContent>
+      </FinancialCard>
 
       <div className="grid lg:grid-cols-3 gap-8">
         <div className="lg:col-span-2">

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,27 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS financial_accounts (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER NOT NULL REFERENCES users(id),
+                name VARCHAR(120) NOT NULL,
+                account_type VARCHAR(40) NOT NULL DEFAULT 'CHECKING',
+                currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+                opening_balance NUMERIC(12, 2) NOT NULL DEFAULT 0,
+                active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE expenses
+            ADD COLUMN IF NOT EXISTS account_id INTEGER
+            REFERENCES financial_accounts(id)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -27,10 +27,25 @@ class Category(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    account_type = db.Column(db.String(40), default="CHECKING", nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    opening_balance = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class Expense(db.Model):
     __tablename__ = "expenses"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    account_id = db.Column(
+        db.Integer, db.ForeignKey("financial_accounts.id"), nullable=True
+    )
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -7,6 +7,7 @@ servers:
   - url: http://localhost:8000
 tags:
   - name: Auth
+  - name: Accounts
   - name: Categories
   - name: Expenses
   - name: Bills
@@ -93,6 +94,36 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
               example: { error: "Missing Authorization Header" }
+
+  /accounts:
+    get:
+      summary: List financial accounts
+      tags: [Accounts]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Active accounts
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FinancialAccount' }
+    post:
+      summary: Create financial account
+      tags: [Accounts]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NewFinancialAccount' }
+      responses:
+        '201': { description: Created }
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
   /categories:
     get:
@@ -503,12 +534,30 @@ components:
       properties:
         id: { type: integer }
         name: { type: string }
+    FinancialAccount:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        account_type: { type: string }
+        currency: { type: string }
+        opening_balance: { type: number, format: float }
+        active: { type: boolean }
+    NewFinancialAccount:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        account_type: { type: string, default: CHECKING }
+        currency: { type: string, default: INR }
+        opening_balance: { type: number, format: float, default: 0 }
     Expense:
       type: object
       properties:
         id: { type: integer }
         amount: { type: number, format: float }
         currency: { type: string }
+        account_id: { type: integer, nullable: true }
         category_id: { type: integer }
         expense_type: { type: string }
         description: { type: string, nullable: true }
@@ -519,6 +568,7 @@ components:
       properties:
         amount: { type: number, format: float }
         currency: { type: string, default: USD }
+        account_id: { type: integer, nullable: true }
         category_id: { type: integer, nullable: true }
         expense_type: { type: string, default: EXPENSE }
         description: { type: string, nullable: true }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -5,6 +5,7 @@ from .bills import bp as bills_bp
 from .reminders import bp as reminders_bp
 from .insights import bp as insights_bp
 from .categories import bp as categories_bp
+from .accounts import bp as accounts_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
 
@@ -16,5 +17,6 @@ def register_routes(app: Flask):
     app.register_blueprint(reminders_bp, url_prefix="/reminders")
     app.register_blueprint(insights_bp, url_prefix="/insights")
     app.register_blueprint(categories_bp, url_prefix="/categories")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,130 @@
+from decimal import Decimal, InvalidOperation
+import logging
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import Expense, FinancialAccount, User
+from ..services.cache import cache_delete_patterns
+
+bp = Blueprint("accounts", __name__)
+logger = logging.getLogger("finmind.accounts")
+
+ACCOUNT_TYPES = {"CHECKING", "SAVINGS", "CREDIT", "CASH", "INVESTMENT", "OTHER"}
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    items = (
+        db.session.query(FinancialAccount)
+        .filter_by(user_id=uid, active=True)
+        .order_by(FinancialAccount.name)
+        .all()
+    )
+    return jsonify([_account_to_dict(account) for account in items])
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    opening_balance = _parse_amount(data.get("opening_balance", 0))
+    if opening_balance is None:
+        return jsonify(error="invalid opening_balance"), 400
+    account_type = _parse_account_type(data.get("account_type"))
+    account = FinancialAccount(
+        user_id=uid,
+        name=name,
+        account_type=account_type,
+        currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
+        opening_balance=opening_balance,
+    )
+    db.session.add(account)
+    db.session.commit()
+    _invalidate_account_cache(uid)
+    logger.info("Created account id=%s user=%s", account.id, uid)
+    return jsonify(_account_to_dict(account)), 201
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid or not account.active:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = (data.get("name") or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        account.name = name
+    if "account_type" in data:
+        account.account_type = _parse_account_type(data.get("account_type"))
+    if "currency" in data:
+        account.currency = str(data.get("currency") or "INR").upper()[:10]
+    if "opening_balance" in data:
+        opening_balance = _parse_amount(data.get("opening_balance"))
+        if opening_balance is None:
+            return jsonify(error="invalid opening_balance"), 400
+        account.opening_balance = opening_balance
+    db.session.commit()
+    _invalidate_account_cache(uid)
+    return jsonify(_account_to_dict(account))
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def delete_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid or not account.active:
+        return jsonify(error="not found"), 404
+    has_transactions = (
+        db.session.query(Expense.id)
+        .filter_by(user_id=uid, account_id=account.id)
+        .first()
+        is not None
+    )
+    if has_transactions:
+        account.active = False
+    else:
+        db.session.delete(account)
+    db.session.commit()
+    _invalidate_account_cache(uid)
+    return jsonify(message="deleted")
+
+
+def _account_to_dict(account: FinancialAccount) -> dict:
+    return {
+        "id": account.id,
+        "name": account.name,
+        "account_type": account.account_type,
+        "currency": account.currency,
+        "opening_balance": float(account.opening_balance or 0),
+        "active": account.active,
+    }
+
+
+def _parse_account_type(raw: str | None) -> str:
+    value = str(raw or "CHECKING").upper().strip()
+    return value if value in ACCOUNT_TYPES else "OTHER"
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _invalidate_account_cache(uid: int):
+    cache_delete_patterns([f"user:{uid}:dashboard_summary:*"])

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -1,10 +1,10 @@
 from datetime import date
-from sqlalchemy import extract, func
+from sqlalchemy import case, extract, func
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
 from ..extensions import db
-from ..models import Bill, Expense, Category
+from ..models import Bill, Expense, Category, FinancialAccount
 from ..services.cache import cache_get, cache_set, dashboard_summary_key
 
 bp = Blueprint("dashboard", __name__)
@@ -34,6 +34,7 @@ def dashboard_summary():
         "recent_transactions": [],
         "upcoming_bills": [],
         "category_breakdown": [],
+        "account_overview": [],
         "errors": [],
     }
 
@@ -86,6 +87,7 @@ def dashboard_summary():
                 "amount": float(e.amount),
                 "date": e.spent_at.isoformat(),
                 "type": e.expense_type,
+                "account_id": e.account_id,
                 "category_id": e.category_id,
                 "currency": e.currency,
             }
@@ -125,6 +127,90 @@ def dashboard_summary():
         payload["summary"]["upcoming_bills_count"] = len(bills)
     except Exception:
         payload["errors"].append("upcoming_bills_unavailable")
+
+    try:
+        account_rows = (
+            db.session.query(
+                FinancialAccount,
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (Expense.expense_type == "INCOME", Expense.amount),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("income"),
+                func.coalesce(
+                    func.sum(
+                        case(
+                            (Expense.expense_type != "INCOME", Expense.amount),
+                            else_=0,
+                        )
+                    ),
+                    0,
+                ).label("expenses"),
+            )
+            .outerjoin(
+                Expense,
+                (Expense.account_id == FinancialAccount.id)
+                & (Expense.user_id == uid)
+                & (extract("year", Expense.spent_at) == year)
+                & (extract("month", Expense.spent_at) == month),
+            )
+            .filter(FinancialAccount.user_id == uid, FinancialAccount.active.is_(True))
+            .group_by(FinancialAccount.id)
+            .order_by(FinancialAccount.name)
+            .all()
+        )
+        unassigned_income = (
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                Expense.account_id.is_(None),
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type == "INCOME",
+            )
+            .scalar()
+        )
+        unassigned_expenses = (
+            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+            .filter(
+                Expense.user_id == uid,
+                Expense.account_id.is_(None),
+                extract("year", Expense.spent_at) == year,
+                extract("month", Expense.spent_at) == month,
+                Expense.expense_type != "INCOME",
+            )
+            .scalar()
+        )
+        payload["account_overview"] = [
+            _account_row_to_dict(account, income, expenses)
+            for account, income, expenses in account_rows
+        ]
+        if float(unassigned_income or 0) or float(unassigned_expenses or 0):
+            payload["account_overview"].append(
+                {
+                    "account_id": None,
+                    "name": "Unassigned",
+                    "account_type": "OTHER",
+                    "currency": None,
+                    "opening_balance": 0.0,
+                    "monthly_income": float(unassigned_income or 0),
+                    "monthly_expenses": float(unassigned_expenses or 0),
+                    "net_flow": round(
+                        float(unassigned_income or 0) - float(unassigned_expenses or 0),
+                        2,
+                    ),
+                    "projected_balance": round(
+                        float(unassigned_income or 0) - float(unassigned_expenses or 0),
+                        2,
+                    ),
+                }
+            )
+    except Exception:
+        payload["errors"].append("account_overview_unavailable")
 
     try:
         category_rows = (
@@ -176,3 +262,21 @@ def _is_valid_month(ym: str) -> bool:
         return False
     m = int(month)
     return 1 <= m <= 12
+
+
+def _account_row_to_dict(account: FinancialAccount, income, expenses) -> dict:
+    income_value = float(income or 0)
+    expense_value = float(expenses or 0)
+    opening_balance = float(account.opening_balance or 0)
+    net_flow = round(income_value - expense_value, 2)
+    return {
+        "account_id": account.id,
+        "name": account.name,
+        "account_type": account.account_type,
+        "currency": account.currency,
+        "opening_balance": opening_balance,
+        "monthly_income": income_value,
+        "monthly_expenses": expense_value,
+        "net_flow": net_flow,
+        "projected_balance": round(opening_balance + net_flow, 2),
+    }

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -5,7 +5,7 @@ from decimal import Decimal, InvalidOperation
 from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
-from ..models import Expense, RecurringCadence, RecurringExpense, User
+from ..models import Expense, FinancialAccount, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
 import logging
@@ -65,11 +65,16 @@ def create_expense():
     description = (data.get("description") or data.get("notes") or "").strip()
     if not description:
         return jsonify(error="description required"), 400
+    try:
+        account_id = _parse_account_id(uid, data.get("account_id"))
+    except ValueError:
+        return jsonify(error="invalid account_id"), 400
     e = Expense(
         user_id=uid,
         amount=amount,
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
+        account_id=account_id,
         category_id=data.get("category_id"),
         notes=description,
         spent_at=date.fromisoformat(raw_date) if raw_date else date.today(),
@@ -221,6 +226,11 @@ def update_expense(expense_id: int):
         e.expense_type = str(data.get("expense_type") or "EXPENSE").upper()
     if "category_id" in data:
         e.category_id = data.get("category_id")
+    if "account_id" in data:
+        try:
+            e.account_id = _parse_account_id(uid, data.get("account_id"))
+        except ValueError:
+            return jsonify(error="invalid account_id"), 400
     if "description" in data or "notes" in data:
         description = (data.get("description") or data.get("notes") or "").strip()
         if not description:
@@ -317,6 +327,7 @@ def _expense_to_dict(e: Expense) -> dict:
         "amount": float(e.amount),
         "currency": e.currency,
         "category_id": e.category_id,
+        "account_id": e.account_id,
         "expense_type": e.expense_type,
         "description": e.notes or "",
         "date": e.spent_at.isoformat(),
@@ -350,6 +361,23 @@ def _parse_recurring_cadence(raw: str | None) -> str | None:
     if val in {"DAILY", "WEEKLY", "MONTHLY", "YEARLY"}:
         return val
     return None
+
+
+def _parse_account_id(uid: int, raw) -> int | None:
+    if raw in (None, ""):
+        return None
+    try:
+        account_id = int(raw)
+    except (TypeError, ValueError):
+        raise ValueError("invalid account_id")
+    exists = (
+        db.session.query(FinancialAccount.id)
+        .filter_by(id=account_id, user_id=uid, active=True)
+        .first()
+    )
+    if not exists:
+        raise ValueError("invalid account_id")
+    return account_id
 
 
 def _advance_recurrence_date(at: date, cadence: str) -> date:

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -3,8 +3,31 @@ import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    def flushdb(self):
+        self.data.clear()
+
+    def set(self, key, value):
+        self.data[key] = value
+
+    def setex(self, key, _ttl, value):
+        self.data[key] = value
+
+    def get(self, key):
+        return self.data.get(key)
+
+    def delete(self, *keys):
+        for key in keys:
+            self.data.pop(key, None)
+
+    def scan(self, cursor=0, match=None, count=100):
+        return 0, []
 
 
 class TestSettings(Settings):
@@ -20,9 +43,13 @@ def _setup_db(app):
 
 
 @pytest.fixture()
-def app_fixture():
+def app_fixture(monkeypatch):
     # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
+    fake_redis = FakeRedis()
+    monkeypatch.setattr("app.extensions.redis_client", fake_redis)
+    monkeypatch.setattr("app.routes.auth.redis_client", fake_redis)
+    monkeypatch.setattr("app.services.cache.redis_client", fake_redis)
     settings = TestSettings(
         database_url="sqlite+pysqlite:///:memory:",
         redis_url="redis://localhost:6379/15",
@@ -32,7 +59,7 @@ def app_fixture():
     app.config.update(TESTING=True)
     _setup_db(app)
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
     yield app
@@ -40,7 +67,7 @@ def app_fixture():
         db.session.remove()
         db.drop_all()
     try:
-        redis_client.flushdb()
+        fake_redis.flushdb()
     except Exception:
         pass
 

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,31 @@
+def test_accounts_crud_smoke(client, auth_header):
+    r = client.post(
+        "/accounts",
+        json={
+            "name": "Primary Checking",
+            "account_type": "checking",
+            "currency": "USD",
+            "opening_balance": 1250.75,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    account = r.get_json()
+    assert account["name"] == "Primary Checking"
+    assert account["account_type"] == "CHECKING"
+    assert account["opening_balance"] == 1250.75
+
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert any(item["id"] == account["id"] for item in r.get_json())
+
+    r = client.patch(
+        f"/accounts/{account['id']}",
+        json={"name": "Everyday Checking", "opening_balance": 1300},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["name"] == "Everyday Checking"
+
+    r = client.delete(f"/accounts/{account['id']}", headers=auth_header)
+    assert r.status_code == 200

--- a/packages/backend/tests/test_dashboard.py
+++ b/packages/backend/tests/test_dashboard.py
@@ -108,3 +108,53 @@ def test_dashboard_summary_supports_month_filter(client, auth_header):
     data_b = r.get_json()
     assert data_b["period"]["month"] == month_b.strftime("%Y-%m")
     assert data_b["summary"]["monthly_expenses"] == 999.0
+
+
+def test_dashboard_summary_groups_by_financial_account(client, auth_header):
+    r = client.post(
+        "/accounts",
+        json={"name": "Checking", "account_type": "CHECKING", "opening_balance": 1000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    checking_id = r.get_json()["id"]
+
+    r = client.post(
+        "/accounts",
+        json={"name": "Savings", "account_type": "SAVINGS", "opening_balance": 5000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    savings_id = r.get_json()["id"]
+
+    today = date.today()
+    for account_id, amount, description, expense_type in [
+        (checking_id, 2500, "Salary", "INCOME"),
+        (checking_id, 400, "Rent", "EXPENSE"),
+        (savings_id, 100, "Interest", "INCOME"),
+    ]:
+        r = client.post(
+            "/expenses",
+            json={
+                "account_id": account_id,
+                "amount": amount,
+                "description": description,
+                "date": today.isoformat(),
+                "expense_type": expense_type,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get(
+        f"/dashboard/summary?month={today.strftime('%Y-%m')}", headers=auth_header
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    accounts = {item["name"]: item for item in payload["account_overview"]}
+    assert accounts["Checking"]["monthly_income"] == 2500
+    assert accounts["Checking"]["monthly_expenses"] == 400
+    assert accounts["Checking"]["projected_balance"] == 3100
+    assert accounts["Savings"]["monthly_income"] == 100
+    assert accounts["Savings"]["projected_balance"] == 5100
+    assert any(t["account_id"] == checking_id for t in payload["recent_transactions"])


### PR DESCRIPTION
## Summary
- Adds a `FinancialAccount` model and authenticated `/accounts` CRUD API.
- Lets expenses attach to an account via `account_id` with validation.
- Extends `/dashboard/summary` with `account_overview`, including monthly income, expenses, net flow, opening balance, and projected balance per account.
- Adds dashboard UI for viewing all accounts in one view and account settings UI for creating accounts.
- Updates OpenAPI/README docs and test coverage.

## Verification
- `python -m black --check packages/backend/app/models.py packages/backend/app/routes/accounts.py packages/backend/app/routes/__init__.py packages/backend/app/routes/expenses.py packages/backend/app/routes/dashboard.py packages/backend/app/__init__.py packages/backend/tests/conftest.py packages/backend/tests/test_accounts.py packages/backend/tests/test_dashboard.py`
- `python -m flake8 packages/backend/app/models.py packages/backend/app/routes/accounts.py packages/backend/app/routes/__init__.py packages/backend/app/routes/expenses.py packages/backend/app/routes/dashboard.py packages/backend/app/__init__.py packages/backend/tests/conftest.py packages/backend/tests/test_accounts.py packages/backend/tests/test_dashboard.py`
- `python -m pytest tests/test_accounts.py tests/test_dashboard.py -q` from `packages/backend`

Note: I could not run the frontend build locally because `npm`/`pnpm` are not installed in this environment.

Closes #132