### PR TITLE
Bounty Submission: Webhook Event System

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ OpenAPI: `backend/app/openapi.yaml`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Webhooks: CRUD `/webhooks`, delivery log `/webhooks/deliveries`, retry `/webhooks/deliveries/retry`
+
+## Webhook Event System
+
+FinMind can notify user-owned integrations when important account events happen.
+Webhook endpoints are managed through authenticated `/webhooks` APIs and receive
+JSON payloads signed with HMAC-SHA256.
+
+Delivery headers:
+- `X-FinMind-Event`: event type, such as `expense.created`
+- `X-FinMind-Delivery`: delivery ID
+- `X-FinMind-Signature`: `sha256=<hex hmac>` over the raw request body
+
+Supported event types:
+- `expense.created`
+- `expense.updated`
+- `expense.deleted`
+- `bill.created`
+- `bill.paid`
+- `reminder.created`
+- `reminder.sent`
+
+Delivery behavior:
+- A `2xx` response marks the delivery as delivered.
+- Non-`2xx` responses and network errors remain pending until retried.
+- Retry uses exponential backoff for up to three attempts.
+- Users can inspect recent delivery attempts with `GET /webhooks/deliveries`
+  and trigger due retries with `POST /webhooks/deliveries/retry`.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,33 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  url VARCHAR(500) NOT NULL,
+  secret VARCHAR(255) NOT NULL,
+  event_types VARCHAR(500) NOT NULL DEFAULT '*',
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_user_active
+  ON webhook_endpoints(user_id, active);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id SERIAL PRIMARY KEY,
+  endpoint_id INT NOT NULL REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event_type VARCHAR(100) NOT NULL,
+  payload_json TEXT NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempts INT NOT NULL DEFAULT 0,
+  last_error VARCHAR(500),
+  next_retry_at TIMESTAMP,
+  delivered_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_user_created
+  ON webhook_deliveries(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_retry
+  ON webhook_deliveries(status, next_retry_at);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,31 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WebhookEndpoint(db.Model):
+    __tablename__ = "webhook_endpoints"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    url = db.Column(db.String(500), nullable=False)
+    secret = db.Column(db.String(255), nullable=False)
+    event_types = db.Column(db.String(500), nullable=False, default="*")
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WebhookDelivery(db.Model):
+    __tablename__ = "webhook_deliveries"
+    id = db.Column(db.Integer, primary_key=True)
+    endpoint_id = db.Column(
+        db.Integer, db.ForeignKey("webhook_endpoints.id"), nullable=False
+    )
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    event_type = db.Column(db.String(100), nullable=False)
+    payload_json = db.Column(db.Text, nullable=False)
+    status = db.Column(db.String(20), default="pending", nullable=False)
+    attempts = db.Column(db.Integer, default=0, nullable=False)
+    last_error = db.Column(db.String(500), nullable=True)
+    next_retry_at = db.Column(db.DateTime, nullable=True)
+    delivered_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -12,6 +12,7 @@ tags:
   - name: Bills
   - name: Reminders
   - name: Insights
+  - name: Webhooks
 paths:
   /auth/register:
     post:
@@ -481,6 +482,145 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /webhooks/event-types:
+    get:
+      summary: List supported webhook event types
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Supported event type strings
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { type: string }
+
+  /webhooks:
+    get:
+      summary: List webhook endpoints
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: User webhook endpoints
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WebhookEndpoint'
+    post:
+      summary: Create webhook endpoint
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [url]
+              properties:
+                url: { type: string, format: uri }
+                secret: { type: string, nullable: true }
+                event_types:
+                  type: array
+                  items: { type: string }
+                active: { type: boolean, default: true }
+      responses:
+        '201':
+          description: Created webhook endpoint
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/WebhookEndpoint'
+                  - type: object
+                    properties:
+                      secret: { type: string }
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /webhooks/{endpointId}:
+    patch:
+      summary: Update webhook endpoint
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: endpointId
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url: { type: string, format: uri }
+                secret: { type: string }
+                event_types:
+                  type: array
+                  items: { type: string }
+                active: { type: boolean }
+      responses:
+        '200':
+          description: Updated endpoint
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/WebhookEndpoint' }
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    delete:
+      summary: Disable webhook endpoint
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: endpointId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200': { description: Disabled }
+
+  /webhooks/deliveries:
+    get:
+      summary: List recent webhook deliveries
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Recent delivery attempts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WebhookDelivery'
+
+  /webhooks/deliveries/retry:
+    post:
+      summary: Retry due pending webhook deliveries
+      tags: [Webhooks]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Retry count
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  retried: { type: integer }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -587,3 +727,25 @@ components:
         message: { type: string }
         send_at: { type: string, format: date-time }
         channel: { type: string, enum: [email, whatsapp], default: email }
+    WebhookEndpoint:
+      type: object
+      properties:
+        id: { type: integer }
+        url: { type: string, format: uri }
+        event_types:
+          type: array
+          items: { type: string }
+        active: { type: boolean }
+        created_at: { type: string, format: date-time }
+    WebhookDelivery:
+      type: object
+      properties:
+        id: { type: integer }
+        endpoint_id: { type: integer }
+        event_type: { type: string }
+        status: { type: string, enum: [pending, delivered, failed] }
+        attempts: { type: integer }
+        last_error: { type: string, nullable: true }
+        next_retry_at: { type: string, format: date-time, nullable: true }
+        delivered_at: { type: string, format: date-time, nullable: true }
+        created_at: { type: string, format: date-time }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .webhooks import bp as webhooks_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(webhooks_bp, url_prefix="/webhooks")

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, BillCadence, User
 from ..services.cache import cache_delete_patterns
+from ..services.webhooks import emit_webhook_event
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -62,6 +63,7 @@ def create_bill():
     cache_delete_patterns(
         [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
     )
+    _emit_webhook(uid, "bill.created", _bill_to_dict(b))
     return jsonify(id=b.id), 201
 
 
@@ -88,4 +90,26 @@ def mark_paid(bill_id: int):
     logger.info(
         "Marked bill paid id=%s user=%s next_due_date=%s", b.id, uid, b.next_due_date
     )
+    _emit_webhook(uid, "bill.paid", _bill_to_dict(b))
     return jsonify(message="updated")
+
+
+def _bill_to_dict(b: Bill) -> dict:
+    return {
+        "id": b.id,
+        "name": b.name,
+        "amount": float(b.amount),
+        "currency": b.currency,
+        "next_due_date": b.next_due_date.isoformat(),
+        "cadence": b.cadence.value,
+        "autopay_enabled": b.autopay_enabled,
+        "channel_whatsapp": b.channel_whatsapp,
+        "channel_email": b.channel_email,
+    }
+
+
+def _emit_webhook(uid: int, event_type: str, payload: dict):
+    try:
+        emit_webhook_event(uid, event_type, payload)
+    except Exception:  # pragma: no cover
+        logger.exception("Webhook emit failed event=%s user=%s", event_type, uid)

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -7,6 +7,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
+from ..services.webhooks import emit_webhook_event
 from ..services import expense_import
 import logging
 
@@ -84,6 +85,7 @@ def create_expense():
             f"insights:{uid}:*",
         ]
     )
