### PR TITLE
Add gzip compression for eligible API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ See `backend/app/db/schema.sql`. Key tables:
   - On expense/bill create/update/delete -> delete affected monthly_summary, upcoming_bills, insights
 - Rate limiting (optional): `rl:{userId}:{endpoint}:{minute}` with short TTL
 
+## API Response Compression
+- The backend gzips compressible 2xx responses when the client sends `Accept-Encoding: gzip`.
+- Compression applies to JSON and text-like responses larger than 512 bytes.
+- Responses that already set `Content-Encoding`, non-2xx responses, and streaming/direct-passthrough responses are left unchanged.
+- Compressed responses include `Vary: Accept-Encoding` so shared caches keep compressed and uncompressed variants separate.
+
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -8,6 +8,7 @@ from .observability import (
     finalize_request,
     init_request_context,
 )
+from .services.compression import maybe_compress_response
 from flask_cors import CORS
 import click
 import os
@@ -62,7 +63,8 @@ def create_app(settings: Settings | None = None) -> Flask:
 
     @app.after_request
     def _after_request(response):
-        return finalize_request(response)
+        response = finalize_request(response)
+        return maybe_compress_response(response)
 
     @app.get("/health")
     def health():

--- a/packages/backend/app/services/compression.py
+++ b/packages/backend/app/services/compression.py
@@ -1,0 +1,52 @@
+import gzip
+
+from flask import Response, request
+
+
+COMPRESSIBLE_MIMETYPES = {
+    "application/json",
+    "application/javascript",
+    "text/css",
+    "text/html",
+    "text/javascript",
+    "text/plain",
+}
+
+MIN_COMPRESS_SIZE_BYTES = 512
+
+
+def maybe_compress_response(response: Response) -> Response:
+    """Gzip compress eligible responses when the client supports it."""
+
+    if "gzip" not in request.headers.get("Accept-Encoding", "").lower():
+        return response
+    if response.status_code < 200 or response.status_code >= 300:
+        return response
+    if response.direct_passthrough:
+        return response
+    if response.headers.get("Content-Encoding"):
+        return response
+    if response.mimetype not in COMPRESSIBLE_MIMETYPES:
+        return response
+
+    payload = response.get_data()
+    if len(payload) < MIN_COMPRESS_SIZE_BYTES:
+        return response
+
+    compressed = gzip.compress(payload)
+    response.set_data(compressed)
+    response.headers["Content-Encoding"] = "gzip"
+    response.headers["Content-Length"] = str(len(compressed))
+    response.headers["Vary"] = _append_vary(response.headers.get("Vary"), "Accept-Encoding")
+    return response
+
+
+def _append_vary(existing: str | None, value: str) -> str:
+    if not existing:
+        return value
+
+    parts = [part.strip() for part in existing.split(",") if part.strip()]
+    if value.lower() not in {part.lower() for part in parts}:
+        parts.append(value)
+    return ", ".join(parts)
+

--- a/packages/backend/tests/test_compression.py
+++ b/packages/backend/tests/test_compression.py
@@ -1,0 +1,42 @@
+import gzip
+
+import pytest
+from flask import jsonify
+
+
+@pytest.fixture()
+def compression_client(app_fixture):
+    @app_fixture.get("/_test/large-json")
+    def large_json():
+        return jsonify(
+            items=[
+                {
+                    "id": idx,
+                    "description": f"Large payload expense {idx:02d}",
+                    "amount": idx + 1,
+                }
+                for idx in range(80)
+            ]
+        )
+
+    return app_fixture.test_client()
+
+
+def test_gzip_compresses_large_json_response(compression_client):
+    r = compression_client.get(
+        "/_test/large-json",
+        headers={"Accept-Encoding": "gzip"},
+    )
+
+    assert r.status_code == 200
+    assert r.headers["Content-Encoding"] == "gzip"
+    assert "Accept-Encoding" in r.headers["Vary"]
+    assert b"Large payload expense" in gzip.decompress(r.data)
+
+
+def test_gzip_skips_clients_without_accept_encoding(compression_client):
+    r = compression_client.get("/_test/large-json")
+
+    assert r.status_code == 200
+    assert "Content-Encoding" not in r.headers
+    assert b"Large payload expense" in r.data


### PR DESCRIPTION
Closes #129

## Summary
- gzip JSON and text-like 2xx responses when clients send `Accept-Encoding: gzip`
- skip small, already encoded, non-2xx, and streaming/direct-passthrough responses
- add `Vary: Accept-Encoding` and focused compression tests

## Tests
- `PYTHONPATH=packages/backend python -m pytest packages/backend/tests/test_compression.py`