### PR TITLE
Add login anomaly detection and security alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ flowchart LR
 ## PostgreSQL Schema (DDL)
 See `backend/app/db/schema.sql`. Key tables:
 - users, categories, expenses, bills, reminders
+- login_events, security_alerts
 - ad_impressions, subscription_plans, user_subscriptions
 - refresh_tokens (optional if rotating), audit_logs
 
@@ -61,11 +62,13 @@ See `backend/app/db/schema.sql`. Key tables:
 
 ## API Endpoints
 OpenAPI: `backend/app/openapi.yaml`
-- Auth: `/auth/register`, `/auth/login`, `/auth/refresh`
+- Auth: `/auth/register`, `/auth/login`, `/auth/refresh`, `/auth/login-history`, `/auth/security-alerts`, `/auth/security-alerts/{id}/acknowledge`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
 - Insights: `/insights/monthly`, `/insights/budget-suggestion`
+
+Login responses include `security_alerts` when a known account signs in from a new IP address, new device/browser, unusual hour, or after a burst of failed attempts. The frontend shows returned login alerts immediately and lists recent security alerts in Account Settings, where users can mark them reviewed.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/__tests__/AccountSecurity.test.tsx
+++ b/app/src/__tests__/AccountSecurity.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Account from '@/pages/Account';
+
+const toastMock = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+jest.mock('@/api/auth', () => ({
+  acknowledgeSecurityAlert: jest.fn(),
+  getSecurityAlerts: jest.fn(),
+  me: jest.fn(),
+  updateMe: jest.fn(),
+}));
+
+jest.mock('@/lib/auth', () => ({
+  setCurrency: jest.fn(),
+}));
+
+import {
+  acknowledgeSecurityAlert,
+  getSecurityAlerts,
+  me,
+  updateMe,
+} from '@/api/auth';
+
+describe('Account security alerts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (me as jest.Mock).mockResolvedValue({
+      id: 1,
+      email: 'demo@finmind.local',
+      preferred_currency: 'USD',
+    });
+    (updateMe as jest.Mock).mockResolvedValue({
+      id: 1,
+      email: 'demo@finmind.local',
+      preferred_currency: 'USD',
+    });
+    (getSecurityAlerts as jest.Mock).mockResolvedValue({
+      unread_count: 1,
+      alerts: [
+        {
+          id: 7,
+          login_event_id: 3,
+          alert_type: 'new_device',
+          severity: 'medium',
+          message: 'New device or browser detected.',
+          details: {
+            ip_address: '203.0.113.9',
+            user_agent: 'NewBrowser/2',
+          },
+          acknowledged: false,
+          created_at: '2026-05-26T05:00:00',
+        },
+      ],
+    });
+    (acknowledgeSecurityAlert as jest.Mock).mockResolvedValue({
+      id: 7,
+      acknowledged: true,
+    });
+  });
+
+  it('shows recent login security alerts and lets users acknowledge them', async () => {
+    render(<Account />);
+
+    expect(await screen.findByText('Security Alerts')).toBeInTheDocument();
+    expect(
+      screen.getByText('New device or browser detected.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/203\.0\.113\.9/)).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /mark reviewed/i }),
+    );
+
+    await waitFor(() => expect(acknowledgeSecurityAlert).toHaveBeenCalledWith(7));
+  });
+});

--- a/app/src/__tests__/SignIn.test.tsx
+++ b/app/src/__tests__/SignIn.test.tsx
@@ -90,6 +90,43 @@ describe('SignIn page', () => {
     expect(navigateMock).toHaveBeenCalled();
   });
 
