### PR TITLE
feat: add login anomaly detection alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ See `backend/app/db/schema.sql`. Key tables:
 
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
-- Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
+- Auth: `/auth/register`, `/auth/login`, `/auth/refresh`, `/auth/security-events`
+- Login security: successful logins are checked against recent known IP/device signals and recent failed attempts; suspicious logins return a `security_alert` for the UI and are stored in `login_events`.
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`

--- a/app/src/__tests__/SignIn.test.tsx
+++ b/app/src/__tests__/SignIn.test.tsx
@@ -90,6 +90,38 @@ describe('SignIn page', () => {
     expect(navigateMock).toHaveBeenCalled();
   });
 
+  it('shows security alert toast when login response includes an anomaly', async () => {
+    (login as jest.Mock).mockResolvedValue({
+      access_token: 'a',
+      refresh_token: 'r',
+      security_alert: {
+        reason: 'new_ip_address',
+        message: 'This sign-in came from a new IP address.',
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <SignIn />
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'demo@finmind.local');
+    await userEvent.type(screen.getByLabelText(/password/i), 'DemoPass123!');
+    await userEvent.click(
+      screen.getByRole('button', { name: /sign in to your account/i })
+    );
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Security alert',
+          description: 'This sign-in came from a new IP address.',
+        })
+      )
+    );
+  });
+
   it('shows error toast on failed login', async () => {
     (login as jest.Mock).mockRejectedValue(new Error('invalid credentials'));
 

--- a/app/src/api/auth.ts
+++ b/app/src/api/auth.ts
@@ -1,6 +1,15 @@
 import { api } from './client';
 
-export type LoginResponse = { access_token: string; refresh_token?: string };
+export type SecurityAlert = {
+  reason: string;
+  message: string;
+};
+
+export type LoginResponse = {
+  access_token: string;
+  refresh_token?: string;
+  security_alert?: SecurityAlert;
+};
 
 export async function login(email: string, password: string): Promise<LoginResponse> {
   return api<LoginResponse>('/auth/login', { method: 'POST', body: { email, password } });

--- a/app/src/pages/SignIn.tsx
+++ b/app/src/pages/SignIn.tsx
@@ -128,6 +128,12 @@ export function SignIn() {
                     } catch {
                       // Keep existing local currency if profile fetch fails.
                     }
+                    if (res.security_alert) {
+                      toast({
+                        title: 'Security alert',
+                        description: res.security_alert.message,
+                      });
+                    }
                     toast({
                       title: 'Welcome back 👋',
                       description: 'You have successfully signed in.',

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,33 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS login_events (
+              id SERIAL PRIMARY KEY,
+              user_id INT REFERENCES users(id) ON DELETE SET NULL,
+              email VARCHAR(255),
+              ip_address VARCHAR(64),
+              user_agent VARCHAR(255),
+              success BOOLEAN NOT NULL DEFAULT FALSE,
+              is_anomalous BOOLEAN NOT NULL DEFAULT FALSE,
+              reason VARCHAR(255),
+              created_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_login_events_user_created
+            ON login_events(user_id, created_at DESC)
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_login_events_email_created
+            ON login_events(email, created_at DESC)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,17 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS login_events (
+  id SERIAL PRIMARY KEY,
+  user_id INT REFERENCES users(id) ON DELETE SET NULL,
+  email VARCHAR(255),
+  ip_address VARCHAR(64),
+  user_agent VARCHAR(255),
+  success BOOLEAN NOT NULL DEFAULT FALSE,
+  is_anomalous BOOLEAN NOT NULL DEFAULT FALSE,
+  reason VARCHAR(255),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_login_events_user_created ON login_events(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_login_events_email_created ON login_events(email, created_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,16 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class LoginEvent(db.Model):
+    __tablename__ = "login_events"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    email = db.Column(db.String(255), nullable=True)
+    ip_address = db.Column(db.String(64), nullable=True)
+    user_agent = db.Column(db.String(255), nullable=True)
+    success = db.Column(db.Boolean, default=False, nullable=False)
+    is_anomalous = db.Column(db.Boolean, default=False, nullable=False)
+    reason = db.Column(db.String(255), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -65,6 +65,9 @@ paths:
               example:
                 access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
                 refresh_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+                security_alert:
+                  reason: new_ip_address
+                  message: This sign-in came from a new IP address.
         '401':
           description: Invalid credentials
           content:
@@ -93,6 +96,28 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
               example: { error: "Missing Authorization Header" }
+  /auth/security-events:
+    get:
+      summary: List recent login security events
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Recent login attempts and anomaly flags
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/LoginEvent'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
 
   /categories:
     get:
@@ -498,6 +523,23 @@ components:
       properties:
         access_token: { type: string }
         refresh_token: { type: string }
+        security_alert:
+          $ref: '#/components/schemas/SecurityAlert'
+    SecurityAlert:
+      type: object
+      properties:
+        reason: { type: string }
+        message: { type: string }
+    LoginEvent:
+      type: object
+      properties:
+        id: { type: integer }
+        success: { type: boolean }
+        is_anomalous: { type: boolean }
+        reason: { type: string, nullable: true }
+        ip_address: { type: string, nullable: true }
+        user_agent: { type: string, nullable: true }
+        created_at: { type: string, format: date-time }
     Category:
       type: object
       properties:

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from flask import Blueprint, request, jsonify
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_jwt_extended import (
@@ -9,7 +10,7 @@ from flask_jwt_extended import (
     get_jwt_identity,
 )
 from ..extensions import db, redis_client
-from ..models import User
+from ..models import AuditLog, LoginEvent, User
 import logging
 import time
 
@@ -58,12 +59,30 @@ def login():
     user = db.session.query(User).filter_by(email=email).first()
     if not user or not check_password_hash(user.password_hash, password):
         logger.warning("Login failed for email=%s", email)
+        _record_login_event(user, email, success=False)
+        db.session.commit()
         return jsonify(error="invalid credentials"), 401
+    alert = _detect_login_anomaly(user, email)
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
+    _record_login_event(
+        user,
+        email,
+        success=True,
+        is_anomalous=alert is not None,
+        reason=alert.get("reason") if alert else None,
+    )
+    if alert:
+        db.session.add(
+            AuditLog(user_id=user.id, action=f"login_anomaly:{alert['reason']}")
+        )
+    db.session.commit()
     logger.info("Login success user_id=%s", user.id)
-    return jsonify(access_token=access, refresh_token=refresh)
+    body = {"access_token": access, "refresh_token": refresh}
+    if alert:
+        body["security_alert"] = alert
+    return jsonify(body)
 
 
 @bp.get("/me")
@@ -98,6 +117,33 @@ def update_me():
         id=user.id,
         email=user.email,
         preferred_currency=user.preferred_currency or "INR",
+    )
+
+
+@bp.get("/security-events")
+@jwt_required()
+def security_events():
+    uid = int(get_jwt_identity())
+    events = (
+        db.session.query(LoginEvent)
+        .filter_by(user_id=uid)
+        .order_by(LoginEvent.created_at.desc())
+        .limit(20)
+        .all()
+    )
+    return jsonify(
+        events=[
+            {
+                "id": event.id,
+                "success": event.success,
+                "is_anomalous": event.is_anomalous,
+                "reason": event.reason,
+                "ip_address": event.ip_address,
+                "user_agent": event.user_agent,
+                "created_at": event.created_at.isoformat(),
+            }
+            for event in events
+        ]
     )
 
 
@@ -137,3 +183,73 @@ def _store_refresh_session(refresh_token: str, uid: str):
         return
     ttl = max(int(exp - time.time()), 1)
     redis_client.setex(_refresh_key(jti), ttl, uid)
+
+
+def _request_ip() -> str | None:
+    forwarded_for = request.headers.get("X-Forwarded-For", "")
+    if forwarded_for:
+        return forwarded_for.split(",", 1)[0].strip()[:64]
+    return (request.remote_addr or "")[:64] or None
+
+
+def _request_user_agent() -> str | None:
+    return (request.headers.get("User-Agent") or "")[:255] or None
+
+
+def _record_login_event(
+    user: User | None,
+    email: str | None,
+    *,
+    success: bool,
+    is_anomalous: bool = False,
+    reason: str | None = None,
+) -> LoginEvent:
+    event = LoginEvent(
+        user_id=user.id if user else None,
+        email=email,
+        ip_address=_request_ip(),
+        user_agent=_request_user_agent(),
+        success=success,
+        is_anomalous=is_anomalous,
+        reason=reason,
+    )
+    db.session.add(event)
+    return event
+
+
+def _detect_login_anomaly(user: User, email: str | None) -> dict | None:
+    ip_address = _request_ip()
+    user_agent = _request_user_agent()
+    recent_cutoff = datetime.utcnow() - timedelta(minutes=15)
+    recent_failures = (
+        db.session.query(LoginEvent)
+        .filter(LoginEvent.email == email)
+        .filter(LoginEvent.success.is_(False))
+        .filter(LoginEvent.created_at >= recent_cutoff)
+        .count()
+    )
+    if recent_failures >= 5:
+        return {
+            "reason": "multiple_failed_attempts",
+            "message": "Multiple failed sign-in attempts were detected before this login.",
+        }
+
+    previous_success = (
+        db.session.query(LoginEvent)
+        .filter_by(user_id=user.id, success=True)
+        .order_by(LoginEvent.created_at.desc())
+        .first()
+    )
+    if not previous_success:
+        return None
+    if previous_success.ip_address and ip_address != previous_success.ip_address:
+        return {
+            "reason": "new_ip_address",
+            "message": "This sign-in came from a new IP address.",
+        }
+    if previous_success.user_agent and user_agent != previous_success.user_agent:
+        return {
+            "reason": "new_device",
+            "message": "This sign-in came from a new browser or device.",
+        }
+    return None

--- a/packages/backend/tests/test_auth.py
+++ b/packages/backend/tests/test_auth.py
@@ -66,3 +66,51 @@ def test_auth_me_and_update_preferred_currency(client):
 
     r = client.patch("/auth/me", json={"preferred_currency": "ZZZ"}, headers=auth)
     assert r.status_code == 400
+
+
+def test_login_from_new_ip_returns_security_alert(client):
+    email = "anomaly@test.com"
+    password = "secret123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        headers={"X-Forwarded-For": "203.0.113.10", "User-Agent": "FinMindTest/1"},
+    )
+    assert r.status_code == 200
+    assert "security_alert" not in r.get_json()
+
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        headers={"X-Forwarded-For": "198.51.100.25", "User-Agent": "FinMindTest/1"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["security_alert"]["reason"] == "new_ip_address"
+
+    access = body["access_token"]
+    r = client.get(
+        "/auth/security-events", headers={"Authorization": f"Bearer {access}"}
+    )
+    assert r.status_code == 200
+    events = r.get_json()["events"]
+    assert events[0]["is_anomalous"] is True
+    assert events[0]["reason"] == "new_ip_address"
+
+
+def test_login_after_repeated_failures_returns_security_alert(client):
+    email = "suspicious@test.com"
+    password = "secret123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+
+    for _ in range(5):
+        r = client.post("/auth/login", json={"email": email, "password": "wrong"})
+        assert r.status_code == 401
+
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    assert r.get_json()["security_alert"]["reason"] == "multiple_failed_attempts"


### PR DESCRIPTION
## Summary
- record login attempts with IP, user agent, success status, and anomaly reason
- flag suspicious logins for new IP/device and repeated failed attempts
- expose /auth/security-events and show a security alert toast on login
- document the API changes and add backend/frontend tests

Fixes #124

## Validation
- [x] python -m py_compile packages/backend/app/models.py packages/backend/app/routes/auth.py packages/backend/app/__init__.py packages/backend/tests/test_auth.py
- [x] git diff --check
- [ ] Full pytest/jest not run locally because pytest, black, and jest are not installed in this environment

## Security and Ownership
- [x] PR opened from a fork
- [x] No secrets added
- [x] No unrelated files changed