### PR TITLE
Add weekly financial digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-summary`
+
+### Weekly Financial Digest
+`GET /insights/weekly-summary` returns an authenticated Monday-Sunday digest for the current week. Pass `week_start=YYYY-MM-DD` to inspect another Monday-starting week and `currency=USD` to override the user's preferred currency. The response includes weekly income, expenses, net flow, savings rate, daily totals, previous-week comparisons, category shares and trends, largest expenses, due bills, deterministic highlights, structured insights, and recommendations. The Analytics page exposes the digest controls and summary cards alongside monthly coaching.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/__tests__/Analytics.integration.test.tsx
+++ b/app/src/__tests__/Analytics.integration.test.tsx
@@ -30,8 +30,10 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 
 const getBudgetSuggestionMock = jest.fn();
+const getWeeklySummaryMock = jest.fn();
 jest.mock('@/api/insights', () => ({
   getBudgetSuggestion: (...args: unknown[]) => getBudgetSuggestionMock(...args),
+  getWeeklySummary: (...args: unknown[]) => getWeeklySummaryMock(...args),
 }));
 
 describe('Analytics integration', () => {
@@ -52,12 +54,92 @@ describe('Analytics integration', () => {
       method: 'heuristic',
       warnings: [],
     });
+    getWeeklySummaryMock.mockResolvedValue({
+      period: {
+        week_start: '2026-05-04',
+        week_end: '2026-05-10',
+        previous_week_start: '2026-04-27',
+        previous_week_end: '2026-05-03',
+        currency: 'USD',
+      },
+      summary: {
+        income: 1000,
+        expenses: 250,
+        net_flow: 750,
+        transaction_count: 4,
+        income_transaction_count: 1,
+        expense_transaction_count: 3,
+        average_daily_expense: 35.71,
+        savings_rate_pct: 75,
+      },
+      comparison: {
+        previous_income: 0,
+        previous_expenses: 100,
+        previous_net_flow: -100,
+        income_delta: 1000,
+        expense_delta: 150,
+        net_flow_delta: 850,
+        income_change_pct: null,
+        expense_change_pct: 150,
+        net_flow_change_pct: null,
+      },
+      daily_breakdown: [],
+      category_breakdown: [
+        {
+          category_id: 1,
+          category_name: 'Food',
+          amount: 200,
+          transaction_count: 2,
+          share_pct: 80,
+          previous_amount: 70,
+          change_amount: 130,
+          change_pct: 185.71,
+        },
+      ],
+      category_trends: [],
+      largest_expenses: [
+        {
+          id: 1,
+          description: 'Groceries',
+          amount: 120,
+          currency: 'USD',
+          date: '2026-05-04',
+          category_id: 1,
+          category_name: 'Food',
+        },
+      ],
+      upcoming_bills: [
+        {
+          id: 1,
+          name: 'Internet',
+          amount: 45,
+          currency: 'USD',
+          next_due_date: '2026-05-09',
+          cadence: 'MONTHLY',
+          autopay_enabled: false,
+        },
+      ],
+      highlights: ['Food led spending at USD 200.00 (80.00% of expenses).'],
+      insights: [
+        {
+          type: 'top_category',
+          severity: 'info',
+          title: 'Food led spending',
+          detail: 'Food represented 80.00% of weekly expenses.',
+        },
+      ],
+      recommendations: ['Move part of this week\'s surplus to savings.'],
+      method: 'heuristic',
+    });
   });
 
   it('loads and renders insights data', async () => {
     render(<Analytics />);
     await waitFor(() => expect(getBudgetSuggestionMock).toHaveBeenCalled());
+    await waitFor(() => expect(getWeeklySummaryMock).toHaveBeenCalled());
     expect(screen.getByText(/live spending analytics/i)).toBeInTheDocument();
+    expect(screen.getByText(/weekly digest/i)).toBeInTheDocument();
+    expect(screen.getByText(/food represented 80/i)).toBeInTheDocument();
     expect(screen.getByText(/suggested budget/i)).toBeInTheDocument();
     expect(screen.getByText(/tip a/i)).toBeInTheDocument();
   });
@@ -68,6 +150,9 @@ describe('Analytics integration', () => {
 
     await userEvent.clear(screen.getByLabelText(/analytics month/i));
     await userEvent.type(screen.getByLabelText(/analytics month/i), '2026-01');
+    await userEvent.clear(screen.getByLabelText(/weekly summary week start/i));
+    await userEvent.type(screen.getByLabelText(/weekly summary week start/i), '2026-05-04');
+    await userEvent.type(screen.getByLabelText(/weekly summary currency/i), 'usd');
     await userEvent.selectOptions(screen.getByLabelText(/analytics persona/i), 'Debt-focused planner');
     await userEvent.type(screen.getByLabelText(/gemini api key/i), 'abc123');
     await userEvent.click(screen.getByRole('button', { name: /refresh insights/i }));
@@ -78,6 +163,14 @@ describe('Analytics integration', () => {
           month: '2026-01',
           persona: 'Debt-focused planner',
           geminiApiKey: 'abc123',
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(getWeeklySummaryMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          weekStart: '2026-05-04',
+          currency: 'USD',
         }),
       ),
     );

--- a/app/src/__tests__/Analytics.integration.test.tsx
+++ b/app/src/__tests__/Analytics.integration.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Analytics } from '@/pages/Analytics';
+import { Analytics, getCurrentMonday } from '@/pages/Analytics';
 
 jest.mock('@/components/ui/button', () => ({
   Button: ({ children, ...props }: React.PropsWithChildren & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
@@ -24,7 +24,8 @@ jest.mock('@/components/ui/financial-card', () => ({
   FinancialCardDescription: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
 }));
 
-const toastMock = jest.fn();
+const toastDismissMock = jest.fn();
+const toastMock = jest.fn(() => ({ dismiss: toastDismissMock }));
 jest.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: toastMock }),
 }));
@@ -133,6 +134,21 @@ describe('Analytics integration', () => {
     });
   });
 
+  it('formats the default weekly start as the local Monday during US evening hours', () => {
+    const previousTimezone = process.env.TZ;
+    process.env.TZ = 'America/New_York';
+
+    try {
+      expect(getCurrentMonday(new Date('2026-05-12T21:00:00-04:00'))).toBe('2026-05-11');
+    } finally {
+      if (previousTimezone === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = previousTimezone;
+      }
+    }
+  });
+
   it('loads and renders insights data', async () => {
     render(<Analytics />);
     await waitFor(() => expect(getBudgetSuggestionMock).toHaveBeenCalled());
@@ -174,5 +190,21 @@ describe('Analytics integration', () => {
         }),
       ),
     );
+  });
+
+  it('dismisses the previous error toast after a successful refresh', async () => {
+    getWeeklySummaryMock.mockRejectedValueOnce(new Error('week_start must be a Monday'));
+
+    render(<Analytics />);
+    await screen.findByText('week_start must be a Monday');
+    expect(toastMock).toHaveBeenCalledWith({
+      title: 'Failed to load insights',
+      description: 'week_start must be a Monday',
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /refresh insights/i }));
+
+    await waitFor(() => expect(screen.getByText(/weekly digest/i)).toBeInTheDocument());
+    expect(toastDismissMock).toHaveBeenCalled();
   });
 });

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,90 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklySummary = {
+  period: {
+    week_start: string;
+    week_end: string;
+    previous_week_start: string;
+    previous_week_end: string;
+    currency: string;
+  };
+  summary: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+    income_transaction_count: number;
+    expense_transaction_count: number;
+    average_daily_expense: number;
+    savings_rate_pct: number;
+  };
+  comparison: {
+    previous_income: number;
+    previous_expenses: number;
+    previous_net_flow: number;
+    income_delta: number;
+    expense_delta: number;
+    net_flow_delta: number;
+    income_change_pct: number | null;
+    expense_change_pct: number | null;
+    net_flow_change_pct: number | null;
+  };
+  daily_breakdown: Array<{
+    date: string;
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+  }>;
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    transaction_count: number;
+    share_pct: number;
+    previous_amount: number;
+    change_amount: number;
+    change_pct: number | null;
+  }>;
+  category_trends: Array<{
+    category_id: number | null;
+    category_name: string;
+    current_amount: number;
+    previous_amount: number;
+    change_amount: number;
+    change_pct: number | null;
+    trend: 'up' | 'down' | 'flat' | string;
+  }>;
+  largest_expenses: Array<{
+    id: number;
+    description: string;
+    amount: number;
+    currency: string;
+    date: string;
+    category_id: number | null;
+    category_name: string;
+  }>;
+  upcoming_bills: Array<{
+    id: number;
+    name: string;
+    amount: number;
+    currency: string;
+    next_due_date: string;
+    cadence: string;
+    autopay_enabled: boolean;
+  }>;
+  highlights: string[];
+  insights: Array<{
+    type: string;
+    severity: 'info' | 'success' | 'warning' | string;
+    title: string;
+    detail: string;
+  }>;
+  recommendations: string[];
+  method: 'heuristic' | string;
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +115,15 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklySummary(params?: {
+  weekStart?: string;
+  currency?: string;
+}): Promise<WeeklySummary> {
+  const query = new URLSearchParams();
+  if (params?.weekStart) query.set('week_start', params.weekStart);
+  if (params?.currency) query.set('currency', params.currency);
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+  return api<WeeklySummary>(`/insights/weekly-summary${suffix}`);
 }

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -26,8 +26,9 @@ const PERSONAS = [
 
 export function Analytics() {
   const { toast } = useToast();
+  const lastErrorToast = useRef<{ dismiss: () => void } | null>(null);
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
-  const [weekStart, setWeekStart] = useState(getCurrentMonday);
+  const [weekStart, setWeekStart] = useState(() => getCurrentMonday());
   const [weeklyCurrency, setWeeklyCurrency] = useState('');
   const [persona, setPersona] = useState(PERSONAS[0]);
   const [geminiKey, setGeminiKey] = useState('');
@@ -53,10 +54,12 @@ export function Analytics() {
       ]);
       setData(payload);
       setWeeklySummary(weeklyPayload);
+      lastErrorToast.current?.dismiss();
+      lastErrorToast.current = null;
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
-      toast({ title: 'Failed to load insights', description: message });
+      lastErrorToast.current = toast({ title: 'Failed to load insights', description: message });
     } finally {
       setLoading(false);
     }
@@ -358,12 +361,19 @@ export function Analytics() {
   );
 }
 
-function getCurrentMonday() {
-  const now = new Date();
+export function getCurrentMonday(currentDate = new Date()) {
+  const now = new Date(currentDate);
   const day = now.getDay();
   const diff = day === 0 ? -6 : 1 - day;
   now.setDate(now.getDate() + diff);
-  return now.toISOString().slice(0, 10);
+  return formatLocalDate(now);
+}
+
+function formatLocalDate(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 function formatPercent(value: number | null) {

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -10,7 +10,12 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
-import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
+import {
+  getBudgetSuggestion,
+  getWeeklySummary,
+  type BudgetSuggestion,
+  type WeeklySummary,
+} from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
 
 const PERSONAS = [
@@ -22,22 +27,32 @@ const PERSONAS = [
 export function Analytics() {
   const { toast } = useToast();
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [weekStart, setWeekStart] = useState(getCurrentMonday);
+  const [weeklyCurrency, setWeeklyCurrency] = useState('');
   const [persona, setPersona] = useState(PERSONAS[0]);
   const [geminiKey, setGeminiKey] = useState('');
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BudgetSuggestion | null>(null);
+  const [weeklySummary, setWeeklySummary] = useState<WeeklySummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
     setLoading(true);
     setError(null);
     try {
-      const payload = await getBudgetSuggestion({
-        month,
-        persona,
-        geminiApiKey: geminiKey.trim() || undefined,
-      });
+      const [payload, weeklyPayload] = await Promise.all([
+        getBudgetSuggestion({
+          month,
+          persona,
+          geminiApiKey: geminiKey.trim() || undefined,
+        }),
+        getWeeklySummary({
+          weekStart,
+          currency: weeklyCurrency.trim().toUpperCase() || undefined,
+        }),
+      ]);
       setData(payload);
+      setWeeklySummary(weeklyPayload);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
@@ -71,7 +86,7 @@ export function Analytics() {
               Live spending analytics with Gemini-powered budget coaching.
             </p>
           </div>
-          <div className="grid gap-2 md:grid-cols-4">
+          <div className="grid gap-2 md:grid-cols-2 lg:grid-cols-6">
             <div>
               <Label htmlFor="analytics-month">Month</Label>
               <Input
@@ -80,6 +95,16 @@ export function Analytics() {
                 type="month"
                 value={month}
                 onChange={(e) => setMonth(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-week">Week Start</Label>
+              <Input
+                id="analytics-week"
+                aria-label="weekly summary week start"
+                type="date"
+                value={weekStart}
+                onChange={(e) => setWeekStart(e.target.value)}
               />
             </div>
             <div>
@@ -97,6 +122,17 @@ export function Analytics() {
                   </option>
                 ))}
               </select>
+            </div>
+            <div>
+              <Label htmlFor="analytics-weekly-currency">Digest Currency</Label>
+              <Input
+                id="analytics-weekly-currency"
+                aria-label="weekly summary currency"
+                value={weeklyCurrency}
+                onChange={(e) => setWeeklyCurrency(e.target.value.toUpperCase())}
+                placeholder="Preferred"
+                maxLength={10}
+              />
             </div>
             <div className="md:col-span-2">
               <Label htmlFor="analytics-key">Gemini API Key (optional BYOK)</Label>
@@ -122,6 +158,131 @@ export function Analytics() {
         <div className="card text-red-600">{error}</div>
       ) : data ? (
         <div className="space-y-6">
+          {weeklySummary ? (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Weekly Digest</FinancialCardTitle>
+                <FinancialCardDescription>
+                  {weeklySummary.period.week_start} to {weeklySummary.period.week_end} ({weeklySummary.period.currency})
+                </FinancialCardDescription>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid gap-3 md:grid-cols-4">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Income</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklySummary.summary.income, weeklySummary.period.currency)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expenses</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklySummary.summary.expenses, weeklySummary.period.currency)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Net Flow</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklySummary.summary.net_flow, weeklySummary.period.currency)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Vs Last Week</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklySummary.comparison.expense_delta, weeklySummary.period.currency)}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {formatPercent(weeklySummary.comparison.expense_change_pct)}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-3">
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Highlights</div>
+                    <div className="space-y-2">
+                      {weeklySummary.highlights.map((item) => (
+                        <div key={item} className="rounded-lg border p-3 text-sm">
+                          {item}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Top Categories</div>
+                    {weeklySummary.category_breakdown.length ? (
+                      <div className="space-y-2">
+                        {weeklySummary.category_breakdown.slice(0, 4).map((item) => (
+                          <div key={`${item.category_id ?? 'uncat'}-${item.category_name}`} className="rounded-lg border p-3">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="font-medium">{item.category_name}</span>
+                              <span>{formatMoney(item.amount, weeklySummary.period.currency)}</span>
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {item.share_pct.toFixed(2)}% of spend, {formatMoney(item.change_amount, weeklySummary.period.currency)} vs last week
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="rounded-lg border p-3 text-sm text-muted-foreground">
+                        No category spending this week.
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Smart Signals</div>
+                    <div className="space-y-2">
+                      {weeklySummary.insights.slice(0, 4).map((item) => (
+                        <div key={`${item.type}-${item.title}`} className="rounded-lg border p-3 text-sm">
+                          <div className="font-medium">{item.title}</div>
+                          <div className="text-muted-foreground">{item.detail}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Largest Expenses</div>
+                    {weeklySummary.largest_expenses.length ? (
+                      <div className="space-y-2">
+                        {weeklySummary.largest_expenses.slice(0, 3).map((item) => (
+                          <div key={item.id} className="flex items-center justify-between gap-3 rounded-lg border p-3 text-sm">
+                            <span>{item.description}</span>
+                            <span className="font-medium">
+                              {formatMoney(item.amount, item.currency)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="rounded-lg border p-3 text-sm text-muted-foreground">
+                        No expenses recorded.
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <div className="mb-2 text-sm font-semibold">Recommendations</div>
+                    <div className="space-y-2">
+                      {weeklySummary.recommendations.map((item) => (
+                        <div key={item} className="rounded-lg border p-3 text-sm">
+                          {item}
+                        </div>
+                      ))}
+                      {weeklySummary.upcoming_bills.length ? (
+                        <div className="rounded-lg border p-3 text-sm">
+                          Next bill: {weeklySummary.upcoming_bills[0].name} on {weeklySummary.upcoming_bills[0].next_due_date}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          ) : null}
+
           <div className="grid gap-4 md:grid-cols-4">
             <FinancialCard variant="financial">
               <FinancialCardHeader className="pb-2">
@@ -195,4 +356,16 @@ export function Analytics() {
       ) : null}
     </div>
   );
+}
+
+function getCurrentMonday() {
+  const now = new Date();
+  const day = now.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  now.setDate(now.getDate() + diff);
+  return now.toISOString().slice(0, 10);
+}
+
+function formatPercent(value: number | null) {
+  return value === null ? 'New activity' : `${value.toFixed(2)}%`;
 }

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,77 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/weekly-summary:
+    get:
+      summary: Get weekly financial digest
+      description: Returns a Monday-Sunday financial summary with previous-week comparison, category trends, daily totals, largest expenses, due bills, highlights, insights, and recommendations.
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          description: Monday date for the requested week. Defaults to the current week.
+          schema: { type: string, format: date }
+        - in: query
+          name: currency
+          required: false
+          description: Optional currency code. Defaults to the user's preferred currency.
+          schema: { type: string, example: USD }
+      responses:
+        '200':
+          description: Weekly financial digest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklySummary'
+              example:
+                period:
+                  week_start: 2026-05-04
+                  week_end: 2026-05-10
+                  previous_week_start: 2026-04-27
+                  previous_week_end: 2026-05-03
+                  currency: USD
+                summary:
+                  income: 1000
+                  expenses: 250
+                  net_flow: 750
+                  transaction_count: 4
+                  income_transaction_count: 1
+                  expense_transaction_count: 3
+                  average_daily_expense: 35.71
+                  savings_rate_pct: 75
+                comparison:
+                  previous_income: 0
+                  previous_expenses: 100
+                  previous_net_flow: -100
+                  income_delta: 1000
+                  expense_delta: 150
+                  net_flow_delta: 850
+                  income_change_pct: null
+                  expense_change_pct: 150
+                  net_flow_change_pct: null
+                highlights:
+                  - Food led spending at USD 200.00 (80.00% of expenses).
+                insights:
+                  - type: top_category
+                    severity: info
+                    title: Food led spending
+                    detail: Food represented 80.00% of weekly expenses.
+                recommendations:
+                  - Move part of this week's surplus to savings.
+                method: heuristic
+        '400':
+          description: Invalid week_start
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -587,3 +658,112 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    WeeklySummary:
+      type: object
+      properties:
+        period:
+          type: object
+          properties:
+            week_start: { type: string, format: date }
+            week_end: { type: string, format: date }
+            previous_week_start: { type: string, format: date }
+            previous_week_end: { type: string, format: date }
+            currency: { type: string }
+        summary:
+          type: object
+          properties:
+            income: { type: number, format: float }
+            expenses: { type: number, format: float }
+            net_flow: { type: number, format: float }
+            transaction_count: { type: integer }
+            income_transaction_count: { type: integer }
+            expense_transaction_count: { type: integer }
+            average_daily_expense: { type: number, format: float }
+            savings_rate_pct: { type: number, format: float }
+        comparison:
+          type: object
+          properties:
+            previous_income: { type: number, format: float }
+            previous_expenses: { type: number, format: float }
+            previous_net_flow: { type: number, format: float }
+            income_delta: { type: number, format: float }
+            expense_delta: { type: number, format: float }
+            net_flow_delta: { type: number, format: float }
+            income_change_pct: { type: number, format: float, nullable: true }
+            expense_change_pct: { type: number, format: float, nullable: true }
+            net_flow_change_pct: { type: number, format: float, nullable: true }
+        daily_breakdown:
+          type: array
+          items:
+            type: object
+            properties:
+              date: { type: string, format: date }
+              income: { type: number, format: float }
+              expenses: { type: number, format: float }
+              net_flow: { type: number, format: float }
+              transaction_count: { type: integer }
+        category_breakdown:
+          type: array
+          items:
+            type: object
+            properties:
+              category_id: { type: integer, nullable: true }
+              category_name: { type: string }
+              amount: { type: number, format: float }
+              transaction_count: { type: integer }
+              share_pct: { type: number, format: float }
+              previous_amount: { type: number, format: float }
+              change_amount: { type: number, format: float }
+              change_pct: { type: number, format: float, nullable: true }
+        category_trends:
+          type: array
+          items:
+            type: object
+            properties:
+              category_id: { type: integer, nullable: true }
+              category_name: { type: string }
+              current_amount: { type: number, format: float }
+              previous_amount: { type: number, format: float }
+              change_amount: { type: number, format: float }
+              change_pct: { type: number, format: float, nullable: true }
+              trend: { type: string, enum: [up, down, flat] }
+        largest_expenses:
+          type: array
+          items:
+            type: object
+            properties:
+              id: { type: integer }
+              description: { type: string }
+              amount: { type: number, format: float }
+              currency: { type: string }
+              date: { type: string, format: date }
+              category_id: { type: integer, nullable: true }
+              category_name: { type: string }
+        upcoming_bills:
+          type: array
+          items:
+            type: object
+            properties:
+              id: { type: integer }
+              name: { type: string }
+              amount: { type: number, format: float }
+              currency: { type: string }
+              next_due_date: { type: string, format: date }
+              cadence: { type: string }
+              autopay_enabled: { type: boolean }
+        highlights:
+          type: array
+          items: { type: string }
+        insights:
+          type: array
+          items:
+            type: object
+            properties:
+              type: { type: string }
+              severity: { type: string }
+              title: { type: string }
+              detail: { type: string }
+        recommendations:
+          type: array
+          items: { type: string }
+        method: { type: string }

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,7 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.weekly_digest import build_weekly_summary
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +24,26 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    raw_week_start = (request.args.get("week_start") or "").strip() or None
+    currency = (request.args.get("currency") or "").strip() or None
+    try:
+        summary = build_weekly_summary(
+            uid,
+            week_start=raw_week_start,
+            currency=currency,
+        )
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+    logger.info(
+        "Weekly financial summary served user=%s week_start=%s currency=%s",
+        uid,
+        summary["period"]["week_start"],
+        summary["period"]["currency"],
+    )
+    return jsonify(summary)

--- a/packages/backend/app/services/weekly_digest.py
+++ b/packages/backend/app/services/weekly_digest.py
@@ -1,0 +1,513 @@
+from datetime import date, timedelta
+
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Bill, Category, Expense, User
+
+
+def build_weekly_summary(
+    user_id: int,
+    week_start: str | None = None,
+    currency: str | None = None,
+) -> dict:
+    start = _parse_week_start(week_start)
+    end = start + timedelta(days=6)
+    previous_start = start - timedelta(days=7)
+    previous_end = start - timedelta(days=1)
+    selected_currency = _resolve_currency(user_id, currency)
+
+    current_rows = _expense_rows(user_id, start, end, selected_currency)
+    previous_rows = _expense_rows(
+        user_id, previous_start, previous_end, selected_currency
+    )
+
+    current = _summarize_transactions(current_rows)
+    previous = _summarize_transactions(previous_rows)
+    daily = _daily_breakdown(current_rows, start)
+    categories = _category_breakdown(current["categories"], previous["categories"])
+    category_trends = _category_trends(current["categories"], previous["categories"])
+    upcoming_bills = _upcoming_bills(user_id, start, end, selected_currency)
+
+    net_flow = _money(current["income"] - current["expenses"])
+    previous_net_flow = _money(previous["income"] - previous["expenses"])
+    summary = {
+        "income": _money(current["income"]),
+        "expenses": _money(current["expenses"]),
+        "net_flow": net_flow,
+        "transaction_count": current["transaction_count"],
+        "income_transaction_count": current["income_transaction_count"],
+        "expense_transaction_count": current["expense_transaction_count"],
+        "average_daily_expense": _money(current["expenses"] / 7),
+        "savings_rate_pct": (
+            round((net_flow / current["income"]) * 100, 2)
+            if current["income"] > 0
+            else 0.0
+        ),
+    }
+    comparison = {
+        "previous_income": _money(previous["income"]),
+        "previous_expenses": _money(previous["expenses"]),
+        "previous_net_flow": previous_net_flow,
+        "income_delta": _money(current["income"] - previous["income"]),
+        "expense_delta": _money(current["expenses"] - previous["expenses"]),
+        "net_flow_delta": _money(net_flow - previous_net_flow),
+        "income_change_pct": _pct_change(current["income"], previous["income"]),
+        "expense_change_pct": _pct_change(current["expenses"], previous["expenses"]),
+        "net_flow_change_pct": _cash_flow_pct_change(net_flow, previous_net_flow),
+    }
+
+    highlights, insights, recommendations = _build_digest_text(
+        summary=summary,
+        comparison=comparison,
+        categories=categories,
+        category_trends=category_trends,
+        daily=daily,
+        upcoming_bills=upcoming_bills,
+        currency=selected_currency,
+    )
+
+    return {
+        "period": {
+            "week_start": start.isoformat(),
+            "week_end": end.isoformat(),
+            "previous_week_start": previous_start.isoformat(),
+            "previous_week_end": previous_end.isoformat(),
+            "currency": selected_currency,
+        },
+        "summary": summary,
+        "comparison": comparison,
+        "daily_breakdown": daily,
+        "category_breakdown": categories,
+        "category_trends": category_trends,
+        "largest_expenses": _largest_expenses(current["expense_rows"]),
+        "upcoming_bills": upcoming_bills,
+        "highlights": highlights,
+        "insights": insights,
+        "recommendations": recommendations,
+        "method": "heuristic",
+    }
+
+
+def _parse_week_start(raw_value: str | None) -> date:
+    if not raw_value:
+        today = date.today()
+        return today - timedelta(days=today.weekday())
+    try:
+        parsed = date.fromisoformat(raw_value.strip())
+    except (AttributeError, ValueError) as exc:
+        raise ValueError("invalid week_start, expected YYYY-MM-DD") from exc
+    if parsed.weekday() != 0:
+        raise ValueError("week_start must be a Monday")
+    return parsed
+
+
+def _resolve_currency(user_id: int, requested: str | None) -> str:
+    cleaned = (requested or "").strip().upper()
+    if cleaned:
+        return cleaned[:10]
+    user = db.session.get(User, user_id)
+    return ((user.preferred_currency if user else None) or "INR").upper()[:10]
+
+
+def _expense_rows(user_id: int, start: date, end: date, currency: str):
+    return (
+        db.session.query(Expense, Category.name)
+        .outerjoin(
+            Category,
+            (Category.id == Expense.category_id) & (Category.user_id == user_id),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+            func.upper(Expense.currency) == currency,
+        )
+        .order_by(Expense.spent_at.asc(), Expense.id.asc())
+        .all()
+    )
+
+
+def _summarize_transactions(rows) -> dict:
+    summary = {
+        "income": 0.0,
+        "expenses": 0.0,
+        "transaction_count": 0,
+        "income_transaction_count": 0,
+        "expense_transaction_count": 0,
+        "categories": {},
+        "expense_rows": [],
+    }
+
+    for expense, category_name in rows:
+        amount = _money(expense.amount)
+        expense_type = (expense.expense_type or "EXPENSE").upper()
+        summary["transaction_count"] += 1
+        if expense_type == "INCOME":
+            summary["income"] += amount
+            summary["income_transaction_count"] += 1
+            continue
+
+        summary["expenses"] += amount
+        summary["expense_transaction_count"] += 1
+        key = expense.category_id if expense.category_id is not None else "uncat"
+        category = summary["categories"].setdefault(
+            key,
+            {
+                "category_id": expense.category_id,
+                "category_name": category_name or "Uncategorized",
+                "amount": 0.0,
+                "transaction_count": 0,
+            },
+        )
+        category["amount"] += amount
+        category["transaction_count"] += 1
+        summary["expense_rows"].append(
+            {
+                "id": expense.id,
+                "description": expense.notes or "Transaction",
+                "amount": amount,
+                "currency": expense.currency,
+                "date": expense.spent_at.isoformat(),
+                "category_id": expense.category_id,
+                "category_name": category["category_name"],
+            }
+        )
+
+    summary["income"] = _money(summary["income"])
+    summary["expenses"] = _money(summary["expenses"])
+    return summary
+
+
+def _daily_breakdown(rows, start: date) -> list[dict]:
+    by_day = {
+        start
+        + timedelta(days=offset): {
+            "date": (start + timedelta(days=offset)).isoformat(),
+            "income": 0.0,
+            "expenses": 0.0,
+            "net_flow": 0.0,
+            "transaction_count": 0,
+        }
+        for offset in range(7)
+    }
+
+    for expense, _category_name in rows:
+        day = by_day.get(expense.spent_at)
+        if day is None:
+            continue
+        amount = _money(expense.amount)
+        if (expense.expense_type or "EXPENSE").upper() == "INCOME":
+            day["income"] += amount
+        else:
+            day["expenses"] += amount
+        day["transaction_count"] += 1
+        day["net_flow"] = day["income"] - day["expenses"]
+
+    return [
+        {
+            **values,
+            "income": _money(values["income"]),
+            "expenses": _money(values["expenses"]),
+            "net_flow": _money(values["net_flow"]),
+        }
+        for values in by_day.values()
+    ]
+
+
+def _category_breakdown(current: dict, previous: dict) -> list[dict]:
+    total = sum(float(item["amount"] or 0) for item in current.values())
+    rows = []
+    for key, item in current.items():
+        amount = _money(item["amount"])
+        previous_amount = _money(previous.get(key, {}).get("amount", 0.0))
+        rows.append(
+            {
+                "category_id": item["category_id"],
+                "category_name": item["category_name"],
+                "amount": amount,
+                "transaction_count": item["transaction_count"],
+                "share_pct": round((amount / total) * 100, 2) if total > 0 else 0.0,
+                "previous_amount": previous_amount,
+                "change_amount": _money(amount - previous_amount),
+                "change_pct": _pct_change(amount, previous_amount),
+            }
+        )
+    return sorted(rows, key=lambda row: (-row["amount"], row["category_name"]))
+
+
+def _category_trends(current: dict, previous: dict) -> list[dict]:
+    rows = []
+    for key in set(current) | set(previous):
+        current_item = current.get(key)
+        previous_item = previous.get(key)
+        display = current_item or previous_item
+        current_amount = _money((current_item or {}).get("amount", 0.0))
+        previous_amount = _money((previous_item or {}).get("amount", 0.0))
+        change_amount = _money(current_amount - previous_amount)
+        rows.append(
+            {
+                "category_id": display["category_id"],
+                "category_name": display["category_name"],
+                "current_amount": current_amount,
+                "previous_amount": previous_amount,
+                "change_amount": change_amount,
+                "change_pct": _pct_change(current_amount, previous_amount),
+                "trend": _trend(change_amount),
+            }
+        )
+    return sorted(
+        rows,
+        key=lambda row: (-abs(row["change_amount"]), row["category_name"]),
+    )
+
+
+def _largest_expenses(rows: list[dict]) -> list[dict]:
+    return sorted(rows, key=lambda row: (-row["amount"], row["date"], row["id"]))[:5]
+
+
+def _upcoming_bills(user_id: int, start: date, end: date, currency: str) -> list[dict]:
+    bills = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == user_id,
+            Bill.active.is_(True),
+            Bill.next_due_date >= start,
+            Bill.next_due_date <= end,
+            func.upper(Bill.currency) == currency,
+        )
+        .order_by(Bill.next_due_date.asc(), Bill.id.asc())
+        .limit(8)
+        .all()
+    )
+    return [
+        {
+            "id": bill.id,
+            "name": bill.name,
+            "amount": _money(bill.amount),
+            "currency": bill.currency,
+            "next_due_date": bill.next_due_date.isoformat(),
+            "cadence": bill.cadence.value,
+            "autopay_enabled": bill.autopay_enabled,
+        }
+        for bill in bills
+    ]
+
+
+def _build_digest_text(
+    summary: dict,
+    comparison: dict,
+    categories: list[dict],
+    category_trends: list[dict],
+    daily: list[dict],
+    upcoming_bills: list[dict],
+    currency: str,
+) -> tuple[list[str], list[dict], list[str]]:
+    highlights: list[str] = []
+    insights: list[dict] = []
+    recommendations: list[str] = []
+
+    if summary["transaction_count"] == 0:
+        highlights.append("No transactions were recorded for this week.")
+        insights.append(
+            {
+                "type": "activity",
+                "severity": "info",
+                "title": "No weekly activity",
+                "detail": (
+                    "Add income and expense transactions to generate weekly trends."
+                ),
+            }
+        )
+        recommendations.append("Log this week's transactions to unlock the digest.")
+        return highlights, insights, recommendations
+
+    highlights.append(
+        "Net flow was "
+        f"{_format_money(summary['net_flow'], currency)} from "
+        f"{_format_money(summary['income'], currency)} income and "
+        f"{_format_money(summary['expenses'], currency)} expenses."
+    )
+
+    expense_delta = comparison["expense_delta"]
+    if comparison["previous_expenses"] > 0:
+        direction = "higher" if expense_delta >= 0 else "lower"
+        highlights.append(
+            "Expenses were "
+            f"{abs(comparison['expense_change_pct']):.2f}% {direction} than last week."
+        )
+    elif summary["expenses"] > 0:
+        highlights.append(
+            "This was the first week with expenses in the comparison window."
+        )
+
+    if categories:
+        top_category = categories[0]
+        highlights.append(
+            f"{top_category['category_name']} led spending at "
+            f"{_format_money(top_category['amount'], currency)} "
+            f"({top_category['share_pct']:.2f}% of expenses)."
+        )
+        insights.append(
+            {
+                "type": "top_category",
+                "severity": "info",
+                "title": f"{top_category['category_name']} led spending",
+                "detail": (
+                    f"{top_category['category_name']} represented "
+                    f"{top_category['share_pct']:.2f}% of weekly expenses."
+                ),
+            }
+        )
+        if top_category["share_pct"] >= 40:
+            recommendations.append(
+                f"Set a cap for {top_category['category_name']} before next week."
+            )
+
+    if summary["net_flow"] >= 0:
+        insights.append(
+            {
+                "type": "cash_flow",
+                "severity": "success",
+                "title": "Positive weekly cash flow",
+                "detail": (
+                    "Income covered expenses by "
+                    f"{_format_money(summary['net_flow'], currency)}."
+                ),
+            }
+        )
+        recommendations.append("Move part of this week's surplus to savings.")
+    else:
+        insights.append(
+            {
+                "type": "cash_flow",
+                "severity": "warning",
+                "title": "Negative weekly cash flow",
+                "detail": (
+                    "Expenses exceeded income by "
+                    f"{_format_money(abs(summary['net_flow']), currency)}."
+                ),
+            }
+        )
+        recommendations.append("Review the largest expense before adding new spend.")
+
+    if expense_delta > 0:
+        insights.append(
+            {
+                "type": "spending_increase",
+                "severity": "warning",
+                "title": "Spending increased",
+                "detail": (
+                    "Weekly expenses increased by "
+                    f"{_format_money(expense_delta, currency)} from the prior week."
+                ),
+            }
+        )
+    elif expense_delta < 0:
+        insights.append(
+            {
+                "type": "spending_decrease",
+                "severity": "success",
+                "title": "Spending decreased",
+                "detail": (
+                    "Weekly expenses decreased by "
+                    f"{_format_money(abs(expense_delta), currency)} "
+                    "from the prior week."
+                ),
+            }
+        )
+
+    if category_trends:
+        trend = category_trends[0]
+        if trend["change_amount"] != 0:
+            insights.append(
+                {
+                    "type": "category_trend",
+                    "severity": "info",
+                    "title": f"{trend['category_name']} changed most",
+                    "detail": (
+                        f"{trend['category_name']} moved "
+                        f"{_format_money(abs(trend['change_amount']), currency)} "
+                        f"{trend['trend']} versus last week."
+                    ),
+                }
+            )
+
+    expense_days = [item for item in daily if item["expenses"] > 0]
+    if expense_days:
+        highest_day = max(expense_days, key=lambda item: item["expenses"])
+        insights.append(
+            {
+                "type": "daily_trend",
+                "severity": "info",
+                "title": "Highest spend day",
+                "detail": (
+                    f"{highest_day['date']} had the highest spending at "
+                    f"{_format_money(highest_day['expenses'], currency)}."
+                ),
+            }
+        )
+
+    if upcoming_bills:
+        total_due = _money(sum(item["amount"] for item in upcoming_bills))
+        highlights.append(
+            f"{len(upcoming_bills)} bill(s) totaling "
+            f"{_format_money(total_due, currency)} are due this week."
+        )
+        insights.append(
+            {
+                "type": "upcoming_bills",
+                "severity": "warning",
+                "title": "Bills due this week",
+                "detail": (
+                    f"{len(upcoming_bills)} upcoming bill(s) total "
+                    f"{_format_money(total_due, currency)}."
+                ),
+            }
+        )
+        recommendations.append(
+            "Reserve cash for bills due before making extra payments."
+        )
+
+    if summary["income"] == 0 and summary["expenses"] > 0:
+        recommendations.append("Record income deposits to track true cash flow.")
+
+    return _dedupe(highlights), insights, _dedupe(recommendations)
+
+
+def _pct_change(current: float, previous: float) -> float | None:
+    if previous == 0:
+        return 0.0 if current == 0 else None
+    return round(((current - previous) / previous) * 100, 2)
+
+
+def _cash_flow_pct_change(current: float, previous: float) -> float | None:
+    if previous <= 0:
+        return 0.0 if current == previous else None
+    return _pct_change(current, previous)
+
+
+def _trend(delta: float) -> str:
+    if delta > 0:
+        return "up"
+    if delta < 0:
+        return "down"
+    return "flat"
+
+
+def _format_money(amount: float, currency: str) -> str:
+    return f"{currency} {float(amount or 0):.2f}"
+
+
+def _money(value) -> float:
+    return round(float(value or 0), 2)
+
+
+def _dedupe(items: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for item in items:
+        if item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -3,8 +3,58 @@ import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class InMemoryRedis:
+    def __init__(self):
+        self._data = {}
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def set(self, key, value):
+        self._data[key] = value
+        return True
+
+    def setex(self, key, _ttl, value):
+        self._data[key] = value
+        return True
+
+    def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            if key in self._data:
+                deleted += 1
+                del self._data[key]
+        return deleted
+
+    def flushdb(self):
+        self._data.clear()
+        return True
+
+    def scan(self, cursor=0, match=None, count=100):
+        import fnmatch
+
+        keys = list(self._data)
+        if match:
+            keys = [key for key in keys if fnmatch.fnmatch(key, match)]
+        return 0, keys[:count]
+
+    def scan_iter(self, match=None):
+        return iter(self.scan(match=match)[1])
+
+
+def _install_test_redis():
+    fake = InMemoryRedis()
+    import app.extensions as extensions
+    import app.routes.auth as auth
+    import app.services.cache as cache
+
+    extensions.redis_client = fake
+    auth.redis_client = fake
+    cache.redis_client = fake
+    return fake
 
 
 class TestSettings(Settings):
@@ -28,21 +78,16 @@ def app_fixture():
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
+    fake_redis = _install_test_redis()
     app = create_app(settings)
     app.config.update(TESTING=True)
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,6 +1,235 @@
 from datetime import date, timedelta
 
 
+def _create_category(client, auth_header, name: str) -> int:
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+def _create_transaction(
+    client,
+    auth_header,
+    amount: float,
+    description: str,
+    spent_at: date,
+    expense_type: str = "EXPENSE",
+    category_id: int | None = None,
+    currency: str = "USD",
+):
+    payload = {
+        "amount": amount,
+        "currency": currency,
+        "description": description,
+        "date": spent_at.isoformat(),
+        "expense_type": expense_type,
+    }
+    if category_id is not None:
+        payload["category_id"] = category_id
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def _auth_header_for(client, email: str) -> dict:
+    password = "password123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def test_weekly_summary_requires_auth(client):
+    r = client.get("/insights/weekly-summary?week_start=2026-05-04")
+    assert r.status_code == 401
+
+
+def test_weekly_summary_validates_monday_week_start(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-05",
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "week_start must be a Monday"
+
+    r = client.get(
+        "/insights/weekly-summary?week_start=not-a-date",
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid week_start, expected YYYY-MM-DD"
+
+
+def test_weekly_summary_returns_empty_digest(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-04&currency=USD",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period"]["week_start"] == "2026-05-04"
+    assert payload["period"]["week_end"] == "2026-05-10"
+    assert payload["period"]["currency"] == "USD"
+    assert payload["summary"]["transaction_count"] == 0
+    assert payload["summary"]["income"] == 0.0
+    assert payload["summary"]["expenses"] == 0.0
+    assert payload["daily_breakdown"][0]["date"] == "2026-05-04"
+    assert payload["daily_breakdown"][-1]["date"] == "2026-05-10"
+    assert payload["category_breakdown"] == []
+    assert payload["largest_expenses"] == []
+    assert payload["insights"][0]["type"] == "activity"
+    assert payload["method"] == "heuristic"
+
+
+def test_weekly_summary_aggregates_trends_bills_and_user_scope(client, auth_header):
+    week_start = date(2026, 5, 4)
+    food_id = _create_category(client, auth_header, "Food")
+    travel_id = _create_category(client, auth_header, "Travel")
+
+    _create_transaction(
+        client,
+        auth_header,
+        1000,
+        "Paycheck",
+        week_start,
+        expense_type="INCOME",
+        currency="USD",
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        120,
+        "Groceries",
+        week_start,
+        category_id=food_id,
+        currency="USD",
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        80,
+        "Dinner",
+        week_start + timedelta(days=2),
+        category_id=food_id,
+        currency="USD",
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        50,
+        "Taxi",
+        week_start + timedelta(days=6),
+        category_id=travel_id,
+        currency="USD",
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        70,
+        "Previous groceries",
+        week_start - timedelta(days=6),
+        category_id=food_id,
+        currency="USD",
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        30,
+        "Previous taxi",
+        week_start - timedelta(days=4),
+        category_id=travel_id,
+        currency="USD",
+    )
+    _create_transaction(
+        client,
+        auth_header,
+        999,
+        "EUR hidden",
+        week_start,
+        currency="EUR",
+    )
+
+    other_header = _auth_header_for(client, "other@example.com")
+    _create_transaction(
+        client,
+        other_header,
+        500,
+        "Other user hidden",
+        week_start,
+        currency="USD",
+    )
+
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 45,
+            "currency": "USD",
+            "next_due_date": "2026-05-09",
+            "cadence": "MONTHLY",
+            "autopay_enabled": True,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-04&currency=USD",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+
+    assert payload["summary"] == {
+        "income": 1000.0,
+        "expenses": 250.0,
+        "net_flow": 750.0,
+        "transaction_count": 4,
+        "income_transaction_count": 1,
+        "expense_transaction_count": 3,
+        "average_daily_expense": 35.71,
+        "savings_rate_pct": 75.0,
+    }
+    assert payload["comparison"]["previous_expenses"] == 100.0
+    assert payload["comparison"]["expense_delta"] == 150.0
+    assert payload["comparison"]["expense_change_pct"] == 150.0
+
+    categories = payload["category_breakdown"]
+    assert categories[0]["category_name"] == "Food"
+    assert categories[0]["amount"] == 200.0
+    assert categories[0]["share_pct"] == 80.0
+    assert categories[0]["previous_amount"] == 70.0
+    assert categories[0]["change_amount"] == 130.0
+    assert categories[1]["category_name"] == "Travel"
+    assert categories[1]["previous_amount"] == 30.0
+
+    assert payload["category_trends"][0]["category_name"] == "Food"
+    assert payload["category_trends"][0]["trend"] == "up"
+
+    by_date = {item["date"]: item for item in payload["daily_breakdown"]}
+    assert by_date["2026-05-04"]["income"] == 1000.0
+    assert by_date["2026-05-04"]["expenses"] == 120.0
+    assert by_date["2026-05-06"]["expenses"] == 80.0
+    assert by_date["2026-05-10"]["expenses"] == 50.0
+
+    assert payload["largest_expenses"][0]["description"] == "Groceries"
+    assert payload["largest_expenses"][0]["amount"] == 120.0
+    assert payload["upcoming_bills"][0]["name"] == "Internet"
+    assert payload["upcoming_bills"][0]["autopay_enabled"] is True
+
+    insight_types = {item["type"] for item in payload["insights"]}
+    assert {
+        "top_category",
+        "cash_flow",
+        "spending_increase",
+        "category_trend",
+        "daily_trend",
+        "upcoming_bills",
+    }.issubset(insight_types)
+    assert any("surplus" in item for item in payload["recommendations"])
+
+
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
     previous = (current.replace(day=1) - timedelta(days=1)).replace(day=10)


### PR DESCRIPTION
## Summary
- Add authenticated `GET /insights/weekly-summary` for an on-demand Monday-Sunday financial digest.
- Include income, expenses, net flow, savings rate, previous-week comparison, daily totals, category breakdowns/trends, largest expenses, due bills, highlights, insights, and recommendations.
- Surface the digest in the existing Analytics page with week-start and currency controls.
- Format the default Week Start from local date fields so the page does not request a non-Monday in negative UTC offsets.
- Update OpenAPI and README docs, and add backend/frontend tests.

## Assumptions
- The weekly digest is deterministic and generated from existing transactions and bills; it does not add a scheduler or LLM dependency.
- If `currency` is omitted, the backend uses the user's preferred currency.

## Validation
- `cd packages/backend && python3 -m pytest -q` -> 26 passed
- `cd packages/backend && python3 -m black --check app tests` -> passed
- `cd packages/backend && python3 -m flake8 app tests` -> passed
- `cd packages/backend && python3 -c "import yaml; yaml.safe_load(open('app/openapi.yaml')); print('openapi yaml ok')"` -> passed
- `cd app && npm test -- --runInBand` -> 29 passed
- `cd app && npm run lint` -> passed
- `cd app && npm run build` -> passed
- Playwright browser smoke with backend-like Monday validation -> initial `week_start=2026-05-11`, refresh to `week_start=2026-05-04&currency=USD`, rendered `2026-05-04 to 2026-05-10 (USD)`, no page errors

## Demo
- Attach `analytics-weekly-digest-demo.mp4`, a short demo video showing the Analytics weekly digest load, currency refresh, and week-start refresh flow.

/claim #121
Closes #121