### PR TITLE
Implement signed webhook event delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ flowchart LR
 ## PostgreSQL Schema (DDL)
 See `backend/app/db/schema.sql`. Key tables:
 - users, categories, expenses, bills, reminders
+- webhook_endpoints, webhook_deliveries
 - ad_impressions, subscription_plans, user_subscriptions
 - refresh_tokens (optional if rotating), audit_logs
 
@@ -66,6 +67,15 @@ OpenAPI: `backend/app/openapi.yaml`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Webhooks: manage `/webhooks`, inspect `/webhooks/deliveries`, run `/webhooks/deliveries/run`
+
+## Webhook Events
+- Configure signed webhook endpoints with `POST /webhooks`.
+- If no secret is supplied, FinMind generates one and returns it once in the create response.
+- Deliveries are queued when matching events happen, signed with `X-FinMind-Signature: sha256=<hmac>` over `{timestamp}.{json_body}`, and retried with exponential backoff.
+- Run pending deliveries with `flask process-webhooks` from a worker/cron process, or with `POST /webhooks/deliveries/run` for the authenticated user's due deliveries.
+- Supported events: `expense.created`, `expense.updated`, `expense.deleted`, `bill.created`, `bill.paid`, `reminder.created`, `reminder.scheduled`, `reminder.sent`.
+- Delivery headers: `X-FinMind-Event`, `X-FinMind-Delivery`, `X-FinMind-Timestamp`, and `X-FinMind-Signature`.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.
@@ -104,11 +114,13 @@ finmind/
         bills.py
         reminders.py
         insights.py
+        webhooks.py
       services/
         __init__.py
         ai.py
         cache.py
         reminders.py
+        webhooks.py
       db/
         schema.sql
       openapi.yaml

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -8,6 +8,7 @@ from .observability import (
     finalize_request,
     init_request_context,
 )
+from .services.webhooks import process_due_deliveries
 from flask_cors import CORS
 import click
 import os
@@ -93,6 +94,16 @@ def create_app(settings: Settings | None = None) -> Flask:
             finally:
                 conn.close()
 
+    @app.cli.command("process-webhooks")
+    def process_webhooks():
+        """Deliver due webhook events and schedule failed attempts for retry."""
+        with app.app_context():
+            result = process_due_deliveries()
+            click.echo(
+                "processed={processed} delivered={delivered} "
+                "retrying={retrying} failed={failed}".format(**result)
+            )
+
     return app
 
 
