### PR TITLE
feat: detect recurring subscription charges

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See `backend/app/db/schema.sql`. Key tables:
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
-- Expenses: CRUD `/expenses`
+- Expenses: CRUD `/expenses`, recurring definitions `/expenses/recurring`, detection `/expenses/recurring/detect`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
@@ -73,7 +73,7 @@ OpenAPI: `backend/app/openapi.yaml`
   - Monthly spend chart, category breakdown donut.
   - Upcoming bills list with due dates and pay status.
   - AI budget suggestion card.
-- Expenses page: add expense (amount, category, notes, date), list & filter.
+- Expenses page: add expense (amount, category, notes, date), list & filter, detect likely recurring subscriptions from repeated charges.
 - Bills page: create bill (name, amount, cadence, due date, channel), toggle WhatsApp/email.
 - Settings: profile, categories, reminders default channel, export (premium).
 

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -222,6 +222,35 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /expenses/recurring/detect:
+    get:
+      summary: Detect recurring expense candidates
+      tags: [Expenses]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: min_occurrences
+          required: false
+          schema: { type: integer, minimum: 2, maximum: 12, default: 3 }
+        - in: query
+          name: lookback_days
+          required: false
+          schema: { type: integer, minimum: 30, maximum: 1095, default: 730 }
+      responses:
+        '200':
+          description: Likely subscriptions inferred from repeated charges
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RecurringExpenseCandidate'
+        '400':
+          description: Invalid detection parameters
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
   /expenses/recurring/{recurringId}/generate:
     post:
       summary: Generate concrete expenses from recurring definition
@@ -548,6 +577,23 @@ components:
         cadence: { type: string, enum: [DAILY, WEEKLY, MONTHLY, YEARLY] }
         start_date: { type: string, format: date }
         end_date: { type: string, format: date, nullable: true }
+    RecurringExpenseCandidate:
+      type: object
+      properties:
+        amount: { type: number, format: float }
+        currency: { type: string }
+        expense_type: { type: string }
+        category_id: { type: integer, nullable: true }
+        description: { type: string }
+        cadence: { type: string, enum: [DAILY, WEEKLY, MONTHLY, YEARLY] }
+        start_date: { type: string, format: date }
+        last_seen_date: { type: string, format: date }
+        next_expected_date: { type: string, format: date }
+        occurrences: { type: integer }
+        confidence: { type: string, enum: [HIGH, MEDIUM] }
+        matching_expense_ids:
+          type: array
+          items: { type: integer }
     Bill:
       type: object
       properties:

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -8,6 +8,10 @@ from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
+from ..services.recurring_detection import (
+    detect_recurring_expenses,
+    recurring_candidate_to_dict,
+)
 import logging
 
 bp = Blueprint("expenses", __name__)
@@ -98,6 +102,35 @@ def list_recurring_expenses():
         .all()
     )
     return jsonify([_recurring_to_dict(r) for r in items])
+
+
+@bp.get("/recurring/detect")
+@jwt_required()
+def detect_recurring_expense_candidates():
+    uid = int(get_jwt_identity())
+    try:
+        min_occurrences = min(12, max(2, int(request.args.get("min_occurrences", "3"))))
+        lookback_days = min(
+            1095, max(30, int(request.args.get("lookback_days", "730")))
+        )
+    except ValueError:
+        return jsonify(error="invalid detection parameters"), 400
+
+    since = date.today() - timedelta(days=lookback_days)
+    expenses = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == uid,
+            Expense.spent_at >= since,
+        )
+        .order_by(Expense.spent_at.asc(), Expense.id.asc())
+        .all()
+    )
+    candidates = detect_recurring_expenses(
+        expenses,
+        min_occurrences=min_occurrences,
+    )
+    return jsonify([recurring_candidate_to_dict(candidate) for candidate in candidates])
 
 
 @bp.post("/recurring")