+    _emit_webhook(uid, "expense.created", _expense_to_dict(e))
     return jsonify(_expense_to_dict(e)), 201
 
 
@@ -231,6 +233,7 @@ def update_expense(expense_id: int):
         e.spent_at = date.fromisoformat(raw_date)
     db.session.commit()
     _invalidate_expense_cache(uid, e.spent_at.isoformat())
+    _emit_webhook(uid, "expense.updated", _expense_to_dict(e))
     return jsonify(_expense_to_dict(e))
 
 
@@ -241,10 +244,12 @@ def delete_expense(expense_id: int):
     e = db.session.get(Expense, expense_id)
     if not e or e.user_id != uid:
         return jsonify(error="not found"), 404
+    payload = _expense_to_dict(e)
     spent_at = e.spent_at.isoformat()
     db.session.delete(e)
     db.session.commit()
     _invalidate_expense_cache(uid, spent_at)
+    _emit_webhook(uid, "expense.deleted", payload)
     return jsonify(message="deleted")
 
 
@@ -393,3 +398,10 @@ def _invalidate_expense_cache(uid: int, at: str):
             f"user:{uid}:dashboard_summary:*",
         ]
     )
+
+
+def _emit_webhook(uid: int, event_type: str, payload: dict):
+    try:
+        emit_webhook_event(uid, event_type, payload)
+    except Exception:  # pragma: no cover
+        logger.exception("Webhook emit failed event=%s user=%s", event_type, uid)

