### PR TITLE
Add resilient reminder retry monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ finmind/
 
 ## Notes on Free-Tier Reminders
 - Primary: schedule via APScheduler in-process with persistence in Postgres (job table) and a simple daily trigger. Alternatively, use Railway/Render cron to hit `/reminders/run`.
+- Reminder dispatch is resilient to transient provider failures. `/reminders/run`
+  records each attempt, keeps successful reminders moving, schedules bounded
+  exponential retries at 5/15/45 minutes, and moves exhausted reminders into a
+  dead-letter state.
+- Operators can monitor reminder jobs at `/reminders/jobs` and reset a failed
+  reminder with `POST /reminders/{id}/retry`.
 - Twilio WhatsApp free trial supports sandbox; email via SMTP (e.g., SendGrid free tier).
 
 ## Security & Scalability

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -91,9 +91,26 @@ CREATE TABLE IF NOT EXISTS reminders (
   message VARCHAR(500) NOT NULL,
   send_at TIMESTAMP NOT NULL,
   sent BOOLEAN NOT NULL DEFAULT FALSE,
-  channel VARCHAR(20) NOT NULL DEFAULT 'email'
+  channel VARCHAR(20) NOT NULL DEFAULT 'email',
+  retry_count INT NOT NULL DEFAULT 0,
+  max_retries INT NOT NULL DEFAULT 3,
+  next_retry_at TIMESTAMP,
+  last_attempt_at TIMESTAMP,
+  last_error VARCHAR(500),
+  failed BOOLEAN NOT NULL DEFAULT FALSE
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
+CREATE INDEX IF NOT EXISTS idx_reminders_retry
+  ON reminders(user_id, failed, next_retry_at, send_at)
+  WHERE sent = FALSE;
+
+ALTER TABLE reminders
+  ADD COLUMN IF NOT EXISTS retry_count INT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS max_retries INT NOT NULL DEFAULT 3,
+  ADD COLUMN IF NOT EXISTS next_retry_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS last_attempt_at TIMESTAMP,
+  ADD COLUMN IF NOT EXISTS last_error VARCHAR(500),
+  ADD COLUMN IF NOT EXISTS failed BOOLEAN NOT NULL DEFAULT FALSE;
 
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -98,6 +98,12 @@ class Reminder(db.Model):
     send_at = db.Column(db.DateTime, nullable=False)
     sent = db.Column(db.Boolean, default=False, nullable=False)
     channel = db.Column(db.String(20), default="email", nullable=False)
+    retry_count = db.Column(db.Integer, default=0, nullable=False)
+    max_retries = db.Column(db.Integer, default=3, nullable=False)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    last_attempt_at = db.Column(db.DateTime, nullable=True)
+    last_error = db.Column(db.String(500), nullable=True)
+    failed = db.Column(db.Boolean, default=False, nullable=False)
 
 
 class AdImpression(db.Model):

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -374,13 +374,75 @@ paths:
 
   /reminders/run:
     post:
-      summary: Process due reminders
+      summary: Process due reminders with retry tracking
       tags: [Reminders]
       security: [{ bearerAuth: [] }]
       responses:
-        '200': { description: Processed count }
+        '200':
+          description: Processed count by outcome
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  processed: { type: integer }
+                  sent: { type: integer }
+                  retrying: { type: integer }
+                  failed: { type: integer }
         '401':
           description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /reminders/jobs:
+    get:
+      summary: Monitor reminder job retry state
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Reminder job summary and dead-letter reminders
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  summary:
+                    type: object
+                    properties:
+                      total: { type: integer }
+                      sent: { type: integer }
+                      failed: { type: integer }
+                      retrying: { type: integer }
+                      pending: { type: integer }
+                  dead_letter:
+                    type: array
+                    items: { $ref: '#/components/schemas/Reminder' }
+
+  /reminders/{reminderId}/retry:
+    post:
+      summary: Reset a failed reminder for retry
+      tags: [Reminders]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: reminderId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Reminder retry state reset
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Reminder' }
+        '400':
+          description: Reminder cannot be retried
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Reminder not found
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
@@ -580,6 +642,12 @@ components:
         send_at: { type: string, format: date-time }
         sent: { type: boolean }
         channel: { type: string, enum: [email, whatsapp] }
+        retry_count: { type: integer }
+        max_retries: { type: integer }
+        next_retry_at: { type: string, format: date-time, nullable: true }
+        last_attempt_at: { type: string, format: date-time, nullable: true }
+        last_error: { type: string, nullable: true }
+        failed: { type: boolean }
     NewReminder:
       type: object
       required: [message, send_at]

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -1,6 +1,7 @@
 from datetime import datetime, time, timedelta
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from sqlalchemy import and_, case, func, or_
 from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
@@ -30,6 +31,16 @@ def list_reminders():
                 "send_at": r.send_at.isoformat(),
                 "sent": r.sent,
                 "channel": r.channel,
+                "retry_count": r.retry_count,
+                "max_retries": r.max_retries,
+                "next_retry_at": (
+                    r.next_retry_at.isoformat() if r.next_retry_at else None
+                ),
+                "last_attempt_at": (
+                    r.last_attempt_at.isoformat() if r.last_attempt_at else None
+                ),
+                "last_error": r.last_error,
+                "failed": r.failed,
             }
             for r in items
         ]
