### PR TITLE
feat: implement signed webhook event system with retry handling

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -33,6 +33,7 @@ def create_app(settings: Settings | None = None) -> Flask:
         TWILIO_AUTH_TOKEN=cfg.twilio_auth_token,
         TWILIO_WHATSAPP_FROM=cfg.twilio_whatsapp_from,
         EMAIL_FROM=cfg.email_from,
+        WEBHOOK_SIGNING_SECRET=cfg.webhook_signing_secret,
     )
 
     # Logging

--- a/packages/backend/app/config.py
+++ b/packages/backend/app/config.py
@@ -23,6 +23,8 @@ class Settings(BaseSettings):
     email_from: str | None = None
     smtp_url: str | None = None  # e.g. smtp+ssl://user:pass@mail:465
 
+    webhook_signing_secret: str = Field(default="finmind-webhook-dev-secret")
+
     # pydantic-settings v2 configuration
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,26 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS webhook_subscriptions (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  url VARCHAR(2048) NOT NULL,
+  event_type VARCHAR(100) NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_subscriptions_event ON webhook_subscriptions(event_type, active);
+
+CREATE TABLE IF NOT EXISTS webhook_delivery_logs (
+  id SERIAL PRIMARY KEY,
+  subscription_id INT NOT NULL REFERENCES webhook_subscriptions(id) ON DELETE CASCADE,
+  event_type VARCHAR(100) NOT NULL,
+  attempt INT NOT NULL,
+  status_code INT,
+  success BOOLEAN NOT NULL DEFAULT FALSE,
+  error_message VARCHAR(1000),
+  response_body VARCHAR(2000),
+  delivered_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_delivery_logs_subscription ON webhook_delivery_logs(subscription_id, delivered_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,28 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WebhookSubscription(db.Model):
+    __tablename__ = "webhook_subscriptions"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    url = db.Column(db.String(2048), nullable=False)
+    event_type = db.Column(db.String(100), nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class WebhookDeliveryLog(db.Model):
+    __tablename__ = "webhook_delivery_logs"
+    id = db.Column(db.Integer, primary_key=True)
+    subscription_id = db.Column(
+        db.Integer, db.ForeignKey("webhook_subscriptions.id"), nullable=False
+    )
+    event_type = db.Column(db.String(100), nullable=False)
+    attempt = db.Column(db.Integer, nullable=False)
+    status_code = db.Column(db.Integer, nullable=True)
+    success = db.Column(db.Boolean, default=False, nullable=False)
+    error_message = db.Column(db.String(1000), nullable=True)
+    response_body = db.Column(db.String(2000), nullable=True)
+    delivered_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .webhooks import bp as webhooks_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(webhooks_bp, url_prefix="/webhooks")

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, current_app, request, jsonify
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_jwt_extended import (
     create_access_token,
@@ -10,6 +10,7 @@ from flask_jwt_extended import (
 )
 from ..extensions import db, redis_client
 from ..models import User
+from ..services.webhook import emit_event
 import logging
 import time
 
@@ -47,6 +48,10 @@ def register():
     db.session.add(user)
     db.session.commit()
     logger.info("Registered user id=%s email=%s", user.id, email)
+    emit_event("user.registered", {
+        "id": user.id,
+        "email": user.email,
+    }, current_app.config.get("WEBHOOK_SIGNING_SECRET", ""))
     return jsonify(message="registered"), 201
 
 

--- a/packages/backend/app/routes/bills.py
+++ b/packages/backend/app/routes/bills.py
@@ -1,9 +1,10 @@
 from datetime import date, timedelta
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
 from ..models import Bill, BillCadence, User
 from ..services.cache import cache_delete_patterns
+from ..services.webhook import emit_event
 import logging
 
 bp = Blueprint("bills", __name__)
@@ -62,6 +63,14 @@ def create_bill():
     cache_delete_patterns(
         [f"user:{uid}:upcoming_bills*", f"user:{uid}:dashboard_summary:*"]
     )
+    emit_event("bill.created", {
+        "id": b.id,
+        "name": b.name,
+        "amount": float(b.amount),
+        "currency": b.currency,
+        "next_due_date": b.next_due_date.isoformat(),
+        "cadence": b.cadence.value,
+    }, current_app.config.get("WEBHOOK_SIGNING_SECRET", ""))
     return jsonify(id=b.id), 201
 
 
@@ -88,4 +97,12 @@ def mark_paid(bill_id: int):
     logger.info(
         "Marked bill paid id=%s user=%s next_due_date=%s", b.id, uid, b.next_due_date
     )
+    emit_event("bill.paid", {
+        "id": b.id,
+        "name": b.name,
+        "amount": float(b.amount),
+        "currency": b.currency,
+        "next_due_date": b.next_due_date.isoformat(),
+        "active": b.active,
+    }, current_app.config.get("WEBHOOK_SIGNING_SECRET", ""))
     return jsonify(message="updated")

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -8,6 +8,7 @@ from ..extensions import db
 from ..models import Expense, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
+from ..services.webhook import emit_event
 import logging
 
 bp = Blueprint("expenses", __name__)
@@ -84,6 +85,7 @@ def create_expense():
             f"insights:{uid}:*",
         ]
     )
+    emit_event("expense.created", _expense_to_dict(e), current_app.config.get("WEBHOOK_SIGNING_SECRET", ""))
     return jsonify(_expense_to_dict(e)), 201
 
 
@@ -231,6 +233,7 @@ def update_expense(expense_id: int):
         e.spent_at = date.fromisoformat(raw_date)
     db.session.commit()
     _invalidate_expense_cache(uid, e.spent_at.isoformat())
+    emit_event("expense.updated", _expense_to_dict(e), current_app.config.get("WEBHOOK_SIGNING_SECRET", ""))
     return jsonify(_expense_to_dict(e))
 
 
@@ -242,9 +245,11 @@ def delete_expense(expense_id: int):
     if not e or e.user_id != uid:
         return jsonify(error="not found"), 404
     spent_at = e.spent_at.isoformat()
+    deleted_data = _expense_to_dict(e)
     db.session.delete(e)
     db.session.commit()
     _invalidate_expense_cache(uid, spent_at)
+    emit_event("expense.deleted", deleted_data, current_app.config.get("WEBHOOK_SIGNING_SECRET", ""))
     return jsonify(message="deleted")
 
 

--- a/packages/backend/app/routes/webhooks.py
+++ b/packages/backend/app/routes/webhooks.py
@@ -1,0 +1,163 @@
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import WebhookSubscription, WebhookDeliveryLog
+import logging
+
+bp = Blueprint("webhooks", __name__)
+logger = logging.getLogger("finmind.webhooks")
+
+VALID_EVENT_TYPES = {
+    "expense.created",
+    "expense.updated",
+    "expense.deleted",
+    "bill.created",
+    "bill.paid",
+    "user.registered",
+}
+
+
+@bp.get("")
+@jwt_required()
+def list_subscriptions():
+    uid = int(get_jwt_identity())
+    items = (
+        db.session.query(WebhookSubscription)
+        .filter_by(user_id=uid)
+        .order_by(WebhookSubscription.created_at.desc())
+        .all()
+    )
+    return jsonify(
+        [
+            {
+                "id": s.id,
+                "url": s.url,
+                "event_type": s.event_type,
+                "active": s.active,
+                "created_at": s.created_at.isoformat(),
+            }
+            for s in items
+        ]
+    )
+
+
+@bp.post("")
+@jwt_required()
+def create_subscription():
+    uid = int(get_jwt_identity())
+    data = request.get_json() or {}
+    url = (data.get("url") or "").strip()
+    event_type = (data.get("event_type") or "").strip()
+    secret = (data.get("secret") or "").strip()
+
+    if not url:
+        return jsonify(error="url required"), 400
+    if event_type not in VALID_EVENT_TYPES:
+        return jsonify(
+            error=f"invalid event_type, must be one of: {', '.join(sorted(VALID_EVENT_TYPES))}"
+        ), 400
+
+    subscription = WebhookSubscription(
+        user_id=uid,
+        url=url,
+        event_type=event_type,
+    )
+    db.session.add(subscription)
+    db.session.commit()
+    logger.info("Created webhook subscription id=%s user=%s event=%s", subscription.id, uid, event_type)
+    return jsonify(
+        id=subscription.id,
+        url=subscription.url,
+        event_type=subscription.event_type,
+        active=subscription.active,
+        created_at=subscription.created_at.isoformat(),
+    ), 201
+
+
+@bp.patch("/<int:subscription_id>")
+@jwt_required()
+def update_subscription(subscription_id: int):
+    uid = int(get_jwt_identity())
+    subscription = db.session.get(WebhookSubscription, subscription_id)
+    if not subscription or subscription.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "url" in data:
+        url = (data.get("url") or "").strip()
+        if not url:
+            return jsonify(error="url required"), 400
+        subscription.url = url
+    if "event_type" in data:
+        event_type = (data.get("event_type") or "").strip()
+        if event_type not in VALID_EVENT_TYPES:
+            return jsonify(
+                error=f"invalid event_type, must be one of: {', '.join(sorted(VALID_EVENT_TYPES))}"
+            ), 400
+        subscription.event_type = event_type
+    if "active" in data:
+        subscription.active = bool(data.get("active"))
+    db.session.commit()
+    return jsonify(
+        id=subscription.id,
+        url=subscription.url,
+        event_type=subscription.event_type,
+        active=subscription.active,
+        created_at=subscription.created_at.isoformat(),
+    )
+
+
+@bp.delete("/<int:subscription_id>")
+@jwt_required()
+def delete_subscription(subscription_id: int):
+    uid = int(get_jwt_identity())
+    subscription = db.session.get(WebhookSubscription, subscription_id)
+    if not subscription or subscription.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(subscription)
+    db.session.commit()
+    return jsonify(message="deleted")
+
+
+@bp.get("/deliveries")
+@jwt_required()
+def list_deliveries():
+    uid = int(get_jwt_identity())
+    subscription_id = request.args.get("subscription_id")
+    event_type = request.args.get("event_type")
+    try:
+        limit = max(1, min(200, int(request.args.get("limit", "50"))))
+    except ValueError:
+        return jsonify(error="invalid limit"), 400
+
+    sub_ids = (
+        db.session.query(WebhookSubscription.id)
+        .filter_by(user_id=uid)
+        .all()
+    )
+    sub_id_list = [row[0] for row in sub_ids]
+    if not sub_id_list:
+        return jsonify([])
+    q = db.session.query(WebhookDeliveryLog).filter(
+        WebhookDeliveryLog.subscription_id.in_(sub_id_list)
+    )
+    if subscription_id:
+        q = q.filter(WebhookDeliveryLog.subscription_id == int(subscription_id))
+    if event_type:
+        q = q.filter(WebhookDeliveryLog.event_type == event_type)
+
+    items = q.order_by(WebhookDeliveryLog.delivered_at.desc()).limit(limit).all()
+    return jsonify(
+        [
+            {
+                "id": d.id,
+                "subscription_id": d.subscription_id,
+                "event_type": d.event_type,
+                "attempt": d.attempt,
+                "status_code": d.status_code,
+                "success": d.success,
+                "error_message": d.error_message,
+                "delivered_at": d.delivered_at.isoformat(),
+            }
+            for d in items
+        ]
+    )

--- a/packages/backend/app/services/webhook.py
+++ b/packages/backend/app/services/webhook.py
@@ -1,0 +1,132 @@
+import hashlib
+import hmac
+import json
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+from ..extensions import db
+from ..models import WebhookDeliveryLog, WebhookSubscription
+
+logger = logging.getLogger("finmind.webhook")
+
+MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2
+REQUEST_TIMEOUT = 10
+
+
+def _compute_signature(secret: str, payload_bytes: bytes) -> str:
+    return hmac.new(
+        secret.encode("utf-8"), payload_bytes, hashlib.sha256
+    ).hexdigest()
+
+
+def _deliver_one(subscription: WebhookSubscription, payload: dict[str, Any], signing_secret: str):
+    payload_bytes = json.dumps(payload).encode("utf-8")
+    signature = _compute_signature(signing_secret, payload_bytes)
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "FinMind-Webhook/1.0",
+        "X-FinMind-Signature": f"sha256={signature}",
+        "X-FinMind-Event": payload.get("event_type", "unknown"),
+        "X-FinMind-Delivery": str(time.time()),
+    }
+
+    try:
+        resp = requests.post(
+            subscription.url, data=payload_bytes, headers=headers, timeout=REQUEST_TIMEOUT
+        )
+        return resp.status_code, None
+    except requests.RequestException as exc:
+        return None, str(exc)
+
+
+def _log_delivery(
+    subscription_id: int,
+    event_type: str,
+    attempt: int,
+    status_code: int | None,
+    error_message: str | None,
+    response_body: str | None,
+):
+    log_entry = WebhookDeliveryLog(
+        subscription_id=subscription_id,
+        event_type=event_type,
+        attempt=attempt,
+        status_code=status_code,
+        success=status_code is not None and 200 <= status_code < 300,
+        error_message=error_message[:1000] if error_message else None,
+        response_body=response_body[:2000] if response_body else None,
+        delivered_at=datetime.now(timezone.utc),
+    )
+    db.session.add(log_entry)
+    db.session.commit()
+
+
+def _dispatch_with_retry(
+    subscription: WebhookSubscription,
+    payload: dict[str, Any],
+    signing_secret: str,
+):
+    event_type = payload.get("event_type", "unknown")
+    for attempt in range(1, MAX_RETRIES + 1):
+        status_code, error = _deliver_one(subscription, payload, signing_secret)
+        _log_delivery(
+            subscription_id=subscription.id,
+            event_type=event_type,
+            attempt=attempt,
+            status_code=status_code,
+            error_message=error,
+            response_body=None,
+        )
+        if status_code is not None and 200 <= status_code < 300:
+            logger.info(
+                "Webhook delivered subscription=%s event=%s attempt=%s status=%s",
+                subscription.id,
+                event_type,
+                attempt,
+                status_code,
+            )
+            return
+        if attempt < MAX_RETRIES:
+            delay = RETRY_BACKOFF_BASE ** (attempt - 1)
+            logger.warning(
+                "Webhook failed subscription=%s event=%s attempt=%s error=%s retry_in=%ss",
+                subscription.id,
+                event_type,
+                attempt,
+                error,
+                delay,
+            )
+            time.sleep(delay)
+
+    logger.error(
+        "Webhook exhausted retries subscription=%s event=%s",
+        subscription.id,
+        event_type,
+    )
+
+
+def emit_event(event_type: str, payload: dict[str, Any], signing_secret: str):
+    subscriptions = (
+        db.session.query(WebhookSubscription)
+        .filter_by(active=True, event_type=event_type)
+        .all()
+    )
+    if not subscriptions:
+        logger.debug("No webhook subscriptions for event=%s", event_type)
+        return
+
+    payload = dict(payload, event_type=event_type, timestamp=datetime.now(timezone.utc).isoformat())
+
+    for subscription in subscriptions:
+        t = threading.Thread(
+            target=_dispatch_with_retry,
+            args=(subscription, payload, signing_secret),
+            daemon=True,
+        )
+        t.start()

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,16 +1,58 @@
 import os
+import sys
+from unittest.mock import MagicMock
+
+
+class FakeRedis:
+    def __init__(self, *args, **kwargs):
+        self._store = {}
+
+    def scan(self, *args, **kwargs):
+        return (0, [])
+
+    def get(self, key, *args, **kwargs):
+        return self._store.get(key)
+
+    def set(self, key, value, *args, **kwargs):
+        self._store[key] = value
+        return True
+
+    def setex(self, key, ttl, value, *args, **kwargs):
+        self._store[key] = value
+        return True
+
+    def delete(self, *keys, **kwargs):
+        for key in keys:
+            self._store.pop(key, None)
+        return len(keys)
+
+    def flushdb(self, *args, **kwargs):
+        self._store.clear()
+
+    @classmethod
+    def from_url(cls, *args, **kwargs):
+        return cls()
+
+    class ConnectionError(Exception):
+        pass
+
+
+fake_redis_mod = MagicMock()
+fake_redis_mod.Redis = FakeRedis
+fake_redis_mod.from_url = FakeRedis.from_url
+fake_redis_mod.ConnectionError = FakeRedis.ConnectionError
+sys.modules["redis"] = fake_redis_mod
+
 import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
-from app import models  # noqa: F401 - ensure models are registered
+import app.models  # noqa: F401 - ensure models are registered
 
 
 class TestSettings(Settings):
-    # Override defaults for tests
     database_url: str = "sqlite+pysqlite:///:memory:"
-    redis_url: str = "redis://localhost:6379/15"  # not used in tests
+    redis_url: str = "redis://localhost:6379/15"
     jwt_secret: str = "test-secret"
 
 
@@ -21,28 +63,20 @@ def _setup_db(app):
 
 @pytest.fixture()
 def app_fixture():
-    # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
     settings = TestSettings(
         database_url="sqlite+pysqlite:///:memory:",
-        redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
+        webhook_signing_secret="test-webhook-secret",
     )
     app = create_app(settings)
     app.config.update(TESTING=True)
+    app.config["WEBHOOK_SIGNING_SECRET"] = "test-webhook-secret"
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
 
 
 @pytest.fixture()
@@ -52,7 +86,6 @@ def client(app_fixture):
 
 @pytest.fixture()
 def auth_header(client):
-    # Register and login a default user, return auth header
     email = "test@example.com"
     password = "password123"
     r = client.post("/auth/register", json={"email": email, "password": password})
@@ -61,7 +94,7 @@ def auth_header(client):
         200,
         201,
         409,
-    ), register_debug  # 409 if already exists
+    ), register_debug
     r = client.post("/auth/login", json={"email": email, "password": password})
     assert r.status_code == 200
     access = r.get_json()["access_token"]