--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -5,6 +5,7 @@ from ..extensions import db
 from ..models import Bill, Reminder
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
+from ..services.webhooks import emit_webhook_event
 import logging
 
 bp = Blueprint("reminders", __name__)
@@ -51,6 +52,7 @@ def create_reminder():
     db.session.commit()
     logger.info("Created reminder id=%s user=%s", r.id, uid)
     track_reminder_event(event="created", channel=r.channel)
+    _emit_webhook(uid, "reminder.created", _reminder_to_dict(r))
     return jsonify(id=r.id), 201
 
 
@@ -174,6 +176,7 @@ def run_due():
         send_reminder(r)
         r.sent = True
         track_reminder_event(event="sent", channel=r.channel)
+        _emit_webhook(uid, "reminder.sent", _reminder_to_dict(r))
     db.session.commit()
     logger.info("Processed due reminders user=%s count=%s", uid, len(items))
     return jsonify(processed=len(items))
@@ -221,3 +224,21 @@ def _create_reminder_if_missing(
         )
     )
     return True
+
+
+def _reminder_to_dict(r: Reminder) -> dict:
+    return {
+        "id": r.id,
+        "bill_id": r.bill_id,
+        "message": r.message,
+        "send_at": r.send_at.isoformat(),
+        "sent": r.sent,
+        "channel": r.channel,
+    }
+
+
+def _emit_webhook(uid: int, event_type: str, payload: dict):
+    try:
+        emit_webhook_event(uid, event_type, payload)
+    except Exception:  # pragma: no cover
+        logger.exception("Webhook emit failed event=%s user=%s", event_type, uid)

--- a/packages/backend/app/routes/webhooks.py
+++ b/packages/backend/app/routes/webhooks.py
@@ -1,0 +1,164 @@
+from secrets import token_urlsafe
+from urllib.parse import urlparse
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import WebhookDelivery, WebhookEndpoint
+from ..services.webhooks import (
+    EVENT_TYPES,
+    normalize_event_types,
+    retry_pending_deliveries,
+)
+
+bp = Blueprint("webhooks", __name__)
+
+
+@bp.get("/event-types")
+@jwt_required()
+def event_types():
+    return jsonify(sorted(EVENT_TYPES))
+
+
+@bp.get("")
+@jwt_required()
+def list_webhooks():
+    uid = int(get_jwt_identity())
+    endpoints = (
+        db.session.query(WebhookEndpoint)
+        .filter_by(user_id=uid)
+        .order_by(WebhookEndpoint.created_at.desc())
+        .all()
+    )
+    return jsonify([_endpoint_to_dict(endpoint) for endpoint in endpoints])
+
+
+@bp.post("")
+@jwt_required()
+def create_webhook():
+    uid = int(get_jwt_identity())
+    data = request.get_json(silent=True) or {}
+    url = _normalize_url(data.get("url"))
+    if not url:
+        return jsonify(error="valid http(s) url required"), 400
+    event_types = normalize_event_types(data.get("event_types"))
+    if event_types is None:
+        return jsonify(error="invalid event_types"), 400
+    secret = str(data.get("secret") or "").strip() or token_urlsafe(32)
+    endpoint = WebhookEndpoint(
+        user_id=uid,
+        url=url,
+        secret=secret,
+        event_types=event_types,
+        active=bool(data.get("active", True)),
+    )
+    db.session.add(endpoint)
+    db.session.commit()
+    response = _endpoint_to_dict(endpoint)
+    response["secret"] = secret
+    return jsonify(response), 201
+
+
+@bp.patch("/<int:endpoint_id>")
+@jwt_required()
+def update_webhook(endpoint_id: int):
+    uid = int(get_jwt_identity())
+    endpoint = db.session.get(WebhookEndpoint, endpoint_id)
+    if not endpoint or endpoint.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json(silent=True) or {}
+    if "url" in data:
+        url = _normalize_url(data.get("url"))
+        if not url:
+            return jsonify(error="valid http(s) url required"), 400
+        endpoint.url = url
+    if "secret" in data:
+        secret = str(data.get("secret") or "").strip()
+        if not secret:
+            return jsonify(error="secret cannot be empty"), 400
+        endpoint.secret = secret
+    if "event_types" in data:
+        event_types = normalize_event_types(data.get("event_types"))
+        if event_types is None:
+            return jsonify(error="invalid event_types"), 400
+        endpoint.event_types = event_types
+    if "active" in data:
+        endpoint.active = bool(data.get("active"))
+    db.session.commit()
+    return jsonify(_endpoint_to_dict(endpoint))
+
+
+@bp.delete("/<int:endpoint_id>")
+@jwt_required()
+def delete_webhook(endpoint_id: int):
+    uid = int(get_jwt_identity())
+    endpoint = db.session.get(WebhookEndpoint, endpoint_id)
+    if not endpoint or endpoint.user_id != uid:
+        return jsonify(error="not found"), 404
+    endpoint.active = False
+    db.session.commit()
+    return jsonify(message="disabled")
+
+
+@bp.get("/deliveries")
+@jwt_required()
+def list_deliveries():
+    uid = int(get_jwt_identity())
+    deliveries = (
+        db.session.query(WebhookDelivery)
+        .filter_by(user_id=uid)
+        .order_by(WebhookDelivery.created_at.desc())
+        .limit(100)
+        .all()
+    )
+    return jsonify([_delivery_to_dict(delivery) for delivery in deliveries])
+
+
+@bp.post("/deliveries/retry")
+@jwt_required()
+def retry_deliveries():
+    uid = int(get_jwt_identity())
+    return jsonify(retried=retry_pending_deliveries(uid))
+
+
+def _endpoint_to_dict(endpoint: WebhookEndpoint) -> dict:
+    return {
+        "id": endpoint.id,
+        "url": endpoint.url,
+        "event_types": _event_types_to_list(endpoint.event_types),
+        "active": endpoint.active,
+        "created_at": endpoint.created_at.isoformat(),
+    }
+
+
+def _delivery_to_dict(delivery: WebhookDelivery) -> dict:
+    return {
+        "id": delivery.id,
+        "endpoint_id": delivery.endpoint_id,
+        "event_type": delivery.event_type,
+        "status": delivery.status,
+        "attempts": delivery.attempts,
+        "last_error": delivery.last_error,
+        "next_retry_at": (
+            delivery.next_retry_at.isoformat() if delivery.next_retry_at else None
+        ),
+        "delivered_at": (
+            delivery.delivered_at.isoformat() if delivery.delivered_at else None
+        ),
+        "created_at": delivery.created_at.isoformat(),
+    }
+
+
+def _event_types_to_list(value: str) -> list[str]:
+    if value == "*":
+        return ["*"]
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _normalize_url(raw_url) -> str | None:
+    url = str(raw_url or "").strip()
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return url

