### PR TITLE
Add multi-account financial dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ flowchart LR
 
 ## PostgreSQL Schema (DDL)
 See `backend/app/db/schema.sql`. Key tables:
-- users, categories, expenses, bills, reminders
+- users, categories, financial_accounts, expenses, bills, reminders
+- financial_accounts store manual cash, bank, card, wallet, savings, loan, and investment accounts
 - ad_impressions, subscription_plans, user_subscriptions
 - refresh_tokens (optional if rotating), audit_logs
 
@@ -54,6 +55,7 @@ See `backend/app/db/schema.sql`. Key tables:
   - `user:{id}:monthly_summary:{yyyy-mm}` — 30 min TTL
   - `user:{id}:categories` — 24h TTL
   - `user:{id}:upcoming_bills` — 15 min TTL
+  - `user:{id}:dashboard_summary:{yyyy-mm}:{account-filter}` — 5 min TTL
   - `insights:{id}` — 24h TTL (invalidate on new expense/bill)
 - Invalidation
   - On expense/bill create/update/delete -> delete affected monthly_summary, upcoming_bills, insights
@@ -62,7 +64,9 @@ See `backend/app/db/schema.sql`. Key tables:
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
 - Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
-- Expenses: CRUD `/expenses`
+- Expenses: CRUD `/expenses`, optional `account_id` assignment/filtering
+- Accounts: CRUD/archive `/accounts` for manual financial accounts
+- Dashboard: `/dashboard/summary`, optional `account_ids=1,2` multi-account filter
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
@@ -70,10 +74,11 @@ OpenAPI: `backend/app/openapi.yaml`
 ## MVP UI/UX Plan
 - Auth screens: register/login.
 - Dashboard:
+  - Multi-account balance overview and account filters.
   - Monthly spend chart, category breakdown donut.
   - Upcoming bills list with due dates and pay status.
   - AI budget suggestion card.
-- Expenses page: add expense (amount, category, notes, date), list & filter.
+- Expenses page: add expense (amount, category, account, notes, date), list & filter.
 - Bills page: create bill (name, amount, cadence, due date, channel), toggle WhatsApp/email.
 - Settings: profile, categories, reminders default channel, export (premium).
 
@@ -165,7 +170,7 @@ finmind/
   - single file: `sh ./scripts/test-backend.sh tests/test_dashboard.py`
 
 ## Testing & CI
-- Backend: pytest, flake8, black. Frontend: vitest, eslint.
+- Backend: pytest, flake8, black. Frontend: Jest, eslint.
 - GitHub Actions `ci.yml` runs lint, tests, and builds both apps; optional docker build.
 
 ## Monitoring (Grafana OSS)

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,6 +10,7 @@ import { Bills } from "./pages/Bills";
 import { Analytics } from "./pages/Analytics";
 import Reminders from "./pages/Reminders";
 import Expenses from "./pages/Expenses";
+import Accounts from "./pages/Accounts";
 import { SignIn } from "./pages/SignIn";
 import { Register } from "./pages/Register";
 import NotFound from "./pages/NotFound";