+  it('shows a security toast when login returns suspicious activity alerts', async () => {
+    (login as jest.Mock).mockResolvedValue({
+      access_token: 'a',
+      refresh_token: 'r',
+      security_alerts: [
+        {
+          id: 7,
+          alert_type: 'failed_login_burst',
+          severity: 'high',
+          message: 'Multiple failed login attempts were detected before this login.',
+          details: {},
+          acknowledged: false,
+          created_at: '2026-05-26T05:00:00',
+        },
+      ],
+    });
+
+    render(
+      <MemoryRouter>
+        <SignIn />
+      </MemoryRouter>
+    );
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'demo@finmind.local');
+    await userEvent.type(screen.getByLabelText(/password/i), 'DemoPass123!');
+    await userEvent.click(screen.getByRole('button', { name: /sign in to your account/i }));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Security alert',
+          description: expect.stringMatching(/failed login attempts/i),
+        }),
+      ),
+    );
+  });
+
   it('shows error toast on failed login', async () => {
     (login as jest.Mock).mockRejectedValue(new Error('invalid credentials'));
 

--- a/app/src/api/auth.ts
+++ b/app/src/api/auth.ts
@@ -1,6 +1,37 @@
 import { api } from './client';
 
-export type LoginResponse = { access_token: string; refresh_token?: string };
+export type SecurityAlert = {
+  id: number;
+  login_event_id?: number | null;
+  alert_type: 'new_ip' | 'new_device' | 'unusual_hour' | 'failed_login_burst';
+  severity: 'medium' | 'high';
+  message: string;
+  details: {
+    ip_address?: string;
+    user_agent?: string;
+    [key: string]: unknown;
+  };
+  acknowledged: boolean;
+  created_at: string;
+};
+
+export type LoginEvent = {
+  id: number;
+  email: string;
+  ip_address: string;
+  user_agent: string;
+  success: boolean;
+  failure_reason?: string | null;
+  is_suspicious: boolean;
+  suspicion_reasons: string[];
+  occurred_at: string;
+};
+
+export type LoginResponse = {
+  access_token: string;
+  refresh_token?: string;
+  security_alerts?: SecurityAlert[];
+};
 
 export async function login(email: string, password: string): Promise<LoginResponse> {
   return api<LoginResponse>('/auth/login', { method: 'POST', body: { email, password } });
@@ -34,4 +65,24 @@ export async function updateMe(payload: {
   preferred_currency: string;
 }): Promise<MeResponse> {
   return api<MeResponse>('/auth/me', { method: 'PATCH', body: payload });
+}
+
+export async function getLoginHistory(limit = 50): Promise<{ events: LoginEvent[] }> {
+  return api<{ events: LoginEvent[] }>(`/auth/login-history?limit=${limit}`);
+}
+
+export async function getSecurityAlerts(
+  limit = 50,
+): Promise<{ alerts: SecurityAlert[]; unread_count: number }> {
+  return api<{ alerts: SecurityAlert[]; unread_count: number }>(
+    `/auth/security-alerts?limit=${limit}`,
+  );
+}
+
+export async function acknowledgeSecurityAlert(
+  alertId: number,
+): Promise<SecurityAlert> {
+  return api<SecurityAlert>(`/auth/security-alerts/${alertId}/acknowledge`, {
+    method: 'POST',
+  });
 }

--- a/app/src/pages/Account.tsx
+++ b/app/src/pages/Account.tsx
@@ -2,8 +2,15 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
-import { me, updateMe } from '@/api/auth';
+import {
+  acknowledgeSecurityAlert,
+  getSecurityAlerts,
+  me,
+  type SecurityAlert,
+  updateMe,
+} from '@/api/auth';
 import { setCurrency } from '@/lib/auth';
+import { AlertTriangle, CheckCircle2, ShieldCheck } from 'lucide-react';
 
 const SUPPORTED_CURRENCIES = [
   { code: 'INR', label: 'Indian Rupee (INR)' },
@@ -21,11 +28,15 @@ export default function Account() {
   const { toast } = useToast();
   const [email, setEmail] = useState('');
   const [currency, setCurrencyState] = useState('INR');
+  const [securityAlerts, setSecurityAlerts] = useState<SecurityAlert[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [securityLoading, setSecurityLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [acknowledgingId, setAcknowledgingId] = useState<number | null>(null);
 
   useEffect(() => {
-    const load = async () => {
+    const loadAccount = async () => {
       setLoading(true);
       try {
         const data = await me();
@@ -39,7 +50,26 @@ export default function Account() {
         setLoading(false);
       }
     };
-    void load();
+
+    const loadSecurityAlerts = async () => {
+      setSecurityLoading(true);
+      try {
+        const data = await getSecurityAlerts();
+        setSecurityAlerts(data.alerts);
+        setUnreadCount(data.unread_count);
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to load security alerts';
+        toast({ title: 'Failed to load security alerts', description: message });
+      } finally {
+        setSecurityLoading(false);
+      }
+    };
+
+    void loadAccount();
+    void loadSecurityAlerts();
   }, [toast]);
 
   const onSave = async () => {
@@ -57,6 +87,35 @@ export default function Account() {
       toast({ title: 'Failed to update account', description: message });
     } finally {
       setSaving(false);
+    }
+  };
+
+  const onAcknowledge = async (alert: SecurityAlert) => {
+    setAcknowledgingId(alert.id);
+    try {
+      const updated = await acknowledgeSecurityAlert(alert.id);
+      setSecurityAlerts((current) =>
+        current.map((item) =>
+          item.id === updated.id
+            ? { ...item, acknowledged: updated.acknowledged }
+            : item,
+        ),
+      );
+      if (!alert.acknowledged && updated.acknowledged) {
+        setUnreadCount((count) => Math.max(0, count - 1));
+      }
+      toast({
+        title: 'Security alert reviewed',
+        description: alert.message,
+      });
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to update security alert';
+      toast({ title: 'Failed to update security alert', description: message });
+    } finally {
+      setAcknowledgingId(null);
     }
   };
 
@@ -108,6 +167,93 @@ export default function Account() {
           </>
         )}
       </div>
+
+      <div className="card card-interactive space-y-5 fade-in-up">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex items-start gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <ShieldCheck className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">
+                Security Alerts
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {unreadCount} unread login {unreadCount === 1 ? 'alert' : 'alerts'}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {securityLoading ? (
+          <div className="text-sm text-muted-foreground">
+            Loading security alerts...
+          </div>
+        ) : securityAlerts.length === 0 ? (
+          <div className="rounded-lg border border-border bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+            No suspicious login activity.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {securityAlerts.map((alert) => (
+              <div
+                key={alert.id}
+                className="rounded-lg border border-border bg-background px-4 py-3"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex min-w-0 items-start gap-3">
+                    {alert.acknowledged ? (
+                      <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" />
+                    ) : (
+                      <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+                    )}
+                    <div className="min-w-0">
+                      <div className="font-medium text-foreground">
+                        {alert.message}
+                      </div>
+                      <div className="mt-1 break-words text-sm text-muted-foreground">
+                        {securityAlertMeta(alert)}
+                      </div>
+                      <div className="mt-1 text-xs uppercase tracking-wide text-muted-foreground">
+                        {alert.severity} severity
+                      </div>
+                    </div>
+                  </div>
+                  {!alert.acknowledged && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => void onAcknowledge(alert)}
+                      disabled={acknowledgingId === alert.id}
+                    >
+                      {acknowledgingId === alert.id
+                        ? 'Reviewing...'
+                        : 'Mark reviewed'}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
+}
+
+function securityAlertMeta(alert: SecurityAlert): string {
+  const ip = alert.details?.ip_address
+    ? `IP ${String(alert.details.ip_address)}`
+    : null;
+  const device = alert.details?.user_agent
+    ? `Device ${String(alert.details.user_agent)}`
+    : null;
+  const timestamp = formatTimestamp(alert.created_at);
+  return [ip, device, timestamp].filter(Boolean).join(' / ');
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
 }

--- a/app/src/pages/SignIn.tsx
+++ b/app/src/pages/SignIn.tsx
@@ -132,6 +132,17 @@ export function SignIn() {
                       title: 'Welcome back 👋',
                       description: 'You have successfully signed in.',
                     });
+                    const securityAlert = res.security_alerts?.[0];
+                    if (securityAlert) {
+                      toast({
+                        variant:
+                          securityAlert.severity === 'high'
+                            ? 'destructive'
+                            : undefined,
+                        title: 'Security alert',
+                        description: securityAlert.message,
+                      });
+                    }
                     nav(from, { replace: true });
                   } catch (err: unknown) {
                     const message = err instanceof Error ? err.message : 'Invalid email or password';

--- a/packages/backend/app/__init__.py
+++ b/packages/backend/app/__init__.py
@@ -100,6 +100,8 @@ def _ensure_schema_compatibility(app: Flask) -> None:
     """Apply minimal compatibility ALTERs for existing deployments."""
     if db.engine.dialect.name != "postgresql":
         return
+    from .models import LoginEvent, SecurityAlert
+
     conn = db.engine.raw_connection()
     try:
         cur = conn.cursor()
@@ -118,3 +120,11 @@ def _ensure_schema_compatibility(app: Flask) -> None:
         conn.rollback()
     finally:
         conn.close()
+
+    try:
+        LoginEvent.__table__.create(bind=db.engine, checkfirst=True)
+        SecurityAlert.__table__.create(bind=db.engine, checkfirst=True)
+    except Exception:
+        app.logger.exception(
+            "Schema compatibility patch failed for login security tables"
+        )

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -11,6 +11,39 @@ CREATE TABLE IF NOT EXISTS users (
 ALTER TABLE users
   ADD COLUMN IF NOT EXISTS preferred_currency VARCHAR(10) NOT NULL DEFAULT 'INR';
 
+CREATE TABLE IF NOT EXISTS login_events (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  email VARCHAR(255) NOT NULL,
+  ip_address VARCHAR(64) NOT NULL,
+  user_agent VARCHAR(500) NOT NULL,
+  success BOOLEAN NOT NULL DEFAULT FALSE,
+  failure_reason VARCHAR(100),
+  is_suspicious BOOLEAN NOT NULL DEFAULT FALSE,
+  suspicion_reasons TEXT NOT NULL DEFAULT '[]',
+  occurred_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_login_events_user_occurred
+  ON login_events(user_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_login_events_user_success
+  ON login_events(user_id, success, occurred_at DESC);
+
+CREATE TABLE IF NOT EXISTS security_alerts (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  login_event_id INT REFERENCES login_events(id) ON DELETE SET NULL,
+  alert_type VARCHAR(50) NOT NULL,
+  severity VARCHAR(20) NOT NULL DEFAULT 'medium',
+  message VARCHAR(500) NOT NULL,
+  details TEXT NOT NULL DEFAULT '{}',
+  acknowledged BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_security_alerts_user_created
+  ON security_alerts(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_security_alerts_user_ack
+  ON security_alerts(user_id, acknowledged);
+
 CREATE TABLE IF NOT EXISTS categories (
   id SERIAL PRIMARY KEY,
   user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -133,3 +133,42 @@ class AuditLog(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
     action = db.Column(db.String(100), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class LoginEvent(db.Model):
+    __tablename__ = "login_events"
+    __table_args__ = (
+        db.Index("idx_login_events_user_occurred", "user_id", "occurred_at"),
+        db.Index("idx_login_events_user_success", "user_id", "success", "occurred_at"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    email = db.Column(db.String(255), nullable=False)
+    ip_address = db.Column(db.String(64), nullable=False)
+    user_agent = db.Column(db.String(500), nullable=False)
+    success = db.Column(db.Boolean, default=False, nullable=False)
+    failure_reason = db.Column(db.String(100), nullable=True)
+    is_suspicious = db.Column(db.Boolean, default=False, nullable=False)
+    suspicion_reasons = db.Column(db.Text, default="[]", nullable=False)
+    occurred_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+
+
+class SecurityAlert(db.Model):
+    __tablename__ = "security_alerts"
+    __table_args__ = (
+        db.Index("idx_security_alerts_user_created", "user_id", "created_at"),
+        db.Index("idx_security_alerts_user_ack", "user_id", "acknowledged"),
+    )
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    login_event_id = db.Column(
+        db.Integer, db.ForeignKey("login_events.id"), nullable=True
+    )
+    alert_type = db.Column(db.String(50), nullable=False)
+    severity = db.Column(db.String(20), default="medium", nullable=False)
+    message = db.Column(db.String(500), nullable=False)
+    details = db.Column(db.Text, default="{}", nullable=False)
+    acknowledged = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -65,12 +65,90 @@ paths:
               example:
                 access_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
                 refresh_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+                security_alerts: []
         '401':
           description: Invalid credentials
           content:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
               example: { error: "invalid credentials" }
+  /auth/login-history:
+    get:
+      summary: List recent login events
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+      responses:
+        '200':
+          description: Login events for the current user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  events:
+                    type: array
+                    items: { $ref: '#/components/schemas/LoginEvent' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+  /auth/security-alerts:
+    get:
+      summary: List login security alerts
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: limit
+          schema: { type: integer, minimum: 1, maximum: 100, default: 50 }
+      responses:
+        '200':
+          description: Security alerts for the current user
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  alerts:
+                    type: array
+                    items: { $ref: '#/components/schemas/SecurityAlert' }
+                  unread_count: { type: integer }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+  /auth/security-alerts/{alertId}/acknowledge:
+    post:
+      summary: Acknowledge a login security alert
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: path
+          name: alertId
+          required: true
+          schema: { type: integer }
+      responses:
+        '200':
+          description: Updated security alert
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SecurityAlert' }
+        '404':
+          description: Alert not found for current user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
   /auth/refresh:
     post:
       summary: Refresh access token
@@ -498,6 +576,38 @@ components:
       properties:
         access_token: { type: string }
         refresh_token: { type: string }
+        security_alerts:
+          type: array
+          items: { $ref: '#/components/schemas/SecurityAlert' }
+    LoginEvent:
+      type: object
+      properties:
+        id: { type: integer }
+        email: { type: string, format: email }
+        ip_address: { type: string }
+        user_agent: { type: string }
+        success: { type: boolean }
+        failure_reason: { type: string, nullable: true }
+        is_suspicious: { type: boolean }
+        suspicion_reasons:
+          type: array
+          items: { type: string }
+        occurred_at: { type: string, format: date-time }
+    SecurityAlert:
+      type: object
+      properties:
+        id: { type: integer }
+        login_event_id: { type: integer, nullable: true }
+        alert_type:
+          type: string
+          enum: [new_ip, new_device, unusual_hour, failed_login_burst]
+        severity: { type: string, enum: [medium, high] }
+        message: { type: string }
+        details:
+          type: object
+          additionalProperties: true
+        acknowledged: { type: boolean }
+        created_at: { type: string, format: date-time }
     Category:
       type: object
       properties:

--- a/packages/backend/app/routes/auth.py
+++ b/packages/backend/app/routes/auth.py
@@ -9,7 +9,13 @@ from flask_jwt_extended import (
     get_jwt_identity,
 )
 from ..extensions import db, redis_client
-from ..models import User
+from ..models import LoginEvent, SecurityAlert, User
+from ..services.security import (
+    record_failed_login,
+    record_successful_login,
+    serialize_login_event,
+    serialize_security_alert,
+)
 import logging
 import time
 
@@ -57,13 +63,70 @@ def login():
     password = data.get("password")
     user = db.session.query(User).filter_by(email=email).first()
     if not user or not check_password_hash(user.password_hash, password):
+        if user:
+            record_failed_login(user, email)
         logger.warning("Login failed for email=%s", email)
         return jsonify(error="invalid credentials"), 401
+    security_alerts = record_successful_login(user)
     access = create_access_token(identity=str(user.id))
     refresh = create_refresh_token(identity=str(user.id))
     _store_refresh_session(refresh, str(user.id))
     logger.info("Login success user_id=%s", user.id)
-    return jsonify(access_token=access, refresh_token=refresh)
+    return jsonify(
+        access_token=access,
+        refresh_token=refresh,
+        security_alerts=[serialize_security_alert(alert) for alert in security_alerts],
+    )
+
+
+@bp.get("/login-history")
+@jwt_required()
+def login_history():
+    uid = int(get_jwt_identity())
+    limit = _bounded_limit(request.args.get("limit"))
+    events = (
+        db.session.query(LoginEvent)
+        .filter_by(user_id=uid)
+        .order_by(LoginEvent.occurred_at.desc(), LoginEvent.id.desc())
+        .limit(limit)
+        .all()
+    )
+    return jsonify(events=[serialize_login_event(event) for event in events])
+
+
+@bp.get("/security-alerts")
+@jwt_required()
+def security_alerts():
+    uid = int(get_jwt_identity())
+    limit = _bounded_limit(request.args.get("limit"))
+    alerts = (
+        db.session.query(SecurityAlert)
+        .filter_by(user_id=uid)
+        .order_by(SecurityAlert.created_at.desc(), SecurityAlert.id.desc())
+        .limit(limit)
+        .all()
+    )
+    unread_count = (
+        db.session.query(SecurityAlert)
+        .filter_by(user_id=uid, acknowledged=False)
+        .count()
+    )
+    return jsonify(
+        alerts=[serialize_security_alert(alert) for alert in alerts],
+        unread_count=unread_count,
+    )
+
+
+@bp.post("/security-alerts/<int:alert_id>/acknowledge")
+@jwt_required()
+def acknowledge_security_alert(alert_id: int):
+    uid = int(get_jwt_identity())
+    alert = db.session.get(SecurityAlert, alert_id)
+    if not alert or alert.user_id != uid:
+        return jsonify(error="not found"), 404
+    alert.acknowledged = True
+    db.session.commit()
+    return jsonify(serialize_security_alert(alert))
 
 
 @bp.get("/me")
@@ -137,3 +200,11 @@ def _store_refresh_session(refresh_token: str, uid: str):
         return
     ttl = max(int(exp - time.time()), 1)
     redis_client.setex(_refresh_key(jti), ttl, uid)
+
+
+def _bounded_limit(raw_limit: str | None, default: int = 50) -> int:
+    try:
+        limit = int(raw_limit or default)
+    except (TypeError, ValueError):
+        limit = default
+    return max(1, min(limit, 100))

--- a/packages/backend/app/services/security.py
+++ b/packages/backend/app/services/security.py
@@ -1,0 +1,172 @@
+import json
+from datetime import UTC, datetime, timedelta
+from flask import request
+from ..extensions import db
+from ..models import LoginEvent, SecurityAlert, User
+
+
+FAILED_LOGIN_WINDOW = timedelta(minutes=15)
+FAILED_LOGIN_THRESHOLD = 5
+
+
+ALERT_MESSAGES = {
+    "new_ip": "New login location detected.",
+    "new_device": "New device or browser detected.",
+    "unusual_hour": "Login happened at an unusual hour.",
+    "failed_login_burst": (
+        "Multiple failed login attempts were detected before this login."
+    ),
+}
+
+
+def request_ip() -> str:
+    forwarded_for = request.headers.get("X-Forwarded-For", "")
+    if forwarded_for:
+        return forwarded_for.split(",", 1)[0].strip() or "unknown"
+    return (request.remote_addr or "unknown").strip() or "unknown"
+
+
+def request_user_agent() -> str:
+    return (request.headers.get("User-Agent") or "unknown").strip()[:500] or "unknown"
+
+
+def record_failed_login(user: User | None, email: str) -> None:
+    if not user:
+        return
+    event = LoginEvent(
+        user_id=user.id,
+        email=email or user.email,
+        ip_address=request_ip(),
+        user_agent=request_user_agent(),
+        success=False,
+        failure_reason="invalid_credentials",
+    )
+    db.session.add(event)
+    db.session.commit()
+
+
+def record_successful_login(user: User) -> list[SecurityAlert]:
+    now = datetime.now(UTC).replace(tzinfo=None)
+    ip_address = request_ip()
+    user_agent = request_user_agent()
+    event = LoginEvent(
+        user_id=user.id,
+        email=user.email,
+        ip_address=ip_address,
+        user_agent=user_agent,
+        success=True,
+        occurred_at=now,
+    )
+    db.session.add(event)
+    db.session.flush()
+
+    reasons = _detect_reasons(user.id, event.id, ip_address, user_agent, now)
+    alerts = [
+        _make_alert(user.id, event.id, reason, ip_address, user_agent)
+        for reason in reasons
+    ]
+    if reasons:
+        event.is_suspicious = True
+        event.suspicion_reasons = json.dumps(reasons)
+        db.session.add_all(alerts)
+
+    db.session.commit()
+    return alerts
+
+
+def serialize_login_event(event: LoginEvent) -> dict:
+    return {
+        "id": event.id,
+        "email": event.email,
+        "ip_address": event.ip_address,
+        "user_agent": event.user_agent,
+        "success": event.success,
+        "failure_reason": event.failure_reason,
+        "is_suspicious": event.is_suspicious,
+        "suspicion_reasons": _loads(event.suspicion_reasons, []),
+        "occurred_at": event.occurred_at.isoformat(),
+    }
+
+
+def serialize_security_alert(alert: SecurityAlert) -> dict:
+    return {
+        "id": alert.id,
+        "login_event_id": alert.login_event_id,
+        "alert_type": alert.alert_type,
+        "severity": alert.severity,
+        "message": alert.message,
+        "details": _loads(alert.details, {}),
+        "acknowledged": alert.acknowledged,
+        "created_at": alert.created_at.isoformat(),
+    }
+
+
+def _detect_reasons(
+    user_id: int,
+    current_event_id: int,
+    ip_address: str,
+    user_agent: str,
+    now: datetime,
+) -> list[str]:
+    reasons: list[str] = []
+    prior_successes = (
+        db.session.query(LoginEvent)
+        .filter(
+            LoginEvent.user_id == user_id,
+            LoginEvent.success.is_(True),
+            LoginEvent.id != current_event_id,
+        )
+        .all()
+    )
+
+    if prior_successes:
+        known_ips = {event.ip_address for event in prior_successes}
+        known_agents = {event.user_agent for event in prior_successes}
+        if ip_address not in known_ips:
+            reasons.append("new_ip")
+        if user_agent not in known_agents:
+            reasons.append("new_device")
+        if now.hour < 5 or now.hour >= 23:
+            reasons.append("unusual_hour")
+
+    failed_count = (
+        db.session.query(LoginEvent)
+        .filter(
+            LoginEvent.user_id == user_id,
+            LoginEvent.success.is_(False),
+            LoginEvent.occurred_at >= now - FAILED_LOGIN_WINDOW,
+        )
+        .count()
+    )
+    if failed_count >= FAILED_LOGIN_THRESHOLD:
+        reasons.append("failed_login_burst")
+
+    return reasons
+
+
+def _make_alert(
+    user_id: int,
+    login_event_id: int,
+    alert_type: str,
+    ip_address: str,
+    user_agent: str,
+) -> SecurityAlert:
+    severity = "high" if alert_type == "failed_login_burst" else "medium"
+    details = {"ip_address": ip_address, "user_agent": user_agent}
+    return SecurityAlert(
+        user_id=user_id,
+        login_event_id=login_event_id,
+        alert_type=alert_type,
+        severity=severity,
+        message=ALERT_MESSAGES[alert_type],
+        details=json.dumps(details),
+    )
+
+
+def _loads(value: str | None, fallback):
+    if not value:
+        return fallback
+    try:
+        return json.loads(value)
+    except (TypeError, ValueError):
+        return fallback

--- a/packages/backend/tests/test_login_security.py
+++ b/packages/backend/tests/test_login_security.py
@@ -1,0 +1,109 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _skip_refresh_session_redis(monkeypatch):
+    monkeypatch.setattr("app.routes.auth._store_refresh_session", lambda *_args: None)
+
+
+def _register(client, email="security@example.com", password="secret123"):
+    r = client.post("/auth/register", json={"email": email, "password": password})
+    assert r.status_code in (201, 409)
+
+
+def _login(client, email, password, ip="10.0.0.1", user_agent="FinMindTest/1.0"):
+    return client.post(
+        "/auth/login",
+        json={"email": email, "password": password},
+        headers={"User-Agent": user_agent},
+        environ_overrides={"REMOTE_ADDR": ip},
+    )
+
+
+def test_login_from_new_ip_and_device_creates_security_alerts(client):
+    email = "alerts@example.com"
+    password = "secret123"
+    _register(client, email, password)
+
+    first = _login(client, email, password, ip="10.0.0.1", user_agent="KnownBrowser/1")
+    assert first.status_code == 200
+    assert first.get_json()["security_alerts"] == []
+
+    second = _login(
+        client, email, password, ip="203.0.113.9", user_agent="NewBrowser/2"
+    )
+    assert second.status_code == 200
+    payload = second.get_json()
+    alert_types = {alert["alert_type"] for alert in payload["security_alerts"]}
+    assert {"new_ip", "new_device"}.issubset(alert_types)
+
+    access = payload["access_token"]
+    history = client.get(
+        "/auth/login-history",
+        headers={"Authorization": f"Bearer {access}"},
+    )
+    assert history.status_code == 200
+    events = history.get_json()["events"]
+    assert len(events) == 2
+    assert events[0]["ip_address"] == "203.0.113.9"
+    assert "new_ip" in events[0]["suspicion_reasons"]
+
+    alerts = client.get(
+        "/auth/security-alerts",
+        headers={"Authorization": f"Bearer {access}"},
+    )
+    assert alerts.status_code == 200
+    assert alerts.get_json()["unread_count"] == len(payload["security_alerts"])
+
+
+def test_failed_login_burst_is_reported_on_next_successful_login(client):
+    email = "burst@example.com"
+    password = "secret123"
+    _register(client, email, password)
+
+    baseline = _login(client, email, password, ip="10.0.0.2", user_agent="Browser/1")
+    assert baseline.status_code == 200
+
+    for _ in range(5):
+        failed = _login(
+            client, email, "wrong-password", ip="10.0.0.2", user_agent="Browser/1"
+        )
+        assert failed.status_code == 401
+
+    success = _login(client, email, password, ip="10.0.0.2", user_agent="Browser/1")
+    assert success.status_code == 200
+    payload = success.get_json()
+    assert any(
+        alert["alert_type"] == "failed_login_burst"
+        for alert in payload["security_alerts"]
+    )
+
+
+def test_security_alerts_can_be_acknowledged(client):
+    email = "ack@example.com"
+    password = "secret123"
+    _register(client, email, password)
+
+    _login(client, email, password, ip="10.0.0.3", user_agent="Browser/1")
+    login = _login(client, email, password, ip="198.51.100.7", user_agent="Browser/1")
+    assert login.status_code == 200
+    access = login.get_json()["access_token"]
+
+    alerts = client.get(
+        "/auth/security-alerts",
+        headers={"Authorization": f"Bearer {access}"},
+    ).get_json()["alerts"]
+    assert alerts
+
+    response = client.post(
+        f"/auth/security-alerts/{alerts[0]['id']}/acknowledge",
+        headers={"Authorization": f"Bearer {access}"},
+    )
+    assert response.status_code == 200
+    assert response.get_json()["acknowledged"] is True
+
+    refreshed = client.get(
+        "/auth/security-alerts",
+        headers={"Authorization": f"Bearer {access}"},
+    ).get_json()
+    assert refreshed["unread_count"] == len(alerts) - 1


### PR DESCRIPTION
## Summary
- record successful and failed auth login attempts with IP, user-agent, timestamps, success status, and suspicion reasons
- detect new IP, new device/browser, unusual-hour logins, and failed-login bursts
- return security alerts from login, add authenticated login history / security alert / acknowledge endpoints, and persist the new tables in schema/model compatibility paths
- show returned login alerts immediately in the frontend and list recent alerts in Account Settings with a mark-reviewed action
- update OpenAPI/README docs and add backend + frontend tests

## Validation
- `cd packages/backend && ../../.venv/bin/black --check .`
- `cd packages/backend && ../../.venv/bin/flake8 .`
- `cd packages/backend && ../../.venv/bin/python -m pytest tests/test_login_security.py`
- `cd packages/backend && ../../.venv/bin/bandit -r app -ll`
- `cd app && npm run lint`
- `cd app && npm test -- --ci`
- `cd app && npm run build`

Note: I did not run the full backend pytest suite locally because this environment has no Redis server or Docker daemon; the GitHub Actions backend job provisions Redis.

/claim #124