### PR TITLE
Implement locale-aware formatting for dates and amounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ See `backend/app/db/schema.sql`. Key tables:
   - On expense/bill create/update/delete -> delete affected monthly_summary, upcoming_bills, insights
 - Rate limiting (optional): `rl:{userId}:{endpoint}:{minute}` with short TTL
 
+## Locale-Aware Formatting
+- Frontend money, number, percent, and date display should go through `app/src/lib/currency.ts`.
+- The shared helpers use the browser locale from `navigator.language` and the user's preferred currency from local storage.
+- Use `formatMoney` for currency amounts, `formatNumber` for plain numbers, `formatPercent` for percentages, and `formatDate` for dates/date-times.
+- Avoid direct `toLocaleString`, `toLocaleDateString`, and hard-coded `$` formatting in pages and reusable UI.
+
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`

--- a/app/src/__tests__/currency.test.ts
+++ b/app/src/__tests__/currency.test.ts
@@ -1,0 +1,45 @@
+import { formatDate, formatMoney, formatNumber, formatPercent } from '@/lib/currency';
+
+jest.mock('@/lib/auth', () => ({
+  getCurrency: () => 'USD',
+}));
+
+describe('locale-aware formatters', () => {
+  const originalLanguage = navigator.language;
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'language', {
+      configurable: true,
+      value: originalLanguage,
+    });
+  });
+
+  it('formats money with the browser locale and selected currency', () => {
+    Object.defineProperty(navigator, 'language', {
+      configurable: true,
+      value: 'en-US',
+    });
+
+    expect(formatMoney(1234.5, 'USD')).toBe('$1,234.50');
+  });
+
+  it('formats numbers and percentages with Intl', () => {
+    Object.defineProperty(navigator, 'language', {
+      configurable: true,
+      value: 'en-US',
+    });
+
+    expect(formatNumber(1234567)).toBe('1,234,567');
+    expect(formatPercent(12.34, 1)).toBe('12.3%');
+  });
+
+  it('formats dates and falls back to the input for invalid dates', () => {
+    Object.defineProperty(navigator, 'language', {
+      configurable: true,
+      value: 'en-US',
+    });
+
+    expect(formatDate('2026-02-20')).toBe('2/20/2026');
+    expect(formatDate('not-a-date')).toBe('not-a-date');
+  });
+});

--- a/app/src/components/ui/chart.tsx
+++ b/app/src/components/ui/chart.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
+import { formatNumber } from "@/lib/currency"
 import { cn } from "@/lib/utils"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
@@ -238,7 +239,7 @@ const ChartTooltipContent = React.forwardRef<
                       </div>
                       {item.value && (
                         <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
+                          {formatNumber(Number(item.value || 0))}
                         </span>
                       )}
                     </div>

--- a/app/src/lib/currency.ts
+++ b/app/src/lib/currency.ts
@@ -1,9 +1,16 @@
 import { getCurrency } from '@/lib/auth';
 
+export function getLocale(): string | undefined {
+  if (typeof navigator !== 'undefined' && navigator.language) {
+    return navigator.language;
+  }
+  return undefined;
+}
+
 export function formatMoney(amount: number, currencyCode?: string): string {
   const currency = (currencyCode || getCurrency() || 'USD').toUpperCase();
   try {
-    return new Intl.NumberFormat(undefined, {
+    return new Intl.NumberFormat(getLocale(), {
       style: 'currency',
       currency,
       minimumFractionDigits: 2,
@@ -11,5 +18,34 @@ export function formatMoney(amount: number, currencyCode?: string): string {
     }).format(Number(amount || 0));
   } catch {
     return `${currency} ${Number(amount || 0).toFixed(2)}`;
+  }
+}
+
+export function formatNumber(value: number, options?: Intl.NumberFormatOptions): string {
+  try {
+    return new Intl.NumberFormat(getLocale(), options).format(Number(value || 0));
+  } catch {
+    return Number(value || 0).toLocaleString('en-US');
+  }
+}
+
+export function formatPercent(value: number, maximumFractionDigits = 0): string {
+  return formatNumber(Number(value || 0) / 100, {
+    style: 'percent',
+    minimumFractionDigits: 0,
+    maximumFractionDigits,
+  });
+}
+
+export function formatDate(value: string | Date, options?: Intl.DateTimeFormatOptions): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === 'string' ? value : '';
+  }
+
+  try {
+    return new Intl.DateTimeFormat(getLocale(), options).format(date);
+  } catch {
+    return date.toISOString().slice(0, 10);
   }
 }

--- a/app/src/pages/Bills.tsx
+++ b/app/src/pages/Bills.tsx
@@ -8,7 +8,7 @@ import { listBills, createBill, markBillPaid, deleteBill, type Bill } from '@/ap
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dailog';
 import { Link } from 'react-router-dom';
-import { formatMoney } from '@/lib/currency';
+import { formatDate, formatMoney } from '@/lib/currency';
 
 const upcomingBills = [
   {
@@ -245,7 +245,7 @@ export function Bills() {
                     <div>
                       <div className="font-medium">{b.name}</div>
                       <div className="text-xs text-muted-foreground">
-                        Due {b.next_due_date || '—'} • {formatMoney(Number(b.amount || 0), b.currency)}
+                        Due {b.next_due_date ? formatDate(b.next_due_date) : '—'} • {formatMoney(Number(b.amount || 0), b.currency)}
                       </div>
                     </div>
                     <div className="flex gap-2">
@@ -321,7 +321,7 @@ export function Bills() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${totalUpcoming.toLocaleString()}
+                {formatMoney(totalUpcoming)}
               </div>
               <div className="text-sm text-muted-foreground">
                 {upcomingBills.length} bills this month
@@ -378,7 +378,7 @@ export function Bills() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${(totalUpcoming * 0.92).toLocaleString()}
+                {formatMoney(totalUpcoming * 0.92)}
               </div>
               <div className="text-sm text-muted-foreground">
                 Last 6 months
@@ -433,7 +433,7 @@ export function Bills() {
                             {bill.name}
                           </div>
                           <div className="text-sm text-muted-foreground">
-                            {bill.provider} • Due {new Date(bill.dueDate).toLocaleDateString()}
+                            {bill.provider} • Due {formatDate(bill.dueDate)}
                           </div>
                           <div className="flex items-center space-x-2 mt-1">
                             <Badge variant="outline" className="text-xs">
@@ -454,7 +454,7 @@ export function Bills() {
                       </div>
                       <div className="text-right">
                         <div className="text-lg font-semibold text-foreground">
-                          ${bill.amount.toFixed(2)}
+                          {formatMoney(bill.amount)}
                         </div>
                         <Button variant="ghost" size="sm" className="mt-1">
                           Pay Now
@@ -493,7 +493,7 @@ export function Bills() {
                         </div>
                       </div>
                       <div className="text-sm font-semibold text-foreground">
-                        ${category.amount.toFixed(2)}
+                        {formatMoney(category.amount)}
                       </div>
                     </div>
                   ))}
@@ -522,12 +522,12 @@ export function Bills() {
                             {payment.name}
                           </div>
                           <div className="text-xs text-muted-foreground">
-                            {new Date(payment.paidDate).toLocaleDateString()} • {payment.method}
+                            {formatDate(payment.paidDate)} • {payment.method}
                           </div>
                         </div>
                       </div>
                       <div className="text-sm font-semibold text-foreground">
-                        ${payment.amount.toFixed(2)}
+                        {formatMoney(payment.amount)}
                       </div>
                     </div>
                   ))}

--- a/app/src/pages/Budgets.tsx
+++ b/app/src/pages/Budgets.tsx
@@ -3,6 +3,7 @@ import { FinancialCard, FinancialCardContent, FinancialCardDescription, Financia
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Calendar, DollarSign, Plus, PieChart, TrendingDown, TrendingUp, Target, AlertCircle, Settings } from 'lucide-react';
+import { formatMoney, formatPercent } from '@/lib/currency';
 
 const budgetCategories = [
   {
@@ -140,7 +141,7 @@ export function Budgets() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${totalAllocated.toLocaleString()}
+                {formatMoney(totalAllocated)}
               </div>
               <div className="text-sm text-muted-foreground">
                 This month's budget
@@ -159,10 +160,10 @@ export function Budgets() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value text-foreground mb-1">
-                ${totalSpent.toLocaleString()}
+                {formatMoney(totalSpent)}
               </div>
               <div className="text-sm text-muted-foreground">
-                {((totalSpent / totalAllocated) * 100).toFixed(1)}% of budget used
+                {formatPercent((totalSpent / totalAllocated) * 100, 1)} of budget used
               </div>
             </FinancialCardContent>
           </FinancialCard>
@@ -182,7 +183,7 @@ export function Budgets() {
             </FinancialCardHeader>
             <FinancialCardContent>
               <div className="metric-value mb-1">
-                ${Math.abs(totalRemaining).toLocaleString()}
+                {formatMoney(Math.abs(totalRemaining))}
               </div>
               <div className="text-sm opacity-80">
                 {totalRemaining < 0 ? 'Overspent this month' : 'Available to spend'}
@@ -220,7 +221,7 @@ export function Budgets() {
                             <div>
                               <div className="font-medium text-foreground">{category.name}</div>
                               <div className="text-sm text-muted-foreground">
-                                ${category.spent} of ${category.allocated}
+                                {formatMoney(category.spent)} of {formatMoney(category.allocated)}
                               </div>
                             </div>
                           </div>
@@ -228,7 +229,7 @@ export function Budgets() {
                             <div className={`font-semibold ${
                               isOverBudget ? 'text-destructive' : 'text-foreground'
                             }`}>
-                              {isOverBudget ? '-' : ''}${Math.abs(category.remaining)}
+                              {isOverBudget ? '-' : ''}{formatMoney(Math.abs(category.remaining))}
                             </div>
                             <div className="flex items-center text-sm">
                               {category.trend === 'up' ? (
@@ -302,10 +303,10 @@ export function Budgets() {
                         <div className="space-y-2">
                           <div className="flex justify-between text-sm">
                             <span className="text-muted-foreground">
-                              ${goal.current.toLocaleString()} / ${goal.target.toLocaleString()}
+                              {formatMoney(goal.current)} / {formatMoney(goal.target)}
                             </span>
                             <span className="text-foreground font-medium">
-                              {percentage.toFixed(0)}%
+                              {formatPercent(percentage)}
                             </span>
                           </div>
                           <div className="chart-track">
@@ -313,7 +314,7 @@ export function Budgets() {
                           </div>
                           <div className="flex justify-between text-xs text-muted-foreground">
                             <span>Target: {goal.deadline}</span>
-                            <span>${goal.monthlyTarget}/mo</span>
+                            <span>{formatMoney(goal.monthlyTarget)}/mo</span>
                           </div>
                         </div>
                       </div>

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react';
 import { getDashboardSummary, type DashboardSummary } from '@/api/dashboard';
 import { useNavigate } from 'react-router-dom';
-import { formatMoney } from '@/lib/currency';
+import { formatDate, formatMoney, formatPercent } from '@/lib/currency';
 
 function currency(n: number, code?: string) {
   return formatMoney(Number(n || 0), code);
@@ -193,7 +193,7 @@ export function Dashboard() {
                           </div>
                           <div>
                             <div className="font-medium text-foreground">{transaction.description}</div>
-                            <div className="text-sm text-muted-foreground">{new Date(transaction.date).toLocaleDateString()}</div>
+                            <div className="text-sm text-muted-foreground">{formatDate(transaction.date)}</div>
                           </div>
                         </div>
                         <div className={`font-semibold ${isIncome ? 'text-success' : 'text-foreground'}`}>
@@ -231,7 +231,7 @@ export function Dashboard() {
                         </div>
                         <div>
                           <div className="font-medium text-foreground text-sm">{bill.name}</div>
-                          <div className="text-xs text-muted-foreground">Due {new Date(bill.next_due_date).toLocaleDateString()}</div>
+                          <div className="text-xs text-muted-foreground">Due {formatDate(bill.next_due_date)}</div>
                         </div>
                       </div>
                       <div className="text-sm font-semibold text-foreground">
@@ -264,7 +264,7 @@ export function Dashboard() {
                     <div key={`${row.category_id ?? 'uncat'}-${row.category_name}`} className="space-y-1">
                       <div className="flex items-center justify-between text-sm">
                         <span className="text-foreground">{row.category_name}</span>
-                        <span className="text-muted-foreground">{currency(row.amount)} ({row.share_pct.toFixed(0)}%)</span>
+                        <span className="text-muted-foreground">{currency(row.amount)} ({formatPercent(row.share_pct)})</span>
                       </div>
                       <div className="chart-track h-2">
                         <div className="chart-fill-primary h-2" style={{ width: `${Math.max(2, Math.min(100, row.share_pct))}%` }} />

--- a/app/src/pages/Reminders.tsx
+++ b/app/src/pages/Reminders.tsx
@@ -15,6 +15,7 @@ import {
   type Reminder,
 } from '@/api/reminders';
 import { listBills, type Bill } from '@/api/bills';
+import { formatDate } from '@/lib/currency';
 
 export function Reminders() {
   const { toast } = useToast();
@@ -268,7 +269,7 @@ export function Reminders() {
                 <div key={r.id} className="interactive-row flex items-center justify-between border-b py-2">
                   <div>
                     <div className="font-medium">{r.message}</div>
-                    <div className="text-xs text-muted-foreground">{new Date(r.send_at).toLocaleString()} • {r.channel} • {r.sent ? 'sent' : 'pending'}</div>
+                    <div className="text-xs text-muted-foreground">{formatDate(r.send_at, { dateStyle: 'short', timeStyle: 'short' })} • {r.channel} • {r.sent ? 'sent' : 'pending'}</div>
                   </div>
                   <AlertDialog>
                     <AlertDialogTrigger asChild>


### PR DESCRIPTION
Closes #131

## Summary
- centralize browser-locale formatting helpers for money, plain numbers, percentages, and dates
- replace hard-coded dollar/date/percent formatting in dashboard, bills, budgets, reminders, and chart tooltips
- document the shared formatting helpers and add focused formatter tests

## Tests
- `npm test -- --runTestsByPath src/__tests__/currency.test.ts`
- `npm run build`