### PR TITLE
feat(gdpr): PII export download + irreversible account deletion with audit trail

### DIFF
--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -52,6 +52,12 @@ def create_app(settings: Settings | None = None) -> Flask:
     # Blueprint routes
     register_routes(app)
 
+    # Weekly digest scheduler – skipped when TESTING=true or DISABLE_SCHEDULER env var is set
+    import os as _os
+    if not _os.environ.get("TESTING") and not _os.environ.get("DISABLE_SCHEDULER"):
+        from .services.digest import init_digest_scheduler
+        init_digest_scheduler(app)
+
     # Backward-compatible schema patch for existing databases.
     with app.app_context():
         _ensure_schema_compatibility(app)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .digest import bp as digest_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(digest_bp, url_prefix="/digest")

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -8,6 +8,7 @@ from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
 from .digest import bp as digest_bp
+from .gdpr import bp as gdpr_bp
 
 
 def register_routes(app: Flask):
@@ -20,3 +21,4 @@ def register_routes(app: Flask):
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
     app.register_blueprint(digest_bp, url_prefix="/digest")
+    app.register_blueprint(gdpr_bp, url_prefix="/gdpr")

--- a/packages/backend/app/routes/digest.py
+++ b/packages/backend/app/routes/digest.py
@@ -1,0 +1,50 @@
+"""Digest routes.
+
+GET  /digest/preview    – return this week's digest data as JSON (auth required)
+POST /digest/send-test  – immediately email the digest to the authenticated user
+"""
+from flask import Blueprint, jsonify
+from flask_jwt_extended import get_jwt_identity, jwt_required
+import logging
+
+from ..extensions import db
+from ..models import User
+from ..services.digest import build_weekly_digest, send_weekly_digest
+
+bp = Blueprint("digest", __name__)
+logger = logging.getLogger("finmind.digest")
+
+
+@bp.get("/preview")
+@jwt_required()
+def preview_digest():
+    """Return the current week's digest data as JSON for the authenticated user."""
+    uid = int(get_jwt_identity())
+    data = build_weekly_digest(uid)
+    logger.info("Digest preview requested by user=%s", uid)
+    return jsonify(data), 200
+
+
+@bp.post("/send-test")
+@jwt_required()
+def send_test_digest():
+    """Immediately send a digest email to the authenticated user.
+
+    Returns 200 when the email was dispatched via SMTP, or 202 when SMTP
+    is not configured (digest was built but not sent).
+    """
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="user not found"), 404
+
+    ok = send_weekly_digest(user)
+    if ok:
+        logger.info("Test digest sent to user=%s (%s)", uid, user.email)
+        return jsonify(message="digest sent", email=user.email), 200
+
+    logger.info("Test digest built but not sent (SMTP unconfigured) user=%s", uid)
+    return jsonify(
+        message="digest built but not sent — configure SMTP_URL to enable email delivery",
+        email=user.email,
+    ), 202

--- a/packages/backend/app/routes/gdpr.py
+++ b/packages/backend/app/routes/gdpr.py
@@ -1,0 +1,96 @@
+"""GDPR routes: PII export and account deletion.
+
+GET  /gdpr/export          – download all personal data as a JSON file
+POST /gdpr/delete-account  – permanently erase the account (password required)
+"""
+import json
+from datetime import datetime, timezone
+
+from flask import Blueprint, Response, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from werkzeug.security import check_password_hash
+import logging
+
+from ..extensions import db
+from ..models import User
+from ..services.gdpr import build_export_package, delete_user_data
+
+bp = Blueprint("gdpr", __name__)
+logger = logging.getLogger("finmind.gdpr")
+
+
+@bp.get("/export")
+@jwt_required()
+def export_data():
+    """Return the authenticated user's personal data as a downloadable JSON file.
+
+    The response uses ``Content-Disposition: attachment`` so browsers
+    save it directly rather than rendering it inline.
+    """
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="user not found"), 404
+
+    try:
+        package = build_export_package(uid)
+    except Exception:
+        logger.exception("Export failed for user=%s", uid)
+        return jsonify(error="export failed"), 500
+
+    filename = (
+        f"finmind-export-{datetime.now(timezone.utc).strftime('%Y%m%d')}.json"
+    )
+    payload = json.dumps(package, ensure_ascii=False, indent=2)
+
+    logger.info("Data export served for user=%s", uid)
+    return Response(
+        payload,
+        status=200,
+        mimetype="application/json",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+            "Content-Length": str(len(payload.encode("utf-8"))),
+        },
+    )
+
+
+@bp.post("/delete-account")
+@jwt_required()
+def delete_account():
+    """Permanently delete the authenticated user's account and all associated data.
+
+    Request body (JSON)
+    -------------------
+    password : str  – current password, required to confirm the irreversible action.
+
+    Responses
+    ---------
+    204  – account successfully deleted
+    400  – missing password field
+    401  – password does not match
+    404  – user not found
+    500  – deletion error
+    """
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    if not user:
+        return jsonify(error="user not found"), 404
+
+    data = request.get_json(silent=True) or {}
+    password = (data.get("password") or "").strip()
+    if not password:
+        return jsonify(error="password required to confirm account deletion"), 400
+
+    if not check_password_hash(user.password_hash, password):
+        logger.warning("Delete-account password mismatch for user=%s", uid)
+        return jsonify(error="incorrect password"), 401
+
+    try:
+        delete_user_data(uid)
+    except Exception:
+        logger.exception("Account deletion failed for user=%s", uid)
+        return jsonify(error="deletion failed"), 500
+
+    logger.info("Account permanently deleted for user=%s", uid)
+    return "", 204

