### PR TITLE
feat(privacy): PII export & delete workflow (GDPR-ready)

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -1,21 +1,22 @@
+from flask import Flask
 from .auth import bp as auth_bp
-from .bills import bp as bills_bp
-from .categories import bp as categories_bp
-from .dashboard import bp as dashboard_bp
-from .docs import bp as docs_bp
 from .expenses import bp as expenses_bp
-from .insights import bp as insights_bp
-from .privacy import bp as privacy_bp
+from .bills import bp as bills_bp
 from .reminders import bp as reminders_bp
+from .insights import bp as insights_bp
+from .categories import bp as categories_bp
+from .docs import bp as docs_bp
+from .dashboard import bp as dashboard_bp
+from .privacy import bp as privacy_bp
 
-__all__ = [
-    "auth_bp",
-    "bills_bp",
-    "categories_bp",
-    "dashboard_bp",
-    "docs_bp",
-    "expenses_bp",
-    "insights_bp",
-    "privacy_bp",
-    "reminders_bp",
-]
+
+def register_routes(app: Flask):
+    app.register_blueprint(auth_bp, url_prefix="/auth")
+    app.register_blueprint(expenses_bp, url_prefix="/expenses")
+    app.register_blueprint(bills_bp, url_prefix="/bills")
+    app.register_blueprint(reminders_bp, url_prefix="/reminders")
+    app.register_blueprint(insights_bp, url_prefix="/insights")
+    app.register_blueprint(categories_bp, url_prefix="/categories")
+    app.register_blueprint(docs_bp, url_prefix="/docs")
+    app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(privacy_bp, url_prefix="/privacy")

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -1,20 +1,21 @@
-from flask import Flask
 from .auth import bp as auth_bp
-from .expenses import bp as expenses_bp
 from .bills import bp as bills_bp
-from .reminders import bp as reminders_bp
-from .insights import bp as insights_bp
 from .categories import bp as categories_bp
-from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .docs import bp as docs_bp
+from .expenses import bp as expenses_bp
+from .insights import bp as insights_bp
+from .privacy import bp as privacy_bp
+from .reminders import bp as reminders_bp
 
-
-def register_routes(app: Flask):
-    app.register_blueprint(auth_bp, url_prefix="/auth")
-    app.register_blueprint(expenses_bp, url_prefix="/expenses")
-    app.register_blueprint(bills_bp, url_prefix="/bills")
-    app.register_blueprint(reminders_bp, url_prefix="/reminders")
-    app.register_blueprint(insights_bp, url_prefix="/insights")
-    app.register_blueprint(categories_bp, url_prefix="/categories")
-    app.register_blueprint(docs_bp, url_prefix="/docs")
-    app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+__all__ = [
+    "auth_bp",
+    "bills_bp",
+    "categories_bp",
+    "dashboard_bp",
+    "docs_bp",
+    "expenses_bp",
+    "insights_bp",
+    "privacy_bp",
+    "reminders_bp",
+]

--- a/packages/backend/app/routes/privacy.py
+++ b/packages/backend/app/routes/privacy.py
@@ -1,0 +1,52 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import (
+    User, Category, Expense, RecurringExpense,
+    Bill, Reminder, AdImpression, UserSubscription, AuditLog,
+)
+from ..services.privacy import export_user_data, delete_user_data
+import logging
+
+bp = Blueprint("privacy", __name__)
+logger = logging.getLogger("finmind.privacy")
+
+
+@bp.get("/export")
+@jwt_required()
+def export_pii():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="not found"), 404
+
+    data = export_user_data(user)
+
+    db.session.add(AuditLog(user_id=uid, action="pii.export"))
+    db.session.commit()
+    logger.info("PII export requested user_id=%s", uid)
+
+    return jsonify(data), 200
+
+
+@bp.delete("/delete")
+@jwt_required()
+def delete_pii():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="not found"), 404
+
+    # Require explicit confirmation
+    data = request.get_json() or {}
+    confirm = data.get("confirm")
+    if confirm != "DELETE_MY_DATA":
+        return jsonify(error="confirmation required: send {\"confirm\": \"DELETE_MY_DATA\"}"), 400
+
+    delete_user_data(uid)
+
+    db.session.add(AuditLog(user_id=None, action="pii.delete", ))
+    db.session.commit()
+    logger.info("PII deletion completed user_id=%s", uid)
+
+    return jsonify(message="all personal data deleted"), 200