--- a/packages/backend/tests/test_webhooks.py
+++ b/packages/backend/tests/test_webhooks.py
@@ -1,0 +1,299 @@
+import threading
+import time
+
+from app.models import WebhookDeliveryLog, WebhookSubscription
+
+
+def test_list_subscriptions_empty(client, auth_header):
+    r = client.get("/webhooks", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_create_and_list_subscription(client, auth_header):
+    r = client.post(
+        "/webhooks",
+        json={"url": "https://example.com/hook", "event_type": "expense.created"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    sub = r.get_json()
+    assert sub["url"] == "https://example.com/hook"
+    assert sub["event_type"] == "expense.created"
+    assert sub["active"] is True
+    assert "id" in sub
+
+    r = client.get("/webhooks", headers=auth_header)
+    assert r.status_code == 200
+    subs = r.get_json()
+    assert len(subs) == 1
+    assert subs[0]["id"] == sub["id"]
+
+
+def test_create_subscription_invalid_event_type(client, auth_header):
+    r = client.post(
+        "/webhooks",
+        json={"url": "https://example.com/hook", "event_type": "invalid.event"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "invalid event_type" in r.get_json()["error"]
+
+
+def test_create_subscription_missing_url(client, auth_header):
+    r = client.post(
+        "/webhooks",
+        json={"event_type": "expense.created"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert "url required" in r.get_json()["error"]
+
+
+def test_update_subscription(client, auth_header):
+    r = client.post(
+        "/webhooks",
+        json={"url": "https://example.com/hook", "event_type": "expense.created"},
+        headers=auth_header,
+    )
+    sub_id = r.get_json()["id"]
+
+    r = client.patch(
+        f"/webhooks/{sub_id}",
+        json={"url": "https://example.com/hook2", "event_type": "bill.created", "active": False},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    updated = r.get_json()
+    assert updated["url"] == "https://example.com/hook2"
+    assert updated["event_type"] == "bill.created"
+    assert updated["active"] is False
+
+
+def test_update_subscription_not_found(client, auth_header):
+    r = client.patch(
+        "/webhooks/99999",
+        json={"url": "https://example.com/hook"},
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+def test_delete_subscription(client, auth_header):
+    r = client.post(
+        "/webhooks",
+        json={"url": "https://example.com/hook", "event_type": "user.registered"},
+        headers=auth_header,
+    )
+    sub_id = r.get_json()["id"]
+
+    r = client.delete(f"/webhooks/{sub_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "deleted"
+
+    r = client.get("/webhooks", headers=auth_header)
+    assert r.get_json() == []
+
+
+def test_delete_subscription_not_found(client, auth_header):
+    r = client.delete("/webhooks/99999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_list_deliveries(client, auth_header, app_fixture):
+    with app_fixture.app_context():
+        from app.extensions import db
+        sub = WebhookSubscription(user_id=1, url="https://example.com/hook", event_type="expense.created")
+        db.session.add(sub)
+        db.session.commit()
+        sub_id = sub.id
+
+        log = WebhookDeliveryLog(
+            subscription_id=sub_id,
+            event_type="expense.created",
+            attempt=1,
+            status_code=200,
+            success=True,
+            error_message=None,
+        )
+        db.session.add(log)
+        db.session.commit()
+
+    r = client.get("/webhooks/deliveries", headers=auth_header)
+    assert r.status_code == 200
+    deliveries = r.get_json()
+    assert len(deliveries) >= 1
+    assert deliveries[0]["subscription_id"] == sub_id
+    assert deliveries[0]["success"] is True
+
+
+def test_expense_create_emits_webhook(client, auth_header, monkeypatch):
+    emitted_events = []
+
+    def fake_emit(event_type, payload, secret):
+        emitted_events.append((event_type, payload))
+
+    monkeypatch.setattr("app.routes.expenses.emit_event", fake_emit)
+
+    cat_id = _create_category(client, auth_header)
+    payload = {
+        "amount": 42.0,
+        "description": "Webhook test expense",
+        "date": "2026-03-15",
+        "category_id": cat_id,
+    }
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+
+    assert len(emitted_events) >= 1
+    event_type, event_payload = emitted_events[0]
+    assert event_type == "expense.created"
+    assert event_payload["amount"] == 42.0
+    assert event_payload["description"] == "Webhook test expense"
+
+
+def test_expense_delete_emits_webhook(client, auth_header, monkeypatch):
+    emitted_events = []
+
+    def fake_emit(event_type, payload, secret):
+        emitted_events.append((event_type, payload))
+
+    monkeypatch.setattr("app.routes.expenses.emit_event", fake_emit)
+
+    payload = {
+        "amount": 10.0,
+        "description": "To be deleted",
+        "date": "2026-03-15",
+    }
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    exp_id = r.get_json()["id"]
+
+    emitted_events.clear()
+
+    r = client.delete(f"/expenses/{exp_id}", headers=auth_header)
+    assert r.status_code == 200
+
+    assert len(emitted_events) >= 1
+    event_type, event_payload = emitted_events[0]
+    assert event_type == "expense.deleted"
+    assert event_payload["id"] == exp_id
+
+
+def test_bill_create_emits_webhook(client, auth_header, monkeypatch):
+    emitted_events = []
+
+    def fake_emit(event_type, payload, secret):
+        emitted_events.append((event_type, payload))
+
+    monkeypatch.setattr("app.routes.bills.emit_event", fake_emit)
+
+    r = client.post(
+        "/bills",
+        json={"name": "Test Bill", "amount": 99.99, "next_due_date": "2026-04-01", "cadence": "MONTHLY"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    assert len(emitted_events) >= 1
+    event_type, event_payload = emitted_events[0]
+    assert event_type == "bill.created"
+    assert event_payload["name"] == "Test Bill"
+
+
+def test_bill_pay_emits_webhook(client, auth_header, monkeypatch):
+    emitted_events = []
+
+    def fake_emit(event_type, payload, secret):
+        emitted_events.append((event_type, payload))
+
+    monkeypatch.setattr("app.routes.bills.emit_event", fake_emit)
+
+    r = client.post(
+        "/bills",
+        json={"name": "Payable Bill", "amount": 50.0, "next_due_date": "2026-03-15", "cadence": "ONCE"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    bill_id = r.get_json()["id"]
+
+    emitted_events.clear()
+
+    r = client.post(f"/bills/{bill_id}/pay", headers=auth_header)
+    assert r.status_code == 200
+
+    assert len(emitted_events) >= 1
+    event_type, event_payload = emitted_events[0]
+    assert event_type == "bill.paid"
+    assert event_payload["id"] == bill_id
+
+
+def test_user_register_emits_webhook(client, auth_header, monkeypatch):
+    emitted_events = []
+
+    def fake_emit(event_type, payload, secret):
+        emitted_events.append((event_type, payload))
+
+    monkeypatch.setattr("app.routes.auth.emit_event", fake_emit)
+
+    r = client.post("/auth/register", json={"email": "webhooktest@example.com", "password": "test123"})
+    assert r.status_code == 201
+
+    assert len(emitted_events) >= 1
+    event_type, event_payload = emitted_events[0]
+    assert event_type == "user.registered"
+    assert event_payload["email"] == "webhooktest@example.com"
+
+
+def test_delivery_retry_and_failure_logging(app_fixture, monkeypatch):
+    import requests
+
+    def fake_post(url, *args, **kwargs):
+        raise requests.ConnectionError("fake connection error")
+
+    monkeypatch.setattr("app.services.webhook.requests.post", fake_post)
+
+    with app_fixture.app_context():
+        from app.extensions import db
+        from app.models import WebhookSubscription
+
+        sub = WebhookSubscription(
+            user_id=1, url="https://fail.example.com/hook", event_type="expense.created"
+        )
+        db.session.add(sub)
+        db.session.commit()
+        sub_id = sub.id
+
+        from app.services.webhook import _dispatch_with_retry
+
+        _dispatch_with_retry(sub, {"event_type": "expense.created", "id": 1, "amount": 5.0}, "test-secret")
+
+        logs = db.session.query(WebhookDeliveryLog).filter_by(subscription_id=sub_id).order_by(
+            WebhookDeliveryLog.id
+        ).all()
+        assert len(logs) == 3
+        for log in logs:
+            assert log.success is False
+            assert log.error_message is not None
+
+
+def test_hmac_signature_scheme():
+    from app.services.webhook import _compute_signature
+
+    sig = _compute_signature("mysecret", b'{"test": true}')
+    assert len(sig) == 64
+    assert isinstance(sig, str)
+
+    sig2 = _compute_signature("mysecret", b'{"test": true}')
+    assert sig == sig2
+
+    sig3 = _compute_signature("wrong", b'{"test": true}')
+    assert sig != sig3
+
+
+def _create_category(client, auth_header, name="General"):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code in (201, 409)
+    r = client.get("/categories", headers=auth_header)
+    assert r.status_code == 200
+    return r.get_json()[0]["id"]


### PR DESCRIPTION
## Summary
- Signed webhook delivery with HMAC-SHA256 for 6 event types
- Automated retry (3 attempts, exponential backoff)
- Webhook subscription CRUD API (`/webhooks`)
- Delivery log endpoint (`/webhooks/deliveries`)
- All tests passing (16 new tests)

Closes #77