@@ -64,6 +65,14 @@ const App = () => (
               element={
                 <ProtectedRoute>
                   <Expenses />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="accounts"
+              element={
+                <ProtectedRoute>
+                  <Accounts />
                 </ProtectedRoute>
               }
             />

--- a/app/src/__tests__/Dashboard.integration.test.tsx
+++ b/app/src/__tests__/Dashboard.integration.test.tsx
@@ -29,7 +29,40 @@ describe('Dashboard integration', () => {
         monthly_expenses: 500,
         upcoming_bills_total: 49.99,
         upcoming_bills_count: 1,
+        total_balance: 3500,
+        account_count: 1,
+        selected_account_count: 1,
       },
+      accounts: [
+        {
+          id: 1,
+          name: 'Checking',
+          account_type: 'CHECKING',
+          institution: null,
+          last_four: null,
+          currency: 'USD',
+          opening_balance: 1000,
+          balance: 3500,
+          monthly_income: 3000,
+          monthly_expenses: 500,
+          monthly_net_flow: 2500,
+        },
+      ],
+      account_breakdown: [
+        {
+          id: 1,
+          name: 'Checking',
+          account_type: 'CHECKING',
+          institution: null,
+          last_four: null,
+          currency: 'USD',
+          opening_balance: 1000,
+          balance: 3500,
+          monthly_income: 3000,
+          monthly_expenses: 500,
+          monthly_net_flow: 2500,
+        },
+      ],
       recent_transactions: [
         {
           id: 1,
@@ -75,6 +108,7 @@ describe('Dashboard integration', () => {
 
     expect(screen.getByText(/financial dashboard/i)).toBeInTheDocument();
     expect(screen.getByText(/salary/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/checking/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/internet/i)).toBeInTheDocument();
     expect(screen.getByText(/category breakdown/i)).toBeInTheDocument();
   });
@@ -89,7 +123,12 @@ describe('Dashboard integration', () => {
         monthly_expenses: 0,
         upcoming_bills_total: 0,
         upcoming_bills_count: 0,
+        total_balance: 0,
+        account_count: 0,
+        selected_account_count: 0,
       },
+      accounts: [],
+      account_breakdown: [],
       recent_transactions: [],
       upcoming_bills: [],
       category_breakdown: [],
@@ -120,7 +159,12 @@ describe('Dashboard integration', () => {
         monthly_expenses: 0,
         upcoming_bills_total: 0,
         upcoming_bills_count: 0,
+        total_balance: 0,
+        account_count: 0,
+        selected_account_count: 0,
       },
+      accounts: [],
+      account_breakdown: [],
       recent_transactions: [],
       upcoming_bills: [],
       category_breakdown: [],
@@ -137,6 +181,6 @@ describe('Dashboard integration', () => {
 
     await waitFor(() => expect(getDashboardSummaryMock).toHaveBeenCalledTimes(1));
     fireEvent.change(screen.getByLabelText(/dashboard month/i), { target: { value: '2026-01' } });
-    await waitFor(() => expect(getDashboardSummaryMock).toHaveBeenLastCalledWith('2026-01'));
+    await waitFor(() => expect(getDashboardSummaryMock).toHaveBeenLastCalledWith('2026-01', []));
   });
 });

--- a/app/src/__tests__/Expenses.integration.test.tsx
+++ b/app/src/__tests__/Expenses.integration.test.tsx
@@ -76,11 +76,33 @@ jest.mock('@/api/categories', () => ({
   listCategories: (...args: unknown[]) => listCategoriesMock(...args),
 }));
 
+const listAccountsMock = jest.fn();
+jest.mock('@/api/accounts', () => ({
+  listAccounts: (...args: unknown[]) => listAccountsMock(...args),
+}));
+
 describe('Expenses page integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     listExpensesMock.mockResolvedValue([]);
     listCategoriesMock.mockResolvedValue([{ id: 1, name: 'Food' }]);
+    listAccountsMock.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Checking',
+        account_type: 'CHECKING',
+        institution: null,
+        last_four: null,
+        currency: 'USD',
+        opening_balance: 0,
+        balance: 0,
+        income_total: 0,
+        expense_total: 0,
+        active: true,
+        created_at: '2026-02-01T00:00:00',
+        updated_at: '2026-02-01T00:00:00',
+      },
+    ]);
     createExpenseMock.mockResolvedValue({
       id: 10,
       amount: 20,
@@ -145,6 +167,7 @@ describe('Expenses page integration', () => {
       expect.arrayContaining([
         expect.objectContaining({ description: 'Taxi', amount: 14.2 }),
       ]),
+      null,
     ));
   });
 

--- a/app/src/__tests__/Navbar.test.tsx
+++ b/app/src/__tests__/Navbar.test.tsx
@@ -27,7 +27,7 @@ describe('Navbar auth state', () => {
   it('shows Account/Logout when signed in (token present)', () => {
     localStorage.setItem('fm_token', 'token');
     renderNav();
-    expect(screen.getByRole('link', { name: /account/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^account$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /logout/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /finmind/i })).toHaveAttribute('href', '/dashboard');
   });

--- a/app/src/api/accounts.ts
+++ b/app/src/api/accounts.ts
@@ -1,0 +1,60 @@
+import { api } from './client';
+
+export type AccountType =
+  | 'CASH'
+  | 'CHECKING'
+  | 'SAVINGS'
+  | 'CREDIT_CARD'
+  | 'INVESTMENT'
+  | 'LOAN'
+  | 'WALLET'
+  | 'OTHER';
+
+export type FinancialAccount = {
+  id: number;
+  name: string;
+  account_type: AccountType;
+  institution: string | null;
+  last_four: string | null;
+  currency: string;
+  opening_balance: number;
+  active: boolean;
+  balance: number;
+  income_total: number;
+  expense_total: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type FinancialAccountCreate = {
+  name: string;
+  account_type?: AccountType;
+  institution?: string | null;
+  last_four?: string | null;
+  currency?: string;
+  opening_balance?: number;
+};
+
+export type FinancialAccountUpdate = Partial<FinancialAccountCreate> & {
+  active?: boolean;
+};
+
+export async function listAccounts(includeArchived = false): Promise<FinancialAccount[]> {
+  const query = includeArchived ? '?include_archived=true' : '';
+  return api<FinancialAccount[]>(`/accounts${query}`);
+}
+
+export async function createAccount(payload: FinancialAccountCreate): Promise<FinancialAccount> {
+  return api<FinancialAccount>('/accounts', { method: 'POST', body: payload });
+}
+
+export async function updateAccount(
+  id: number,
+  payload: FinancialAccountUpdate,
+): Promise<FinancialAccount> {
+  return api<FinancialAccount>(`/accounts/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function archiveAccount(id: number): Promise<{ message: string }> {
+  return api<{ message: string }>(`/accounts/${id}`, { method: 'DELETE' });
+}

--- a/app/src/api/dashboard.ts
+++ b/app/src/api/dashboard.ts
@@ -1,4 +1,5 @@
 import { api } from './client';
+import type { AccountType } from './accounts';
 
 export type DashboardSummary = {
   period: { month: string };
@@ -8,7 +9,37 @@ export type DashboardSummary = {
     monthly_expenses: number;
     upcoming_bills_total: number;
     upcoming_bills_count: number;
+    total_balance?: number;
+    account_count?: number;
+    selected_account_count?: number;
   };
+  selected_account_ids?: number[];
+  accounts?: Array<{
+    id: number;
+    name: string;
+    account_type: AccountType;
+    institution: string | null;
+    last_four: string | null;
+    currency: string;
+    opening_balance: number;
+    balance: number;
+    monthly_income: number;
+    monthly_expenses: number;
+    monthly_net_flow: number;
+  }>;
+  account_breakdown?: Array<{
+    id: number;
+    name: string;
+    account_type: AccountType;
+    institution: string | null;
+    last_four: string | null;
+    currency: string;
+    opening_balance: number;
+    balance: number;
+    monthly_income: number;
+    monthly_expenses: number;
+    monthly_net_flow: number;
+  }>;
   recent_transactions: Array<{
     id: number;
     description: string;
@@ -16,6 +47,8 @@ export type DashboardSummary = {
     date: string;
     type: 'INCOME' | 'EXPENSE' | string;
     category_id: number | null;
+    account_id?: number | null;
+    account_name?: string | null;
     currency: string;
   }>;
   upcoming_bills: Array<{
@@ -37,7 +70,13 @@ export type DashboardSummary = {
   errors?: string[];
 };
 
-export async function getDashboardSummary(month?: string): Promise<DashboardSummary> {
-  const query = month ? `?month=${encodeURIComponent(month)}` : '';
+export async function getDashboardSummary(
+  month?: string,
+  accountIds?: number[],
+): Promise<DashboardSummary> {
+  const qs = new URLSearchParams();
+  if (month) qs.set('month', month);
+  if (accountIds && accountIds.length > 0) qs.set('account_ids', accountIds.join(','));
+  const query = qs.toString() ? `?${qs.toString()}` : '';
   return api<DashboardSummary>(`/dashboard/summary${query}`);
 }

--- a/app/src/api/expenses.ts
+++ b/app/src/api/expenses.ts
@@ -6,6 +6,8 @@ export type Expense = {
   currency?: string;
   description: string;
   category_id: number | null;
+  account_id?: number | null;
+  account_name?: string | null;
   date: string; // ISO date
 };
 
@@ -13,6 +15,7 @@ export type ExpenseCreate = {
   amount: number;
   description: string;
   category_id?: number | null;
+  account_id?: number | null;
   date: string; // ISO date
 };
 
@@ -23,6 +26,7 @@ export type ImportTransaction = {
   amount: number;
   description: string;
   category_id?: number | null;
+  account_id?: number | null;
   currency?: string;
 };
 
@@ -49,6 +53,7 @@ export type RecurringExpenseCreate = {
   amount: number;
   description: string;
   category_id?: number | null;
+  account_id?: number | null;
   cadence: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
   start_date: string;
   end_date?: string | null;
@@ -60,6 +65,7 @@ export async function listExpenses(params?: {
   from?: string;
   to?: string;
   category_id?: number;
+  account_id?: number;
   search?: string;
   page?: number;
   page_size?: number;
@@ -111,10 +117,11 @@ export async function previewExpenseImport(file: File): Promise<ImportPreviewRes
 
 export async function commitExpenseImport(
   transactions: ImportTransaction[],
+  accountId?: number | null,
 ): Promise<{ inserted: number; duplicates: number }> {
   return api<{ inserted: number; duplicates: number }>('/expenses/import/commit', {
     method: 'POST',
-    body: { transactions },
+    body: { transactions, account_id: accountId ?? null },
   });
 }
 

--- a/app/src/components/layout/Navbar.tsx
+++ b/app/src/components/layout/Navbar.tsx
@@ -12,6 +12,7 @@ const navigation = [
   { name: 'Bills', href: '/bills' },
   { name: 'Reminders', href: '/reminders' },
   { name: 'Expenses', href: '/expenses' },
+  { name: 'Accounts', href: '/accounts' },
   { name: 'Analytics', href: '/analytics' },
 ];
 

--- a/app/src/pages/Accounts.tsx
+++ b/app/src/pages/Accounts.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import {
+  archiveAccount,
+  createAccount,
+  listAccounts,
+  updateAccount,
+  type AccountType,
+  type FinancialAccount,
+} from '@/api/accounts';
+import { formatMoney } from '@/lib/currency';
+
+const accountTypes: AccountType[] = [
+  'CASH',
+  'CHECKING',
+  'SAVINGS',
+  'CREDIT_CARD',
+  'INVESTMENT',
+  'LOAN',
+  'WALLET',
+  'OTHER',
+];
+
+export default function Accounts() {
+  const { toast } = useToast();
+  const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [editing, setEditing] = useState<FinancialAccount | null>(null);
+  const [name, setName] = useState('');
+  const [accountType, setAccountType] = useState<AccountType>('CHECKING');
+  const [institution, setInstitution] = useState('');
+  const [lastFour, setLastFour] = useState('');
+  const [currency, setCurrency] = useState('INR');
+  const [openingBalance, setOpeningBalance] = useState('0');
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setAccounts(await listAccounts());
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to load accounts';
+      setError(message);
+      toast({ title: 'Failed to load accounts', description: message });
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const totals = useMemo(() => {
+    const balance = accounts.reduce((sum, account) => sum + Number(account.balance || 0), 0);
+    return { balance };
+  }, [accounts]);
+
+  function resetForm() {
+    setEditing(null);
+    setName('');
+    setAccountType('CHECKING');
+    setInstitution('');
+    setLastFour('');
+    setCurrency('INR');
+    setOpeningBalance('0');
+    setError(null);
+  }
+
+  function startEdit(account: FinancialAccount) {
+    setEditing(account);
+    setName(account.name);
+    setAccountType(account.account_type);
+    setInstitution(account.institution || '');
+    setLastFour(account.last_four || '');
+    setCurrency(account.currency || 'INR');
+    setOpeningBalance(String(account.opening_balance ?? 0));
+  }
+
+  async function saveAccount() {
+    if (!name.trim()) {
+      setError('Account name is required');
+      return;
+    }
+    if (Number.isNaN(Number(openingBalance))) {
+      setError('Opening balance must be a number');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        name: name.trim(),
+        account_type: accountType,
+        institution: institution.trim() || null,
+        last_four: lastFour.trim() || null,
+        currency: currency.trim() || 'INR',
+        opening_balance: Number(openingBalance || 0),
+      };
+      if (editing) {
+        const updated = await updateAccount(editing.id, payload);
+        setAccounts((prev) => prev.map((account) => (account.id === updated.id ? updated : account)));
+        toast({ title: 'Account updated' });
+      } else {
+        const created = await createAccount(payload);
+        setAccounts((prev) => [...prev, created].sort((a, b) => a.name.localeCompare(b.name)));
+        toast({ title: 'Account created' });
+      }
+      resetForm();
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to save account';
+      setError(message);
+      toast({ title: 'Failed to save account', description: message });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function archive(id: number) {
+    setSaving(true);
+    try {
+      await archiveAccount(id);
+      setAccounts((prev) => prev.filter((account) => account.id !== id));
+      if (editing?.id === id) resetForm();
+      toast({ title: 'Account archived' });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Failed to archive account';
+      setError(message);
+      toast({ title: 'Failed to archive account', description: message });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="page-wrap space-y-5">
+      <div className="page-header">
+        <div className="relative flex items-center justify-between gap-4">
+          <div>
+            <h2 className="page-title text-2xl md:text-3xl">Financial Accounts</h2>
+            <p className="page-subtitle">Track cash, bank, card, wallet, and savings balances in one place.</p>
+          </div>
+          <div className="card px-4 py-3 text-right">
+            <div className="text-xs text-muted-foreground">Total balance</div>
+            <div className="text-xl font-semibold">{formatMoney(totals.balance, accounts[0]?.currency)}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[360px_1fr]">
+        <div className="card card-interactive p-4 space-y-3 fade-in-up">
+          <h3 className="text-base font-semibold">{editing ? 'Edit account' : 'Add account'}</h3>
+          <div>
+            <Label htmlFor="account-name">Name</Label>
+            <Input id="account-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Main checking" />
+          </div>
+          <div>
+            <Label htmlFor="account-type">Type</Label>
+            <select id="account-type" className="input" value={accountType} onChange={(e) => setAccountType(e.target.value as AccountType)}>
+              {accountTypes.map((type) => (
+                <option key={type} value={type}>{type.replace('_', ' ')}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <Label htmlFor="institution">Institution</Label>
+            <Input id="institution" value={institution} onChange={(e) => setInstitution(e.target.value)} placeholder="Bank or provider" />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label htmlFor="last-four">Last 4</Label>
+              <Input id="last-four" value={lastFour} onChange={(e) => setLastFour(e.target.value)} maxLength={4} />
+            </div>
+            <div>
+              <Label htmlFor="currency">Currency</Label>
+              <Input id="currency" value={currency} onChange={(e) => setCurrency(e.target.value.toUpperCase())} maxLength={10} />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="opening-balance">Opening balance</Label>
+            <Input id="opening-balance" type="number" step="0.01" value={openingBalance} onChange={(e) => setOpeningBalance(e.target.value)} />
+          </div>
+          {error && <div className="error">{error}</div>}
+          <div className="flex gap-2">
+            <Button onClick={saveAccount} disabled={saving}>{editing ? 'Save account' : 'Create account'}</Button>
+            {editing && <Button variant="outline" onClick={resetForm} disabled={saving}>Cancel</Button>}
+          </div>
+        </div>
+
+        <div className="card fade-in-up">
+          {loading ? (
+            <div>Loading accounts...</div>
+          ) : accounts.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No accounts yet. Add one to unlock the multi-account dashboard.</div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-muted-foreground">
+                    <th className="py-2">Account</th>
+                    <th className="py-2">Type</th>
+                    <th className="py-2">Opening</th>
+                    <th className="py-2">Balance</th>
+                    <th className="py-2">Activity</th>
+                    <th className="py-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {accounts.map((account) => (
+                    <tr key={account.id} className="border-t transition-colors hover:bg-muted/30">
+                      <td className="py-3">
+                        <div className="font-medium">{account.name}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {[account.institution, account.last_four ? `•••• ${account.last_four}` : null].filter(Boolean).join(' · ') || 'Manual account'}
+                        </div>
+                      </td>
+                      <td className="py-3">{account.account_type.replace('_', ' ')}</td>
+                      <td className="py-3">{formatMoney(account.opening_balance, account.currency)}</td>
+                      <td className="py-3 font-semibold">{formatMoney(account.balance, account.currency)}</td>
+                      <td className="py-3 text-xs text-muted-foreground">
+                        Income {formatMoney(account.income_total, account.currency)} · Expenses {formatMoney(account.expense_total, account.currency)}
+                      </td>
+                      <td className="py-3">
+                        <div className="flex justify-end gap-2">
+                          <Button variant="outline" onClick={() => startEdit(account)} disabled={saving}>Edit</Button>
+                          <Button variant="outline" onClick={() => archive(account.id)} disabled={saving}>Archive</Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -33,13 +33,14 @@ export function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [selectedAccountIds, setSelectedAccountIds] = useState<number[]>([]);
 
   useEffect(() => {
     (async () => {
       setLoading(true);
       setError(null);
       try {
-        const res = await getDashboardSummary(month);
+        const res = await getDashboardSummary(month, selectedAccountIds);
         setData(res);
       } catch (error: unknown) {
         setError(error instanceof Error ? error.message : 'Failed to load dashboard');
@@ -47,7 +48,7 @@ export function Dashboard() {
         setLoading(false);
       }
     })();
-  }, [month]);
+  }, [month, selectedAccountIds]);
 
   const summary = useMemo(() => {
     if (!data) {
@@ -57,12 +58,23 @@ export function Dashboard() {
         monthly_expenses: 0,
         upcoming_bills_total: 0,
         upcoming_bills_count: 0,
+        total_balance: 0,
+        account_count: 0,
+        selected_account_count: 0,
       };
     }
     return data.summary;
   }, [data]);
 
   const summaryCards = [
+    {
+      title: 'Total Balance',
+      amount: currency(summary.total_balance || 0),
+      change: `${summary.selected_account_count || summary.account_count || 0} account(s)`,
+      trend: 'up',
+      icon: Wallet,
+      description: selectedAccountIds.length > 0 ? 'Selected accounts' : 'All accounts',
+    },
     {
       title: 'Net Flow',
       amount: currency(summary.net_flow),
@@ -97,9 +109,19 @@ export function Dashboard() {
     },
   ] as const;
 
+  const accounts = data?.accounts ?? [];
+  const accountBreakdown = data?.account_breakdown ?? [];
   const transactions = data?.recent_transactions ?? [];
   const upcomingBills = data?.upcoming_bills ?? [];
   const categoryBreakdown = data?.category_breakdown ?? [];
+
+  function toggleAccount(accountId: number) {
+    setSelectedAccountIds((current) => (
+      current.includes(accountId)
+        ? current.filter((id) => id !== accountId)
+        : [...current, accountId].sort((a, b) => a - b)
+    ));
+  }
 
   return (
     <div className="page-wrap">
@@ -141,7 +163,51 @@ export function Dashboard() {
         </div>
       )}
 
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 mb-8">
+      <FinancialCard variant="financial" className="mb-6 fade-in-up">
+        <FinancialCardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <FinancialCardTitle className="section-title">Account Overview</FinancialCardTitle>
+              <FinancialCardDescription>Filter the dashboard by one or more financial accounts.</FinancialCardDescription>
+            </div>
+            {selectedAccountIds.length > 0 && (
+              <Button variant="outline" size="sm" onClick={() => setSelectedAccountIds([])}>
+                Show All
+              </Button>
+            )}
+          </div>
+        </FinancialCardHeader>
+        <FinancialCardContent>
+          {accounts.length === 0 ? (
+            <div className="text-sm text-muted-foreground">No accounts yet. Add accounts from the Accounts page to see balances here.</div>
+          ) : (
+            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+              {accounts.map((account) => {
+                const selected = selectedAccountIds.includes(account.id);
+                return (
+                  <button
+                    key={account.id}
+                    type="button"
+                    onClick={() => toggleAccount(account.id)}
+                    className={`rounded-xl border p-3 text-left transition hover:border-primary ${selected ? 'border-primary bg-primary/5' : 'border-border bg-background'}`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium text-foreground">{account.name}</span>
+                      <span className="text-xs text-muted-foreground">{account.account_type.replace('_', ' ')}</span>
+                    </div>
+                    <div className="mt-2 text-lg font-semibold">{currency(account.balance, account.currency)}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      Net this month {currency(account.monthly_net_flow, account.currency)}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </FinancialCardContent>
+      </FinancialCard>
+
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5 mb-8">
         {summaryCards.map((card, index) => (
           <FinancialCard key={index} variant="financial" className="group card-interactive fade-in-up">
             <FinancialCardHeader className="pb-3">
@@ -193,7 +259,10 @@ export function Dashboard() {
                           </div>
                           <div>
                             <div className="font-medium text-foreground">{transaction.description}</div>
-                            <div className="text-sm text-muted-foreground">{new Date(transaction.date).toLocaleDateString()}</div>
+                            <div className="text-sm text-muted-foreground">
+                              {new Date(transaction.date).toLocaleDateString()}
+                              {transaction.account_name ? ` · ${transaction.account_name}` : ''}
+                            </div>
                           </div>
                         </div>
                         <div className={`font-semibold ${isIncome ? 'text-success' : 'text-foreground'}`}>
@@ -248,6 +317,32 @@ export function Dashboard() {
                 Add New Bill
               </Button>
             </FinancialCardFooter>
+          </FinancialCard>
+
+          <FinancialCard variant="financial" className="fade-in-up">
+            <FinancialCardHeader>
+              <FinancialCardTitle className="section-title">Account Breakdown</FinancialCardTitle>
+              <FinancialCardDescription>Balance and monthly movement by account</FinancialCardDescription>
+            </FinancialCardHeader>
+            <FinancialCardContent>
+              {accountBreakdown.length === 0 ? (
+                <div className="text-sm text-muted-foreground">No account data yet.</div>
+              ) : (
+                <div className="space-y-3">
+                  {accountBreakdown.slice(0, 6).map((account) => (
+                    <div key={account.id} className="interactive-row space-y-1">
+                      <div className="flex items-center justify-between text-sm">
+                        <span className="font-medium text-foreground">{account.name}</span>
+                        <span className="text-foreground">{currency(account.balance, account.currency)}</span>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Income {currency(account.monthly_income, account.currency)} · Expenses {currency(account.monthly_expenses, account.currency)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </FinancialCardContent>
           </FinancialCard>
 
           <FinancialCard variant="financial" className="fade-in-up">

--- a/app/src/pages/Expenses.tsx
+++ b/app/src/pages/Expenses.tsx
@@ -46,6 +46,7 @@ import {
   type RecurringExpense,
 } from '@/api/expenses';
 import { listCategories, type Category } from '@/api/categories';
+import { listAccounts, type FinancialAccount } from '@/api/accounts';
 import { formatMoney } from '@/lib/currency';
 
 export default function Expenses() {
@@ -58,6 +59,7 @@ export default function Expenses() {
   const [error, setError] = useState<string | null>(null);
 
   const [categories, setCategories] = useState<Category[]>([]);
+  const [accounts, setAccounts] = useState<FinancialAccount[]>([]);
 
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<Expense | null>(null);
@@ -66,6 +68,7 @@ export default function Expenses() {
   const [description, setDescription] = useState('');
   const [date, setDate] = useState<string>(() => new Date().toISOString().slice(0, 10));
   const [categoryId, setCategoryId] = useState<string>('');
+  const [accountId, setAccountId] = useState<string>('');
   const [saving, setSaving] = useState(false);
 
   const [importFile, setImportFile] = useState<File | null>(null);
@@ -73,6 +76,7 @@ export default function Expenses() {
   const [previewDuplicates, setPreviewDuplicates] = useState<number>(0);
   const [importLoading, setImportLoading] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [importAccountId, setImportAccountId] = useState<string>('');
   const [recurringItems, setRecurringItems] = useState<RecurringExpense[]>([]);
   const [recurringAmount, setRecurringAmount] = useState('');
   const [recurringDescription, setRecurringDescription] = useState('');
@@ -87,6 +91,7 @@ export default function Expenses() {
   const [from, setFrom] = useState<string>('');
   const [to, setTo] = useState<string>('');
   const [filterCategoryId, setFilterCategoryId] = useState<string>('');
+  const [filterAccountId, setFilterAccountId] = useState<string>('');
   const [search, setSearch] = useState<string>('');
   const [page, setPage] = useState<number>(1);
   const [pageSize, setPageSize] = useState<number>(10);
@@ -99,6 +104,7 @@ export default function Expenses() {
         from: from || undefined,
         to: to || undefined,
         category_id: filterCategoryId ? Number(filterCategoryId) : undefined,
+        account_id: filterAccountId ? Number(filterAccountId) : undefined,
         search: search || undefined,
         page,
         page_size: pageSize,
@@ -113,7 +119,7 @@ export default function Expenses() {
     } finally {
       setLoading(false);
     }
-  }, [filterCategoryId, from, page, pageSize, search, to, toast]);
+  }, [filterAccountId, filterCategoryId, from, page, pageSize, search, to, toast]);
 
   const loadCategories = useCallback(async () => {
     try {
@@ -121,6 +127,14 @@ export default function Expenses() {
       setCategories(cats);
     } catch {
       toast({ title: 'Failed to load categories', description: 'Please try again.' });
+    }
+  }, [toast]);
+
+  const loadAccounts = useCallback(async () => {
+    try {
+      setAccounts(await listAccounts());
+    } catch {
+      toast({ title: 'Failed to load accounts', description: 'Please try again.' });
     }
   }, [toast]);
 
@@ -139,14 +153,16 @@ export default function Expenses() {
   useEffect(() => {
     void refresh();
     void loadCategories();
+    void loadAccounts();
     void loadRecurring();
-  }, [refresh, loadCategories, loadRecurring]);
+  }, [refresh, loadAccounts, loadCategories, loadRecurring]);
 
   function resetForm() {
     setAmount('');
     setDescription('');
     setDate(new Date().toISOString().slice(0, 10));
     setCategoryId('');
+    setAccountId('');
     setEditing(null);
   }
 
@@ -161,6 +177,7 @@ export default function Expenses() {
     setDescription(exp.description || '');
     setDate(exp.date.slice(0, 10));
     setCategoryId(exp.category_id ? String(exp.category_id) : '');
+    setAccountId(exp.account_id ? String(exp.account_id) : '');
     setOpen(true);
   }
 
@@ -192,6 +209,7 @@ export default function Expenses() {
           description,
           date,
           category_id: categoryId ? Number(categoryId) : null,
+          account_id: accountId ? Number(accountId) : null,
         });
         setAllItems((prev) => prev.map((x) => (x.id === editing.id ? updated : x)));
         setItems((prev) => prev.map((x) => (x.id === editing.id ? updated : x)));
@@ -202,6 +220,7 @@ export default function Expenses() {
           description,
           date,
           category_id: categoryId ? Number(categoryId) : null,
+          account_id: accountId ? Number(accountId) : null,
         });
         setAllItems((prev) => [created, ...prev]);
         setItems((prev) => (page === 1 ? [created, ...prev].slice(0, pageSize) : prev));
@@ -269,7 +288,7 @@ export default function Expenses() {
     setImporting(true);
     setError(null);
     try {
-      const res = await commitExpenseImport(preview);
+      const res = await commitExpenseImport(preview, importAccountId ? Number(importAccountId) : null);
       toast({
         title: 'Import complete',
         description: `${res.inserted} added, ${res.duplicates} duplicates skipped.`,
@@ -298,6 +317,7 @@ export default function Expenses() {
         amount: Number(recurringAmount),
         description: recurringDescription.trim(),
         category_id: categoryId ? Number(categoryId) : null,
+        account_id: accountId ? Number(accountId) : null,
         cadence: recurringCadence,
         start_date: recurringStartDate,
         end_date: recurringEndDate || null,
@@ -338,6 +358,7 @@ export default function Expenses() {
   }
 
   const categoryMap = useMemo(() => new Map(categories.map((c) => [c.id, c.name])), [categories]);
+  const accountMap = useMemo(() => new Map(accounts.map((a) => [a.id, a.name])), [accounts]);
   const totals = useMemo(() => {
     const sum = allItems.reduce((acc, e) => acc + Number(e.amount || 0), 0);
     return { sum };
@@ -394,6 +415,15 @@ export default function Expenses() {
                   ))}
                 </select>
               </div>
+              <div>
+                <Label htmlFor="account">Account</Label>
+                <select id="account" className="input" value={accountId} onChange={(e) => setAccountId(e.target.value)}>
+                  <option value="">Unassigned</option>
+                  {accounts.map((account) => (
+                    <option key={account.id} value={account.id}>{account.name}</option>
+                  ))}
+                </select>
+              </div>
             </div>
             {error && <div className="error">{error}</div>}
             <DialogFooter>
@@ -431,6 +461,15 @@ export default function Expenses() {
               ))}
             </select>
           </div>
+          <div>
+            <Label htmlFor="q-account">Account</Label>
+            <select id="q-account" className="input" value={accountId} onChange={(e) => setAccountId(e.target.value)}>
+              <option value="">Unassigned</option>
+              {accounts.map((account) => (
+                <option key={account.id} value={account.id}>{account.name}</option>
+              ))}
+            </select>
+          </div>
           <Button onClick={onSubmit} disabled={saving}>Save Expense</Button>
         </div>
 
@@ -443,6 +482,15 @@ export default function Expenses() {
             accept=".pdf,.csv,application/pdf,text/csv"
             onChange={(e) => setImportFile(e.target.files?.[0] || null)}
           />
+          <div>
+            <Label htmlFor="import-account">Import into account</Label>
+            <select id="import-account" className="input" value={importAccountId} onChange={(e) => setImportAccountId(e.target.value)}>
+              <option value="">Unassigned</option>
+              {accounts.map((account) => (
+                <option key={account.id} value={account.id}>{account.name}</option>
+              ))}
+            </select>
+          </div>
           <div className="flex gap-2">
             <Button variant="outline" onClick={onPreviewImport} disabled={importLoading || !importFile}>Preview Import</Button>
             <Button onClick={onCommitImport} disabled={importing || preview.length === 0}>Confirm Import</Button>
@@ -468,7 +516,7 @@ export default function Expenses() {
 
       <div className="card card-interactive p-4 space-y-4 fade-in-up">
         <h3 className="text-base font-semibold">Recurring Expenses</h3>
-        <div className="grid gap-3 md:grid-cols-6">
+        <div className="grid gap-3 md:grid-cols-7">
           <Input
             aria-label="recurring amount"
             type="number"
@@ -507,6 +555,17 @@ export default function Expenses() {
             value={recurringEndDate}
             onChange={(e) => setRecurringEndDate(e.target.value)}
           />
+          <select
+            aria-label="recurring account"
+            className="input"
+            value={accountId}
+            onChange={(e) => setAccountId(e.target.value)}
+          >
+            <option value="">Unassigned</option>
+            {accounts.map((account) => (
+              <option key={account.id} value={account.id}>{account.name}</option>
+            ))}
+          </select>
           <Button onClick={onCreateRecurring} disabled={recurringSaving}>
             Add Recurring
           </Button>
@@ -529,7 +588,7 @@ export default function Expenses() {
         </div>
       </div>
 
-      <div className="card p-4 grid md:grid-cols-5 gap-3 fade-in-up">
+      <div className="card p-4 grid md:grid-cols-6 gap-3 fade-in-up">
         <div>
           <Label htmlFor="from">From</Label>
           <Input id="from" type="date" value={from} onChange={(e) => setFrom(e.target.value)} />
@@ -548,11 +607,20 @@ export default function Expenses() {
           </select>
         </div>
         <div>
+          <Label htmlFor="faccount">Account</Label>
+          <select id="faccount" className="input" value={filterAccountId} onChange={(e) => setFilterAccountId(e.target.value)}>
+            <option value="">All</option>
+            {accounts.map((account) => (
+              <option key={account.id} value={account.id}>{account.name}</option>
+            ))}
+          </select>
+        </div>
+        <div>
           <Label htmlFor="search">Search</Label>
           <Input id="search" placeholder="description contains..." value={search} onChange={(e) => setSearch(e.target.value)} />
         </div>
         <div className="flex items-end gap-2">
-          <Button variant="outline" onClick={() => { setFrom(''); setTo(''); setFilterCategoryId(''); setSearch(''); setPage(1); }}>Reset</Button>
+          <Button variant="outline" onClick={() => { setFrom(''); setTo(''); setFilterCategoryId(''); setFilterAccountId(''); setSearch(''); setPage(1); }}>Reset</Button>
           <Button onClick={() => { setPage(1); refresh(); }}>Apply</Button>
         </div>
       </div>
@@ -571,6 +639,7 @@ export default function Expenses() {
                     <th className="py-2">Date</th>
                     <th className="py-2">Description</th>
                     <th className="py-2">Category</th>
+                    <th className="py-2">Account</th>
                     <th className="py-2">Amount</th>
                     <th className="py-2"></th>
                   </tr>
@@ -581,6 +650,7 @@ export default function Expenses() {
                       <td className="py-2">{e.date.slice(0, 10)}</td>
                       <td className="py-2">{e.description}</td>
                       <td className="py-2">{e.category_id ? categoryMap.get(e.category_id) : '—'}</td>
+                      <td className="py-2">{e.account_id ? (e.account_name || accountMap.get(e.account_id)) : '—'}</td>
                       <td className="py-2 font-medium">{formatMoney(e.amount, e.currency)}</td>
                       <td className="py-2">
                         <div className="flex gap-2 justify-end">
@@ -607,7 +677,7 @@ export default function Expenses() {
                     </tr>
                   ))}
                   <tr className="border-t bg-muted/30">
-                    <td className="py-2" colSpan={3}>Total</td>
+                    <td className="py-2" colSpan={4}>Total</td>
                     <td className="py-2 font-semibold">{formatMoney(totals.sum)}</td>
                     <td></td>
                   </tr>

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -110,6 +110,61 @@ def _ensure_schema_compatibility(app: Flask) -> None:
             NOT NULL DEFAULT 'INR'
             """
         )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS financial_accounts (
+              id SERIAL PRIMARY KEY,
+              user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+              name VARCHAR(120) NOT NULL,
+              account_type VARCHAR(40) NOT NULL DEFAULT 'CHECKING',
+              institution VARCHAR(120),
+              last_four VARCHAR(4),
+              currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+              opening_balance NUMERIC(12,2) NOT NULL DEFAULT 0,
+              active BOOLEAN NOT NULL DEFAULT TRUE,
+              created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+              updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_financial_accounts_user_active
+            ON financial_accounts(user_id, active)
+            """
+        )
+        cur.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_financial_accounts_user_name
+            ON financial_accounts(user_id, name)
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE expenses
+            ADD COLUMN IF NOT EXISTS account_id INT
+            REFERENCES financial_accounts(id) ON DELETE SET NULL
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_expenses_user_account
+            ON expenses(user_id, account_id)
+            """
+        )
+        cur.execute(
+            """
+            ALTER TABLE recurring_expenses
+            ADD COLUMN IF NOT EXISTS account_id INT
+            REFERENCES financial_accounts(id) ON DELETE SET NULL
+            """
+        )
+        cur.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_recurring_expenses_user_account
+            ON recurring_expenses(user_id, account_id)
+            """
+        )
         conn.commit()
     except Exception:
         app.logger.exception(

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -18,10 +18,27 @@ CREATE TABLE IF NOT EXISTS categories (
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
+CREATE TABLE IF NOT EXISTS financial_accounts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  name VARCHAR(120) NOT NULL,
+  account_type VARCHAR(40) NOT NULL DEFAULT 'CHECKING',
+  institution VARCHAR(120),
+  last_four VARCHAR(4),
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  opening_balance NUMERIC(12,2) NOT NULL DEFAULT 0,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_financial_accounts_user_active ON financial_accounts(user_id, active);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_financial_accounts_user_name ON financial_accounts(user_id, name);
+
 CREATE TABLE IF NOT EXISTS expenses (
   id SERIAL PRIMARY KEY,
   user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   category_id INT REFERENCES categories(id) ON DELETE SET NULL,
+  account_id INT REFERENCES financial_accounts(id) ON DELETE SET NULL,
   amount NUMERIC(12,2) NOT NULL,
   currency VARCHAR(10) NOT NULL DEFAULT 'INR',
   expense_type VARCHAR(20) NOT NULL DEFAULT 'EXPENSE',
@@ -30,9 +47,13 @@ CREATE TABLE IF NOT EXISTS expenses (
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_expenses_user_spent_at ON expenses(user_id, spent_at DESC);
+CREATE INDEX IF NOT EXISTS idx_expenses_user_account ON expenses(user_id, account_id);
 
 ALTER TABLE expenses
   ADD COLUMN IF NOT EXISTS expense_type VARCHAR(20) NOT NULL DEFAULT 'EXPENSE';
+
+ALTER TABLE expenses
+  ADD COLUMN IF NOT EXISTS account_id INT REFERENCES financial_accounts(id) ON DELETE SET NULL;
 
 DO $$ BEGIN
   CREATE TYPE recurring_cadence AS ENUM ('DAILY','WEEKLY','MONTHLY','YEARLY');
@@ -44,6 +65,7 @@ CREATE TABLE IF NOT EXISTS recurring_expenses (
   id SERIAL PRIMARY KEY,
   user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   category_id INT REFERENCES categories(id) ON DELETE SET NULL,
+  account_id INT REFERENCES financial_accounts(id) ON DELETE SET NULL,
   amount NUMERIC(12,2) NOT NULL,
   currency VARCHAR(10) NOT NULL DEFAULT 'INR',
   expense_type VARCHAR(20) NOT NULL DEFAULT 'EXPENSE',
@@ -55,6 +77,10 @@ CREATE TABLE IF NOT EXISTS recurring_expenses (
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX IF NOT EXISTS idx_recurring_expenses_user_start ON recurring_expenses(user_id, start_date);
+CREATE INDEX IF NOT EXISTS idx_recurring_expenses_user_account ON recurring_expenses(user_id, account_id);
+
+ALTER TABLE recurring_expenses
+  ADD COLUMN IF NOT EXISTS account_id INT REFERENCES financial_accounts(id) ON DELETE SET NULL;
 
 ALTER TABLE expenses
   ADD COLUMN IF NOT EXISTS source_recurring_id INT REFERENCES recurring_expenses(id) ON DELETE SET NULL;

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -27,11 +27,31 @@ class Category(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class FinancialAccount(db.Model):
+    __tablename__ = "financial_accounts"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    account_type = db.Column(db.String(40), default="CHECKING", nullable=False)
+    institution = db.Column(db.String(120), nullable=True)
+    last_four = db.Column(db.String(4), nullable=True)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    opening_balance = db.Column(db.Numeric(12, 2), default=0, nullable=False)
+    active = db.Column(db.Boolean, default=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+
 class Expense(db.Model):
     __tablename__ = "expenses"
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    account_id = db.Column(
+        db.Integer, db.ForeignKey("financial_accounts.id"), nullable=True
+    )
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
     expense_type = db.Column(db.String(20), default="EXPENSE", nullable=False)
@@ -55,6 +75,9 @@ class RecurringExpense(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     category_id = db.Column(db.Integer, db.ForeignKey("categories.id"), nullable=True)
+    account_id = db.Column(
+        db.Integer, db.ForeignKey("financial_accounts.id"), nullable=True
+    )
     amount = db.Column(db.Numeric(12, 2), nullable=False)
     currency = db.Column(db.String(10), default="INR", nullable=False)
     expense_type = db.Column(db.String(20), default="EXPENSE", nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -8,6 +8,8 @@ servers:
 tags:
   - name: Auth
   - name: Categories
+  - name: Accounts
+  - name: Dashboard
   - name: Expenses
   - name: Bills
   - name: Reminders
@@ -144,11 +146,130 @@ paths:
               schema: { $ref: '#/components/schemas/Error' }
               example: { error: "category already exists" }
 
+  /accounts:
+    get:
+      summary: List financial accounts
+      tags: [Accounts]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: include_archived
+          required: false
+          schema: { type: boolean, default: false }
+      responses:
+        '200':
+          description: List of financial accounts
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FinancialAccount' }
+    post:
+      summary: Create financial account
+      tags: [Accounts]
+      security: [{ bearerAuth: [] }]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NewFinancialAccount' }
+      responses:
+        '201': { description: Created }
+        '400':
+          description: Validation error
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '409':
+          description: Already exists
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /accounts/{accountId}:
+    patch:
+      summary: Update financial account
+      tags: [Accounts]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: accountId
+          required: true
+          schema: { type: integer }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/NewFinancialAccount' }
+      responses:
+        '200': { description: Updated }
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+    delete:
+      summary: Archive financial account
+      tags: [Accounts]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: accountId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200': { description: Archived }
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
+  /dashboard/summary:
+    get:
+      summary: Get dashboard summary with optional account filter
+      tags: [Dashboard]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: month
+          required: false
+          schema: { type: string, pattern: '^\d{4}-\d{2}$' }
+        - in: query
+          name: account_ids
+          required: false
+          schema: { type: string, example: '1,2' }
+      responses:
+        '200':
+          description: Dashboard summary
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DashboardSummary' }
+        '400':
+          description: Invalid filters
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '404':
+          description: Account not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
   /expenses:
     get:
       summary: List expenses
       tags: [Expenses]
       security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: account_id
+          required: false
+          schema: { type: integer }
+        - in: query
+          name: category_id
+          required: false
+          schema: { type: integer }
       responses:
         '200':
           description: List of expenses
@@ -503,13 +624,75 @@ components:
       properties:
         id: { type: integer }
         name: { type: string }
+    FinancialAccount:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        account_type: { type: string, enum: [CASH, CHECKING, SAVINGS, CREDIT_CARD, INVESTMENT, LOAN, WALLET, OTHER] }
+        institution: { type: string, nullable: true }
+        last_four: { type: string, nullable: true }
+        currency: { type: string }
+        opening_balance: { type: number, format: float }
+        balance: { type: number, format: float }
+        income_total: { type: number, format: float }
+        expense_total: { type: number, format: float }
+        active: { type: boolean }
+        created_at: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+    NewFinancialAccount:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        account_type: { type: string, enum: [CASH, CHECKING, SAVINGS, CREDIT_CARD, INVESTMENT, LOAN, WALLET, OTHER], default: CHECKING }
+        institution: { type: string, nullable: true }
+        last_four: { type: string, nullable: true }
+        currency: { type: string, default: INR }
+        opening_balance: { type: number, format: float, default: 0 }
+        active: { type: boolean }
+    DashboardSummary:
+      type: object
+      properties:
+        period:
+          type: object
+          properties:
+            month: { type: string }
+        summary:
+          type: object
+          additionalProperties: true
+        selected_account_ids:
+          type: array
+          items: { type: integer }
+        accounts:
+          type: array
+          items: { $ref: '#/components/schemas/FinancialAccount' }
+        account_breakdown:
+          type: array
+          items: { $ref: '#/components/schemas/FinancialAccount' }
+        recent_transactions:
+          type: array
+          items: { $ref: '#/components/schemas/Expense' }
+        upcoming_bills:
+          type: array
+          items: { $ref: '#/components/schemas/Bill' }
+        category_breakdown:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        errors:
+          type: array
+          items: { type: string }
     Expense:
       type: object
       properties:
         id: { type: integer }
         amount: { type: number, format: float }
         currency: { type: string }
-        category_id: { type: integer }
+        category_id: { type: integer, nullable: true }
+        account_id: { type: integer, nullable: true }
+        account_name: { type: string, nullable: true }
         expense_type: { type: string }
         description: { type: string, nullable: true }
         date: { type: string, format: date }
@@ -520,6 +703,7 @@ components:
         amount: { type: number, format: float }
         currency: { type: string, default: USD }
         category_id: { type: integer, nullable: true }
+        account_id: { type: integer, nullable: true }
         expense_type: { type: string, default: EXPENSE }
         description: { type: string, nullable: true }
         date: { type: string, format: date, nullable: true }
@@ -531,6 +715,7 @@ components:
         currency: { type: string }
         expense_type: { type: string }
         category_id: { type: integer, nullable: true }
+        account_id: { type: integer, nullable: true }
         description: { type: string }
         cadence: { type: string, enum: [DAILY, WEEKLY, MONTHLY, YEARLY] }
         start_date: { type: string, format: date }
@@ -544,6 +729,7 @@ components:
         currency: { type: string, default: INR }
         expense_type: { type: string, default: EXPENSE }
         category_id: { type: integer, nullable: true }
+        account_id: { type: integer, nullable: true }
         description: { type: string }
         cadence: { type: string, enum: [DAILY, WEEKLY, MONTHLY, YEARLY] }
         start_date: { type: string, format: date }

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -5,6 +5,7 @@ from .bills import bp as bills_bp
 from .reminders import bp as reminders_bp
 from .insights import bp as insights_bp
 from .categories import bp as categories_bp
+from .accounts import bp as accounts_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
 
@@ -16,5 +17,6 @@ def register_routes(app: Flask):
     app.register_blueprint(reminders_bp, url_prefix="/reminders")
     app.register_blueprint(insights_bp, url_prefix="/insights")
     app.register_blueprint(categories_bp, url_prefix="/categories")
+    app.register_blueprint(accounts_bp, url_prefix="/accounts")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")

--- a/packages/backend/app/routes/accounts.py
+++ b/packages/backend/app/routes/accounts.py
@@ -1,0 +1,214 @@
+from decimal import Decimal, InvalidOperation
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from sqlalchemy import func
+
+from ..extensions import db
+from ..models import Expense, FinancialAccount, User
+from ..services.cache import cache_delete_patterns
+
+bp = Blueprint("accounts", __name__)
+
+ACCOUNT_TYPES = {
+    "CASH",
+    "CHECKING",
+    "SAVINGS",
+    "CREDIT_CARD",
+    "INVESTMENT",
+    "LOAN",
+    "WALLET",
+    "OTHER",
+}
+
+
+@bp.get("")
+@jwt_required()
+def list_accounts():
+    uid = int(get_jwt_identity())
+    include_archived = request.args.get("include_archived") == "true"
+    query = db.session.query(FinancialAccount).filter_by(user_id=uid)
+    if not include_archived:
+        query = query.filter(FinancialAccount.active.is_(True))
+    accounts = query.order_by(FinancialAccount.name.asc()).all()
+    return jsonify(
+        [_account_to_dict(account, include_totals=True) for account in accounts]
+    )
+
+
+@bp.post("")
+@jwt_required()
+def create_account():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+    name = (data.get("name") or "").strip()
+    if not name:
+        return jsonify(error="name required"), 400
+    account_type = _parse_account_type(data.get("account_type") or data.get("type"))
+    if account_type is None:
+        return jsonify(error="invalid account_type"), 400
+    opening_balance = _parse_amount(data.get("opening_balance", 0))
+    if opening_balance is None:
+        return jsonify(error="invalid opening_balance"), 400
+    exists = (
+        db.session.query(FinancialAccount.id).filter_by(user_id=uid, name=name).first()
+    )
+    if exists:
+        return jsonify(error="account already exists"), 409
+    account = FinancialAccount(
+        user_id=uid,
+        name=name,
+        account_type=account_type,
+        institution=_clean_optional(data.get("institution"), 120),
+        last_four=_parse_last_four(data.get("last_four")),
+        currency=(data.get("currency") or (user.preferred_currency if user else "INR"))[
+            :10
+        ],
+        opening_balance=opening_balance,
+        active=True,
+    )
+    db.session.add(account)
+    db.session.commit()
+    _invalidate_account_caches(uid)
+    return jsonify(_account_to_dict(account, include_totals=True)), 201
+
+
+@bp.patch("/<int:account_id>")
+@jwt_required()
+def update_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    data = request.get_json() or {}
+    if "name" in data:
+        name = (data.get("name") or "").strip()
+        if not name:
+            return jsonify(error="name required"), 400
+        exists = (
+            db.session.query(FinancialAccount.id)
+            .filter(
+                FinancialAccount.user_id == uid,
+                FinancialAccount.name == name,
+                FinancialAccount.id != account.id,
+            )
+            .first()
+        )
+        if exists:
+            return jsonify(error="account already exists"), 409
+        account.name = name
+    if "account_type" in data or "type" in data:
+        account_type = _parse_account_type(data.get("account_type") or data.get("type"))
+        if account_type is None:
+            return jsonify(error="invalid account_type"), 400
+        account.account_type = account_type
+    if "institution" in data:
+        account.institution = _clean_optional(data.get("institution"), 120)
+    if "last_four" in data:
+        account.last_four = _parse_last_four(data.get("last_four"))
+    if "currency" in data:
+        account.currency = str(data.get("currency") or "INR")[:10]
+    if "opening_balance" in data:
+        opening_balance = _parse_amount(data.get("opening_balance"))
+        if opening_balance is None:
+            return jsonify(error="invalid opening_balance"), 400
+        account.opening_balance = opening_balance
+    if "active" in data:
+        account.active = bool(data.get("active"))
+    db.session.commit()
+    _invalidate_account_caches(uid)
+    return jsonify(_account_to_dict(account, include_totals=True))
+
+
+@bp.delete("/<int:account_id>")
+@jwt_required()
+def archive_account(account_id: int):
+    uid = int(get_jwt_identity())
+    account = db.session.get(FinancialAccount, account_id)
+    if not account or account.user_id != uid:
+        return jsonify(error="not found"), 404
+    account.active = False
+    db.session.commit()
+    _invalidate_account_caches(uid)
+    return jsonify(message="archived")
+
+
+def account_belongs_to_user(account_id: int | None, uid: int) -> bool:
+    if account_id is None:
+        return True
+    return (
+        db.session.query(FinancialAccount.id)
+        .filter_by(id=account_id, user_id=uid)
+        .first()
+        is not None
+    )
+
+
+def _account_to_dict(account: FinancialAccount, include_totals: bool = False) -> dict:
+    payload = {
+        "id": account.id,
+        "name": account.name,
+        "account_type": account.account_type,
+        "institution": account.institution,
+        "last_four": account.last_four,
+        "currency": account.currency,
+        "opening_balance": float(account.opening_balance or 0),
+        "active": account.active,
+        "created_at": account.created_at.isoformat(),
+        "updated_at": account.updated_at.isoformat(),
+    }
+    if include_totals:
+        totals = _account_totals(account.id)
+        payload.update(totals)
+    return payload
+
+
+def _account_totals(account_id: int) -> dict:
+    income = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(Expense.account_id == account_id, Expense.expense_type == "INCOME")
+        .scalar()
+    )
+    expenses = (
+        db.session.query(func.coalesce(func.sum(Expense.amount), 0))
+        .filter(Expense.account_id == account_id, Expense.expense_type != "INCOME")
+        .scalar()
+    )
+    balance = Decimal(str(income or 0)) - Decimal(str(expenses or 0))
+    opening = Decimal(
+        str(db.session.get(FinancialAccount, account_id).opening_balance or 0)
+    )
+    return {
+        "income_total": float(income or 0),
+        "expense_total": float(expenses or 0),
+        "balance": float((opening + balance).quantize(Decimal("0.01"))),
+    }
+
+
+def _parse_amount(raw) -> Decimal | None:
+    try:
+        return Decimal(str(raw)).quantize(Decimal("0.01"))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _parse_account_type(raw) -> str | None:
+    account_type = str(raw or "CHECKING").upper().strip()
+    return account_type if account_type in ACCOUNT_TYPES else None
+
+
+def _parse_last_four(raw) -> str | None:
+    value = str(raw or "").strip()
+    if not value:
+        return None
+    return value[-4:]
+
+
+def _clean_optional(raw, limit: int) -> str | None:
+    value = str(raw or "").strip()
+    return value[:limit] if value else None
+
+
+def _invalidate_account_caches(uid: int) -> None:
+    cache_delete_patterns([f"user:{uid}:dashboard_summary:*"])

--- a/packages/backend/app/routes/dashboard.py
+++ b/packages/backend/app/routes/dashboard.py
@@ -1,10 +1,12 @@
 from datetime import date
-from sqlalchemy import extract, func
+from decimal import Decimal
+
 from flask import Blueprint, jsonify, request
-from flask_jwt_extended import jwt_required, get_jwt_identity
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from sqlalchemy import extract, func
 
 from ..extensions import db
-from ..models import Bill, Expense, Category
+from ..models import Bill, Category, Expense, FinancialAccount
 from ..services.cache import cache_get, cache_set, dashboard_summary_key
 
 bp = Blueprint("dashboard", __name__)
@@ -17,7 +19,15 @@ def dashboard_summary():
     ym = (request.args.get("month") or date.today().strftime("%Y-%m")).strip()
     if not _is_valid_month(ym):
         return jsonify(error="invalid month, expected YYYY-MM"), 400
-    key = dashboard_summary_key(uid, ym)
+
+    account_ids, account_error = _parse_account_ids(request.args.get("account_ids"))
+    if account_error:
+        return jsonify(error=account_error), 400
+    if account_ids and not _accounts_belong_to_user(uid, account_ids):
+        return jsonify(error="account not found"), 404
+
+    account_filter_key = "all" if not account_ids else ",".join(map(str, account_ids))
+    key = dashboard_summary_key(uid, ym, account_filter_key)
     cached = cache_get(key)
     if cached:
         return jsonify(cached)
@@ -30,7 +40,13 @@ def dashboard_summary():
             "monthly_expenses": 0.0,
             "upcoming_bills_total": 0.0,
             "upcoming_bills_count": 0,
+            "total_balance": 0.0,
+            "account_count": 0,
+            "selected_account_count": 0,
         },
+        "selected_account_ids": account_ids,
+        "accounts": [],
+        "account_breakdown": [],
         "recent_transactions": [],
         "upcoming_bills": [],
         "category_breakdown": [],
@@ -41,26 +57,46 @@ def dashboard_summary():
     today = date.today()
 
     try:
-        income = (
-            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
-            .filter(
-                Expense.user_id == uid,
-                extract("year", Expense.spent_at) == year,
-                extract("month", Expense.spent_at) == month,
-                Expense.expense_type == "INCOME",
-            )
-            .scalar()
+        accounts = _active_accounts(uid)
+        payload["accounts"] = [
+            _account_summary(account, year, month) for account in accounts
+        ]
+        selected = (
+            [a for a in payload["accounts"] if a["id"] in account_ids]
+            if account_ids
+            else payload["accounts"]
         )
-        expenses = (
-            db.session.query(func.coalesce(func.sum(Expense.amount), 0))
-            .filter(
-                Expense.user_id == uid,
-                extract("year", Expense.spent_at) == year,
-                extract("month", Expense.spent_at) == month,
-                Expense.expense_type != "INCOME",
-            )
-            .scalar()
+        payload["account_breakdown"] = selected
+        payload["summary"]["total_balance"] = round(
+            sum(float(a["balance"] or 0) for a in selected), 2
         )
+        payload["summary"]["account_count"] = len(accounts)
+        payload["summary"]["selected_account_count"] = len(selected)
+    except Exception:
+        payload["errors"].append("accounts_unavailable")
+
+    try:
+        income_query = db.session.query(
+            func.coalesce(func.sum(Expense.amount), 0)
+        ).filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type == "INCOME",
+        )
+        expense_query = db.session.query(
+            func.coalesce(func.sum(Expense.amount), 0)
+        ).filter(
+            Expense.user_id == uid,
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+            Expense.expense_type != "INCOME",
+        )
+        if account_ids:
+            income_query = income_query.filter(Expense.account_id.in_(account_ids))
+            expense_query = expense_query.filter(Expense.account_id.in_(account_ids))
+        income = income_query.scalar()
+        expenses = expense_query.scalar()
         payload["summary"]["monthly_income"] = float(income or 0)
         payload["summary"]["monthly_expenses"] = float(expenses or 0)
         payload["summary"]["net_flow"] = round(
@@ -72,25 +108,15 @@ def dashboard_summary():
         payload["errors"].append("summary_unavailable")
 
     try:
+        rows_query = db.session.query(Expense).filter(Expense.user_id == uid)
+        if account_ids:
+            rows_query = rows_query.filter(Expense.account_id.in_(account_ids))
         rows = (
-            db.session.query(Expense)
-            .filter(Expense.user_id == uid)
-            .order_by(Expense.spent_at.desc(), Expense.id.desc())
+            rows_query.order_by(Expense.spent_at.desc(), Expense.id.desc())
             .limit(10)
             .all()
         )
-        payload["recent_transactions"] = [
-            {
-                "id": e.id,
-                "description": e.notes or "Transaction",
-                "amount": float(e.amount),
-                "date": e.spent_at.isoformat(),
-                "type": e.expense_type,
-                "category_id": e.category_id,
-                "currency": e.currency,
-            }
-            for e in rows
-        ]
+        payload["recent_transactions"] = [_transaction_to_dict(e) for e in rows]
     except Exception:
         payload["errors"].append("recent_transactions_unavailable")
 
@@ -127,7 +153,7 @@ def dashboard_summary():
         payload["errors"].append("upcoming_bills_unavailable")
 
     try:
-        category_rows = (
+        category_query = (
             db.session.query(
                 Expense.category_id,
                 func.coalesce(Category.name, "Uncategorized").label("category_name"),
@@ -143,7 +169,11 @@ def dashboard_summary():
                 extract("month", Expense.spent_at) == month,
                 Expense.expense_type != "INCOME",
             )
-            .group_by(Expense.category_id, Category.name)
+        )
+        if account_ids:
+            category_query = category_query.filter(Expense.account_id.in_(account_ids))
+        category_rows = (
+            category_query.group_by(Expense.category_id, Category.name)
             .order_by(func.sum(Expense.amount).desc())
             .all()
         )
@@ -176,3 +206,99 @@ def _is_valid_month(ym: str) -> bool:
         return False
     m = int(month)
     return 1 <= m <= 12
+
+
+def _parse_account_ids(raw: str | None) -> tuple[list[int], str | None]:
+    if not raw:
+        return [], None
+    account_ids: list[int] = []
+    for part in raw.split(","):
+        value = part.strip()
+        if not value:
+            continue
+        if not value.isdigit():
+            return [], "invalid account_ids"
+        account_ids.append(int(value))
+    return sorted(set(account_ids)), None
+
+
+def _accounts_belong_to_user(uid: int, account_ids: list[int]) -> bool:
+    count = (
+        db.session.query(func.count(FinancialAccount.id))
+        .filter(FinancialAccount.user_id == uid, FinancialAccount.id.in_(account_ids))
+        .scalar()
+    )
+    return count == len(account_ids)
+
+
+def _active_accounts(uid: int) -> list[FinancialAccount]:
+    return (
+        db.session.query(FinancialAccount)
+        .filter_by(user_id=uid, active=True)
+        .order_by(FinancialAccount.name.asc())
+        .all()
+    )
+
+
+def _account_summary(account: FinancialAccount, year: int, month: int) -> dict:
+    all_income = _sum_expenses(account.id, "INCOME")
+    all_expenses = _sum_expenses(account.id, "EXPENSE")
+    monthly_income = _sum_expenses(account.id, "INCOME", year, month)
+    monthly_expenses = _sum_expenses(account.id, "EXPENSE", year, month)
+    opening = Decimal(str(account.opening_balance or 0))
+    balance = opening + all_income - all_expenses
+    return {
+        "id": account.id,
+        "name": account.name,
+        "account_type": account.account_type,
+        "institution": account.institution,
+        "last_four": account.last_four,
+        "currency": account.currency,
+        "opening_balance": float(opening),
+        "balance": float(balance.quantize(Decimal("0.01"))),
+        "monthly_income": float(monthly_income),
+        "monthly_expenses": float(monthly_expenses),
+        "monthly_net_flow": float(
+            (monthly_income - monthly_expenses).quantize(Decimal("0.01"))
+        ),
+    }
+
+
+def _sum_expenses(
+    account_id: int,
+    expense_kind: str,
+    year: int | None = None,
+    month: int | None = None,
+) -> Decimal:
+    query = db.session.query(func.coalesce(func.sum(Expense.amount), 0)).filter(
+        Expense.account_id == account_id,
+    )
+    if expense_kind == "INCOME":
+        query = query.filter(Expense.expense_type == "INCOME")
+    else:
+        query = query.filter(Expense.expense_type != "INCOME")
+    if year is not None and month is not None:
+        query = query.filter(
+            extract("year", Expense.spent_at) == year,
+            extract("month", Expense.spent_at) == month,
+        )
+    return Decimal(str(query.scalar() or 0)).quantize(Decimal("0.01"))
+
+
+def _transaction_to_dict(expense: Expense) -> dict:
+    account = (
+        db.session.get(FinancialAccount, expense.account_id)
+        if expense.account_id
+        else None
+    )
+    return {
+        "id": expense.id,
+        "description": expense.notes or "Transaction",
+        "amount": float(expense.amount),
+        "date": expense.spent_at.isoformat(),
+        "type": expense.expense_type,
+        "category_id": expense.category_id,
+        "account_id": expense.account_id,
+        "account_name": account.name if account else None,
+        "currency": expense.currency,
+    }

--- a/packages/backend/app/routes/expenses.py
+++ b/packages/backend/app/routes/expenses.py
@@ -5,7 +5,7 @@ from decimal import Decimal, InvalidOperation
 from flask import Blueprint, current_app, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
-from ..models import Expense, RecurringCadence, RecurringExpense, User
+from ..models import Expense, FinancialAccount, RecurringCadence, RecurringExpense, User
 from ..services.cache import cache_delete_patterns, monthly_summary_key
 from ..services import expense_import
 import logging
@@ -23,6 +23,7 @@ def list_expenses():
     to_date = request.args.get("to")
     search = (request.args.get("search") or "").strip()
     category_id = request.args.get("category_id")
+    account_id = request.args.get("account_id")
     try:
         page = max(1, int(request.args.get("page", "1")))
         page_size = min(200, max(1, int(request.args.get("page_size", "200"))))
@@ -36,6 +37,11 @@ def list_expenses():
             q = q.filter(Expense.spent_at <= date.fromisoformat(to_date))
         if category_id:
             q = q.filter(Expense.category_id == int(category_id))
+        if account_id:
+            account_id_int = int(account_id)
+            if not _account_belongs_to_user(account_id_int, uid):
+                return jsonify(error="account not found"), 404
+            q = q.filter(Expense.account_id == account_id_int)
     except ValueError:
         return jsonify(error="invalid filter values"), 400
     if search:
@@ -65,12 +71,18 @@ def create_expense():
     description = (data.get("description") or data.get("notes") or "").strip()
     if not description:
         return jsonify(error="description required"), 400
+    account_id = _resolve_account_id(data.get("account_id"), uid)
+    if account_id == "missing":
+        return jsonify(error="account not found"), 404
+    if account_id == "invalid":
+        return jsonify(error="invalid account_id"), 400
     e = Expense(
         user_id=uid,
         amount=amount,
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
         category_id=data.get("category_id"),
+        account_id=account_id,
         notes=description,
         spent_at=date.fromisoformat(raw_date) if raw_date else date.today(),
     )
@@ -130,9 +142,15 @@ def create_recurring_expense():
             return jsonify(error="invalid end_date"), 400
         if end_date < start_date:
             return jsonify(error="end_date must be on or after start_date"), 400
+    account_id = _resolve_account_id(data.get("account_id"), uid)
+    if account_id == "missing":
+        return jsonify(error="account not found"), 404
+    if account_id == "invalid":
+        return jsonify(error="invalid account_id"), 400
     recurring = RecurringExpense(
         user_id=uid,
         category_id=data.get("category_id"),
+        account_id=account_id,
         amount=amount,
         currency=(data.get("currency") or (user.preferred_currency if user else "INR")),
         expense_type=str(data.get("expense_type") or "EXPENSE").upper(),
@@ -185,6 +203,7 @@ def generate_recurring_expenses(recurring_id: int):
                 Expense(
                     user_id=uid,
                     category_id=recurring.category_id,
+                    account_id=recurring.account_id,
                     amount=recurring.amount,
                     currency=recurring.currency,
                     expense_type=recurring.expense_type,
@@ -221,6 +240,13 @@ def update_expense(expense_id: int):
         e.expense_type = str(data.get("expense_type") or "EXPENSE").upper()
     if "category_id" in data:
         e.category_id = data.get("category_id")
+    if "account_id" in data:
+        account_id = _resolve_account_id(data.get("account_id"), uid)
+        if account_id == "missing":
+            return jsonify(error="account not found"), 404
+        if account_id == "invalid":
+            return jsonify(error="invalid account_id"), 400
+        e.account_id = account_id
     if "description" in data or "notes" in data:
         description = (data.get("description") or data.get("notes") or "").strip()
         if not description:
@@ -286,10 +312,20 @@ def import_commit():
     if not isinstance(rows, list) or not rows:
         return jsonify(error="transactions required"), 400
     transactions = expense_import.normalize_import_rows(rows)
+    default_account_id = _resolve_account_id(data.get("account_id"), uid)
+    if default_account_id == "missing":
+        return jsonify(error="account not found"), 404
+    if default_account_id == "invalid":
+        return jsonify(error="invalid account_id"), 400
     inserted = 0
     duplicates = 0
     touched_months: set[str] = set()
     for t in transactions:
+        account_id = _resolve_account_id(t.get("account_id", default_account_id), uid)
+        if account_id == "missing":
+            return jsonify(error="account not found"), 404
+        if account_id == "invalid":
+            return jsonify(error="invalid account_id"), 400
         if _is_duplicate(uid, t):
             duplicates += 1
             continue
@@ -299,6 +335,7 @@ def import_commit():
             currency=t.get("currency") or (user.preferred_currency if user else "INR"),
             expense_type=str(t.get("expense_type") or "EXPENSE").upper(),
             category_id=t.get("category_id"),
+            account_id=account_id,
             notes=t["description"],
             spent_at=date.fromisoformat(t["date"]),
         )
@@ -312,11 +349,14 @@ def import_commit():
 
 
 def _expense_to_dict(e: Expense) -> dict:
+    account = db.session.get(FinancialAccount, e.account_id) if e.account_id else None
     return {
         "id": e.id,
         "amount": float(e.amount),
         "currency": e.currency,
         "category_id": e.category_id,
+        "account_id": e.account_id,
+        "account_name": account.name if account else None,
         "expense_type": e.expense_type,
         "description": e.notes or "",
         "date": e.spent_at.isoformat(),
@@ -330,6 +370,7 @@ def _recurring_to_dict(r: RecurringExpense) -> dict:
         "currency": r.currency,
         "expense_type": r.expense_type,
         "category_id": r.category_id,
+        "account_id": r.account_id,
         "description": r.notes,
         "cadence": r.cadence.value,
         "start_date": r.start_date.isoformat(),
@@ -343,6 +384,27 @@ def _parse_amount(raw) -> Decimal | None:
         return Decimal(str(raw)).quantize(Decimal("0.01"))
     except (InvalidOperation, ValueError, TypeError):
         return None
+
+
+def _resolve_account_id(raw, uid: int):
+    if raw in (None, ""):
+        return None
+    try:
+        account_id = int(raw)
+    except (TypeError, ValueError):
+        return "invalid"
+    if not _account_belongs_to_user(account_id, uid):
+        return "missing"
+    return account_id
+
+
+def _account_belongs_to_user(account_id: int, uid: int) -> bool:
+    return (
+        db.session.query(FinancialAccount.id)
+        .filter_by(id=account_id, user_id=uid)
+        .first()
+        is not None
+    )
 
 
 def _parse_recurring_cadence(raw: str | None) -> str | None:

--- a/packages/backend/app/services/cache.py
+++ b/packages/backend/app/services/cache.py
@@ -19,8 +19,8 @@ def insights_key(user_id: int, ym: str) -> str:
     return f"insights:{user_id}:{ym}"
 
 
-def dashboard_summary_key(user_id: int, ym: str) -> str:
-    return f"user:{user_id}:dashboard_summary:{ym}"
+def dashboard_summary_key(user_id: int, ym: str, account_filter: str = "all") -> str:
+    return f"user:{user_id}:dashboard_summary:{ym}:{account_filter}"
 
 
 def cache_set(key: str, value, ttl_seconds: int | None = None):

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -3,8 +3,36 @@ import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value):
+        self.store[str(key)] = value
+
+    def setex(self, key, _ttl, value):
+        self.store[str(key)] = value
+
+    def get(self, key):
+        return self.store.get(str(key))
+
+    def delete(self, *keys):
+        for key in keys:
+            self.store.pop(str(key), None)
+
+    def scan(self, cursor=0, match=None, count=100):
+        import fnmatch
+
+        keys = list(self.store)
+        if match:
+            keys = [key for key in keys if fnmatch.fnmatch(key, match)]
+        return 0, keys[:count]
+
+    def flushdb(self):
+        self.store.clear()
 
 
 class TestSettings(Settings):
@@ -19,6 +47,16 @@ def _setup_db(app):
         db.create_all()
 
 
+def _patch_redis(fake_redis):
+    import app.extensions as extensions
+    import app.routes.auth as auth_route
+    import app.services.cache as cache_service
+
+    extensions.redis_client = fake_redis
+    auth_route.redis_client = fake_redis
+    cache_service.redis_client = fake_redis
+
+
 @pytest.fixture()
 def app_fixture():
     # Ensure a clean env for tests
@@ -28,21 +66,17 @@ def app_fixture():
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
+    fake_redis = FakeRedis()
+    _patch_redis(fake_redis)
     app = create_app(settings)
     app.config.update(TESTING=True)
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_accounts.py
+++ b/packages/backend/tests/test_accounts.py
@@ -1,0 +1,84 @@
+def test_accounts_crud_and_archive(client, auth_header):
+    r = client.post(
+        "/accounts",
+        json={
+            "name": "Main Checking",
+            "account_type": "CHECKING",
+            "institution": "Example Bank",
+            "last_four": "1234",
+            "currency": "USD",
+            "opening_balance": 1000,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    account = r.get_json()
+    account_id = account["id"]
+    assert account["name"] == "Main Checking"
+    assert account["account_type"] == "CHECKING"
+    assert account["balance"] == 1000.0
+
+    r = client.post(
+        "/accounts",
+        json={"name": "Main Checking", "account_type": "CHECKING"},
+        headers=auth_header,
+    )
+    assert r.status_code == 409
+
+    r = client.patch(
+        f"/accounts/{account_id}",
+        json={"name": "Everyday Checking", "opening_balance": 1250},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    updated = r.get_json()
+    assert updated["name"] == "Everyday Checking"
+    assert updated["opening_balance"] == 1250.0
+
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert [a["name"] for a in r.get_json()] == ["Everyday Checking"]
+
+    r = client.delete(f"/accounts/{account_id}", headers=auth_header)
+    assert r.status_code == 200
+
+    r = client.get("/accounts", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+    r = client.get("/accounts?include_archived=true", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()[0]["active"] is False
+
+
+def test_accounts_are_scoped_to_authenticated_user(client, auth_header):
+    r = client.post("/accounts", json={"name": "Private"}, headers=auth_header)
+    assert r.status_code == 201
+    account_id = r.get_json()["id"]
+
+    client.post(
+        "/auth/register",
+        json={"email": "other@example.com", "password": "password123"},
+    )
+    login = client.post(
+        "/auth/login",
+        json={"email": "other@example.com", "password": "password123"},
+    )
+    other_header = {"Authorization": f"Bearer {login.get_json()['access_token']}"}
+
+    r = client.patch(
+        f"/accounts/{account_id}", json={"name": "Stolen"}, headers=other_header
+    )
+    assert r.status_code == 404
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 10,
+            "description": "Cross-account attempt",
+            "date": "2026-02-01",
+            "account_id": account_id,
+        },
+        headers=other_header,
+    )
+    assert r.status_code == 404

--- a/packages/backend/tests/test_dashboard.py
+++ b/packages/backend/tests/test_dashboard.py
@@ -65,6 +65,70 @@ def test_dashboard_summary_returns_live_data(client, auth_header):
     assert any(c["category_name"] == "Food" for c in payload["category_breakdown"])
 
 
+def test_dashboard_summary_supports_multi_account_overview_and_filter(
+    client, auth_header
+):
+    month = date.today().replace(day=1)
+    r = client.post(
+        "/accounts",
+        json={"name": "Checking", "opening_balance": 1000, "currency": "USD"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    checking_id = r.get_json()["id"]
+    r = client.post(
+        "/accounts",
+        json={"name": "Savings", "opening_balance": 500, "currency": "USD"},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    savings_id = r.get_json()["id"]
+
+    entries = [
+        (3000, "Salary", "INCOME", checking_id),
+        (200, "Groceries", "EXPENSE", checking_id),
+        (100, "Interest", "INCOME", savings_id),
+        (50, "Maintenance", "EXPENSE", savings_id),
+    ]
+    for amount, description, expense_type, account_id in entries:
+        r = client.post(
+            "/expenses",
+            json={
+                "amount": amount,
+                "description": description,
+                "date": month.isoformat(),
+                "expense_type": expense_type,
+                "account_id": account_id,
+            },
+            headers=auth_header,
+        )
+        assert r.status_code == 201
+
+    r = client.get(
+        f"/dashboard/summary?month={month.strftime('%Y-%m')}", headers=auth_header
+    )
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["summary"]["monthly_income"] == 3100.0
+    assert payload["summary"]["monthly_expenses"] == 250.0
+    assert payload["summary"]["total_balance"] == 4350.0
+    assert payload["summary"]["account_count"] == 2
+    assert {a["name"] for a in payload["account_breakdown"]} == {"Checking", "Savings"}
+    assert any(t["account_name"] == "Checking" for t in payload["recent_transactions"])
+
+    r = client.get(
+        f"/dashboard/summary?month={month.strftime('%Y-%m')}&account_ids={savings_id}",
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    filtered = r.get_json()
+    assert filtered["selected_account_ids"] == [savings_id]
+    assert filtered["summary"]["monthly_income"] == 100.0
+    assert filtered["summary"]["monthly_expenses"] == 50.0
+    assert filtered["summary"]["total_balance"] == 550.0
+    assert [a["name"] for a in filtered["account_breakdown"]] == ["Savings"]
+
+
 def test_dashboard_summary_supports_month_filter(client, auth_header):
     month_a = date.today().replace(day=1)
     month_b = (month_a - timedelta(days=1)).replace(day=1)

--- a/packages/backend/tests/test_expenses.py
+++ b/packages/backend/tests/test_expenses.py
@@ -59,6 +59,62 @@ def test_expenses_crud_filters_and_canonical_fields(client, auth_header):
     assert r.get_json() == []
 
 
+def test_expenses_support_account_assignment_and_filter(client, auth_header):
+    r = client.post(
+        "/accounts", json={"name": "Cash", "opening_balance": 50}, headers=auth_header
+    )
+    assert r.status_code == 201
+    cash_id = r.get_json()["id"]
+    r = client.post("/accounts", json={"name": "Savings"}, headers=auth_header)
+    assert r.status_code == 201
+    savings_id = r.get_json()["id"]
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 12.5,
+            "description": "Cash lunch",
+            "date": "2026-02-12",
+            "account_id": cash_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    created = r.get_json()
+    assert created["account_id"] == cash_id
+    assert created["account_name"] == "Cash"
+
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 20,
+            "description": "Savings transfer fee",
+            "date": "2026-02-13",
+            "account_id": savings_id,
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get(f"/expenses?account_id={cash_id}", headers=auth_header)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert len(items) == 1
+    assert items[0]["description"] == "Cash lunch"
+
+    r = client.patch(
+        f"/expenses/{items[0]['id']}",
+        json={"account_id": savings_id},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    assert r.get_json()["account_id"] == savings_id
+
+    r = client.get(f"/expenses?account_id={cash_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
 def test_expense_create_defaults_to_user_preferred_currency(client, auth_header):
     r = client.patch(
         "/auth/me", json={"preferred_currency": "INR"}, headers=auth_header


### PR DESCRIPTION
## Summary
- Adds manual financial accounts with CRUD/archive APIs and an Accounts UI.
- Lets expenses and imports be assigned to accounts, then filters dashboard summaries by selected accounts.
- Extends dashboard account balance/breakdown data, schema compatibility, OpenAPI docs, README, and tests.

Closes #132

## Test plan
- [x] `PYTHONPATH=/home/kali/earnMoney/FinMind/packages/backend /home/kali/earnMoney/FinMind/.venv/bin/python -m pytest /home/kali/earnMoney/FinMind/packages/backend/tests -q`
- [x] `npm test --prefix /home/kali/earnMoney/FinMind/app`
- [x] `npm run lint --prefix /home/kali/earnMoney/FinMind/app`
- [x] `npm run build --prefix /home/kali/earnMoney/FinMind/app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
