### PR TITLE
Add weekly financial digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-summary`
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/__tests__/Analytics.integration.test.tsx
+++ b/app/src/__tests__/Analytics.integration.test.tsx
@@ -30,8 +30,10 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 
 const getBudgetSuggestionMock = jest.fn();
+const getWeeklySummaryMock = jest.fn();
 jest.mock('@/api/insights', () => ({
   getBudgetSuggestion: (...args: unknown[]) => getBudgetSuggestionMock(...args),
+  getWeeklySummary: (...args: unknown[]) => getWeeklySummaryMock(...args),
 }));
 
 describe('Analytics integration', () => {
@@ -52,14 +54,64 @@ describe('Analytics integration', () => {
       method: 'heuristic',
       warnings: [],
     });
+    getWeeklySummaryMock.mockResolvedValue({
+      period: {
+        week_start: '2026-05-18',
+        week_end: '2026-05-24',
+        previous_week_start: '2026-05-11',
+        previous_week_end: '2026-05-17',
+      },
+      currency: 'USD',
+      summary: {
+        income: 1500,
+        expenses: 420,
+        net_flow: 1080,
+        transaction_count: 4,
+        average_daily_expense: 60,
+        savings_rate_pct: 72,
+      },
+      comparison: {
+        previous_expenses: 500,
+        expense_change: -80,
+        expense_change_pct: -16,
+        trend: 'down',
+      },
+      category_breakdown: [
+        {
+          category_id: 1,
+          category_name: 'Groceries',
+          amount: 220,
+          share_pct: 52.38,
+          previous_amount: 240,
+          change_pct: -8.33,
+          transaction_count: 2,
+        },
+      ],
+      daily_breakdown: [
+        { date: '2026-05-18', day: 'Mon', expenses: 0 },
+        { date: '2026-05-19', day: 'Tue', expenses: 220 },
+        { date: '2026-05-20', day: 'Wed', expenses: 0 },
+        { date: '2026-05-21', day: 'Thu', expenses: 200 },
+        { date: '2026-05-22', day: 'Fri', expenses: 0 },
+        { date: '2026-05-23', day: 'Sat', expenses: 0 },
+        { date: '2026-05-24', day: 'Sun', expenses: 0 },
+      ],
+      largest_expenses: [],
+      upcoming_bills: [],
+      highlights: ['Expenses were lower than last week.'],
+      insights: ['Net flow stayed positive.'],
+      recommendations: ['Keep the current weekly pattern.'],
+    });
   });
 
   it('loads and renders insights data', async () => {
     render(<Analytics />);
     await waitFor(() => expect(getBudgetSuggestionMock).toHaveBeenCalled());
     expect(screen.getByText(/live spending analytics/i)).toBeInTheDocument();
+    expect(await screen.findByText(/weekly smart digest/i)).toBeInTheDocument();
     expect(screen.getByText(/suggested budget/i)).toBeInTheDocument();
     expect(screen.getByText(/tip a/i)).toBeInTheDocument();
+    expect(screen.getByText(/keep the current weekly pattern/i)).toBeInTheDocument();
   });
 
   it('refreshes insights with month/persona/key controls', async () => {
@@ -68,6 +120,9 @@ describe('Analytics integration', () => {
 
     await userEvent.clear(screen.getByLabelText(/analytics month/i));
     await userEvent.type(screen.getByLabelText(/analytics month/i), '2026-01');
+    await userEvent.clear(screen.getByLabelText(/analytics week start/i));
+    await userEvent.type(screen.getByLabelText(/analytics week start/i), '2026-05-18');
+    await userEvent.type(screen.getByLabelText(/analytics currency/i), 'usd');
     await userEvent.selectOptions(screen.getByLabelText(/analytics persona/i), 'Debt-focused planner');
     await userEvent.type(screen.getByLabelText(/gemini api key/i), 'abc123');
     await userEvent.click(screen.getByRole('button', { name: /refresh insights/i }));
@@ -78,6 +133,14 @@ describe('Analytics integration', () => {
           month: '2026-01',
           persona: 'Debt-focused planner',
           geminiApiKey: 'abc123',
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(getWeeklySummaryMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          weekStart: '2026-05-18',
+          currency: 'USD',
         }),
       ),
     );

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,60 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklySummary = {
+  period: {
+    week_start: string;
+    week_end: string;
+    previous_week_start: string;
+    previous_week_end: string;
+  };
+  currency: string;
+  summary: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+    average_daily_expense: number;
+    savings_rate_pct: number;
+  };
+  comparison: {
+    previous_expenses: number;
+    expense_change: number;
+    expense_change_pct: number;
+    trend: 'up' | 'down' | 'flat' | string;
+  };
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    share_pct: number;
+    previous_amount: number;
+    change_pct: number;
+    transaction_count: number;
+  }>;
+  daily_breakdown: Array<{
+    date: string;
+    day: string;
+    expenses: number;
+  }>;
+  largest_expenses: Array<{
+    id: number;
+    description: string;
+    amount: number;
+    date: string;
+  }>;
+  upcoming_bills: Array<{
+    id: number;
+    name: string;
+    amount: number;
+    due_date: string;
+    autopay_enabled: boolean;
+  }>;
+  highlights: string[];
+  insights: string[];
+  recommendations: string[];
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +85,15 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklySummary(params?: {
+  weekStart?: string;
+  currency?: string;
+}): Promise<WeeklySummary> {
+  const query = new URLSearchParams();
+  if (params?.weekStart) query.set('week_start', params.weekStart);
+  if (params?.currency) query.set('currency', params.currency);
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+  return api<WeeklySummary>(`/insights/weekly-summary${suffix}`);
 }

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -10,7 +10,12 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
-import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
+import {
+  getBudgetSuggestion,
+  getWeeklySummary,
+  type BudgetSuggestion,
+  type WeeklySummary,
+} from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
 
 const PERSONAS = [
@@ -19,25 +24,47 @@ const PERSONAS = [
   'Debt-focused planner',
 ];
 
+function dateInputValue(date: Date): string {
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+  return local.toISOString().slice(0, 10);
+}
+
+function currentWeekStart(): string {
+  const today = new Date();
+  const mondayOffset = (today.getDay() + 6) % 7;
+  today.setDate(today.getDate() - mondayOffset);
+  return dateInputValue(today);
+}
+
 export function Analytics() {
   const { toast } = useToast();
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [weekStart, setWeekStart] = useState(currentWeekStart);
+  const [currency, setCurrency] = useState('');
   const [persona, setPersona] = useState(PERSONAS[0]);
   const [geminiKey, setGeminiKey] = useState('');
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BudgetSuggestion | null>(null);
+  const [weeklyData, setWeeklyData] = useState<WeeklySummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
     setLoading(true);
     setError(null);
     try {
-      const payload = await getBudgetSuggestion({
-        month,
-        persona,
-        geminiApiKey: geminiKey.trim() || undefined,
-      });
-      setData(payload);
+      const [monthlyPayload, weeklyPayload] = await Promise.all([
+        getBudgetSuggestion({
+          month,
+          persona,
+          geminiApiKey: geminiKey.trim() || undefined,
+        }),
+        getWeeklySummary({
+          weekStart,
+          currency: currency.trim() || undefined,
+        }),
+      ]);
+      setData(monthlyPayload);
+      setWeeklyData(weeklyPayload);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
@@ -71,7 +98,7 @@ export function Analytics() {
               Live spending analytics with Gemini-powered budget coaching.
             </p>
           </div>
-          <div className="grid gap-2 md:grid-cols-4">
+          <div className="grid gap-2 md:grid-cols-6">
             <div>
               <Label htmlFor="analytics-month">Month</Label>
               <Input
@@ -80,6 +107,27 @@ export function Analytics() {
                 type="month"
                 value={month}
                 onChange={(e) => setMonth(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-week">Week Start</Label>
+              <Input
+                id="analytics-week"
+                aria-label="analytics week start"
+                type="date"
+                value={weekStart}
+                onChange={(e) => setWeekStart(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-currency">Currency</Label>
+              <Input
+                id="analytics-currency"
+                aria-label="analytics currency"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+                placeholder="Default"
+                maxLength={10}
               />
             </div>
             <div>
@@ -122,6 +170,103 @@ export function Analytics() {
         <div className="card text-red-600">{error}</div>
       ) : data ? (
         <div className="space-y-6">
+          <FinancialCard variant="financial">
+            <FinancialCardHeader>
+              <FinancialCardTitle>Weekly Smart Digest</FinancialCardTitle>
+              <FinancialCardDescription>
+                {weeklyData
+                  ? `${weeklyData.period.week_start} to ${weeklyData.period.week_end}`
+                  : 'Current week'}
+              </FinancialCardDescription>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              <div className="grid gap-3 md:grid-cols-4">
+                <div className="rounded-lg border p-3">
+                  <div className="text-sm text-muted-foreground">Weekly Expenses</div>
+                  <div className="font-semibold">
+                    {formatMoney(weeklyData?.summary.expenses || 0, weeklyData?.currency)}
+                  </div>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <div className="text-sm text-muted-foreground">Net Flow</div>
+                  <div className="font-semibold">
+                    {formatMoney(weeklyData?.summary.net_flow || 0, weeklyData?.currency)}
+                  </div>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <div className="text-sm text-muted-foreground">Week Over Week</div>
+                  <div className="font-semibold">
+                    {weeklyData?.comparison.expense_change_pct.toFixed(2) || '0.00'}%
+                  </div>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <div className="text-sm text-muted-foreground">Bills Due</div>
+                  <div className="font-semibold">{weeklyData?.upcoming_bills.length || 0}</div>
+                </div>
+              </div>
+
+              {weeklyData ? (
+                <div className="mt-4 grid gap-4 lg:grid-cols-3">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm font-semibold">Daily Spend</div>
+                    <div className="mt-3 space-y-2">
+                      {weeklyData.daily_breakdown.map((day) => {
+                        const max = Math.max(
+                          ...weeklyData.daily_breakdown.map((item) => item.expenses),
+                          1,
+                        );
+                        return (
+                          <div key={day.date} className="space-y-1">
+                            <div className="flex justify-between text-xs">
+                              <span>{day.day}</span>
+                              <span>{formatMoney(day.expenses, weeklyData.currency)}</span>
+                            </div>
+                            <div className="h-2 rounded-full bg-muted">
+                              <div
+                                className="h-2 rounded-full bg-primary"
+                                style={{ width: `${Math.round((day.expenses / max) * 100)}%` }}
+                              />
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm font-semibold">Top Categories</div>
+                    <div className="mt-3 space-y-2">
+                      {weeklyData.category_breakdown.length ? (
+                        weeklyData.category_breakdown.slice(0, 4).map((category) => (
+                          <div key={`${category.category_id}-${category.category_name}`}>
+                            <div className="flex justify-between text-xs">
+                              <span>{category.category_name}</span>
+                              <span>{category.share_pct.toFixed(1)}%</span>
+                            </div>
+                            <div className="text-sm font-medium">
+                              {formatMoney(category.amount, weeklyData.currency)}
+                            </div>
+                          </div>
+                        ))
+                      ) : (
+                        <div className="text-sm text-muted-foreground">No category spend yet.</div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm font-semibold">Recommended Actions</div>
+                    <ul className="mt-3 list-disc pl-5 text-sm space-y-1">
+                      {weeklyData.recommendations.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              ) : null}
+            </FinancialCardContent>
+          </FinancialCard>
+
           <div className="grid gap-4 md:grid-cols-4">
             <FinancialCard variant="financial">
               <FinancialCardHeader className="pb-2">

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,6 +1,8 @@
-from datetime import date
+from datetime import date, timedelta
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
+from ..extensions import db
+from ..models import Bill, Category, Expense, User
 from ..services.ai import monthly_budget_suggestion
 import logging
 
@@ -23,3 +25,323 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    raw_week_start = request.args.get("week_start")
+    try:
+        week_start = _parse_week_start(raw_week_start)
+    except ValueError:
+        return jsonify(error="invalid week_start"), 400
+
+    currency = (
+        (
+            request.args.get("currency")
+            or (user.preferred_currency if user else None)
+            or "INR"
+        )
+        .strip()[:10]
+        .upper()
+    )
+    payload = _build_weekly_summary(uid, week_start, currency)
+    logger.info(
+        "Weekly summary served user=%s week_start=%s currency=%s",
+        uid,
+        week_start.isoformat(),
+        currency,
+    )
+    return jsonify(payload)
+
+
+def _parse_week_start(raw: str | None) -> date:
+    if raw and raw.strip():
+        selected = date.fromisoformat(raw.strip())
+    else:
+        selected = date.today()
+    return selected - timedelta(days=selected.weekday())
+
+
+def _build_weekly_summary(uid: int, week_start: date, currency: str) -> dict:
+    week_end = week_start + timedelta(days=6)
+    previous_start = week_start - timedelta(days=7)
+    previous_end = week_start - timedelta(days=1)
+    current_expenses = _expenses_for_period(uid, week_start, week_end, currency)
+    previous_expenses = _expenses_for_period(
+        uid, previous_start, previous_end, currency
+    )
+    current_breakdown = _aggregate_expenses(current_expenses)
+    previous_breakdown = _aggregate_expenses(previous_expenses)
+    category_names = _category_names(
+        uid,
+        [
+            category_id
+            for category_id in current_breakdown["categories"].keys()
+            if category_id is not None
+        ],
+    )
+
+    category_breakdown = _category_breakdown(
+        current_breakdown["categories"],
+        previous_breakdown["categories"],
+        current_breakdown["expenses_total"],
+        category_names,
+    )
+    daily_breakdown = _daily_breakdown(week_start, current_expenses)
+    upcoming_bills = _upcoming_bills(uid, week_start, week_end, currency)
+    comparison = _comparison(
+        current_breakdown["expenses_total"], previous_breakdown["expenses_total"]
+    )
+    summary = {
+        "income": _money(current_breakdown["income_total"]),
+        "expenses": _money(current_breakdown["expenses_total"]),
+        "net_flow": _money(
+            current_breakdown["income_total"] - current_breakdown["expenses_total"]
+        ),
+        "transaction_count": len(current_expenses),
+        "average_daily_expense": _money(current_breakdown["expenses_total"] / 7),
+        "savings_rate_pct": _percent(
+            current_breakdown["income_total"] - current_breakdown["expenses_total"],
+            current_breakdown["income_total"],
+        ),
+    }
+    return {
+        "period": {
+            "week_start": week_start.isoformat(),
+            "week_end": week_end.isoformat(),
+            "previous_week_start": previous_start.isoformat(),
+            "previous_week_end": previous_end.isoformat(),
+        },
+        "currency": currency,
+        "summary": summary,
+        "comparison": comparison,
+        "category_breakdown": category_breakdown,
+        "daily_breakdown": daily_breakdown,
+        "largest_expenses": _largest_expenses(current_expenses),
+        "upcoming_bills": upcoming_bills,
+        "highlights": _highlights(summary, category_breakdown, comparison),
+        "insights": _insights(summary, category_breakdown, daily_breakdown),
+        "recommendations": _recommendations(
+            summary, category_breakdown, comparison, upcoming_bills
+        ),
+    }
+
+
+def _expenses_for_period(
+    uid: int, start: date, end: date, currency: str
+) -> list[Expense]:
+    return (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == uid,
+            Expense.currency == currency,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .order_by(Expense.spent_at.asc(), Expense.id.asc())
+        .all()
+    )
+
+
+def _aggregate_expenses(items: list[Expense]) -> dict:
+    income_total = 0.0
+    expenses_total = 0.0
+    categories: dict[int | None, dict] = {}
+    for item in items:
+        amount = float(item.amount or 0)
+        if str(item.expense_type or "").upper() == "INCOME":
+            income_total += amount
+            continue
+        expenses_total += amount
+        bucket = categories.setdefault(
+            item.category_id,
+            {"amount": 0.0, "transaction_count": 0},
+        )
+        bucket["amount"] += amount
+        bucket["transaction_count"] += 1
+    return {
+        "income_total": income_total,
+        "expenses_total": expenses_total,
+        "categories": categories,
+    }
+
+
+def _category_names(uid: int, category_ids: list[int]) -> dict[int, str]:
+    if not category_ids:
+        return {}
+    rows = (
+        db.session.query(Category)
+        .filter(Category.user_id == uid, Category.id.in_(category_ids))
+        .all()
+    )
+    return {row.id: row.name for row in rows}
+
+
+def _category_breakdown(
+    current: dict, previous: dict, current_total: float, names: dict[int, str]
+) -> list[dict]:
+    rows = []
+    for category_id, data in current.items():
+        amount = data["amount"]
+        previous_amount = previous.get(category_id, {}).get("amount", 0.0)
+        rows.append(
+            {
+                "category_id": category_id,
+                "category_name": names.get(category_id, "Uncategorized"),
+                "amount": _money(amount),
+                "share_pct": _percent(amount, current_total),
+                "previous_amount": _money(previous_amount),
+                "change_pct": _percent(amount - previous_amount, previous_amount),
+                "transaction_count": data["transaction_count"],
+            }
+        )
+    return sorted(rows, key=lambda row: row["amount"], reverse=True)
+
+
+def _daily_breakdown(week_start: date, items: list[Expense]) -> list[dict]:
+    days = {week_start + timedelta(days=offset): 0.0 for offset in range(7)}
+    for item in items:
+        if str(item.expense_type or "").upper() == "INCOME":
+            continue
+        if item.spent_at in days:
+            days[item.spent_at] += float(item.amount or 0)
+    return [
+        {
+            "date": day.isoformat(),
+            "day": day.strftime("%a"),
+            "expenses": _money(amount),
+        }
+        for day, amount in days.items()
+    ]
+
+
+def _upcoming_bills(uid: int, start: date, end: date, currency: str) -> list[dict]:
+    bills = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == uid,
+            Bill.active.is_(True),
+            Bill.currency == currency,
+            Bill.next_due_date >= start,
+            Bill.next_due_date <= end,
+        )
+        .order_by(Bill.next_due_date.asc(), Bill.id.asc())
+        .all()
+    )
+    return [
+        {
+            "id": bill.id,
+            "name": bill.name,
+            "amount": _money(float(bill.amount or 0)),
+            "due_date": bill.next_due_date.isoformat(),
+            "autopay_enabled": bill.autopay_enabled,
+        }
+        for bill in bills
+    ]
+
+
+def _comparison(current: float, previous: float) -> dict:
+    change = current - previous
+    if change > 0:
+        trend = "up"
+    elif change < 0:
+        trend = "down"
+    else:
+        trend = "flat"
+    return {
+        "previous_expenses": _money(previous),
+        "expense_change": _money(change),
+        "expense_change_pct": _percent(change, previous),
+        "trend": trend,
+    }
+
+
+def _largest_expenses(items: list[Expense]) -> list[dict]:
+    expenses = [
+        item for item in items if str(item.expense_type or "").upper() != "INCOME"
+    ]
+    expenses.sort(key=lambda item: float(item.amount or 0), reverse=True)
+    return [
+        {
+            "id": item.id,
+            "description": item.notes or "Expense",
+            "amount": _money(float(item.amount or 0)),
+            "date": item.spent_at.isoformat(),
+        }
+        for item in expenses[:5]
+    ]
+
+
+def _highlights(summary: dict, categories: list[dict], comparison: dict) -> list[str]:
+    if summary["transaction_count"] == 0:
+        return ["No transactions were recorded for this week."]
+    top = categories[0]["category_name"] if categories else "uncategorized spending"
+    direction = "lower" if comparison["trend"] == "down" else "higher"
+    return [
+        f"You logged {summary['transaction_count']} transactions this week.",
+        f"Top spending area: {top}.",
+        (
+            f"Expenses were {direction} than last week by "
+            f"{abs(comparison['expense_change_pct'])}%."
+        ),
+    ]
+
+
+def _insights(
+    summary: dict, categories: list[dict], daily_breakdown: list[dict]
+) -> list[str]:
+    insights = []
+    if summary["net_flow"] >= 0:
+        insights.append(f"Net flow stayed positive at {summary['net_flow']}.")
+    else:
+        insights.append(f"Net flow was negative at {summary['net_flow']}.")
+    if categories and categories[0]["share_pct"] >= 50:
+        insights.append(
+            f"{categories[0]['category_name']} made up "
+            f"{categories[0]['share_pct']}% of spending."
+        )
+    peak_day = max(daily_breakdown, key=lambda row: row["expenses"])
+    if peak_day["expenses"] > 0:
+        insights.append(f"Highest spending day was {peak_day['day']}.")
+    if not insights:
+        insights.append("No spending signals yet; add transactions to build a digest.")
+    return insights
+
+
+def _recommendations(
+    summary: dict, categories: list[dict], comparison: dict, bills: list[dict]
+) -> list[str]:
+    recommendations = []
+    if comparison["trend"] == "up" and comparison["expense_change_pct"] >= 15:
+        recommendations.append(
+            "Review this week's largest expenses before next week starts."
+        )
+    if categories and categories[0]["share_pct"] >= 50:
+        recommendations.append(
+            f"Set a soft cap for {categories[0]['category_name']} next week."
+        )
+    unpaid_manual_bills = [bill for bill in bills if not bill["autopay_enabled"]]
+    if unpaid_manual_bills:
+        recommendations.append("Schedule manual bill payments before their due dates.")
+    if summary["net_flow"] < 0:
+        recommendations.append(
+            "Move one flexible purchase out of this week to recover cash flow."
+        )
+    if not recommendations:
+        recommendations.append(
+            "Keep the current weekly pattern and recheck after new expenses post."
+        )
+    return recommendations
+
+
+def _money(value: float) -> float:
+    return round(float(value or 0), 2)
+
+
+def _percent(numerator: float, denominator: float) -> float:
+    if not denominator:
+        return 0.0
+    return round((float(numerator) / float(denominator)) * 100, 2)

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,53 @@
 import os
+import fnmatch
 import pytest
 from app import create_app
 from app.config import Settings
+from app import extensions
 from app.extensions import db
-from app.extensions import redis_client
+from app.routes import auth as auth_routes
+from app.services import cache as cache_service
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class _MemoryRedis:
+    def __init__(self):
+        self._values = {}
+
+    def flushdb(self):
+        self._values.clear()
+        return True
+
+    def set(self, key, value):
+        self._values[key] = value
+        return True
+
+    def setex(self, key, _ttl, value):
+        self._values[key] = value
+        return True
+
+    def get(self, key):
+        return self._values.get(key)
+
+    def delete(self, *keys):
+        deleted = 0
+        for key in keys:
+            if key in self._values:
+                del self._values[key]
+                deleted += 1
+        return deleted
+
+    def scan(self, cursor=0, match=None, count=100):
+        del cursor, count
+        pattern = match or "*"
+        keys = [key for key in self._values if fnmatch.fnmatch(key, pattern)]
+        return 0, keys
+
+
+redis_client = _MemoryRedis()
+extensions.redis_client = redis_client
+auth_routes.redis_client = redis_client
+cache_service.redis_client = redis_client
 
 
 class TestSettings(Settings):

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -1,6 +1,105 @@
 from datetime import date, timedelta
 
 
+def test_weekly_summary_returns_trends_categories_and_bills(client, auth_header):
+    monday = date(2026, 5, 18)
+
+    r = client.post("/categories", json={"name": "Groceries"}, headers=auth_header)
+    assert r.status_code == 201
+    groceries_id = r.get_json()["id"]
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 240,
+            "description": "Weekly paycheck",
+            "date": monday.isoformat(),
+            "expense_type": "INCOME",
+            "currency": "USD",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 60,
+            "description": "Market run",
+            "date": (monday + timedelta(days=1)).isoformat(),
+            "expense_type": "EXPENSE",
+            "currency": "USD",
+            "category_id": groceries_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 40,
+            "description": "Previous market run",
+            "date": (monday - timedelta(days=6)).isoformat(),
+            "expense_type": "EXPENSE",
+            "currency": "USD",
+            "category_id": groceries_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 70,
+            "currency": "USD",
+            "next_due_date": (monday + timedelta(days=3)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get(
+        f"/insights/weekly-summary?week_start={monday.isoformat()}&currency=USD",
+        headers=auth_header,
+    )
+
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period"]["week_start"] == "2026-05-18"
+    assert payload["period"]["week_end"] == "2026-05-24"
+    assert payload["currency"] == "USD"
+    assert payload["summary"]["income"] == 240.0
+    assert payload["summary"]["expenses"] == 60.0
+    assert payload["summary"]["net_flow"] == 180.0
+    assert payload["comparison"]["previous_expenses"] == 40.0
+    assert payload["comparison"]["trend"] == "up"
+    assert payload["category_breakdown"][0]["category_name"] == "Groceries"
+    assert payload["category_breakdown"][0]["share_pct"] == 100.0
+    assert len(payload["daily_breakdown"]) == 7
+    assert payload["upcoming_bills"][0]["name"] == "Internet"
+    assert payload["largest_expenses"][0]["description"] == "Market run"
+    assert payload["highlights"]
+    assert payload["insights"]
+    assert payload["recommendations"]
+
+
+def test_weekly_summary_normalizes_dates_and_rejects_bad_dates(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-21",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["period"]["week_start"] == "2026-05-18"
+
+    r = client.get(
+        "/insights/weekly-summary?week_start=not-a-date",
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "invalid week_start"
+
+
 def test_budget_suggestion_returns_analytics_fields(client, auth_header):
     current = date.today().replace(day=10)
     previous = (current.replace(day=1) - timedelta(days=1)).replace(day=10)


### PR DESCRIPTION
## Summary
- Add a JWT-protected `GET /insights/weekly-summary` endpoint that normalizes the requested week to Monday and returns weekly cash flow, week-over-week spend comparison, category and daily breakdowns, largest expenses, upcoming bills, highlights, insights, and recommendations.
- Wire the existing Analytics page to load the weekly digest alongside the monthly budget suggestion, with week start and currency controls.
- Add typed frontend API support plus backend and frontend coverage for the new digest flow.

## Validation
- `..\..\.venv\Scripts\python -m pytest tests\test_insights.py -q`
- `.\.venv\Scripts\python -m black --check packages\backend\app\routes\insights.py packages\backend\tests\test_insights.py packages\backend\tests\conftest.py`
- `.\.venv\Scripts\python -m flake8 packages\backend\app\routes\insights.py packages\backend\tests\test_insights.py packages\backend\tests\conftest.py`
- `npm --prefix app test -- Analytics.integration.test.tsx`
- `npm --prefix app run build`
- `git diff --check`

/claim #121