--- a/packages/backend/app/services/recurring_detection.py
+++ b/packages/backend/app/services/recurring_detection.py
@@ -1,0 +1,184 @@
+import calendar
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import date, timedelta
+from decimal import Decimal
+
+from app.models import Expense, RecurringCadence
+
+
+@dataclass(frozen=True)
+class RecurringCandidate:
+    amount: Decimal
+    currency: str
+    expense_type: str
+    category_id: int | None
+    description: str
+    cadence: str
+    start_date: date
+    last_seen_date: date
+    next_expected_date: date
+    occurrences: int
+    confidence: str
+    matching_expense_ids: list[int]
+
+
+def detect_recurring_expenses(
+    expenses: list[Expense],
+    *,
+    min_occurrences: int = 3,
+) -> list[RecurringCandidate]:
+    groups: dict[tuple, list[Expense]] = defaultdict(list)
+    for expense in expenses:
+        if expense.source_recurring_id is not None:
+            continue
+        if str(expense.expense_type).upper() == "INCOME":
+            continue
+        key = (
+            _normalize_description(expense.notes or ""),
+            Decimal(expense.amount).quantize(Decimal("0.01")),
+            expense.currency,
+            str(expense.expense_type).upper(),
+            expense.category_id,
+        )
+        if not key[0]:
+            continue
+        groups[key].append(expense)
+
+    candidates: list[RecurringCandidate] = []
+    for (
+        _normalized,
+        amount,
+        currency,
+        expense_type,
+        category_id,
+    ), items in groups.items():
+        if len(items) < min_occurrences:
+            continue
+        ordered = sorted(items, key=lambda item: item.spent_at)
+        cadence, confidence = _infer_cadence([item.spent_at for item in ordered])
+        if cadence is None:
+            continue
+        descriptions = [item.notes or "" for item in ordered]
+        description = Counter(descriptions).most_common(1)[0][0]
+        last_seen = ordered[-1].spent_at
+        candidates.append(
+            RecurringCandidate(
+                amount=amount,
+                currency=currency,
+                expense_type=expense_type,
+                category_id=category_id,
+                description=description,
+                cadence=cadence,
+                start_date=ordered[0].spent_at,
+                last_seen_date=last_seen,
+                next_expected_date=_advance_date(last_seen, cadence),
+                occurrences=len(ordered),
+                confidence=confidence,
+                matching_expense_ids=[item.id for item in ordered],
+            )
+        )
+
+    return sorted(
+        candidates,
+        key=lambda candidate: (
+            _confidence_rank(candidate.confidence),
+            candidate.occurrences,
+            candidate.last_seen_date,
+        ),
+        reverse=True,
+    )
+
+
+def recurring_candidate_to_dict(candidate: RecurringCandidate) -> dict:
+    return {
+        "amount": float(candidate.amount),
+        "currency": candidate.currency,
+        "expense_type": candidate.expense_type,
+        "category_id": candidate.category_id,
+        "description": candidate.description,
+        "cadence": candidate.cadence,
+        "start_date": candidate.start_date.isoformat(),
+        "last_seen_date": candidate.last_seen_date.isoformat(),
+        "next_expected_date": candidate.next_expected_date.isoformat(),
+        "occurrences": candidate.occurrences,
+        "confidence": candidate.confidence,
+        "matching_expense_ids": candidate.matching_expense_ids,
+    }
+
+
+def _normalize_description(description: str) -> str:
+    value = description.lower()
+    value = re.sub(r"\b\d{2,}\b", " ", value)
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def _infer_cadence(dates: list[date]) -> tuple[str | None, str | None]:
+    unique_dates = sorted(set(dates))
+    if len(unique_dates) < 2:
+        return None, None
+    deltas = [
+        (right - left).days for left, right in zip(unique_dates, unique_dates[1:])
+    ]
+    checks = [
+        (RecurringCadence.DAILY.value, _matches_fixed_delta(deltas, 1, tolerance=0)),
+        (RecurringCadence.WEEKLY.value, _matches_fixed_delta(deltas, 7, tolerance=1)),
+        (RecurringCadence.MONTHLY.value, _matches_monthly(unique_dates)),
+        (RecurringCadence.YEARLY.value, _matches_yearly(unique_dates)),
+    ]
+    cadence, score = max(checks, key=lambda item: item[1])
+    if score < 0.75:
+        return None, None
+    return cadence, "HIGH" if score == 1.0 else "MEDIUM"
+
+
+def _matches_fixed_delta(deltas: list[int], expected: int, *, tolerance: int) -> float:
+    if not deltas:
+        return 0.0
+    matches = sum(1 for delta in deltas if abs(delta - expected) <= tolerance)
+    return matches / len(deltas)
+
+
+def _matches_monthly(dates: list[date]) -> float:
+    return _matches_calendar_cadence(dates, RecurringCadence.MONTHLY.value, tolerance=3)
+
+
+def _matches_yearly(dates: list[date]) -> float:
+    return _matches_calendar_cadence(dates, RecurringCadence.YEARLY.value, tolerance=7)
+
+
+def _matches_calendar_cadence(
+    dates: list[date],
+    cadence: str,
+    *,
+    tolerance: int,
+) -> float:
+    if len(dates) < 2:
+        return 0.0
+    matches = 0
+    for left, right in zip(dates, dates[1:]):
+        expected = _advance_date(left, cadence)
+        if abs((right - expected).days) <= tolerance:
+            matches += 1
+    return matches / (len(dates) - 1)
+
+
+def _advance_date(at: date, cadence: str) -> date:
+    if cadence == RecurringCadence.DAILY.value:
+        return at + timedelta(days=1)
+    if cadence == RecurringCadence.WEEKLY.value:
+        return at + timedelta(days=7)
+    if cadence == RecurringCadence.MONTHLY.value:
+        year = at.year + (1 if at.month == 12 else 0)
+        month = 1 if at.month == 12 else at.month + 1
+        day = min(at.day, calendar.monthrange(year, month)[1])
+        return date(year, month, day)
+    year = at.year + 1
+    day = min(at.day, calendar.monthrange(year, at.month)[1])
+    return date(year, at.month, day)
+
+
+def _confidence_rank(confidence: str) -> int:
+    return {"HIGH": 2, "MEDIUM": 1}.get(confidence, 0)