@@ -110,10 +121,60 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS webhook_endpoints (
+              id SERIAL PRIMARY KEY,
+              user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              url VARCHAR(500) NOT NULL,
+              secret VARCHAR(255) NOT NULL,
+              event_types TEXT NOT NULL DEFAULT '["*"]',
+              active BOOLEAN NOT NULL DEFAULT TRUE,
+              created_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_user_active
+              ON webhook_endpoints(user_id, active)
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS webhook_deliveries (
+              id SERIAL PRIMARY KEY,
+              endpoint_id INT NOT NULL
+                REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+              user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              event_type VARCHAR(100) NOT NULL,
+              payload_json TEXT NOT NULL,
+              status VARCHAR(20) NOT NULL DEFAULT 'pending',
+              attempts INT NOT NULL DEFAULT 0,
+              next_attempt_at TIMESTAMP NOT NULL DEFAULT NOW(),
+              last_error VARCHAR(500),
+              delivered_at TIMESTAMP,
+              created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+              updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_due
+              ON webhook_deliveries(status, next_attempt_at)
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_user_status
+              ON webhook_deliveries(user_id, status, created_at DESC)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(
-            "Schema compatibility patch failed for users.preferred_currency"
+            "Schema compatibility patch failed for core compatibility tables"
         )
         conn.rollback()
     finally:

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -95,6 +95,37 @@ CREATE TABLE IF NOT EXISTS reminders (
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
 
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  url VARCHAR(500) NOT NULL,
+  secret VARCHAR(255) NOT NULL,
+  event_types TEXT NOT NULL DEFAULT '["*"]',
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_user_active
+  ON webhook_endpoints(user_id, active);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id SERIAL PRIMARY KEY,
+  endpoint_id INT NOT NULL REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event_type VARCHAR(100) NOT NULL,
+  payload_json TEXT NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempts INT NOT NULL DEFAULT 0,
+  next_attempt_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  last_error VARCHAR(500),
+  delivered_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_due
+  ON webhook_deliveries(status, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_user_status
+  ON webhook_deliveries(user_id, status, created_at DESC);
+
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,
   user_id INT REFERENCES users(id) ON DELETE SET NULL,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -100,6 +100,37 @@ class Reminder(db.Model):
     channel = db.Column(db.String(20), default="email", nullable=False)
 
 
+class WebhookEndpoint(db.Model):
+    __tablename__ = "webhook_endpoints"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    url = db.Column(db.String(500), nullable=False)
+    secret = db.Column(db.String(255), nullable=False)
+    event_types = db.Column(db.Text, default='["*"]', nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WebhookDelivery(db.Model):
+    __tablename__ = "webhook_deliveries"
+    id = db.Column(db.Integer, primary_key=True)
+    endpoint_id = db.Column(
+        db.Integer, db.ForeignKey("webhook_endpoints.id"), nullable=False
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    event_type = db.Column(db.String(100), nullable=False)
+    payload_json = db.Column(db.Text, nullable=False)
+    status = db.Column(db.String(20), default="pending", nullable=False)
+    attempts = db.Column(db.Integer, default=0, nullable=False)
+    next_attempt_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    last_error = db.Column(db.String(500), nullable=True)
+    delivered_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+    endpoint = db.relationship("WebhookEndpoint")
+
+
 class AdImpression(db.Model):
     __tablename__ = "ad_impressions"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -12,6 +12,7 @@ tags:
   - name: Bills
   - name: Reminders
   - name: Insights
+  - name: Webhooks
 paths:
   /auth/register:
     post:
@@ -481,6 +482,161 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /webhooks:
+    get:
+      summary: List webhook endpoints
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Webhook endpoints
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WebhookEndpoint'
+    post:
+      summary: Create signed webhook endpoint
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewWebhookEndpoint'
+            example:
+              url: https://example.com/finmind/webhook
+              event_types: [expense.created, bill.paid]
+      responses:
+        '201':
+          description: Created endpoint. Secret is returned only on create.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/WebhookEndpoint'
+                  - type: object
+                    properties:
+                      secret: { type: string }
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /webhooks/{endpointId}:
+    patch:
+      summary: Update webhook endpoint
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: endpointId
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewWebhookEndpoint'
+      responses:
+        '200':
+          description: Updated endpoint
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/WebhookEndpoint' }
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    delete:
+      summary: Disable webhook endpoint
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: endpointId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Disabled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string }
+
+  /webhooks/events:
+    get:
+      summary: List supported webhook event types
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Supported event names
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items: { type: string }
+              example:
+                events:
+                  - expense.created
+                  - expense.updated
+                  - expense.deleted
+                  - bill.created
+                  - bill.paid
+                  - reminder.created
+                  - reminder.scheduled
+                  - reminder.sent
+
+  /webhooks/deliveries:
+    get:
+      summary: List webhook deliveries
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema: { type: string, enum: [pending, delivered, failed] }
+      responses:
+        '200':
+          description: Delivery records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WebhookDelivery'
+
+  /webhooks/deliveries/run:
+    post:
+      summary: Process due webhook deliveries
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Delivery processing summary
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  processed: { type: integer }
+                  delivered: { type: integer }
+                  retrying: { type: integer }
+                  failed: { type: integer }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -587,3 +743,47 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    WebhookEndpoint:
+      type: object
+      properties:
+        id: { type: integer }
+        url: { type: string, format: uri }
+        event_types:
+          type: array
+          items: { type: string }
+        active: { type: boolean }
+        created_at: { type: string, format: date-time }
+    NewWebhookEndpoint:
+      type: object
+      required: [url]
+      properties:
+        url: { type: string, format: uri }
+        event_types:
+          type: array
+          items:
+            type: string
+            enum:
+              - '*'
+              - expense.created
+              - expense.updated
+              - expense.deleted
+              - bill.created
+              - bill.paid
+              - reminder.created
+              - reminder.scheduled
+              - reminder.sent
+          default: ['*']
+        secret: { type: string, nullable: true }
+        active: { type: boolean, default: true }
+    WebhookDelivery:
+      type: object
+      properties:
+        id: { type: integer }
+        endpoint_id: { type: integer }
+        event_type: { type: string }
+        status: { type: string, enum: [pending, delivered, failed] }
+        attempts: { type: integer }
+        next_attempt_at: { type: string, format: date-time, nullable: true }
+        last_error: { type: string, nullable: true }
+        delivered_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .webhooks import bp as webhooks_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(webhooks_bp, url_prefix="/webhooks")

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, BillCadence, User
 from ..services.cache import cache_delete_patterns
+from ..services.webhooks import publish_webhook_event
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -62,6 +63,7 @@ def create_bill():
     cache_delete_patterns(
         [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
     )
+    publish_webhook_event(uid, "bill.created", _bill_to_dict(b))
     return jsonify(id=b.id), 201
 
 
@@ -88,4 +90,20 @@ def mark_paid(bill_id: int):
     logger.info(
         "Marked bill paid id=%s user=%s next_due_date=%s", b.id, uid, b.next_due_date
     )
+    publish_webhook_event(uid, "bill.paid", _bill_to_dict(b))
     return jsonify(message="updated")
+
+
+def _bill_to_dict(b: Bill) -> dict:
+    return {
+        "id": b.id,
+        "name": b.name,
+        "amount": float(b.amount),
+        "currency": b.currency,
+        "next_due_date": b.next_due_date.isoformat(),
+        "cadence": b.cadence.value,
+        "autopay_enabled": b.autopay_enabled,
+        "channel_whatsapp": b.channel_whatsapp,
+        "channel_email": b.channel_email,
+        "active": b.active,
+    }

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -7,6 +7,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
+from ..services.webhooks import publish_webhook_event
 from ..services import expense_import
 import logging
 
@@ -84,6 +85,7 @@ def create_expense():
             f"insights:{uid}:*",
         ]
     )
+    publish_webhook_event(uid, "expense.created", _expense_to_dict(e))
     return jsonify(_expense_to_dict(e)), 201
 
 
@@ -231,6 +233,7 @@ def update_expense(expense_id: int):
         e.spent_at = date.fromisoformat(raw_date)
     db.session.commit()
     _invalidate_expense_cache(uid, e.spent_at.isoformat())
+    publish_webhook_event(uid, "expense.updated", _expense_to_dict(e))
     return jsonify(_expense_to_dict(e))
 
 
@@ -242,9 +245,11 @@ def delete_expense(expense_id: int):
     if not e or e.user_id != uid:
         return jsonify(error="not found"), 404
     spent_at = e.spent_at.isoformat()
+    payload = _expense_to_dict(e)
     db.session.delete(e)
     db.session.commit()
     _invalidate_expense_cache(uid, spent_at)
+    publish_webhook_event(uid, "expense.deleted", payload)
     return jsonify(message="deleted")
 
 
@@ -289,6 +294,7 @@ def import_commit():
     inserted = 0
     duplicates = 0
     touched_months: set[str] = set()
+    created_expenses: list[Expense] = []
     for t in transactions:
         if _is_duplicate(uid, t):
             duplicates += 1
@@ -303,11 +309,14 @@ def import_commit():
             spent_at=date.fromisoformat(t["date"]),
         )
         db.session.add(expense)
+        created_expenses.append(expense)
         inserted += 1
         touched_months.add(t["date"][:7])
     db.session.commit()
     for ym in touched_months:
         _invalidate_expense_cache(uid, ym + "-01")
+    for expense in created_expenses:
+        publish_webhook_event(uid, "expense.created", _expense_to_dict(expense))
     return jsonify(inserted=inserted, duplicates=duplicates), 201
 
 

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -5,6 +5,7 @@ from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
+from ..services.webhooks import publish_webhook_event
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -51,6 +52,7 @@ def create_reminder():
     db.session.commit()
     logger.info("Created reminder id=%s user=%s", r.id, uid)
     track_reminder_event(event="created", channel=r.channel)
+    publish_webhook_event(uid, "reminder.created", _reminder_to_dict(r))
     return jsonify(id=r.id), 201
 
 
@@ -115,6 +117,11 @@ def schedule_bill_reminders(bill_id: int):
                 track_reminder_event(event="scheduled", channel=channel)
 
     db.session.commit()
+    publish_webhook_event(
+        uid,
+        "reminder.scheduled",
+        {"bill_id": bill.id, "created": created, "offsets_days": offsets},
+    )
     return jsonify(created=created), 200
 
 
@@ -174,9 +181,21 @@ def run_due():
         send_reminder(r)
         r.sent = True
         track_reminder_event(event="sent", channel=r.channel)
+        publish_webhook_event(uid, "reminder.sent", _reminder_to_dict(r))
     db.session.commit()
     logger.info("Processed due reminders user=%s count=%s", uid, len(items))
     return jsonify(processed=len(items))
+
+
+def _reminder_to_dict(r: Reminder) -> dict:
+    return {
+        "id": r.id,
+        "bill_id": r.bill_id,
+        "message": r.message,
+        "send_at": r.send_at.isoformat(),
+        "sent": r.sent,
+        "channel": r.channel,
+    }
 
 
 def _bill_channels(bill: Bill) -> list[str]:

--- a/packages/backend/app/routes/webhooks.py
+++ b/packages/backend/app/routes/webhooks.py
@@ -1,0 +1,160 @@
+import json
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import WebhookDelivery, WebhookEndpoint
+from ..services.webhooks import (
+    EVENT_TYPES,
+    endpoint_event_types,
+    generate_secret,
+    normalize_event_types,
+    process_due_deliveries,
+    validate_target_url,
+)
+
+
+bp = Blueprint("webhooks", __name__)
+
+
+@bp.get("")
+@jwt_required()
+def list_webhooks():
+    uid = int(get_jwt_identity())
+    endpoints = (
+        db.session.query(WebhookEndpoint)
+        .filter_by(user_id=uid)
+        .order_by(WebhookEndpoint.created_at.desc())
+        .all()
+    )
+    return jsonify([_endpoint_to_dict(endpoint) for endpoint in endpoints])
+
+
+@bp.post("")
+@jwt_required()
+def create_webhook():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    try:
+        url = validate_target_url(data.get("url"))
+        event_types = normalize_event_types(data.get("event_types"))
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+
+    secret = str(data.get("secret") or "").strip() or generate_secret()
+    endpoint = WebhookEndpoint(
+        user_id=uid,
+        url=url,
+        secret=secret,
+        event_types=json.dumps(event_types),
+        active=bool(data.get("active", True)),
+    )
+    db.session.add(endpoint)
+    db.session.commit()
+    payload = _endpoint_to_dict(endpoint)
+    payload["secret"] = secret
+    return jsonify(payload), 201
+
+
+@bp.patch("/<int:endpoint_id>")
+@jwt_required()
+def update_webhook(endpoint_id: int):
+    uid = int(get_jwt_identity())
+    endpoint = db.session.get(WebhookEndpoint, endpoint_id)
+    if not endpoint or endpoint.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+
+    if "url" in data:
+        try:
+            endpoint.url = validate_target_url(data.get("url"))
+        except ValueError as exc:
+            return jsonify(error=str(exc)), 400
+    if "event_types" in data:
+        try:
+            endpoint.event_types = json.dumps(
+                normalize_event_types(data.get("event_types"))
+            )
+        except ValueError as exc:
+            return jsonify(error=str(exc)), 400
+    if "active" in data:
+        endpoint.active = bool(data.get("active"))
+    if "secret" in data:
+        secret = str(data.get("secret") or "").strip()
+        if not secret:
+            return jsonify(error="secret cannot be empty"), 400
+        endpoint.secret = secret
+
+    db.session.commit()
+    return jsonify(_endpoint_to_dict(endpoint))
+
+
+@bp.delete("/<int:endpoint_id>")
+@jwt_required()
+def delete_webhook(endpoint_id: int):
+    uid = int(get_jwt_identity())
+    endpoint = db.session.get(WebhookEndpoint, endpoint_id)
+    if not endpoint or endpoint.user_id != uid:
+        return jsonify(error="not found"), 404
+    endpoint.active = False
+    db.session.commit()
+    return jsonify(message="disabled")
+
+
+@bp.get("/events")
+@jwt_required()
+def list_supported_events():
+    return jsonify(events=sorted(EVENT_TYPES))
+
+
+@bp.get("/deliveries")
+@jwt_required()
+def list_deliveries():
+    uid = int(get_jwt_identity())
+    status = (request.args.get("status") or "").strip()
+    query = (
+        db.session.query(WebhookDelivery)
+        .filter_by(user_id=uid)
+        .order_by(WebhookDelivery.created_at.desc())
+    )
+    if status:
+        query = query.filter(WebhookDelivery.status == status)
+    deliveries = query.limit(100).all()
+    return jsonify([_delivery_to_dict(delivery) for delivery in deliveries])
+
+
+@bp.post("/deliveries/run")
+@jwt_required()
+def run_due_deliveries():
+    uid = int(get_jwt_identity())
+    result = process_due_deliveries(user_id=uid)
+    return jsonify(result), 200
+
+
+def _endpoint_to_dict(endpoint: WebhookEndpoint) -> dict:
+    return {
+        "id": endpoint.id,
+        "url": endpoint.url,
+        "event_types": endpoint_event_types(endpoint),
+        "active": endpoint.active,
+        "created_at": endpoint.created_at.isoformat(),
+    }
+
+
+def _delivery_to_dict(delivery: WebhookDelivery) -> dict:
+    return {
+        "id": delivery.id,
+        "endpoint_id": delivery.endpoint_id,
+        "event_type": delivery.event_type,
+        "status": delivery.status,
+        "attempts": delivery.attempts,
+        "next_attempt_at": (
+            delivery.next_attempt_at.isoformat() if delivery.next_attempt_at else None
+        ),
+        "last_error": delivery.last_error,
+        "delivered_at": (
+            delivery.delivered_at.isoformat() if delivery.delivered_at else None
+        ),
+        "created_at": delivery.created_at.isoformat(),
+    }

--- a/packages/backend/app/services/webhooks.py
+++ b/packages/backend/app/services/webhooks.py
@@ -1,0 +1,208 @@
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlparse
+
+import requests
+from flask import current_app
+
+from ..extensions import db
+from ..models import WebhookDelivery, WebhookEndpoint
+
+
+logger = logging.getLogger("finmind.webhooks")
+
+EVENT_TYPES = {
+    "expense.created",
+    "expense.updated",
+    "expense.deleted",
+    "bill.created",
+    "bill.paid",
+    "reminder.created",
+    "reminder.scheduled",
+    "reminder.sent",
+}
+
+MAX_ATTEMPTS = 3
+REQUEST_TIMEOUT_SECONDS = 5
+
+
+def generate_secret() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def validate_target_url(url: str) -> str:
+    parsed = urlparse(str(url or "").strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("url must be an http or https URL")
+    if len(parsed.geturl()) > 500:
+        raise ValueError("url is too long")
+    return parsed.geturl()
+
+
+def normalize_event_types(raw) -> list[str]:
+    if raw is None:
+        return ["*"]
+    if isinstance(raw, str):
+        values = [raw]
+    elif isinstance(raw, list):
+        values = raw
+    else:
+        raise ValueError("event_types must be a list")
+
+    normalized = sorted({str(value).strip() for value in values if str(value).strip()})
+    if not normalized or "*" in normalized:
+        return ["*"]
+
+    unsupported = [value for value in normalized if value not in EVENT_TYPES]
+    if unsupported:
+        raise ValueError(f"unsupported event type: {unsupported[0]}")
+    return normalized
+
+
+def endpoint_event_types(endpoint: WebhookEndpoint) -> list[str]:
+    try:
+        parsed = json.loads(endpoint.event_types)
+    except json.JSONDecodeError:
+        return ["*"]
+    if not isinstance(parsed, list):
+        return ["*"]
+    return [str(value) for value in parsed]
+
+
+def endpoint_accepts_event(endpoint: WebhookEndpoint, event_type: str) -> bool:
+    configured = endpoint_event_types(endpoint)
+    return "*" in configured or event_type in configured
+
+
+def build_event_payload(event_type: str, data: dict) -> dict:
+    return {
+        "event": event_type,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "data": data,
+    }
+
+
+def queue_webhook_event(user_id: int, event_type: str, data: dict) -> int:
+    if event_type not in EVENT_TYPES:
+        raise ValueError(f"unsupported event type: {event_type}")
+
+    endpoints = (
+        db.session.query(WebhookEndpoint)
+        .filter_by(user_id=user_id, active=True)
+        .order_by(WebhookEndpoint.id)
+        .all()
+    )
+    queued = 0
+    for endpoint in endpoints:
+        if not endpoint_accepts_event(endpoint, event_type):
+            continue
+        payload = build_event_payload(event_type, data)
+        db.session.add(
+            WebhookDelivery(
+                endpoint_id=endpoint.id,
+                user_id=user_id,
+                event_type=event_type,
+                payload_json=json.dumps(payload, separators=(",", ":"), default=str),
+                status="pending",
+                next_attempt_at=datetime.utcnow(),
+            )
+        )
+        queued += 1
+    if queued:
+        db.session.commit()
+    return queued
+
+
+def publish_webhook_event(user_id: int, event_type: str, data: dict) -> None:
+    try:
+        queue_webhook_event(user_id=user_id, event_type=event_type, data=data)
+    except Exception:
+        current_app.logger.exception("Failed to queue webhook event %s", event_type)
+        db.session.rollback()
+
+
+def sign_payload(secret: str, timestamp: str, payload_json: str) -> str:
+    signed = f"{timestamp}.{payload_json}".encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), signed, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def deliver_webhook(
+    endpoint: WebhookEndpoint, delivery: WebhookDelivery
+) -> tuple[bool, str | None]:
+    timestamp = str(int(datetime.now(timezone.utc).timestamp()))
+    signature = sign_payload(endpoint.secret, timestamp, delivery.payload_json)
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "FinMind-Webhooks/1.0",
+        "X-FinMind-Event": delivery.event_type,
+        "X-FinMind-Delivery": str(delivery.id),
+        "X-FinMind-Timestamp": timestamp,
+        "X-FinMind-Signature": signature,
+    }
+    try:
+        response = requests.post(
+            endpoint.url,
+            data=delivery.payload_json.encode("utf-8"),
+            headers=headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        return False, str(exc)[:500]
+
+    if 200 <= response.status_code < 300:
+        return True, None
+    return False, f"HTTP {response.status_code}"[:500]
+
+
+def process_due_deliveries(
+    *, user_id: int | None = None, now: datetime | None = None, limit: int = 100
+) -> dict:
+    now = now or datetime.utcnow()
+    query = (
+        db.session.query(WebhookDelivery)
+        .join(WebhookEndpoint, WebhookEndpoint.id == WebhookDelivery.endpoint_id)
+        .filter(
+            WebhookDelivery.status == "pending",
+            WebhookDelivery.next_attempt_at <= now,
+            WebhookEndpoint.active.is_(True),
+        )
+    )
+    if user_id is not None:
+        query = query.filter(WebhookDelivery.user_id == user_id)
+    query = query.order_by(WebhookDelivery.created_at, WebhookDelivery.id).limit(limit)
+
+    processed = delivered = failed = retrying = 0
+    for delivery in query.all():
+        processed += 1
+        delivery.attempts += 1
+        ok, error = deliver_webhook(delivery.endpoint, delivery)
+        delivery.updated_at = now
+        if ok:
+            delivery.status = "delivered"
+            delivery.delivered_at = now
+            delivery.last_error = None
+            delivered += 1
+            continue
+
+        delivery.last_error = error or "delivery failed"
+        if delivery.attempts >= MAX_ATTEMPTS:
+            delivery.status = "failed"
+            failed += 1
+        else:
+            backoff_minutes = 2 ** (delivery.attempts - 1)
+            delivery.next_attempt_at = now + timedelta(minutes=backoff_minutes)
+            retrying += 1
+
+    if processed:
+        db.session.commit()
+    return {
+        "processed": processed,
+        "delivered": delivered,
+        "retrying": retrying,
+        "failed": failed,
+    }

--- a/packages/backend/tests/test_webhooks.py
+++ b/packages/backend/tests/test_webhooks.py
@@ -1,0 +1,140 @@
+from datetime import datetime
+
+from app.extensions import db
+from app.models import WebhookDelivery
+from app.services.webhooks import process_due_deliveries, sign_payload
+
+
+class _Response:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+
+def _create_webhook(client, auth_header, *, event_types=None, secret="supersecret"):
+    payload = {
+        "url": "https://example.com/finmind-webhook",
+        "secret": secret,
+    }
+    if event_types is not None:
+        payload["event_types"] = event_types
+    r = client.post("/webhooks", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def _create_expense(client, auth_header, description="Webhook groceries"):
+    payload = {
+        "amount": 18.75,
+        "currency": "USD",
+        "description": description,
+        "date": "2026-02-12",
+    }
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def test_webhook_endpoint_queues_signed_delivery_for_expense(
+    client, auth_header, monkeypatch
+):
+    endpoint = _create_webhook(
+        client,
+        auth_header,
+        event_types=["expense.created"],
+        secret="supersecret",
+    )
+    assert endpoint["event_types"] == ["expense.created"]
+
+    _create_expense(client, auth_header)
+
+    r = client.get("/webhooks/deliveries", headers=auth_header)
+    assert r.status_code == 200
+    deliveries = r.get_json()
+    assert len(deliveries) == 1
+    assert deliveries[0]["event_type"] == "expense.created"
+    assert deliveries[0]["status"] == "pending"
+
+    captured = {}
+
+    def fake_post(url, data, headers, timeout):
+        captured["url"] = url
+        captured["data"] = data.decode("utf-8")
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _Response(204)
+
+    monkeypatch.setattr("app.services.webhooks.requests.post", fake_post)
+
+    r = client.post("/webhooks/deliveries/run", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["delivered"] == 1
+    assert captured["url"] == "https://example.com/finmind-webhook"
+    assert captured["headers"]["X-FinMind-Event"] == "expense.created"
+    assert captured["headers"]["X-FinMind-Signature"] == sign_payload(
+        "supersecret",
+        captured["headers"]["X-FinMind-Timestamp"],
+        captured["data"],
+    )
+
+    r = client.get("/webhooks/deliveries?status=delivered", headers=auth_header)
+    assert r.status_code == 200
+    assert len(r.get_json()) == 1
+
+
+def test_webhook_delivery_retries_then_marks_failed(
+    client, auth_header, app_fixture, monkeypatch
+):
+    _create_webhook(client, auth_header, event_types=["expense.created"])
+    _create_expense(client, auth_header, description="Retry groceries")
+
+    monkeypatch.setattr(
+        "app.services.webhooks.requests.post",
+        lambda *args, **kwargs: _Response(500),
+    )
+
+    with app_fixture.app_context():
+        delivery = db.session.query(WebhookDelivery).one()
+        uid = delivery.user_id
+        now = datetime.utcnow()
+
+        first = process_due_deliveries(user_id=uid, now=now)
+        assert first == {"processed": 1, "delivered": 0, "retrying": 1, "failed": 0}
+        assert delivery.status == "pending"
+        assert delivery.attempts == 1
+        assert delivery.last_error == "HTTP 500"
+
+        delivery.next_attempt_at = now
+        db.session.commit()
+        second = process_due_deliveries(user_id=uid, now=now)
+        assert second["retrying"] == 1
+        assert delivery.status == "pending"
+        assert delivery.attempts == 2
+
+        delivery.next_attempt_at = now
+        db.session.commit()
+        third = process_due_deliveries(user_id=uid, now=now)
+        assert third == {"processed": 1, "delivered": 0, "retrying": 0, "failed": 1}
+        assert delivery.status == "failed"
+        assert delivery.attempts == 3
+
+
+def test_webhook_event_filter_ignores_unsubscribed_events(client, auth_header):
+    _create_webhook(client, auth_header, event_types=["bill.created"])
+    _create_expense(client, auth_header)
+
+    r = client.get("/webhooks/deliveries", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_webhook_rejects_unknown_event_type(client, auth_header):
+    r = client.post(
+        "/webhooks",
+        json={
+            "url": "https://example.com/finmind-webhook",
+            "event_types": ["unknown.event"],
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "unsupported event type" in r.get_json()["error"]


### PR DESCRIPTION
## Summary
- Adds user-managed webhook endpoints and queued delivery records.
- Signs webhook payloads with `X-FinMind-Signature` HMAC headers and includes event, delivery, and timestamp headers.
- Adds retry/failure handling via `flask process-webhooks` and `POST /webhooks/deliveries/run`.
- Publishes expense, bill, and reminder lifecycle events.
- Documents supported event types in README and OpenAPI.

## Validation
- [x] `python -m black --check app tests`
- [x] `python -m flake8 app tests`
- [x] `python -m pytest -q tests` (local venv with temporary in-memory Redis protocol test server because Docker/Redis are not available in this environment)

## Security and Ownership
- [x] PR opened from a fork
- [x] No secrets added
- [x] No unrelated files changed

Closes #77