@@ -166,17 +177,131 @@ def run_due():
         .filter(
             Reminder.user_id == uid,
             Reminder.sent.is_(False),
+            Reminder.failed.is_(False),
             Reminder.send_at <= now,
+            or_(Reminder.next_retry_at.is_(None), Reminder.next_retry_at <= now),
         )
         .all()
     )
+    sent = 0
+    retrying = 0
+    failed = 0
     for r in items:
-        send_reminder(r)
+        r.last_attempt_at = datetime.utcnow()
+        try:
+            send_reminder(r)
+        except Exception as exc:
+            _mark_reminder_attempt_failed(r, exc)
+            if r.failed:
+                failed += 1
+                track_reminder_event(event="failed", channel=r.channel, status="error")
+            else:
+                retrying += 1
+                track_reminder_event(
+                    event="retry_scheduled", channel=r.channel, status="error"
+                )
+            logger.warning(
+                "Reminder dispatch failed id=%s user=%s retry=%s failed=%s",
+                r.id,
+                uid,
+                r.retry_count,
+                r.failed,
+                exc_info=True,
+            )
+            continue
+
         r.sent = True
+        r.last_error = None
+        r.next_retry_at = None
+        sent += 1
         track_reminder_event(event="sent", channel=r.channel)
     db.session.commit()
-    logger.info("Processed due reminders user=%s count=%s", uid, len(items))
-    return jsonify(processed=len(items))
+    logger.info(
+        "Processed due reminders user=%s processed=%s sent=%s retrying=%s failed=%s",
+        uid,
+        len(items),
+        sent,
+        retrying,
+        failed,
+    )
+    return jsonify(processed=len(items), sent=sent, retrying=retrying, failed=failed)
+
+
+@bp.get("/jobs")
+@jwt_required()
+def reminder_job_status():
+    uid = int(get_jwt_identity())
+    totals = (
+        db.session.query(
+            func.count(Reminder.id).label("total"),
+            func.sum(case((Reminder.sent.is_(True), 1), else_=0)).label("sent"),
+            func.sum(case((Reminder.failed.is_(True), 1), else_=0)).label("failed"),
+            func.sum(
+                case(
+                    (
+                        and_(
+                            Reminder.sent.is_(False),
+                            Reminder.failed.is_(False),
+                            Reminder.retry_count > 0,
+                        ),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ).label("retrying"),
+            func.sum(
+                case(
+                    (
+                        and_(
+                            Reminder.sent.is_(False),
+                            Reminder.failed.is_(False),
+                            Reminder.retry_count == 0,
+                        ),
+                        1,
+                    ),
+                    else_=0,
+                )
+            ).label("pending"),
+        )
+        .filter(Reminder.user_id == uid)
+        .one()
+    )
+    dead_letter = (
+        db.session.query(Reminder)
+        .filter_by(user_id=uid, failed=True)
+        .order_by(Reminder.last_attempt_at.desc().nullslast(), Reminder.id.desc())
+        .limit(20)
+        .all()
+    )
+    return jsonify(
+        summary={
+            "total": int(totals.total or 0),
+            "sent": int(totals.sent or 0),
+            "failed": int(totals.failed or 0),
+            "retrying": int(totals.retrying or 0),
+            "pending": int(totals.pending or 0),
+        },
+        dead_letter=[_reminder_job_payload(r) for r in dead_letter],
+    )
+
+
+@bp.post("/<int:reminder_id>/retry")
+@jwt_required()
+def retry_failed_reminder(reminder_id: int):
+    uid = int(get_jwt_identity())
+    reminder = db.session.get(Reminder, reminder_id)
+    if not reminder or reminder.user_id != uid:
+        return jsonify(error="not found"), 404
+    if reminder.sent:
+        return jsonify(error="already sent"), 400
+
+    reminder.failed = False
+    reminder.retry_count = 0
+    reminder.next_retry_at = None
+    reminder.last_error = None
+    db.session.commit()
+    track_reminder_event(event="manual_retry", channel=reminder.channel)
+    return jsonify(_reminder_job_payload(reminder)), 200
 
 
 def _bill_channels(bill: Bill) -> list[str]:
@@ -221,3 +346,39 @@ def _create_reminder_if_missing(
         )
     )
     return True
+
+
+def _mark_reminder_attempt_failed(reminder: Reminder, exc: Exception) -> None:
+    reminder.retry_count += 1
+    reminder.last_error = str(exc)[:500]
+    if reminder.retry_count >= reminder.max_retries:
+        reminder.failed = True
+        reminder.next_retry_at = None
+        return
+    reminder.next_retry_at = datetime.utcnow() + _retry_backoff(reminder.retry_count)
+
+
+def _retry_backoff(retry_count: int) -> timedelta:
+    minutes = (5, 15, 45)
+    index = max(0, min(retry_count - 1, len(minutes) - 1))
+    return timedelta(minutes=minutes[index])
+
+
+def _reminder_job_payload(reminder: Reminder) -> dict:
+    return {
+        "id": reminder.id,
+        "message": reminder.message,
+        "channel": reminder.channel,
+        "sent": reminder.sent,
+        "failed": reminder.failed,
+        "retry_count": reminder.retry_count,
+        "max_retries": reminder.max_retries,
+        "send_at": reminder.send_at.isoformat(),
+        "next_retry_at": (
+            reminder.next_retry_at.isoformat() if reminder.next_retry_at else None
+        ),
+        "last_attempt_at": (
+            reminder.last_attempt_at.isoformat() if reminder.last_attempt_at else None
+        ),
+        "last_error": reminder.last_error,
+    }

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -1,4 +1,6 @@
-from datetime import date
+from datetime import date, datetime, timedelta
+
+import app.routes.reminders as reminder_routes
 
 
 def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = False):