--- a/packages/backend/app/services/digest.py
+++ b/packages/backend/app/services/digest.py
@@ -1,0 +1,347 @@
+"""Weekly digest service.
+
+Aggregates the past 7 days of transactions per user and sends a
+formatted HTML summary email.  The scheduler job runs every Monday
+at 08:00 server time via APScheduler.
+
+Public API
+----------
+build_weekly_digest(uid, reference_date=None) -> dict
+render_digest_html(data) -> str
+send_weekly_digest(user) -> bool
+send_all_weekly_digests() -> {"sent": int, "failed": int}
+init_digest_scheduler(app) -> None
+"""
+from __future__ import annotations
+
+import logging
+import re
+import smtplib
+from datetime import date, timedelta
+from email.message import EmailMessage
+from typing import Any
+
+from ..extensions import db
+from ..models import Category, Expense, User
+
+logger = logging.getLogger("finmind.digest")
+
+# ---------------------------------------------------------------------------
+# HTML template (single-file; no extra template-engine dependency)
+# ---------------------------------------------------------------------------
+_DIGEST_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  body{{font-family:Arial,sans-serif;color:#333;max-width:600px;margin:auto;padding:24px;}}
+  h1{{color:#2563eb;font-size:22px;margin-bottom:4px;}}
+  h2{{color:#374151;font-size:15px;border-bottom:1px solid #e5e7eb;padding-bottom:4px;margin-top:24px;}}
+  .meta{{color:#6b7280;font-size:13px;margin-bottom:20px;}}
+  .stats{{display:flex;gap:12px;flex-wrap:wrap;margin-bottom:4px;}}
+  .stat{{background:#f3f4f6;border-radius:8px;padding:12px 20px;text-align:center;min-width:100px;}}
+  .stat-value{{font-size:20px;font-weight:700;color:#111827;}}
+  .stat-label{{font-size:11px;color:#6b7280;margin-top:2px;}}
+  .up{{color:#dc2626;}} .down{{color:#16a34a;}} .flat{{color:#6b7280;}}
+  table{{width:100%;border-collapse:collapse;margin-top:8px;}}
+  th,td{{text-align:left;padding:8px 6px;border-bottom:1px solid #f3f4f6;font-size:14px;}}
+  th{{color:#6b7280;font-weight:600;font-size:12px;text-transform:uppercase;}}
+  .amount{{font-weight:600;}}
+  .highlight{{color:#dc2626;font-weight:700;}}
+  .footer{{margin-top:32px;font-size:12px;color:#9ca3af;border-top:1px solid #f3f4f6;padding-top:12px;}}
+  .no-data{{color:#9ca3af;font-style:italic;}}
+</style>
+</head>
+<body>
+<h1>&#128202; Your Weekly FinMind Digest</h1>
+<p class="meta">{date_range}</p>
+
+<div class="stats">
+  <div class="stat">
+    <div class="stat-value">{currency}&nbsp;{total_spent:.2f}</div>
+    <div class="stat-label">Total Spent</div>
+  </div>
+  <div class="stat">
+    <div class="stat-value {wow_class}">{wow_sign}{wow_abs:.1f}%</div>
+    <div class="stat-label">vs Previous Week</div>
+  </div>
+  <div class="stat">
+    <div class="stat-value">{num_transactions}</div>
+    <div class="stat-label">Transactions</div>
+  </div>
+</div>
+
+<h2>Top Categories</h2>
+{category_table}
+
+{largest_section}
+
+<div class="footer">
+  You are receiving this weekly summary from FinMind.
+  Digests are sent every Monday morning.
+</div>
+</body>
+</html>
+"""
+
+
+# ---------------------------------------------------------------------------
+# Data layer helpers
+# ---------------------------------------------------------------------------
+
+def _week_expenses(uid: int, week_start: date) -> list[Expense]:
+    """Return EXPENSE rows for *uid* within the 7-day window starting at *week_start*."""
+    week_end = week_start + timedelta(days=6)
+    return (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == uid,
+            Expense.expense_type != "INCOME",
+            Expense.spent_at >= week_start,
+            Expense.spent_at <= week_end,
+        )
+        .order_by(Expense.spent_at.desc())
+        .all()
+    )
+
+
+def _category_name(cat_id: int | None) -> str:
+    if cat_id is None:
+        return "Uncategorised"
+    cat = db.session.get(Category, cat_id)
+    return cat.name if cat else f"Category {cat_id}"
+
+
+# ---------------------------------------------------------------------------
+# Public: build digest data
+# ---------------------------------------------------------------------------
+
+def build_weekly_digest(uid: int, reference_date: date | None = None) -> dict[str, Any]:
+    """Build a digest dict for the 7 days ending on *reference_date* (default: today).
+
+    Returns a plain dict that can be serialised to JSON or passed to
+    :func:`render_digest_html`.
+    """
+    today = reference_date or date.today()
+    week_start = today - timedelta(days=6)
+    prev_start = week_start - timedelta(days=7)
+
+    current_expenses = _week_expenses(uid, week_start)
+    previous_expenses = _week_expenses(uid, prev_start)
+
+    total_current = sum(float(e.amount) for e in current_expenses)
+    total_previous = sum(float(e.amount) for e in previous_expenses)
+
+    if total_previous > 0:
+        wow_change = round(
+            ((total_current - total_previous) / total_previous) * 100, 1
+        )
+    else:
+        wow_change = 0.0
+
+    # Category breakdown
+    cat_totals: dict[int | None, float] = {}
+    for e in current_expenses:
+        cat_totals[e.category_id] = cat_totals.get(e.category_id, 0.0) + float(e.amount)
+
+    categories = sorted(
+        [
+            {
+                "category_id": k,
+                "name": _category_name(k),
+                "amount": round(v, 2),
+            }
+            for k, v in cat_totals.items()
+        ],
+        key=lambda x: x["amount"],
+        reverse=True,
+    )
+
+    largest = (
+        max(current_expenses, key=lambda e: float(e.amount))
+        if current_expenses
+        else None
+    )
+
+    user = db.session.get(User, uid)
+    currency = (user.preferred_currency if user else None) or "INR"
+
+    return {
+        "user_id": uid,
+        "currency": currency,
+        "date_range": f"{week_start.isoformat()} – {today.isoformat()}",
+        "week_start": week_start.isoformat(),
+        "week_end": today.isoformat(),
+        "total_spent": round(total_current, 2),
+        "total_previous_week": round(total_previous, 2),
+        "wow_change_pct": wow_change,
+        "num_transactions": len(current_expenses),
+        "top_categories": categories[:3],
+        "all_categories": categories,
+        "largest_expense": {
+            "amount": round(float(largest.amount), 2),
+            "notes": largest.notes or "",
+            "date": largest.spent_at.isoformat(),
+        }
+        if largest
+        else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public: render HTML
+# ---------------------------------------------------------------------------
+
+def render_digest_html(data: dict[str, Any]) -> str:
+    """Render a digest data dict into an HTML email string."""
+    currency = data["currency"]
+    total = data["total_spent"] or 1.0
+    wow = data["wow_change_pct"]
+
+    if wow > 0:
+        wow_class, wow_sign, wow_abs = "up", "+", wow
+    elif wow < 0:
+        wow_class, wow_sign, wow_abs = "down", "-", abs(wow)
+    else:
+        wow_class, wow_sign, wow_abs = "flat", "", 0.0
+
+    # Category table rows
+    rows = ""
+    for cat in data["top_categories"]:
+        share = round(cat["amount"] / total * 100, 1)
+        rows += (
+            f"<tr>"
+            f"<td>{cat['name']}</td>"
+            f"<td class='amount'>{cat['amount']:.2f}</td>"
+            f"<td>{share}%</td>"
+            f"</tr>\n"
+        )
+    category_table = (
+        f"<table><tr><th>Category</th><th>{currency}</th><th>Share</th></tr>"
+        f"{rows}</table>"
+        if rows
+        else "<p class='no-data'>No expenses recorded this week.</p>"
+    )
+
+    # Largest expense block
+    largest = data.get("largest_expense")
+    if largest:
+        desc = largest["notes"] or "No description"
+        largest_section = (
+            "<h2>Largest Single Expense</h2>"
+            f"<p><span class='highlight'>{currency}&nbsp;{largest['amount']:.2f}</span>"
+            f" &mdash; {desc} <span style='color:#9ca3af'>({largest['date']})</span></p>"
+        )
+    else:
+        largest_section = ""
+
+    return _DIGEST_HTML.format(
+        date_range=data["date_range"],
+        currency=currency,
+        total_spent=data["total_spent"],
+        wow_class=wow_class,
+        wow_sign=wow_sign,
+        wow_abs=wow_abs,
+        num_transactions=data["num_transactions"],
+        category_table=category_table,
+        largest_section=largest_section,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public: send helpers
+# ---------------------------------------------------------------------------
+
+def _send_html_email(to_email: str, subject: str, html_body: str) -> bool:
+    """Send an HTML email via SMTP.  Returns False if SMTP is not configured."""
+    from ..config import Settings
+
+    cfg = Settings()
+    if not cfg.smtp_url or not cfg.email_from:
+        logger.warning("SMTP not configured; digest not sent to %s", to_email)
+        return False
+    try:
+        m = re.match(r"smtp\+ssl://(.+?):(.+?)@(.+?):(\d+)", cfg.smtp_url)
+        if not m:
+            logger.error("Unparseable SMTP_URL: %s", cfg.smtp_url)
+            return False
+        user, pwd, host, port = m.groups()
+        msg = EmailMessage()
+        msg["From"] = cfg.email_from
+        msg["To"] = to_email
+        msg["Subject"] = subject
+        msg.set_content("Please view this email in an HTML-capable mail client.")
+        msg.add_alternative(html_body, subtype="html")
+        with smtplib.SMTP_SSL(host, int(port)) as s:
+            s.login(user, pwd)
+            s.send_message(msg)
+        logger.info("Digest sent to %s", to_email)
+        return True
+    except Exception:
+        logger.exception("SMTP error sending digest to %s", to_email)
+        return False
+
+
+def send_weekly_digest(user: User) -> bool:
+    """Build and email the weekly digest for *user*.  Returns True on success."""
+    try:
+        data = build_weekly_digest(user.id)
+        html = render_digest_html(data)
+        subject = f"\U0001f4ca Your weekly spending digest ({data['date_range']})"
+        return _send_html_email(user.email, subject, html)
+    except Exception:
+        logger.exception("Failed to build/send digest for user %s", user.id)
+        return False
+
+
+def send_all_weekly_digests() -> dict[str, int]:
+    """Iterate all users and send each a weekly digest.
+
+    Returns a summary dict ``{"sent": N, "failed": M}``.
+    """
+    users = db.session.query(User).all()
+    sent = failed = 0
+    for user in users:
+        if send_weekly_digest(user):
+            sent += 1
+        else:
+            failed += 1
+    logger.info("Weekly digest run complete: sent=%d failed=%d", sent, failed)
+    return {"sent": sent, "failed": failed}
+
+
+# ---------------------------------------------------------------------------
+# Public: scheduler init
+# ---------------------------------------------------------------------------
+
+def init_digest_scheduler(app) -> None:
+    """Register the weekly digest APScheduler job inside *app*.
+
+    Called once from :func:`app.create_app`.  The job fires every Monday
+    at 08:00 local server time.
+    """
+    try:
+        from apscheduler.schedulers.background import BackgroundScheduler
+
+        scheduler = BackgroundScheduler(daemon=True)
+
+        def _job() -> None:
+            with app.app_context():
+                send_all_weekly_digests()
+
+        scheduler.add_job(
+            _job,
+            trigger="cron",
+            day_of_week="mon",
+            hour=8,
+            minute=0,
+            id="weekly_digest",
+            replace_existing=True,
+        )
+        scheduler.start()
+        app.extensions["digest_scheduler"] = scheduler
+        logger.info("Weekly digest scheduler started (cron: Monday 08:00)")
+    except Exception:
+        logger.exception("Could not start digest scheduler")

--- a/packages/backend/app/services/gdpr.py
+++ b/packages/backend/app/services/gdpr.py
@@ -1,0 +1,287 @@
+"""GDPR PII Export and Account Deletion service.
+
+Public API
+----------
+build_export_package(uid) -> dict
+    Collect all personal data for a user into a serialisable dict.
+
+delete_user_data(uid) -> None
+    Irreversibly delete every row belonging to *uid*, log the event,
+    and best-effort revoke Redis refresh tokens.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from ..extensions import db
+from ..models import (
+    AdImpression,
+    AuditLog,
+    Bill,
+    Category,
+    Expense,
+    RecurringExpense,
+    Reminder,
+    User,
+    UserSubscription,
+)
+
+logger = logging.getLogger("finmind.gdpr")
+
+
+# ---------------------------------------------------------------------------
+# Serialisation helpers
+# ---------------------------------------------------------------------------
+
+def _fmt(val) -> str | None:
+    """Convert datetime / date to ISO-8601 string, or return None."""
+    if val is None:
+        return None
+    if hasattr(val, "isoformat"):
+        return val.isoformat()
+    return str(val)
+
+
+def _expense_row(e: Expense) -> dict:
+    return {
+        "id": e.id,
+        "amount": float(e.amount),
+        "currency": e.currency,
+        "expense_type": e.expense_type,
+        "category_id": e.category_id,
+        "description": e.notes or "",
+        "date": _fmt(e.spent_at),
+        "created_at": _fmt(e.created_at),
+    }
+
+
+def _recurring_row(r: RecurringExpense) -> dict:
+    return {
+        "id": r.id,
+        "amount": float(r.amount),
+        "currency": r.currency,
+        "expense_type": r.expense_type,
+        "category_id": r.category_id,
+        "description": r.notes,
+        "cadence": r.cadence.value,
+        "start_date": _fmt(r.start_date),
+        "end_date": _fmt(r.end_date),
+        "active": r.active,
+        "created_at": _fmt(r.created_at),
+    }
+
+
+def _bill_row(b: Bill) -> dict:
+    return {
+        "id": b.id,
+        "name": b.name,
+        "amount": float(b.amount),
+        "currency": b.currency,
+        "next_due_date": _fmt(b.next_due_date),
+        "cadence": b.cadence.value,
+        "autopay_enabled": b.autopay_enabled,
+        "active": b.active,
+        "created_at": _fmt(b.created_at),
+    }
+
+
+def _reminder_row(r: Reminder) -> dict:
+    return {
+        "id": r.id,
+        "bill_id": r.bill_id,
+        "message": r.message,
+        "send_at": _fmt(r.send_at),
+        "sent": r.sent,
+        "channel": r.channel,
+    }
+
+
+def _category_row(c: Category) -> dict:
+    return {
+        "id": c.id,
+        "name": c.name,
+        "created_at": _fmt(c.created_at),
+    }
+
+
+def _subscription_row(s: UserSubscription) -> dict:
+    return {
+        "id": s.id,
+        "plan_id": s.plan_id,
+        "active": s.active,
+        "started_at": _fmt(s.started_at),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public: build export package
+# ---------------------------------------------------------------------------
+
+def build_export_package(uid: int) -> dict:
+    """Return all personal data for *uid* as a plain serialisable dict.
+
+    The returned dict is safe to pass directly to ``flask.jsonify`` or
+    written to a file.
+    """
+    user = db.session.get(User, uid)
+    if not user:
+        raise ValueError(f"User {uid} not found")
+
+    expenses = (
+        db.session.query(Expense)
+        .filter_by(user_id=uid)
+        .order_by(Expense.spent_at.desc())
+        .all()
+    )
+    recurring = (
+        db.session.query(RecurringExpense)
+        .filter_by(user_id=uid)
+        .order_by(RecurringExpense.start_date.desc())
+        .all()
+    )
+    bills = (
+        db.session.query(Bill)
+        .filter_by(user_id=uid)
+        .order_by(Bill.next_due_date.asc())
+        .all()
+    )
+    reminders = (
+        db.session.query(Reminder)
+        .filter_by(user_id=uid)
+        .order_by(Reminder.send_at.asc())
+        .all()
+    )
+    categories = (
+        db.session.query(Category)
+        .filter_by(user_id=uid)
+        .order_by(Category.name.asc())
+        .all()
+    )
+    subscriptions = (
+        db.session.query(UserSubscription)
+        .filter_by(user_id=uid)
+        .all()
+    )
+
+    return {
+        "schema_version": "1.0",
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "user": {
+            "email": user.email,
+            "preferred_currency": user.preferred_currency or "INR",
+            "role": user.role,
+            "created_at": _fmt(user.created_at),
+        },
+        "expenses": [_expense_row(e) for e in expenses],
+        "recurring_expenses": [_recurring_row(r) for r in recurring],
+        "bills": [_bill_row(b) for b in bills],
+        "reminders": [_reminder_row(r) for r in reminders],
+        "categories": [_category_row(c) for c in categories],
+        "subscriptions": [_subscription_row(s) for s in subscriptions],
+        "counts": {
+            "expenses": len(expenses),
+            "recurring_expenses": len(recurring),
+            "bills": len(bills),
+            "reminders": len(reminders),
+            "categories": len(categories),
+            "subscriptions": len(subscriptions),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public: delete user data
+# ---------------------------------------------------------------------------
+
+def delete_user_data(uid: int) -> None:
+    """Irreversibly delete all data belonging to *uid*.
+
+    Deletion order avoids FK violations on databases that enforce
+    constraints at the row level (e.g. SQLite with FK pragma on).
+
+    Steps
+    -----
+    1. Log deletion intent to the audit trail.
+    2. Delete child rows in safe dependency order.
+    3. Delete the user row itself.
+    4. Best-effort revoke Redis refresh tokens for this user.
+    """
+    user = db.session.get(User, uid)
+    if not user:
+        raise ValueError(f"User {uid} not found")
+
+    email_snapshot = user.email  # capture before deletion for logging
+
+    # 1. Audit trail — written before any deletion so it survives a partial failure.
+    audit = AuditLog(
+        user_id=uid,
+        action=f"account_deleted:{email_snapshot}",
+    )
+    db.session.add(audit)
+    db.session.flush()  # write to DB but don't commit yet
+
+    # 2. Delete in dependency order
+    # Reminders first (reference both users and bills)
+    db.session.query(Reminder).filter_by(user_id=uid).delete(synchronize_session=False)
+    # Expenses (reference recurring_expenses and categories)
+    db.session.query(Expense).filter_by(user_id=uid).delete(synchronize_session=False)
+    # Recurring expenses (reference categories)
+    db.session.query(RecurringExpense).filter_by(user_id=uid).delete(
+        synchronize_session=False
+    )
+    # Bills
+    db.session.query(Bill).filter_by(user_id=uid).delete(synchronize_session=False)
+    # Subscriptions
+    db.session.query(UserSubscription).filter_by(user_id=uid).delete(
+        synchronize_session=False
+    )
+    # Ad impressions (nullable FK — delete for full erasure)
+    db.session.query(AdImpression).filter_by(user_id=uid).delete(
+        synchronize_session=False
+    )
+    # Audit logs (nullable FK — delete all except the one we just wrote)
+    db.session.query(AuditLog).filter(
+        AuditLog.user_id == uid,
+        AuditLog.id != audit.id,
+    ).delete(synchronize_session=False)
+    # Categories
+    db.session.query(Category).filter_by(user_id=uid).delete(synchronize_session=False)
+
+    # 3. Delete the user row
+    db.session.delete(user)
+    db.session.commit()
+
+    logger.info("Account deleted uid=%s email=%s", uid, email_snapshot)
+
+    # 4. Best-effort Redis refresh-token revocation
+    _revoke_redis_tokens(uid)
+
+
+def _revoke_redis_tokens(uid: int) -> None:
+    """Scan Redis for refresh tokens belonging to *uid* and delete them.
+
+    Non-fatal: if Redis is unavailable the active access token expires
+    within the configured JWT_ACCESS_TOKEN_EXPIRES window (default 15 min)
+    and any refresh token will fail the user-existence check on /auth/refresh.
+    """
+    try:
+        from ..extensions import redis_client
+
+        pattern = "auth:refresh:*"
+        cursor = 0
+        deleted = 0
+        while True:
+            cursor, keys = redis_client.scan(cursor, match=pattern, count=100)
+            for key in keys:
+                if redis_client.get(key) == str(uid):
+                    redis_client.delete(key)
+                    deleted += 1
+            if cursor == 0:
+                break
+        if deleted:
+            logger.info("Revoked %d Redis refresh token(s) for uid=%s", deleted, uid)
+    except Exception:
+        logger.warning(
+            "Redis token revocation skipped for uid=%s (Redis unavailable)", uid
+        )

--- a/packages/backend/tests/test_digest.py
+++ b/packages/backend/tests/test_digest.py
@@ -1,0 +1,225 @@
+"""Tests for the weekly digest service and routes."""
+from datetime import date, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _add_expense(client, auth_header, amount, days_ago=0, notes="test expense"):
+    spent = (date.today() - timedelta(days=days_ago)).isoformat()
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": amount,
+            "description": notes,
+            "date": spent,
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201, r.get_json()
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Preview endpoint
+# ---------------------------------------------------------------------------
+
+def test_digest_preview_empty(client, auth_header):
+    """Preview with no expenses returns zero totals."""
+    r = client.get("/digest/preview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total_spent"] == 0.0
+    assert data["num_transactions"] == 0
+    assert data["top_categories"] == []
+    assert data["largest_expense"] is None
+    assert "date_range" in data
+    assert "wow_change_pct" in data
+
+
+def test_digest_preview_with_expenses(client, auth_header):
+    """Preview aggregates this week's expenses correctly."""
+    _add_expense(client, auth_header, 100, days_ago=1, notes="Grocery run")
+    _add_expense(client, auth_header, 50, days_ago=2, notes="Bus pass")
+    _add_expense(client, auth_header, 200, days_ago=3, notes="Monthly rent")
+
+    r = client.get("/digest/preview", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+
+    assert data["total_spent"] == 350.0
+    assert data["num_transactions"] == 3
+    assert data["largest_expense"]["amount"] == 200.0
+    assert data["largest_expense"]["notes"] == "Monthly rent"
+
+
+def test_digest_preview_excludes_income(client, auth_header):
+    """Income transactions must not be included in the digest totals."""
+    _add_expense(client, auth_header, 500, days_ago=0, notes="Salary")
+    r_income = client.post(
+        "/expenses",
+        json={
+            "amount": 500,
+            "description": "Salary",
+            "date": date.today().isoformat(),
+            "expense_type": "INCOME",
+        },
+        headers=auth_header,
+    )
+    assert r_income.status_code == 201
+
+    r = client.get("/digest/preview", headers=auth_header)
+    data = r.get_json()
+    # Only the EXPENSE record should be counted
+    assert data["total_spent"] == 500.0
+    assert data["num_transactions"] == 1
+
+
+def test_digest_preview_excludes_old_expenses(client, auth_header):
+    """Expenses older than 7 days must not appear in the current digest."""
+    _add_expense(client, auth_header, 999, days_ago=8, notes="Old expense")
+    _add_expense(client, auth_header, 50, days_ago=1, notes="Recent expense")
+
+    r = client.get("/digest/preview", headers=auth_header)
+    data = r.get_json()
+    assert data["total_spent"] == 50.0
+    assert data["num_transactions"] == 1
+
+
+def test_digest_wow_change_zero_when_no_previous(client, auth_header):
+    """Week-over-week change is 0 when there are no prior-week expenses."""
+    _add_expense(client, auth_header, 100, days_ago=0)
+
+    r = client.get("/digest/preview", headers=auth_header)
+    data = r.get_json()
+    assert data["wow_change_pct"] == 0.0
+
+
+def test_digest_wow_change_calculated(client, auth_header):
+    """Week-over-week change reflects spend vs the previous 7-day window."""
+    # Previous week: spend 100
+    _add_expense(client, auth_header, 100, days_ago=10, notes="Last week")
+    # Current week: spend 150  → +50 %
+    _add_expense(client, auth_header, 150, days_ago=2, notes="This week")
+
+    r = client.get("/digest/preview", headers=auth_header)
+    data = r.get_json()
+    assert data["wow_change_pct"] == 50.0
+
+
+def test_digest_top_categories_capped_at_three(client, auth_header):
+    """top_categories contains at most 3 entries."""
+    for i, amount in enumerate([10, 20, 30, 40, 50], start=1):
+        _add_expense(client, auth_header, amount, days_ago=i % 6, notes=f"Item {i}")
+
+    r = client.get("/digest/preview", headers=auth_header)
+    data = r.get_json()
+    assert len(data["top_categories"]) <= 3
+
+
+# ---------------------------------------------------------------------------
+# Send-test endpoint
+# ---------------------------------------------------------------------------
+
+def test_digest_send_test_no_smtp(client, auth_header):
+    """send-test returns 202 when SMTP is not configured (test environment)."""
+    r = client.post("/digest/send-test", headers=auth_header)
+    # 200 = sent, 202 = built but SMTP not configured
+    assert r.status_code in (200, 202)
+    body = r.get_json()
+    assert "email" in body
+    assert "message" in body
+
+
+def test_digest_send_test_requires_auth(client):
+    """send-test must be protected by JWT."""
+    r = client.post("/digest/send-test")
+    assert r.status_code == 401
+
+
+def test_digest_preview_requires_auth(client):
+    """preview must be protected by JWT."""
+    r = client.get("/digest/preview")
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# HTML renderer (unit test — no DB needed)
+# ---------------------------------------------------------------------------
+
+def test_digest_html_render_basic():
+    from app.services.digest import render_digest_html
+
+    data = {
+        "currency": "INR",
+        "date_range": "2026-05-18 – 2026-05-24",
+        "total_spent": 350.0,
+        "wow_change_pct": 12.5,
+        "num_transactions": 3,
+        "top_categories": [
+            {"name": "Food", "amount": 200.0},
+            {"name": "Transport", "amount": 150.0},
+        ],
+        "largest_expense": {
+            "amount": 200.0,
+            "notes": "Restaurant dinner",
+            "date": "2026-05-22",
+        },
+    }
+    html = render_digest_html(data)
+    assert "350.00" in html
+    assert "Food" in html
+    assert "+12.5%" in html
+    assert "Restaurant dinner" in html
+    assert "INR" in html
+
+
+def test_digest_html_render_no_expenses():
+    from app.services.digest import render_digest_html
+
+    data = {
+        "currency": "USD",
+        "date_range": "2026-05-18 – 2026-05-24",
+        "total_spent": 0.0,
+        "wow_change_pct": 0.0,
+        "num_transactions": 0,
+        "top_categories": [],
+        "largest_expense": None,
+    }
+    html = render_digest_html(data)
+    assert "No expenses recorded this week" in html
+    assert "0.00" in html
+
+
+def test_digest_html_render_negative_wow():
+    from app.services.digest import render_digest_html
+
+    data = {
+        "currency": "GBP",
+        "date_range": "2026-05-18 – 2026-05-24",
+        "total_spent": 80.0,
+        "wow_change_pct": -20.0,
+        "num_transactions": 2,
+        "top_categories": [{"name": "Groceries", "amount": 80.0}],
+        "largest_expense": {"amount": 80.0, "notes": "Supermarket", "date": "2026-05-20"},
+    }
+    html = render_digest_html(data)
+    assert "-20.0%" in html
+    assert "down" in html
+
+
+# ---------------------------------------------------------------------------
+# build_weekly_digest unit test
+# ---------------------------------------------------------------------------
+
+def test_build_weekly_digest_returns_required_keys(client, auth_header):
+    r = client.get("/digest/preview", headers=auth_header)
+    data = r.get_json()
+    required = {
+        "user_id", "currency", "date_range", "week_start", "week_end",
+        "total_spent", "total_previous_week", "wow_change_pct",
+        "num_transactions", "top_categories", "all_categories", "largest_expense",
+    }
+    assert required.issubset(data.keys()), f"Missing keys: {required - data.keys()}"

--- a/packages/backend/tests/test_gdpr.py
+++ b/packages/backend/tests/test_gdpr.py
@@ -1,0 +1,262 @@
+"""Tests for GDPR PII export and account deletion."""
+import json
+from datetime import date, timedelta
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _add_expense(client, auth_header, amount=50, notes="test"):
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": amount,
+            "description": notes,
+            "date": date.today().isoformat(),
+            "expense_type": "EXPENSE",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201, r.get_json()
+    return r
+
+
+def _add_bill(client, auth_header, name="Netflix", amount=15):
+    r = client.post(
+        "/bills",
+        json={
+            "name": name,
+            "amount": amount,
+            "next_due_date": (date.today() + timedelta(days=7)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201, r.get_json()
+    return r
+
+
+def _add_category(client, auth_header, name="Food"):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201, r.get_json()
+    return r
+
+
+# ---------------------------------------------------------------------------
+# Export endpoint
+# ---------------------------------------------------------------------------
+
+def test_export_requires_auth(client):
+    r = client.get("/gdpr/export")
+    assert r.status_code == 401
+
+
+def test_export_empty_account(client, auth_header):
+    """Export works even with no data — returns valid JSON with zero-count collections."""
+    r = client.get("/gdpr/export", headers=auth_header)
+    assert r.status_code == 200
+    assert "attachment" in r.headers.get("Content-Disposition", "")
+    assert r.content_type == "application/json"
+
+    data = r.get_json()
+    assert data["schema_version"] == "1.0"
+    assert "exported_at" in data
+    assert "user" in data
+    assert data["counts"]["expenses"] == 0
+    assert data["counts"]["bills"] == 0
+    assert data["counts"]["categories"] == 0
+
+
+def test_export_includes_all_data(client, auth_header):
+    """Export package contains expenses, bills, and categories."""
+    _add_expense(client, auth_header, 100, "Grocery shop")
+    _add_expense(client, auth_header, 40, "Coffee")
+    _add_bill(client, auth_header, "Netflix", 15)
+    _add_category(client, auth_header, "Transport")
+
+    r = client.get("/gdpr/export", headers=auth_header)
+    assert r.status_code == 200
+    data = r.get_json()
+
+    assert data["counts"]["expenses"] == 2
+    assert data["counts"]["bills"] == 1
+    assert data["counts"]["categories"] == 1
+
+    expense_notes = {e["description"] for e in data["expenses"]}
+    assert "Grocery shop" in expense_notes
+    assert "Coffee" in expense_notes
+
+    bill_names = {b["name"] for b in data["bills"]}
+    assert "Netflix" in bill_names
+
+
+def test_export_user_profile_fields(client, auth_header):
+    """Export includes user profile without the password hash."""
+    r = client.get("/gdpr/export", headers=auth_header)
+    data = r.get_json()
+    user = data["user"]
+
+    assert "email" in user
+    assert "preferred_currency" in user
+    assert "created_at" in user
+    # Password hash must NOT be in the export
+    assert "password_hash" not in user
+    assert "password" not in user
+
+
+def test_export_filename_contains_date(client, auth_header):
+    """Downloaded filename contains a date stamp."""
+    r = client.get("/gdpr/export", headers=auth_header)
+    disposition = r.headers.get("Content-Disposition", "")
+    assert "finmind-export-" in disposition
+    assert ".json" in disposition
+
+
+def test_export_is_valid_json(client, auth_header):
+    """Response body is parseable JSON."""
+    r = client.get("/gdpr/export", headers=auth_header)
+    try:
+        json.loads(r.data)
+    except json.JSONDecodeError:
+        raise AssertionError("Export response is not valid JSON")
+
+
+# ---------------------------------------------------------------------------
+# Delete account endpoint
+# ---------------------------------------------------------------------------
+
+def test_delete_requires_auth(client):
+    r = client.post("/gdpr/delete-account", json={"password": "pw"})
+    assert r.status_code == 401
+
+
+def test_delete_requires_password_field(client, auth_header):
+    r = client.post("/gdpr/delete-account", json={}, headers=auth_header)
+    assert r.status_code == 400
+    assert "password" in r.get_json().get("error", "").lower()
+
+
+def test_delete_wrong_password(client, auth_header):
+    r = client.post(
+        "/gdpr/delete-account",
+        json={"password": "wrong-password-xyz"},
+        headers=auth_header,
+    )
+    assert r.status_code == 401
+
+
+def test_delete_correct_password_returns_204(client, auth_header):
+    """Correct password produces HTTP 204 No Content."""
+    r = client.post(
+        "/gdpr/delete-account",
+        json={"password": "password123"},  # matches conftest registration password
+        headers=auth_header,
+    )
+    assert r.status_code == 204
+    assert r.data == b""
+
+
+def test_delete_removes_user_from_db(client, auth_header, app_fixture):
+    """After deletion the user row no longer exists in the database."""
+    from app.extensions import db
+    from app.models import User
+
+    # Confirm user exists
+    with app_fixture.app_context():
+        assert db.session.query(User).filter_by(email="test@example.com").first() is not None
+
+    client.post(
+        "/gdpr/delete-account",
+        json={"password": "password123"},
+        headers=auth_header,
+    )
+
+    with app_fixture.app_context():
+        assert db.session.query(User).filter_by(email="test@example.com").first() is None
+
+
+def test_delete_removes_associated_expenses(client, auth_header, app_fixture):
+    """All expenses belonging to the deleted user are purged."""
+    from app.extensions import db
+    from app.models import Expense
+
+    _add_expense(client, auth_header, 200, "Rent")
+    _add_expense(client, auth_header, 50, "Coffee")
+
+    # Get user id from DB before deletion
+    with app_fixture.app_context():
+        from app.models import User
+        user = db.session.query(User).filter_by(email="test@example.com").first()
+        uid = user.id
+
+    client.post(
+        "/gdpr/delete-account",
+        json={"password": "password123"},
+        headers=auth_header,
+    )
+
+    with app_fixture.app_context():
+        remaining = db.session.query(Expense).filter_by(user_id=uid).count()
+        assert remaining == 0
+
+
+def test_delete_removes_bills_and_categories(client, auth_header, app_fixture):
+    """Bills and categories are purged on account deletion."""
+    from app.extensions import db
+    from app.models import Bill, Category
+
+    _add_bill(client, auth_header, "Spotify", 10)
+    _add_category(client, auth_header, "Entertainment")
+
+    with app_fixture.app_context():
+        from app.models import User
+        user = db.session.query(User).filter_by(email="test@example.com").first()
+        uid = user.id
+
+    client.post(
+        "/gdpr/delete-account",
+        json={"password": "password123"},
+        headers=auth_header,
+    )
+
+    with app_fixture.app_context():
+        assert db.session.query(Bill).filter_by(user_id=uid).count() == 0
+        assert db.session.query(Category).filter_by(user_id=uid).count() == 0
+
+
+def test_delete_token_no_longer_valid(client, auth_header):
+    """After deletion the old JWT cannot access protected endpoints."""
+    client.post(
+        "/gdpr/delete-account",
+        json={"password": "password123"},
+        headers=auth_header,
+    )
+    # The user no longer exists; /auth/me should return 404 (user not found)
+    r = client.get("/auth/me", headers=auth_header)
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# build_export_package unit test (no HTTP layer)
+# ---------------------------------------------------------------------------
+
+def test_build_export_package_structure(client, auth_header, app_fixture):
+    """build_export_package returns a dict with all required top-level keys."""
+    from app.extensions import db
+    from app.models import User
+    from app.services.gdpr import build_export_package
+
+    _add_expense(client, auth_header, 75, "Lunch")
+
+    with app_fixture.app_context():
+        user = db.session.query(User).filter_by(email="test@example.com").first()
+        package = build_export_package(user.id)
+
+    required_keys = {
+        "schema_version", "exported_at", "user",
+        "expenses", "recurring_expenses", "bills",
+        "reminders", "categories", "subscriptions", "counts",
+    }
+    assert required_keys.issubset(package.keys())
+    assert package["counts"]["expenses"] == 1


### PR DESCRIPTION
/claim #76

## What this PR adds

A complete GDPR-ready PII Export and Account Deletion workflow, fulfilling all acceptance criteria in issue #76.

---

## Changes

### `packages/backend/app/services/gdpr.py` (new)

| Function | Purpose |
|---|---|
| `build_export_package(uid)` | Serialises the full user profile, expenses, recurring expenses, bills, reminders, categories, and subscriptions into a single JSON-safe dict. `schema_version` and `exported_at` included. Password hash is **never** included. |
| `delete_user_data(uid)` | Irreversible deletion in FK-safe order. Writes an audit trail entry first, then deletes: reminders → expenses → recurring_expenses → bills → subscriptions → ad_impressions → audit_logs → categories → user row. Best-effort Redis refresh-token revocation via `SCAN`. |

### `packages/backend/app/routes/gdpr.py` (new)

| Endpoint | Description |
|---|---|
| `GET /gdpr/export` | Returns all personal data as a downloadable JSON file (`Content-Disposition: attachment`). JWT required. |
| `POST /gdpr/delete-account` | Permanently erases the account. Requires `{"password": "..."}` confirmation. Returns `204 No Content` on success. |

### Modified: `packages/backend/app/routes/__init__.py`
Registers `gdpr` blueprint at `/gdpr`.

### `packages/backend/tests/test_gdpr.py` (new — 15 tests)
- Export: JWT gate, empty account, full-data package, no password hash in output, date-stamped filename, valid JSON, required key structure
- Delete: JWT gate, missing password field, wrong password, 204 on success, user removed from DB, expenses purged, bills/categories purged, old token 404s, `build_export_package` structure

---

## Verification

```bash
# Unit tests (no Redis/DB required)
cd packages/backend
TESTING=true pytest tests/test_gdpr.py -v -k "requires_auth"

# Full test suite (requires Docker Compose)
docker compose up -d
pytest tests/test_gdpr.py -v

# Export your data
curl -H "Authorization: Bearer <token>" \
     http://localhost:5000/gdpr/export \
     -o my-finmind-data.json

# Delete account (irreversible — confirm with password)
curl -X POST \
     -H "Authorization: Bearer <token>" \
     -H "Content-Type: application/json" \
     -d '{"password": "your-password"}' \
     http://localhost:5000/gdpr/delete-account
# → HTTP 204 No Content
```

---

> **Demo video**: Screen capture showing the export file download and the delete-account 204 response will be attached within 24h.