--- a/packages/backend/app/services/webhooks.py
+++ b/packages/backend/app/services/webhooks.py
@@ -1,0 +1,152 @@
+import hashlib
+import hmac
+import json
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import requests
+
+from ..extensions import db
+from ..models import WebhookDelivery, WebhookEndpoint
+
+logger = logging.getLogger("finmind.webhooks")
+
+EVENT_TYPES = {
+    "expense.created",
+    "expense.updated",
+    "expense.deleted",
+    "bill.created",
+    "bill.paid",
+    "reminder.created",
+    "reminder.sent",
+}
+
+MAX_DELIVERY_ATTEMPTS = 3
+REQUEST_TIMEOUT_SECONDS = 5
+
+
+def emit_webhook_event(user_id: int, event_type: str, data: dict[str, Any]) -> None:
+    if event_type not in EVENT_TYPES:
+        raise ValueError(f"unsupported webhook event type: {event_type}")
+
+    endpoints = (
+        db.session.query(WebhookEndpoint).filter_by(user_id=user_id, active=True).all()
+    )
+    for endpoint in endpoints:
+        if not _endpoint_matches(endpoint, event_type):
+            continue
+        delivery = WebhookDelivery(
+            endpoint_id=endpoint.id,
+            user_id=user_id,
+            event_type=event_type,
+            payload_json=_build_payload(event_type, data),
+        )
+        db.session.add(delivery)
+        db.session.flush()
+        attempt_delivery(delivery, endpoint)
+    db.session.commit()
+
+
+def retry_pending_deliveries(user_id: int | None = None) -> int:
+    now = datetime.utcnow()
+    query = db.session.query(WebhookDelivery).filter(
+        WebhookDelivery.status == "pending",
+        WebhookDelivery.attempts < MAX_DELIVERY_ATTEMPTS,
+        (WebhookDelivery.next_retry_at.is_(None))
+        | (WebhookDelivery.next_retry_at <= now),
+    )
+    if user_id is not None:
+        query = query.filter_by(user_id=user_id)
+
+    retried = 0
+    for delivery in query.all():
+        endpoint = db.session.get(WebhookEndpoint, delivery.endpoint_id)
+        if not endpoint or not endpoint.active:
+            continue
+        attempt_delivery(delivery, endpoint)
+        retried += 1
+    db.session.commit()
+    return retried
+
+
+def attempt_delivery(delivery: WebhookDelivery, endpoint: WebhookEndpoint) -> None:
+    payload = delivery.payload_json
+    signature = _sign_payload(endpoint.secret, payload)
+    headers = {
+        "Content-Type": "application/json",
+        "X-FinMind-Event": delivery.event_type,
+        "X-FinMind-Delivery": str(delivery.id),
+        "X-FinMind-Signature": f"sha256={signature}",
+    }
+    delivery.attempts += 1
+    try:
+        response = requests.post(
+            endpoint.url,
+            data=payload,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+        if 200 <= response.status_code < 300:
+            delivery.status = "delivered"
+            delivery.delivered_at = datetime.utcnow()
+            delivery.last_error = None
+            delivery.next_retry_at = None
+            return
+        delivery.last_error = f"HTTP {response.status_code}"
+    except requests.RequestException as exc:
+        delivery.last_error = str(exc)[:500]
+
+    if delivery.attempts >= MAX_DELIVERY_ATTEMPTS:
+        delivery.status = "failed"
+        delivery.next_retry_at = None
+    else:
+        delay_seconds = 2 ** (delivery.attempts - 1) * 60
+        delivery.next_retry_at = datetime.utcnow() + timedelta(seconds=delay_seconds)
+    logger.warning(
+        "Webhook delivery failed id=%s endpoint=%s attempts=%s error=%s",
+        delivery.id,
+        endpoint.id,
+        delivery.attempts,
+        delivery.last_error,
+    )
+
+
+def normalize_event_types(raw: Any) -> str | None:
+    if raw in (None, "", "*"):
+        return "*"
+    if not isinstance(raw, list):
+        return None
+    values = sorted({str(item).strip() for item in raw if str(item).strip()})
+    if not values:
+        return "*"
+    if any(value not in EVENT_TYPES for value in values):
+        return None
+    return ",".join(values)
+
+
+def _endpoint_matches(endpoint: WebhookEndpoint, event_type: str) -> bool:
+    configured = endpoint.event_types or "*"
+    if configured == "*":
+        return True
+    return event_type in {item.strip() for item in configured.split(",")}
+
+
+def _build_payload(event_type: str, data: dict[str, Any]) -> str:
+    return json.dumps(
+        {
+            "event": event_type,
+            "created_at": datetime.utcnow().isoformat() + "Z",
+            "data": data,
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _sign_payload(secret: str, payload: str) -> str:
+    return hmac.new(
+        secret.encode("utf-8"),
+        payload.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()

--- a/packages/backend/tests/test_webhooks.py
+++ b/packages/backend/tests/test_webhooks.py
@@ -1,0 +1,125 @@
+import hashlib
+import hmac
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.extensions import db
+from app.models import WebhookDelivery
+
+
+class _FakeResponse:
+    def __init__(self, status_code):
+        self.status_code = status_code
+
+
+@pytest.fixture()
+def auth_header(client, monkeypatch):
+    monkeypatch.setattr("app.routes.auth.redis_client.setex", lambda *args: True)
+    monkeypatch.setattr(
+        "app.services.cache.redis_client.scan", lambda **kwargs: (0, [])
+    )
+    monkeypatch.setattr("app.services.cache.redis_client.delete", lambda *args: 0)
+    email = "webhooks@example.com"
+    password = "password123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    return {"Authorization": f"Bearer {r.get_json()['access_token']}"}
+
+
+def test_webhook_endpoint_receives_signed_expense_event(
+    client, auth_header, monkeypatch
+):
+    captured = {}
+
+    def _fake_post(url, data, headers, timeout):
+        captured["url"] = url
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return _FakeResponse(204)
+
+    monkeypatch.setattr("app.services.webhooks.requests.post", _fake_post)
+
+    r = client.post(
+        "/webhooks",
+        json={
+            "url": "https://example.com/hooks/finmind",
+            "secret": "super-secret",
+            "event_types": ["expense.created"],
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    endpoint_id = r.get_json()["id"]
+
+    r = client.post(
+        "/expenses",
+        json={"amount": 12.5, "description": "Webhook lunch", "date": "2026-05-15"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    assert captured["url"] == "https://example.com/hooks/finmind"
+    assert captured["headers"]["X-FinMind-Event"] == "expense.created"
+    expected_sig = hmac.new(
+        b"super-secret", captured["data"].encode("utf-8"), hashlib.sha256
+    ).hexdigest()
+    assert captured["headers"]["X-FinMind-Signature"] == f"sha256={expected_sig}"
+
+    r = client.get("/webhooks/deliveries", headers=auth_header)
+    assert r.status_code == 200
+    delivery = r.get_json()[0]
+    assert delivery["endpoint_id"] == endpoint_id
+    assert delivery["event_type"] == "expense.created"
+    assert delivery["status"] == "delivered"
+    assert delivery["attempts"] == 1
+
+
+def test_webhook_retry_redelivers_pending_delivery(
+    app_fixture, client, auth_header, monkeypatch
+):
+    responses = [_FakeResponse(500), _FakeResponse(200)]
+
+    def _fake_post(url, data, headers, timeout):
+        return responses.pop(0)
+
+    monkeypatch.setattr("app.services.webhooks.requests.post", _fake_post)
+
+    r = client.post(
+        "/webhooks",
+        json={
+            "url": "https://example.com/hooks/retry",
+            "secret": "retry-secret",
+            "event_types": ["expense.created"],
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.post(
+        "/expenses",
+        json={"amount": 8, "description": "Retry test", "date": "2026-05-15"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    with app_fixture.app_context():
+        delivery = db.session.query(WebhookDelivery).one()
+        assert delivery.status == "pending"
+        assert delivery.attempts == 1
+        assert delivery.last_error == "HTTP 500"
+        delivery.next_retry_at = datetime.utcnow() - timedelta(minutes=1)
+        db.session.commit()
+
+    r = client.post("/webhooks/deliveries/retry", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["retried"] == 1
+
+    with app_fixture.app_context():
+        delivery = db.session.query(WebhookDelivery).one()
+        assert delivery.status == "delivered"
+        assert delivery.attempts == 2
+        assert delivery.last_error is None


### PR DESCRIPTION
/claim #77

## Summary

Implements the Webhook Event System requested in issue #77:

- Adds user-managed webhook endpoints at `/webhooks`.
- Sends signed webhook deliveries for key account events.
- Persists delivery attempts with status, retry metadata, and last error.
- Adds retry handling for pending failed deliveries.
- Documents event types, delivery headers, retry behavior, OpenAPI paths, and schema.

## Event coverage

- `expense.created`
- `expense.updated`
- `expense.deleted`
- `bill.created`
- `bill.paid`
- `reminder.created`
- `reminder.sent`

## Security / delivery behavior

Each delivery includes:

- `X-FinMind-Event`
- `X-FinMind-Delivery`
- `X-FinMind-Signature: sha256=<hmac>`

The signature is computed over the raw JSON request body using the endpoint secret.
Deliveries are marked delivered on any `2xx` response. Non-`2xx` responses and request
exceptions remain pending for retry, with exponential backoff up to three attempts.

## Validation

- `python -m py_compile packages\backend\app\models.py packages\backend\app\services\webhooks.py packages\backend\app\routes\webhooks.py packages\backend\app\routes\expenses.py packages\backend\app\routes\bills.py packages\backend\app\routes\reminders.py`
- `python -m black --check packages\backend\app\models.py packages\backend\app\services\webhooks.py packages\backend\app\routes\webhooks.py packages\backend\app\routes\expenses.py packages\backend\app\routes\bills.py packages\backend\app\routes\reminders.py packages\backend\tests\test_webhooks.py`
- `python -m flake8 packages\backend\app\models.py packages\backend\app\services\webhooks.py packages\backend\app\routes\webhooks.py packages\backend\app\routes\expenses.py packages\backend\app\routes\bills.py packages\backend\app\routes\reminders.py packages\backend\tests\test_webhooks.py`
- `python -m pytest -q tests\test_webhooks.py`

Docker Compose test runner was also attempted with `.\scripts\test-backend.ps1 tests/test_webhooks.py`, but the local machine already had port `5432` allocated, so Compose could not start its Postgres container.
