### PR TITLE
Add login anomaly alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ finmind/
 
 ## Security & Scalability
 - JWT access/refresh, secure cookies OR Authorization header.
+- Login anomaly alerts are recorded in `login_events` and returned from `/auth/login`
+  when a new IP, new user agent, or recent failed-attempt pattern is detected.
 - RBAC-ready via roles on `users.role`.
 - N+1 avoided via SQLAlchemy eager loading.
 - Redis caching for hot paths to cut DB load.

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -111,10 +111,36 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             """
         )
         conn.commit()
-    except Exception:
-        app.logger.exception(
-            "Schema compatibility patch failed for users.preferred_currency"
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS login_events (
+              id SERIAL PRIMARY KEY,
+              user_id INT REFERENCES users(id) ON DELETE SET NULL,
+              email VARCHAR(255) NOT NULL,
+              ip_address VARCHAR(45),
+              user_agent VARCHAR(500),
+              successful BOOLEAN NOT NULL DEFAULT FALSE,
+              anomaly_detected BOOLEAN NOT NULL DEFAULT FALSE,
+              anomaly_reason VARCHAR(255),
+              created_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
         )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_login_events_user_created
+            ON login_events(user_id, created_at DESC)
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_login_events_email_created
+            ON login_events(email, created_at DESC)
+            """
+        )
+        conn.commit()
+    except Exception:
+        app.logger.exception("Schema compatibility patch failed")
         conn.rollback()
     finally:
         conn.close()

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,17 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS login_events (
+  id SERIAL PRIMARY KEY,
+  user_id INT REFERENCES users(id) ON DELETE SET NULL,
+  email VARCHAR(255) NOT NULL,
+  ip_address VARCHAR(45),
+  user_agent VARCHAR(500),
+  successful BOOLEAN NOT NULL DEFAULT FALSE,
+  anomaly_detected BOOLEAN NOT NULL DEFAULT FALSE,
+  anomaly_reason VARCHAR(255),
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_login_events_user_created ON login_events(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_login_events_email_created ON login_events(email, created_at DESC);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -19,6 +19,19 @@ class User(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class LoginEvent(db.Model):
+    __tablename__ = "login_events"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    email = db.Column(db.String(255), nullable=False)
+    ip_address = db.Column(db.String(45), nullable=True)
+    user_agent = db.Column(db.String(500), nullable=True)
+    successful = db.Column(db.Boolean, default=False, nullable=False)
+    anomaly_detected = db.Column(db.Boolean, default=False, nullable=False)
+    anomaly_reason = db.Column(db.String(255), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
 class Category(db.Model):
     __tablename__ = "categories"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -65,6 +65,9 @@ paths:
               example:
                 access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
                 refresh_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+                security_alert:
+                  suspicious: false
+                  reason: null
         '401':
           description: Invalid credentials
           content:
@@ -498,6 +501,14 @@ components:
       properties:
         access_token: { type: string }
         refresh_token: { type: string }
+        security_alert:
+          type: object
+          properties:
+            suspicious: { type: boolean }
+            reason:
+              type: string
+              nullable: true
+              enum: [new_ip_address, new_user_agent, recent_failed_attempts, null]
     Category:
       type: object
       properties:

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -9,7 +9,8 @@ from flask_jwt_extended import (
     get_jwt_identity,
 )
 from ..extensions import db, redis_client
-from ..models import User
+from ..models import AuditLog, LoginEvent, User
+from datetime import datetime, timedelta
 import logging
 import time
 
@@ -57,13 +58,44 @@ def login():
     password = data.get("password")
     user = db.session.query(User).filter_by(email=email).first()
     if not user or not check_password_hash(user.password_hash, password):
+        _record_login_event(
+            email=email or "",
+            user=None,
+            successful=False,
+            anomaly_detected=False,
+            anomaly_reason=None,
+        )
+        db.session.commit()
         logger.warning("Login failed for email=%s", email)
         return jsonify(error="invalid credentials"), 401
+    anomaly = _detect_login_anomaly(user)
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
+    _record_login_event(
+        email=user.email,
+        user=user,
+        successful=True,
+        anomaly_detected=anomaly["detected"],
+        anomaly_reason=anomaly["reason"],
+    )
+    if anomaly["detected"]:
+        db.session.add(
+            AuditLog(
+                user_id=user.id,
+                action=f"login_anomaly:{anomaly['reason']}",
+            )
+        )
+    db.session.commit()
     logger.info("Login success user_id=%s", user.id)
-    return jsonify(access_token=access, refresh_token=refresh)
+    return jsonify(
+        access_token=access,
+        refresh_token=refresh,
+        security_alert={
+            "suspicious": anomaly["detected"],
+            "reason": anomaly["reason"],
+        },
+    )
 
 
 @bp.get("/me")
@@ -137,3 +169,67 @@ def _store_refresh_session(refresh_token: str, uid: str):
         return
     ttl = max(int(exp - time.time()), 1)
     redis_client.setex(_refresh_key(jti), ttl, uid)
+
+
+def _client_ip() -> str | None:
+    forwarded_for = request.headers.get("X-Forwarded-For", "")
+    if forwarded_for:
+        return forwarded_for.split(",", 1)[0].strip() or None
+    return request.remote_addr
+
+
+def _client_user_agent() -> str | None:
+    user_agent = request.headers.get("User-Agent")
+    if not user_agent:
+        return None
+    return user_agent[:500]
+
+
+def _record_login_event(
+    email: str,
+    user: User | None,
+    successful: bool,
+    anomaly_detected: bool,
+    anomaly_reason: str | None,
+) -> None:
+    db.session.add(
+        LoginEvent(
+            user_id=user.id if user else None,
+            email=email,
+            ip_address=_client_ip(),
+            user_agent=_client_user_agent(),
+            successful=successful,
+            anomaly_detected=anomaly_detected,
+            anomaly_reason=anomaly_reason,
+        )
+    )
+
+
+def _detect_login_anomaly(user: User) -> dict[str, str | bool | None]:
+    ip_address = _client_ip()
+    user_agent = _client_user_agent()
+    previous_login = (
+        db.session.query(LoginEvent)
+        .filter_by(user_id=user.id, successful=True)
+        .order_by(LoginEvent.created_at.desc())
+        .first()
+    )
+    if previous_login:
+        if ip_address and previous_login.ip_address != ip_address:
+            return {"detected": True, "reason": "new_ip_address"}
+        if user_agent and previous_login.user_agent != user_agent:
+            return {"detected": True, "reason": "new_user_agent"}
+
+    window_start = datetime.utcnow() - timedelta(minutes=15)
+    failed_attempts = (
+        db.session.query(LoginEvent)
+        .filter(
+            LoginEvent.email == user.email,
+            LoginEvent.successful.is_(False),
+            LoginEvent.created_at >= window_start,
+        )
+        .count()
+    )
+    if failed_attempts >= 5:
+        return {"detected": True, "reason": "recent_failed_attempts"}
+    return {"detected": False, "reason": None}

--- a/packages/backend/tests/test_auth.py
+++ b/packages/backend/tests/test_auth.py
@@ -21,6 +21,61 @@ def test_auth_refresh_flow(client):
     assert isinstance(new_access, str) and len(new_access) > 10
 
 
+def test_login_returns_non_suspicious_alert_for_first_success(client):
+    email = "first-login@test.com"
+    password = "secret123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        headers={"User-Agent": "FinMindTest/1.0", "X-Forwarded-For": "203.0.113.10"},
+    )
+    assert r.status_code == 200
+    alert = r.get_json()["security_alert"]
+    assert alert == {"suspicious": False, "reason": None}
+
+
+def test_login_flags_new_ip_address_after_successful_login(client):
+    email = "new-ip@test.com"
+    password = "secret123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        headers={"User-Agent": "FinMindTest/1.0", "X-Forwarded-For": "203.0.113.10"},
+    )
+    assert r.status_code == 200
+
+    r = client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        headers={"User-Agent": "FinMindTest/1.0", "X-Forwarded-For": "203.0.113.99"},
+    )
+    assert r.status_code == 200
+    alert = r.get_json()["security_alert"]
+    assert alert == {"suspicious": True, "reason": "new_ip_address"}
+
+
+def test_login_flags_recent_failed_attempts(client):
+    email = "failed-attempts@test.com"
+    password = "secret123"
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+
+    for _ in range(5):
+        r = client.post("/auth/login", json={"email": email, "password": "wrong"})
+        assert r.status_code == 401
+
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200
+    alert = r.get_json()["security_alert"]
+    assert alert == {"suspicious": True, "reason": "recent_failed_attempts"}
+
+
 def test_auth_logout_revokes_refresh_token(client):
     email = "logout@test.com"
     password = "secret123"


### PR DESCRIPTION
## Summary
- add persistent login event tracking for successful and failed auth attempts
- flag suspicious logins for new IP address, new user agent, or recent failed attempts
- return `security_alert` metadata from `/auth/login` and record anomaly audit log entries
- update schema, OpenAPI docs, README, and auth coverage

## Tests
- `python -m pytest -q` from `packages/backend` with Redis available
- `python -m black --check packages/backend`
- `python -m flake8 packages/backend`

Addresses #124