### PR TITLE
feat: add savings goals and milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
+- Savings goals: CRUD `/savings-goals`, progress tracking, milestones, completion status
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
 
 ## MVP UI/UX Plan
@@ -75,6 +76,7 @@ OpenAPI: `backend/app/openapi.yaml`
   - AI budget suggestion card.
 - Expenses page: add expense (amount, category, notes, date), list & filter.
 - Bills page: create bill (name, amount, cadence, due date, channel), toggle WhatsApp/email.
+- Savings goals page: create target balances, update saved progress, and view reached milestones.
 - Settings: profile, categories, reminders default channel, export (premium).
 
 ## Monetization Plan

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,6 +9,7 @@ import { Budgets } from "./pages/Budgets";
 import { Bills } from "./pages/Bills";
 import { Analytics } from "./pages/Analytics";
 import Reminders from "./pages/Reminders";
+import SavingsGoals from "./pages/SavingsGoals";
 import Expenses from "./pages/Expenses";
 import { SignIn } from "./pages/SignIn";
 import { Register } from "./pages/Register";
@@ -80,6 +81,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Reminders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="savings-goals"
+              element={
+                <ProtectedRoute>
+                  <SavingsGoals />
                 </ProtectedRoute>
               }
             />

--- a/app/src/api/savingsGoals.ts
+++ b/app/src/api/savingsGoals.ts
@@ -1,0 +1,51 @@
+import { api } from './client';
+
+export type SavingsMilestone = {
+  id: number;
+  goal_id: number;
+  name: string;
+  amount: number;
+  reached: boolean;
+  reached_at: string | null;
+};
+
+export type SavingsGoal = {
+  id: number;
+  name: string;
+  target_amount: number;
+  current_amount: number;
+  currency: string;
+  target_date: string | null;
+  status: 'ACTIVE' | 'COMPLETED';
+  progress_pct: number;
+  remaining_amount: number;
+  milestones: SavingsMilestone[];
+};
+
+export type SavingsGoalCreate = {
+  name: string;
+  target_amount: number;
+  current_amount?: number;
+  currency?: string;
+  target_date?: string;
+  milestones?: Array<{ name: string; amount: number }>;
+};
+
+export async function listSavingsGoals(): Promise<SavingsGoal[]> {
+  return api<SavingsGoal[]>('/savings-goals');
+}
+
+export async function createSavingsGoal(payload: SavingsGoalCreate): Promise<SavingsGoal> {
+  return api<SavingsGoal>('/savings-goals', { method: 'POST', body: payload });
+}
+
+export async function updateSavingsGoal(
+  id: number,
+  payload: Partial<SavingsGoalCreate>,
+): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings-goals/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function deleteSavingsGoal(id: number): Promise<{ message?: string }> {
+  return api<{ message?: string }>(`/savings-goals/${id}`, { method: 'DELETE' });
+}

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -11,6 +11,7 @@ const navigation = [
   { name: 'Budgets', href: '/budgets' },
   { name: 'Bills', href: '/bills' },
   { name: 'Reminders', href: '/reminders' },
+  { name: 'Savings', href: '/savings-goals' },
   { name: 'Expenses', href: '/expenses' },
   { name: 'Analytics', href: '/analytics' },
 ];