@@ -80,3 +82,79 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def test_due_reminders_retry_failures_without_blocking_successes(
+    client, auth_header, monkeypatch
+):
+    due = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    for message in ("send ok", "fail once"):
+        r = client.post(
+            "/reminders",
+            json={"message": message, "send_at": due, "channel": "email"},
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    def fake_send(reminder):
+        if reminder.message == "fail once":
+            raise RuntimeError("provider unavailable")
+
+    monkeypatch.setattr(reminder_routes, "send_reminder", fake_send)
+
+    r = client.post("/reminders/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == {"processed": 2, "sent": 1, "retrying": 1, "failed": 0}
+
+    r = client.get("/reminders", headers=auth_header)
+    reminders = {item["message"]: item for item in r.get_json()}
+    assert reminders["send ok"]["sent"] is True
+    assert reminders["fail once"]["sent"] is False
+    assert reminders["fail once"]["failed"] is False
+    assert reminders["fail once"]["retry_count"] == 1
+    assert reminders["fail once"]["next_retry_at"] is not None
+    assert reminders["fail once"]["last_error"] == "provider unavailable"
+
+
+def test_due_reminders_move_to_dead_letter_and_can_be_retried(
+    client, auth_header, monkeypatch
+):
+    due = (datetime.utcnow() - timedelta(minutes=5)).isoformat()
+    r = client.post(
+        "/reminders",
+        json={"message": "always fail", "send_at": due, "channel": "email"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    reminder_id = r.get_json()["id"]
+
+    def fake_send(_reminder):
+        raise RuntimeError("smtp down")
+
+    monkeypatch.setattr(reminder_routes, "send_reminder", fake_send)
+
+    for _ in range(3):
+        r = client.post("/reminders/run", headers=auth_header)
+        assert r.status_code == 200
+        with client.application.app_context():
+            from app.extensions import db
+            from app.models import Reminder
+
+            reminder = db.session.get(Reminder, reminder_id)
+            reminder.next_retry_at = datetime.utcnow() - timedelta(minutes=1)
+            db.session.commit()
+
+    r = client.get("/reminders/jobs", headers=auth_header)
+    assert r.status_code == 200
+    jobs = r.get_json()
+    assert jobs["summary"]["failed"] == 1
+    assert jobs["summary"]["retrying"] == 0
+    assert jobs["dead_letter"][0]["id"] == reminder_id
+    assert jobs["dead_letter"][0]["last_error"] == "smtp down"
+
+    r = client.post(f"/reminders/{reminder_id}/retry", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["failed"] is False
+    assert payload["retry_count"] == 0
+    assert payload["last_error"] is None


### PR DESCRIPTION
## Summary

Implements resilient reminder background-job retry and monitoring for #130.

- Adds persisted retry state to reminders: retry count, max retries, next retry time, last attempt, last error, and failed/dead-letter state.
- Updates `/reminders/run` so one provider failure no longer blocks other due reminders. Successful reminders are marked sent, transient failures are scheduled with bounded 5/15/45 minute backoff, and exhausted jobs move to a failed state.
- Adds `/reminders/jobs` for retry/dead-letter monitoring and `POST /reminders/{id}/retry` for manual reset.
- Updates PostgreSQL schema, OpenAPI docs, README notes, and backend coverage.

## Verification

- `sh ./scripts/test-backend.sh tests/test_reminders.py` passed: 4 tests.
- `sh ./scripts/test-backend.sh` passed: 24 tests.
- `docker compose run --rm backend sh -lc "black --check app tests && flake8 app tests"` passed.

/claim #130