--- a/packages/backend/app/services/privacy.py
+++ b/packages/backend/app/services/privacy.py
@@ -1,0 +1,90 @@
+from ..extensions import db
+from ..models import (
+    User, Category, Expense, RecurringExpense,
+    Bill, Reminder, AdImpression, UserSubscription, AuditLog,
+)
+import logging
+
+logger = logging.getLogger("finmind.privacy")
+
+
+def export_user_data(user: User) -> dict:
+    uid = user.id
+
+    expenses = db.session.query(Expense).filter_by(user_id=uid).all()
+    categories = db.session.query(Category).filter_by(user_id=uid).all()
+    recurring = db.session.query(RecurringExpense).filter_by(user_id=uid).all()
+    bills = db.session.query(Bill).filter_by(user_id=uid).all()
+    reminders = db.session.query(Reminder).filter_by(user_id=uid).all()
+    subscriptions = db.session.query(UserSubscription).filter_by(user_id=uid).all()
+
+    return {
+        "user": {
+            "id": user.id,
+            "email": user.email,
+            "preferred_currency": user.preferred_currency,
+            "created_at": user.created_at.isoformat(),
+        },
+        "categories": [
+            {"id": c.id, "name": c.name, "created_at": c.created_at.isoformat()}
+            for c in categories
+        ],
+        "expenses": [
+            {
+                "id": e.id,
+                "amount": float(e.amount),
+                "currency": e.currency,
+                "expense_type": e.expense_type,
+                "notes": e.notes,
+                "spent_at": e.spent_at.isoformat(),
+                "created_at": e.created_at.isoformat(),
+            }
+            for e in expenses
+        ],
+        "recurring_expenses": [
+            {
+                "id": r.id,
+                "amount": float(r.amount),
+                "currency": r.currency,
+                "cadence": r.cadence.value,
+                "notes": r.notes,
+                "active": r.active,
+            }
+            for r in recurring
+        ],
+        "bills": [
+            {
+                "id": b.id,
+                "name": b.name,
+                "amount": float(b.amount),
+                "next_due_date": b.next_due_date.isoformat(),
+                "cadence": b.cadence.value,
+            }
+            for b in bills
+        ],
+        "reminders": [
+            {"id": r.id, "message": r.message, "send_at": r.send_at.isoformat(), "sent": r.sent}
+            for r in reminders
+        ],
+        "subscriptions": [
+            {"id": s.id, "plan_id": s.plan_id, "active": s.active}
+            for s in subscriptions
+        ],
+    }
+
+
+def delete_user_data(uid: int) -> None:
+    # Delete in dependency order (children first)
+    db.session.query(Reminder).filter_by(user_id=uid).delete()
+    db.session.query(UserSubscription).filter_by(user_id=uid).delete()
+    db.session.query(AdImpression).filter_by(user_id=uid).delete()
+    db.session.query(Bill).filter_by(user_id=uid).delete()
+    db.session.query(Expense).filter_by(user_id=uid).delete()
+    db.session.query(RecurringExpense).filter_by(user_id=uid).delete()
+    db.session.query(Category).filter_by(user_id=uid).delete()
+    # Audit logs are retained for compliance (user_id set to None)
+    db.session.query(AuditLog).filter_by(user_id=uid).update({"user_id": None})
+    # Finally delete the user record
+    db.session.query(User).filter_by(id=uid).delete()
+    db.session.flush()
+    logger.info("Deleted all PII for user_id=%s", uid)


### PR DESCRIPTION
## Changes

Implements GDPR-ready PII export and deletion as requested in #76.

### New files
- `packages/backend/app/routes/privacy.py` - Two authenticated endpoints:
  - `GET /privacy/export` - Exports all user data (profile, expenses, categories, bills, reminders, subscriptions) as JSON
  - `DELETE /privacy/delete` - Irreversibly deletes all personal data (requires `{"confirm": "DELETE_MY_DATA"}` body)
- `packages/backend/app/services/privacy.py` - Service layer with `export_user_data()` and `delete_user_data()`

### Modified files
- `packages/backend/app/routes/__init__.py` - Register privacy blueprint at `/privacy`

### Security
- Both endpoints require JWT authentication
- Deletion requires explicit confirmation string
- Deletion happens in dependency order (children first)
- Audit logs are retained with `user_id=NULL` for compliance
- All operations are logged

### Testing
`ash
curl -H 'Authorization: Bearer <token>' http://localhost:5000/privacy/export
curl -X DELETE -H 'Authorization: Bearer <token>' -H 'Content-Type: application/json' -d '{"confirm":"DELETE_MY_DATA"}' http://localhost:5000/privacy/delete
``n
Fixes #76

---
Wallet: zp6