--- a/packages/backend/tests/test_expenses.py
+++ b/packages/backend/tests/test_expenses.py
@@ -235,6 +235,83 @@ def test_recurring_expense_create_list_and_generate(client, auth_header):
     assert len(generated) == 3
 
 
+def test_recurring_expense_detection_finds_subscription_candidates(client, auth_header):
+    cat_id = _create_category(client, auth_header, name="Subscriptions")
+    for spent_at in ["2026-01-05", "2026-02-05", "2026-03-06"]:
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": 15.99,
+                "currency": "USD",
+                "category_id": cat_id,
+                "description": "Netflix Streaming 483920",
+                "date": spent_at,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+    for spent_at in ["2026-01-02", "2026-01-07", "2026-01-19"]:
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": 15.99,
+                "currency": "USD",
+                "category_id": cat_id,
+                "description": "Groceries",
+                "date": spent_at,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get("/expenses/recurring/detect", headers=auth_header)
+
+    assert r.status_code == 200
+    candidates = r.get_json()
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate["description"] == "Netflix Streaming 483920"
+    assert candidate["amount"] == 15.99
+    assert candidate["currency"] == "USD"
+    assert candidate["category_id"] == cat_id
+    assert candidate["cadence"] == "MONTHLY"
+    assert candidate["confidence"] == "HIGH"
+    assert candidate["occurrences"] == 3
+    assert candidate["start_date"] == "2026-01-05"
+    assert candidate["last_seen_date"] == "2026-03-06"
+    assert candidate["next_expected_date"] == "2026-04-06"
+    assert len(candidate["matching_expense_ids"]) == 3
+
+
+def test_recurring_expense_detection_ignores_generated_recurring_rows(
+    client, auth_header
+):
+    r = client.post(
+        "/expenses/recurring",
+        json={
+            "amount": 9.99,
+            "description": "Cloud Storage",
+            "cadence": "MONTHLY",
+            "start_date": "2026-01-10",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    recurring_id = r.get_json()["id"]
+    r = client.post(
+        f"/expenses/recurring/{recurring_id}/generate",
+        json={"through_date": "2026-03-31"},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["inserted"] == 3
+
+    r = client.get("/expenses/recurring/detect", headers=auth_header)
+
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
 def test_recurring_expense_generate_respects_end_date(client, auth_header):
     create_payload = {
         "amount": 100.0,

--- a/packages/backend/tests/test_recurring_detection.py
+++ b/packages/backend/tests/test_recurring_detection.py
@@ -1,0 +1,67 @@
+from datetime import date
+from decimal import Decimal
+from types import SimpleNamespace
+
+from app.services.recurring_detection import detect_recurring_expenses
+
+
+def _expense(
+    expense_id,
+    description,
+    spent_at,
+    *,
+    amount="15.99",
+    currency="USD",
+    expense_type="EXPENSE",
+    category_id=1,
+    source_recurring_id=None,
+):
+    return SimpleNamespace(
+        id=expense_id,
+        amount=Decimal(amount),
+        currency=currency,
+        expense_type=expense_type,
+        category_id=category_id,
+        notes=description,
+        spent_at=date.fromisoformat(spent_at),
+        source_recurring_id=source_recurring_id,
+    )
+
+
+def test_detect_recurring_expenses_finds_monthly_subscription_noise():
+    expenses = [
+        _expense(1, "Netflix Streaming 483920", "2026-01-05"),
+        _expense(2, "Netflix Streaming 582011", "2026-02-05"),
+        _expense(3, "Netflix Streaming 671102", "2026-03-06"),
+        _expense(4, "Groceries", "2026-01-05"),
+        _expense(5, "Groceries", "2026-01-13"),
+        _expense(6, "Groceries", "2026-01-28"),
+    ]
+
+    candidates = detect_recurring_expenses(expenses)
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.description == "Netflix Streaming 483920"
+    assert candidate.amount == Decimal("15.99")
+    assert candidate.currency == "USD"
+    assert candidate.category_id == 1
+    assert candidate.cadence == "MONTHLY"
+    assert candidate.confidence == "HIGH"
+    assert candidate.start_date == date(2026, 1, 5)
+    assert candidate.last_seen_date == date(2026, 3, 6)
+    assert candidate.next_expected_date == date(2026, 4, 6)
+    assert candidate.matching_expense_ids == [1, 2, 3]
+
+
+def test_detect_recurring_expenses_skips_generated_rows_and_income():
+    expenses = [
+        _expense(1, "Cloud Storage", "2026-01-10", source_recurring_id=7),
+        _expense(2, "Cloud Storage", "2026-02-10", source_recurring_id=7),
+        _expense(3, "Cloud Storage", "2026-03-10", source_recurring_id=7),
+        _expense(4, "Payroll Deposit", "2026-01-15", expense_type="INCOME"),
+        _expense(5, "Payroll Deposit", "2026-02-15", expense_type="INCOME"),
+        _expense(6, "Payroll Deposit", "2026-03-15", expense_type="INCOME"),
+    ]
+
+    assert detect_recurring_expenses(expenses) == []


### PR DESCRIPTION
/claim #109

## Summary
- Add a recurring-charge detection service that groups same-merchant/same-amount expenses, normalizes statement noise, infers daily/weekly/monthly/yearly cadence, and skips income or generated recurring rows.
- Expose `GET /expenses/recurring/detect` with bounded `min_occurrences` and `lookback_days` query parameters.
- Document the endpoint in README/OpenAPI and add regression coverage for candidate detection and generated-row exclusion.

## Validation
- `. .venv/bin/activate && PYTHONPATH=packages/backend pytest packages/backend/tests/test_recurring_detection.py`
- `. .venv/bin/activate && black --check packages/backend/app/services/recurring_detection.py packages/backend/app/routes/expenses.py packages/backend/tests/test_expenses.py packages/backend/tests/test_recurring_detection.py`
- `. .venv/bin/activate && flake8 packages/backend/app/services/recurring_detection.py packages/backend/app/routes/expenses.py packages/backend/tests/test_expenses.py packages/backend/tests/test_recurring_detection.py`
- `git diff --check`
- `sh ./scripts/test-backend.sh tests/test_expenses.py` could not run locally because Docker is not available (`Docker is required to run backend tests.`).