--- a/app/src/pages/SavingsGoals.tsx
+++ b/app/src/pages/SavingsGoals.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Target, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Progress } from '@/components/ui/progress';
+import { useToast } from '@/hooks/use-toast';
+import {
+  createSavingsGoal,
+  deleteSavingsGoal,
+  listSavingsGoals,
+  updateSavingsGoal,
+  type SavingsGoal,
+} from '@/api/savingsGoals';
+
+export default function SavingsGoals() {
+  const { toast } = useToast();
+  const [goals, setGoals] = useState<SavingsGoal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [name, setName] = useState('');
+  const [targetAmount, setTargetAmount] = useState('');
+  const [currentAmount, setCurrentAmount] = useState('0');
+  const [targetDate, setTargetDate] = useState('');
+  const [milestones, setMilestones] = useState('25%:250, 50%:500, Done:1000');
+
+  const getErrorMessage = (error: unknown, fallback: string) =>
+    error instanceof Error ? error.message : fallback;
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      setGoals(await listSavingsGoals());
+    } catch (error: unknown) {
+      toast({ title: 'Failed to load savings goals', description: getErrorMessage(error, 'Please try again.') });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  async function onCreate() {
+    if (!name.trim() || !targetAmount) return;
+    setSaving(true);
+    try {
+      await createSavingsGoal({
+        name: name.trim(),
+        target_amount: Number(targetAmount),
+        current_amount: Number(currentAmount || 0),
+        target_date: targetDate || undefined,
+        milestones: parseMilestones(milestones),
+      });
+      setName('');
+      setTargetAmount('');
+      setCurrentAmount('0');
+      setTargetDate('');
+      toast({ title: 'Savings goal created' });
+      await refresh();
+    } catch (error: unknown) {
+      toast({ title: 'Failed to create goal', description: getErrorMessage(error, 'Please check the form.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onProgress(goal: SavingsGoal, amount: number) {
+    setSaving(true);
+    try {
+      await updateSavingsGoal(goal.id, { current_amount: amount });
+      await refresh();
+      toast({ title: 'Progress updated' });
+    } catch (error: unknown) {
+      toast({ title: 'Failed to update progress', description: getErrorMessage(error, 'Please try again.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onDelete(id: number) {
+    setSaving(true);
+    try {
+      await deleteSavingsGoal(id);
+      setGoals((prev) => prev.filter((goal) => goal.id !== id));
+      toast({ title: 'Savings goal deleted' });
+    } catch (error: unknown) {
+      toast({ title: 'Failed to delete goal', description: getErrorMessage(error, 'Please try again.') });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="page-wrap space-y-6">
+      <div className="page-header">
+        <div className="relative flex flex-col gap-2">
+          <h2 className="page-title text-2xl md:text-3xl">Savings Goals</h2>
+          <p className="page-subtitle">Track target balances, progress, and milestone wins.</p>
+        </div>
+      </div>
+
+      <section className="card p-5">
+        <div className="grid gap-4 md:grid-cols-5">
+          <div className="md:col-span-2">
+            <Label htmlFor="goal-name">Goal</Label>
+            <Input id="goal-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Emergency fund" />
+          </div>
+          <div>
+            <Label htmlFor="target-amount">Target</Label>
+            <Input id="target-amount" type="number" min="0" value={targetAmount} onChange={(e) => setTargetAmount(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="current-amount">Saved</Label>
+            <Input id="current-amount" type="number" min="0" value={currentAmount} onChange={(e) => setCurrentAmount(e.target.value)} />
+          </div>
+          <div>
+            <Label htmlFor="target-date">Target date</Label>
+            <Input id="target-date" type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} />
+          </div>
+        </div>
+        <div className="mt-4 grid gap-3 md:grid-cols-[1fr_auto]">
+          <div>
+            <Label htmlFor="milestones">Milestones</Label>
+            <Input id="milestones" value={milestones} onChange={(e) => setMilestones(e.target.value)} placeholder="Starter:250, Halfway:500" />
+          </div>
+          <Button className="self-end" onClick={onCreate} disabled={saving || !name.trim() || !targetAmount}>
+            Add Goal
+          </Button>
+        </div>
+      </section>
+
+      {loading ? (
+        <div className="card p-5">Loading...</div>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {goals.map((goal) => (
+            <article key={goal.id} className="card card-interactive p-5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex items-start gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Target className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-semibold">{goal.name}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {goal.currency} {goal.current_amount.toFixed(2)} of {goal.target_amount.toFixed(2)}
+                    </p>
+                  </div>
+                </div>
+                <Button variant="ghost" size="icon" onClick={() => onDelete(goal.id)} disabled={saving} aria-label="Delete goal">
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <div className="mt-4 space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span>{goal.progress_pct.toFixed(0)}% complete</span>
+                  <span>{goal.remaining_amount.toFixed(2)} remaining</span>
+                </div>
+                <Progress value={Math.min(goal.progress_pct, 100)} />
+              </div>
+
+              <div className="mt-4 grid gap-2">
+                {goal.milestones.map((milestone) => (
+                  <div key={milestone.id} className="flex items-center justify-between rounded-md bg-muted px-3 py-2 text-sm">
+                    <span>{milestone.name}</span>
+                    <span className={milestone.reached ? 'font-semibold text-primary' : 'text-muted-foreground'}>
+                      {milestone.reached ? 'Reached' : `${goal.currency} ${milestone.amount.toFixed(2)}`}
+                    </span>
+                  </div>
+                ))}
+              </div>
+
+              <div className="mt-4 grid grid-cols-[1fr_auto] gap-2">
+                <Input
+                  type="number"
+                  min="0"
+                  defaultValue={goal.current_amount}
+                  aria-label={`Update ${goal.name} progress`}
+                  onBlur={(e) => {
+                    const next = Number(e.target.value);
+                    if (Number.isFinite(next) && next !== goal.current_amount) void onProgress(goal, next);
+                  }}
+                />
+                <Button variant="outline" onClick={() => onProgress(goal, goal.target_amount)} disabled={saving}>
+                  Mark Done
+                </Button>
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function parseMilestones(value: string): Array<{ name: string; amount: number }> {
+  return value
+    .split(',')
+    .map((part) => {
+      const [rawName, rawAmount] = part.split(':');
+      const amount = Number(rawAmount);
+      return { name: (rawName || '').trim(), amount };
+    })
+    .filter((row) => row.name && Number.isFinite(row.amount) && row.amount > 0);
+}

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,35 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS savings_goals (
+              id SERIAL PRIMARY KEY,
+              user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              name VARCHAR(160) NOT NULL,
+              target_amount NUMERIC(12,2) NOT NULL,
+              current_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+              currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+              target_date DATE,
+              status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+              created_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS savings_milestones (
+              id SERIAL PRIMARY KEY,
+              goal_id INT NOT NULL REFERENCES savings_goals(id) ON DELETE CASCADE,
+              user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              name VARCHAR(160) NOT NULL,
+              amount NUMERIC(12,2) NOT NULL,
+              reached BOOLEAN NOT NULL DEFAULT FALSE,
+              reached_at TIMESTAMP,
+              created_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -95,6 +95,31 @@ CREATE TABLE IF NOT EXISTS reminders (
 );
 CREATE INDEX IF NOT EXISTS idx_reminders_due ON reminders(user_id, sent, send_at);
 
+CREATE TABLE IF NOT EXISTS savings_goals (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(160) NOT NULL,
+  target_amount NUMERIC(12,2) NOT NULL,
+  current_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  target_date DATE,
+  status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_goals_user_status ON savings_goals(user_id, status);
+
+CREATE TABLE IF NOT EXISTS savings_milestones (
+  id SERIAL PRIMARY KEY,
+  goal_id INT NOT NULL REFERENCES savings_goals(id) ON DELETE CASCADE,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(160) NOT NULL,
+  amount NUMERIC(12,2) NOT NULL,
+  reached BOOLEAN NOT NULL DEFAULT FALSE,
+  reached_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_milestones_goal_amount ON savings_milestones(goal_id, amount);
+
 CREATE TABLE IF NOT EXISTS ad_impressions (
   id SERIAL PRIMARY KEY,
   user_id INT REFERENCES users(id) ON DELETE SET NULL,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -100,6 +100,31 @@ class Reminder(db.Model):
     channel = db.Column(db.String(20), default="email", nullable=False)
 
 
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(160), nullable=False)
+    target_amount = db.Column(db.Numeric(12, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    target_date = db.Column(db.Date, nullable=True)
+    status = db.Column(db.String(20), default="ACTIVE", nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SavingsMilestone(db.Model):
+    __tablename__ = "savings_milestones"
+    id = db.Column(db.Integer, primary_key=True)
+    goal_id = db.Column(db.Integer, db.ForeignKey("savings_goals.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(160), nullable=False)
+    amount = db.Column(db.Numeric(12, 2), nullable=False)
+    reached = db.Column(db.Boolean, default=False, nullable=False)
+    reached_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class AdImpression(db.Model):
     __tablename__ = "ad_impressions"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -11,6 +11,7 @@ tags:
   - name: Expenses
   - name: Bills
   - name: Reminders
+  - name: Savings Goals
   - name: Insights
 paths:
   /auth/register:
@@ -444,6 +445,73 @@ paths:
                 properties:
                   created: { type: integer }
 
+  /savings-goals:
+    get:
+      summary: List savings goals
+      tags: [Savings Goals]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: List of savings goals with milestone state
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SavingsGoal'
+    post:
+      summary: Create savings goal
+      tags: [Savings Goals]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewSavingsGoal'
+      responses:
+        '201': { description: Created }
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /savings-goals/{goalId}:
+    patch:
+      summary: Update savings goal progress or metadata
+      tags: [Savings Goals]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: goalId
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewSavingsGoal'
+      responses:
+        '200': { description: Updated }
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    delete:
+      summary: Delete savings goal and milestones
+      tags: [Savings Goals]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: goalId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200': { description: Deleted }
+
   /insights/budget-suggestion:
     get:
       summary: Get monthly budget suggestion
@@ -587,3 +655,45 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    SavingsMilestone:
+      type: object
+      properties:
+        id: { type: integer }
+        goal_id: { type: integer }
+        name: { type: string }
+        amount: { type: number, format: float }
+        reached: { type: boolean }
+        reached_at: { type: string, format: date-time, nullable: true }
+    SavingsGoal:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        target_amount: { type: number, format: float }
+        current_amount: { type: number, format: float }
+        currency: { type: string }
+        target_date: { type: string, format: date, nullable: true }
+        status: { type: string, enum: [ACTIVE, COMPLETED] }
+        progress_pct: { type: number, format: float }
+        remaining_amount: { type: number, format: float }
+        milestones:
+          type: array
+          items:
+            $ref: '#/components/schemas/SavingsMilestone'
+    NewSavingsGoal:
+      type: object
+      required: [name, target_amount]
+      properties:
+        name: { type: string }
+        target_amount: { type: number, format: float }
+        current_amount: { type: number, format: float, default: 0 }
+        currency: { type: string, default: INR }
+        target_date: { type: string, format: date, nullable: true }
+        milestones:
+          type: array
+          items:
+            type: object
+            required: [name, amount]
+            properties:
+              name: { type: string }
+              amount: { type: number, format: float }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings_goals import bp as savings_goals_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_goals_bp, url_prefix="/savings-goals")

--- a/packages/backend/app/routes/savings_goals.py
+++ b/packages/backend/app/routes/savings_goals.py
@@ -1,0 +1,239 @@
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import AuditLog, SavingsGoal, SavingsMilestone, User
+
+bp = Blueprint("savings_goals", __name__)
+
+
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    goals = (
+        db.session.query(SavingsGoal)
+        .filter_by(user_id=uid)
+        .order_by(SavingsGoal.created_at.desc(), SavingsGoal.id.desc())
+        .all()
+    )
+    milestones = _milestones_for_goals(uid, [g.id for g in goals])
+    return jsonify([_goal_to_dict(g, milestones.get(g.id, [])) for g in goals])
+
+
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    name = str(data.get("name") or "").strip()
+    target_amount = _parse_amount(data.get("target_amount"))
+    current_amount = _parse_amount(data.get("current_amount") or 0)
+    if not name:
+        return jsonify(error="name required"), 400
+    if target_amount is None or target_amount <= 0:
+        return jsonify(error="target_amount must be positive"), 400
+    if current_amount is None or current_amount < 0:
+        return jsonify(error="current_amount must be non-negative"), 400
+    target_date = _parse_optional_date(data.get("target_date"))
+    if target_date is False:
+        return jsonify(error="invalid target_date"), 400
+
+    user = db.session.get(User, uid)
+    goal = SavingsGoal(
+        user_id=uid,
+        name=name[:160],
+        target_amount=target_amount,
+        current_amount=current_amount,
+        currency=str(data.get("currency") or (user.preferred_currency if user else "INR"))[:10],
+        target_date=target_date,
+        status=_goal_status(current_amount, target_amount),
+    )
+    db.session.add(goal)
+    db.session.flush()
+    _replace_milestones(uid, goal, data.get("milestones") or [])
+    db.session.add(AuditLog(user_id=uid, action=f"savings_goal_created:{goal.id}"))
+    db.session.commit()
+    return jsonify(_goal_to_dict(goal, _ordered_milestones(goal.id, uid))), 201
+
+
+@bp.patch("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = str(data.get("name") or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        goal.name = name[:160]
+    if "target_amount" in data:
+        amount = _parse_amount(data.get("target_amount"))
+        if amount is None or amount <= 0:
+            return jsonify(error="target_amount must be positive"), 400
+        goal.target_amount = amount
+    if "current_amount" in data:
+        amount = _parse_amount(data.get("current_amount"))
+        if amount is None or amount < 0:
+            return jsonify(error="current_amount must be non-negative"), 400
+        goal.current_amount = amount
+    if "currency" in data:
+        goal.currency = str(data.get("currency") or "INR")[:10]
+    if "target_date" in data:
+        target_date = _parse_optional_date(data.get("target_date"))
+        if target_date is False:
+            return jsonify(error="invalid target_date"), 400
+        goal.target_date = target_date
+    goal.status = _goal_status(goal.current_amount, goal.target_amount)
+    _sync_reached_milestones(goal)
+    db.session.add(AuditLog(user_id=uid, action=f"savings_goal_updated:{goal.id}"))
+    db.session.commit()
+    return jsonify(_goal_to_dict(goal, _ordered_milestones(goal.id, uid)))
+
+
+@bp.post("/<int:goal_id>/milestones")
+@jwt_required()
+def create_milestone(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    milestone, error = _build_milestone(uid, goal, request.get_json() or {})
+    if error:
+        return jsonify(error=error), 400
+    db.session.add(milestone)
+    _sync_reached_milestones(goal)
+    db.session.commit()
+    return jsonify(_milestone_to_dict(milestone)), 201
+
+
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.query(SavingsMilestone).filter_by(goal_id=goal.id, user_id=uid).delete()
+    db.session.delete(goal)
+    db.session.add(AuditLog(user_id=uid, action=f"savings_goal_deleted:{goal.id}"))
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+def _replace_milestones(uid: int, goal: SavingsGoal, rows: list[dict]):
+    for row in rows:
+        milestone, error = _build_milestone(uid, goal, row)
+        if error:
+            continue
+        db.session.add(milestone)
+    _sync_reached_milestones(goal)
+
+
+def _build_milestone(uid: int, goal: SavingsGoal, row: dict):
+    name = str(row.get("name") or "").strip()
+    amount = _parse_amount(row.get("amount"))
+    if not name:
+        return None, "milestone name required"
+    if amount is None or amount <= 0:
+        return None, "milestone amount must be positive"
+    milestone = SavingsMilestone(
+        user_id=uid,
+        goal_id=goal.id,
+        name=name[:160],
+        amount=amount,
+        reached=goal.current_amount >= amount,
+        reached_at=datetime.utcnow() if goal.current_amount >= amount else None,
+    )
+    return milestone, None
+
+
+def _sync_reached_milestones(goal: SavingsGoal):
+    now = datetime.utcnow()
+    milestones = _ordered_milestones(goal.id, goal.user_id)
+    for milestone in milestones:
+        should_be_reached = goal.current_amount >= milestone.amount
+        if should_be_reached and not milestone.reached:
+            milestone.reached = True
+            milestone.reached_at = now
+        elif not should_be_reached and milestone.reached:
+            milestone.reached = False
+            milestone.reached_at = None
+
+
+def _milestones_for_goals(uid: int, goal_ids: list[int]) -> dict[int, list[SavingsMilestone]]:
+    if not goal_ids:
+        return {}
+    rows = (
+        db.session.query(SavingsMilestone)
+        .filter(SavingsMilestone.user_id == uid, SavingsMilestone.goal_id.in_(goal_ids))
+        .order_by(SavingsMilestone.amount.asc(), SavingsMilestone.id.asc())
+        .all()
+    )
+    grouped: dict[int, list[SavingsMilestone]] = {}
+    for row in rows:
+        grouped.setdefault(row.goal_id, []).append(row)
+    return grouped
+
+
+def _ordered_milestones(goal_id: int, uid: int) -> list[SavingsMilestone]:
+    return (
+        db.session.query(SavingsMilestone)
+        .filter_by(goal_id=goal_id, user_id=uid)
+        .order_by(SavingsMilestone.amount.asc(), SavingsMilestone.id.asc())
+        .all()
+    )
+
+
+def _goal_to_dict(goal: SavingsGoal, milestones: list[SavingsMilestone]) -> dict:
+    target = float(goal.target_amount)
+    current = float(goal.current_amount)
+    return {
+        "id": goal.id,
+        "name": goal.name,
+        "target_amount": target,
+        "current_amount": current,
+        "currency": goal.currency,
+        "target_date": goal.target_date.isoformat() if goal.target_date else None,
+        "status": goal.status,
+        "progress_pct": round((current / target) * 100, 2) if target else 0,
+        "remaining_amount": round(max(target - current, 0), 2),
+        "milestones": [_milestone_to_dict(m) for m in milestones],
+    }
+
+
+def _milestone_to_dict(milestone: SavingsMilestone) -> dict:
+    return {
+        "id": milestone.id,
+        "goal_id": milestone.goal_id,
+        "name": milestone.name,
+        "amount": float(milestone.amount),
+        "reached": milestone.reached,
+        "reached_at": milestone.reached_at.isoformat() if milestone.reached_at else None,
+    }
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _parse_optional_date(raw):
+    if raw in (None, ""):
+        return None
+    try:
+        return date.fromisoformat(str(raw))
+    except ValueError:
+        return False
+
+
+def _goal_status(current_amount: Decimal, target_amount: Decimal) -> str:
+    return "COMPLETED" if current_amount >= target_amount else "ACTIVE"

--- a/packages/backend/tests/test_savings_goals.py
+++ b/packages/backend/tests/test_savings_goals.py
@@ -1,0 +1,52 @@
+def test_create_and_list_savings_goal_with_milestones(client, auth_header):
+    res = client.post(
+        "/savings-goals",
+        headers=auth_header,
+        json={
+            "name": "Emergency fund",
+            "target_amount": 1000,
+            "current_amount": 250,
+            "currency": "USD",
+            "target_date": "2026-12-31",
+            "milestones": [
+                {"name": "First quarter", "amount": 250},
+                {"name": "Halfway", "amount": 500},
+            ],
+        },
+    )
+
+    assert res.status_code == 201
+    goal = res.get_json()
+    assert goal["progress_pct"] == 25.0
+    assert goal["remaining_amount"] == 750.0
+    assert goal["milestones"][0]["reached"] is True
+    assert goal["milestones"][1]["reached"] is False
+
+    res = client.get("/savings-goals", headers=auth_header)
+    assert res.status_code == 200
+    assert res.get_json()[0]["name"] == "Emergency fund"
+
+
+def test_update_goal_reaches_milestones_and_completes(client, auth_header):
+    created = client.post(
+        "/savings-goals",
+        headers=auth_header,
+        json={
+            "name": "Laptop",
+            "target_amount": 600,
+            "current_amount": 100,
+            "milestones": [{"name": "Ready to buy", "amount": 600}],
+        },
+    ).get_json()
+
+    res = client.patch(
+        f"/savings-goals/{created['id']}",
+        headers=auth_header,
+        json={"current_amount": 600},
+    )
+
+    assert res.status_code == 200
+    goal = res.get_json()
+    assert goal["status"] == "COMPLETED"
+    assert goal["progress_pct"] == 100.0
+    assert goal["milestones"][0]["reached"] is True


### PR DESCRIPTION
## Summary
- Adds authenticated savings goal CRUD endpoints with progress percentage, remaining balance, milestone state, and audit logging.
- Adds Postgres schema/init compatibility for savings goals and milestones.
- Adds a Savings Goals UI page, API client, navigation entry, backend tests, README notes, and OpenAPI docs.

Fixes #133

## Validation
- python -m py_compile packages\backend\app\models.py packages\backend\app\routes\savings_goals.py packages\backend\app\routes\__init__.py packages\backend\app\__init__.py packages\backend\tests\test_savings_goals.py
- git diff --check

## Notes
- Full backend pytest could not be run locally because pytest is not installed in this environment.
- Frontend build could not be run locally because node_modules/tsc is not installed in this environment.