### PR TITLE
feat: Calendar Heatmap with Spending Intensity Visualization

### DIFF
--- a/app/src/api/heatmap.ts
+++ b/app/src/api/heatmap.ts
@@ -1,0 +1,34 @@
+/**
+ * Calendar Heatmap API client.
+ */
+
+export interface HeatmapDay {
+  date: string;
+  amount: number;
+  count: number;
+  intensity: 0 | 1 | 2 | 3 | 4;
+}
+
+export interface HeatmapData {
+  year: number;
+  month: number | null;
+  start_date: string;
+  end_date: string;
+  total_spending: number;
+  total_transactions: number;
+  active_days: number;
+  max_daily: number;
+  avg_daily: number;
+  current_streak: number;
+  days: HeatmapDay[];
+}
+
+export async function fetchHeatmap(year: number, month?: number | null): Promise<HeatmapData> {
+  let url = `/heatmap?year=${year}`;
+  if (month != null) url += `&month=${month}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${localStorage.getItem("token")}` },
+  });
+  if (!res.ok) throw new Error("Failed to fetch heatmap data");
+  return res.json();
+}

--- a/app/src/pages/SpendingHeatmap.tsx
+++ b/app/src/pages/SpendingHeatmap.tsx
@@ -1,0 +1,125 @@
+/**
+ * Calendar Heatmap Page — spending intensity visualization.
+ */
+
+import React, { useEffect, useState } from "react";
+import { fetchHeatmap, HeatmapData, HeatmapDay } from "../api/heatmap";
+
+const COLORS = ["#1a1a2e", "#16213e", "#0f3460", "#533483", "#e94560"];
+
+const HeatmapSquare: React.FC<{ day: HeatmapDay; size?: number }> = ({ day, size = 14 }) => (
+  <div
+    title={`${day.date}: $${day.amount.toFixed(2)} (${day.count} txns)`}
+    style={{
+      width: size,
+      height: size,
+      backgroundColor: COLORS[day.intensity],
+      borderRadius: 2,
+      margin: 1,
+      display: "inline-block",
+    }}
+  />
+);
+
+const MonthRow: React.FC<{
+  days: HeatmapDay[];
+  label: string;
+  daySize?: number;
+}> = ({ days, label, daySize = 14 }) => (
+  <div style={{ display: "flex", alignItems: "center", marginBottom: 4 }}>
+    <span style={{ width: 40, fontSize: 12, color: "#aaa" }}>{label}</span>
+    <div style={{ display: "flex", flexWrap: "wrap" }}>
+      {days.map((d) => (
+        <HeatmapSquare key={d.date} day={d} size={daySize} />
+      ))}
+    </div>
+  </div>
+);
+
+export const SpendingHeatmap: React.FC = () => {
+  const currentYear = new Date().getFullYear();
+  const [year, setYear] = useState(currentYear);
+  const [month, setMonth] = useState<number | null>(null);
+  const [data, setData] = useState<HeatmapData | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchHeatmap(year, month)
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [year, month]);
+
+  const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+  // Group days by month
+  const byMonth: Record<number, HeatmapDay[]> = {};
+  if (data) {
+    for (const d of data.days) {
+      const m = new Date(d.date).getMonth();
+      if (!byMonth[m]) byMonth[m] = [];
+      byMonth[m].push(d);
+    }
+  }
+
+  return (
+    <div style={{ padding: 24, maxWidth: 900 }}>
+      <h2>Spending Heatmap</h2>
+
+      <div style={{ display: "flex", gap: 12, marginBottom: 16 }}>
+        <select value={year} onChange={(e) => setYear(+e.target.value)}>
+          {[currentYear, currentYear - 1, currentYear - 2].map((y) => (
+            <option key={y} value={y}>{y}</option>
+          ))}
+        </select>
+        <select value={month ?? "all"} onChange={(e) => setMonth(e.target.value === "all" ? null : +e.target.value)}>
+          <option value="all">Full Year</option>
+          {monthNames.map((n, i) => (
+            <option key={i} value={i + 1}>{n}</option>
+          ))}
+        </select>
+      </div>
+
+      {loading && <p>Loading...</p>}
+
+      {data && (
+        <>
+          <div style={{ display: "flex", gap: 24, marginBottom: 20 }}>
+            <div style={{ background: "#1a1a2e", padding: 16, borderRadius: 8, flex: 1 }}>
+              <div style={{ color: "#aaa", fontSize: 12 }}>Total</div>
+              <div style={{ fontSize: 24, fontWeight: "bold" }}>${data.total_spending.toFixed(2)}</div>
+            </div>
+            <div style={{ background: "#1a1a2e", padding: 16, borderRadius: 8, flex: 1 }}>
+              <div style={{ color: "#aaa", fontSize: 12 }}>Active Days</div>
+              <div style={{ fontSize: 24, fontWeight: "bold" }}>{data.active_days}</div>
+            </div>
+            <div style={{ background: "#1a1a2e", padding: 16, borderRadius: 8, flex: 1 }}>
+              <div style={{ color: "#aaa", fontSize: 12 }}>Avg/Day</div>
+              <div style={{ fontSize: 24, fontWeight: "bold" }}>${data.avg_daily.toFixed(2)}</div>
+            </div>
+            <div style={{ background: "#1a1a2e", padding: 16, borderRadius: 8, flex: 1 }}>
+              <div style={{ color: "#aaa", fontSize: 12 }}>Streak</div>
+              <div style={{ fontSize: 24, fontWeight: "bold" }}>{data.current_streak} days</div>
+            </div>
+          </div>
+
+          <div style={{ background: "#0d1117", padding: 16, borderRadius: 8 }}>
+            {Object.entries(byMonth).map(([m, days]) => (
+              <MonthRow key={m} days={days} label={monthNames[+m]} />
+            ))}
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 12 }}>
+            <span style={{ fontSize: 12, color: "#aaa" }}>Less</span>
+            {COLORS.map((c, i) => (
+              <div key={i} style={{ width: 14, height: 14, backgroundColor: c, borderRadius: 2, margin: 1 }} />
+            ))}
+            <span style={{ fontSize: 12, color: "#aaa" }}>More</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default SpendingHeatmap;

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .heatmap import bp as heatmap_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(heatmap_bp, url_prefix="/heatmap")

--- a/packages/backend/app/routes/heatmap.py
+++ b/packages/backend/app/routes/heatmap.py
@@ -1,0 +1,39 @@
+"""Calendar heatmap endpoint for FinMind."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..services.heatmap import get_heatmap_data
+
+bp = Blueprint("heatmap", __name__)
+
+
+@bp.get("")
+@jwt_required()
+def heatmap():
+    """Get calendar heatmap data.
+
+    Query params:
+        year (int): Required. Year to fetch.
+        month (int): Optional. Month (1-12). If omitted, returns full year.
+    """
+    uid = int(get_jwt_identity())
+
+    try:
+        year = int(request.args.get("year"))
+    except (TypeError, ValueError):
+        return jsonify(error="year query parameter is required"), 400
+
+    month = request.args.get("month")
+    if month:
+        try:
+            month = int(month)
+            if not 1 <= month <= 12:
+                raise ValueError
+        except (TypeError, ValueError):
+            return jsonify(error="month must be between 1 and 12"), 400
+    else:
+        month = None
+
+    data = get_heatmap_data(uid, year, month)
+    return jsonify(data)

--- a/packages/backend/app/services/heatmap.py
+++ b/packages/backend/app/services/heatmap.py
@@ -1,0 +1,131 @@
+"""Calendar heatmap service for FinMind.
+
+Generates daily spending data suitable for calendar heatmap visualization.
+"""
+
+import logging
+from datetime import date, timedelta
+from collections import defaultdict
+from flask_jwt_extended import get_jwt_identity
+
+from ..extensions import db
+from ..models import Expense
+from sqlalchemy import func
+
+logger = logging.getLogger("finmind.heatmap")
+
+
+def get_heatmap_data(user_id: int, year: int, month: int | None = None) -> dict:
+    """Generate heatmap data for a user.
+
+    Args:
+        user_id: The user ID
+        year: Year to generate heatmap for
+        month: Optional month (1-12). If None, generates full year.
+
+    Returns:
+        Dict with daily totals and metadata for heatmap rendering.
+    """
+    if month:
+        start = date(year, month, 1)
+        if month == 12:
+            end = date(year + 1, 1, 1) - timedelta(days=1)
+        else:
+            end = date(year, month + 1, 1) - timedelta(days=1)
+    else:
+        start = date(year, 1, 1)
+        end = date(year, 12, 31)
+
+    # Query daily totals
+    rows = (
+        db.session.query(
+            Expense.spent_at,
+            func.sum(Expense.amount).label("total"),
+            func.count(Expense.id).label("count"),
+        )
+        .filter(
+            Expense.user_id == user_id,
+            Expense.expense_type == "EXPENSE",
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .group_by(Expense.spent_at)
+        .order_by(Expense.spent_at)
+        .all()
+    )
+
+    # Build daily data map
+    daily = {}
+    for row in rows:
+        day_str = row.spent_at.isoformat()
+        daily[day_str] = {
+            "amount": float(row.total),
+            "count": row.count,
+        }
+
+    # Fill in missing days with zero
+    all_amounts = [d["amount"] for d in daily.values()]
+    max_amount = max(all_amounts) if all_amounts else 0
+    total = sum(all_amounts)
+    active_days = len(all_amounts)
+
+    # Generate complete date range
+    days = []
+    current = start
+    while current <= end:
+        day_str = current.isoformat()
+        entry = daily.get(day_str, {"amount": 0, "count": 0})
+        # Intensity: 0-4 scale (0=no spending, 4=max spending)
+        intensity = 0
+        if max_amount > 0 and entry["amount"] > 0:
+            ratio = entry["amount"] / max_amount
+            if ratio <= 0.25:
+                intensity = 1
+            elif ratio <= 0.50:
+                intensity = 2
+            elif ratio <= 0.75:
+                intensity = 3
+            else:
+                intensity = 4
+
+        days.append({
+            "date": day_str,
+            "amount": entry["amount"],
+            "count": entry["count"],
+            "intensity": intensity,
+        })
+        current += timedelta(days=1)
+
+    # Streak calculation
+    streak = _calculate_streak(daily, start, end)
+
+    return {
+        "year": year,
+        "month": month,
+        "start_date": start.isoformat(),
+        "end_date": end.isoformat(),
+        "total_spending": round(total, 2),
+        "total_transactions": sum(d["count"] for d in daily.values()),
+        "active_days": active_days,
+        "max_daily": round(max_amount, 2),
+        "avg_daily": round(total / max(active_days, 1), 2),
+        "current_streak": streak,
+        "days": days,
+    }
+
+
+def _calculate_streak(daily: dict, start: date, end: date) -> int:
+    """Calculate current spending streak from today backwards."""
+    today = date.today()
+    streak = 0
+    current = today
+
+    while current >= start:
+        day_str = current.isoformat()
+        if day_str in daily:
+            streak += 1
+        elif current < today:
+            break  # Gap in streak
+        current -= timedelta(days=1)
+
+    return streak

--- a/packages/backend/tests/test_heatmap.py
+++ b/packages/backend/tests/test_heatmap.py
@@ -1,0 +1,70 @@
+"""
+Tests for the calendar heatmap endpoint.
+"""
+
+import json
+import pytest
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from app.models import Expense, Category
+
+
+@pytest.fixture(autouse=True)
+def seed_expenses(db_session):
+    """Add some test expenses."""
+    cat = Category(user_id=1, name="Food")
+    db_session.add(cat)
+    db_session.commit()
+
+    today = date.today()
+    for i in range(5):
+        e = Expense(
+            user_id=1,
+            category_id=cat.id,
+            amount=100 + i * 50,
+            currency="INR",
+            expense_type="EXPENSE",
+            spent_at=today - timedelta(days=i),
+        )
+        db_session.add(e)
+    db_session.commit()
+
+
+class TestHeatmapEndpoint:
+    def test_full_year(self, client, auth_header):
+        r = client.get(f"/heatmap?year={date.today().year}", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert "days" in data
+        assert data["year"] == date.today().year
+        assert data["total_spending"] > 0
+        assert data["active_days"] >= 1
+        assert len(data["days"]) > 0
+
+    def test_single_month(self, client, auth_header):
+        r = client.get(f"/heatmap?year={date.today().year}&month={date.today().month}", headers=auth_header)
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data["month"] == date.today().month
+        assert all(d["intensity"] >= 0 and d["intensity"] <= 4 for d in data["days"])
+
+    def test_missing_year(self, client, auth_header):
+        r = client.get("/heatmap", headers=auth_header)
+        assert r.status_code == 400
+
+    def test_invalid_month(self, client, auth_header):
+        r = client.get(f"/heatmap?year={date.today().year}&month=13", headers=auth_header)
+        assert r.status_code == 400
+
+    def test_intensity_scale(self, client, auth_header):
+        r = client.get(f"/heatmap?year={date.today().year}&month={date.today().month}", headers=auth_header)
+        data = r.get_json()
+        active = [d for d in data["days"] if d["amount"] > 0]
+        if len(active) >= 2:
+            intensities = [d["intensity"] for d in active]
+            assert max(intensities) == 4  # Highest spending day
+
+    def test_auth_required(self, client):
+        r = client.get(f"/heatmap?year={date.today().year}")
+        assert r.status_code in (401, 422)


### PR DESCRIPTION
## Summary
Implements **Calendar Heatmap** as requested in #126.

### Changes
- **Backend Service** (`services/heatmap.py`):
  - Daily spending aggregation with 0-4 intensity scale
  - Supports full year or single month views
  - Streak calculation (consecutive spending days)
  - Stats: total spending, active days, avg/day, max daily
- **API** (`routes/heatmap.py`):
  - `GET /heatmap?year=YYYY&month=MM` (month optional)
  - JWT auth required
- **Frontend** (`pages/SpendingHeatmap.tsx` + `api/heatmap.ts`):
  - Color-coded calendar squares (5-level intensity)
  - Year/month selector
  - Summary stats cards (total, active days, avg, streak)
  - Responsive layout
- **Tests** (`tests/test_heatmap.py`):
  - Full year, single month, missing params, auth, intensity scale

Closes #126