### PR TITLE
feat: Smart Caching Strategy with Tag-Based Invalidation

### DIFF
--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .cache_admin import bp as cache_admin_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(cache_admin_bp, url_prefix="/cache")

--- a/packages/backend/app/routes/cache_admin.py
+++ b/packages/backend/app/routes/cache_admin.py
@@ -1,0 +1,50 @@
+"""Cache administration endpoints for FinMind."""
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required, get_jwt_identity
+
+from ..models import User
+from ..services.smart_cache import cache
+from flask_jwt_extended import get_jwt_identity
+
+bp = Blueprint("cache_admin", __name__)
+
+
+@bp.get("/metrics")
+@jwt_required()
+def get_metrics():
+    """Get cache performance metrics (admin only)."""
+    uid = int(get_jwt_identity())
+    user = User.query.get(uid)
+    if not user or user.role != "ADMIN":
+        return jsonify(error="Admin access required"), 403
+
+    namespace = request.args.get("namespace", "")
+    if namespace:
+        return jsonify(cache.get_metrics(namespace))
+
+    # Return metrics for known namespaces
+    namespaces = ["dashboard", "analytics", "expenses", "heatmap", "insights"]
+    return jsonify([cache.get_metrics(ns) for ns in namespaces])
+
+
+@bp.delete("/invalidate")
+@jwt_required()
+def invalidate():
+    """Invalidate cache by tag or namespace (admin only)."""
+    uid = int(get_jwt_identity())
+    user = User.query.get(uid)
+    if not user or user.role != "ADMIN":
+        return jsonify(error="Admin access required"), 403
+
+    tag = request.args.get("tag")
+    namespace = request.args.get("namespace")
+
+    if tag:
+        count = cache.invalidate_tag(tag)
+        return jsonify(invalidated=count, method="tag", tag=tag)
+    elif namespace:
+        count = cache.invalidate_namespace(namespace)
+        return jsonify(invalidated=count, method="namespace", namespace=namespace)
+    else:
+        return jsonify(error="Provide tag or namespace parameter"), 400

--- a/packages/backend/app/services/smart_cache.py
+++ b/packages/backend/app/services/smart_cache.py
@@ -1,0 +1,191 @@
+"""Smart caching service with intelligent invalidation for FinMind.
+
+Provides cache-aside pattern with:
+- Tag-based cache invalidation
+- Automatic TTL based on data freshness requirements
+- Cache hit/miss metrics
+- Dashboard and analytics specific caching strategies
+"""
+
+import json
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+from functools import wraps
+
+from ..extensions import redis_client
+
+logger = logging.getLogger("finmind.cache")
+
+# Cache key prefixes
+CACHE_PREFIX = "finmind:cache:"
+METRICS_PREFIX = "finmind:cache:metrics:"
+TAG_PREFIX = "finmind:cache:tag:"
+
+# TTL presets (seconds)
+TTL_PRESETS = {
+    "realtime": 30,       # 30 seconds - dashboard live data
+    "frequent": 300,      # 5 minutes - recent transactions
+    "standard": 900,      # 15 minutes - analytics
+    "daily": 86400,       # 1 day - historical reports
+    "weekly": 604800,     # 1 week - aggregated stats
+}
+
+
+class SmartCache:
+    """Intelligent cache with tag-based invalidation."""
+
+    def __init__(self, redis=None):
+        self.redis = redis or redis_client
+
+    def _make_key(self, namespace: str, key: str) -> str:
+        return f"{CACHE_PREFIX}{namespace}:{key}"
+
+    def _make_tag_key(self, tag: str) -> str:
+        return f"{TAG_PREFIX}{tag}"
+
+    def _make_metric_key(self, namespace: str) -> str:
+        return f"{METRICS_PREFIX}{namespace}"
+
+    def get(self, namespace: str, key: str) -> Optional[Any]:
+        """Retrieve cached value. Returns None on miss."""
+        cache_key = self._make_key(namespace, key)
+        raw = self.redis.get(cache_key)
+        if raw is None:
+            self._record_miss(namespace)
+            return None
+        self._record_hit(namespace)
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return raw
+
+    def set(
+        self,
+        namespace: str,
+        key: str,
+        value: Any,
+        ttl: str = "standard",
+        tags: list[str] | None = None,
+    ) -> bool:
+        """Store value with TTL and optional tags for invalidation."""
+        cache_key = self._make_key(namespace, key)
+        ttl_seconds = TTL_PRESETS.get(ttl, 900)
+
+        serialized = json.dumps(value, default=str)
+        pipe = self.redis.pipeline()
+        pipe.setex(cache_key, ttl_seconds, serialized)
+
+        # Register under tags for bulk invalidation
+        if tags:
+            for tag in tags:
+                tag_key = self._make_tag_key(tag)
+                pipe.sadd(tag_key, cache_key)
+                pipe.expire(tag_key, ttl_seconds + 60)  # Tag lives slightly longer
+            pipe.execute()
+        else:
+            pipe.execute()
+
+        return True
+
+    def delete(self, namespace: str, key: str) -> bool:
+        """Delete a specific cache entry."""
+        cache_key = self._make_key(namespace, key)
+        return bool(self.redis.delete(cache_key))
+
+    def invalidate_tag(self, tag: str) -> int:
+        """Invalidate all cache entries associated with a tag."""
+        tag_key = self._make_tag_key(tag)
+        keys = self.redis.smembers(tag_key)
+        if not keys:
+            return 0
+        deleted = self.redis.delete(*list(keys))
+        self.redis.delete(tag_key)
+        logger.info("Invalidated tag=%s keys=%d", tag, deleted)
+        return deleted
+
+    def invalidate_namespace(self, namespace: str) -> int:
+        """Invalidate all entries in a namespace using SCAN."""
+        pattern = self._make_key(namespace, "*")
+        keys = list(self.redis.scan_iter(pattern))
+        if not keys:
+            return 0
+        deleted = self.redis.delete(*keys)
+        logger.info("Invalidated namespace=%s keys=%d", namespace, deleted)
+        return deleted
+
+    def get_or_set(
+        self,
+        namespace: str,
+        key: str,
+        factory: callable,
+        ttl: str = "standard",
+        tags: list[str] | None = None,
+    ) -> Any:
+        """Cache-aside pattern: get from cache, or compute and store."""
+        cached = self.get(namespace, key)
+        if cached is not None:
+            return cached
+        value = factory()
+        self.set(namespace, key, value, ttl=ttl, tags=tags)
+        return value
+
+    # ---- Metrics ----
+
+    def _record_hit(self, namespace: str):
+        key = self._make_metric_key(namespace)
+        pipe = self.redis.pipeline()
+        pipe.hincrby(key, "hits", 1)
+        pipe.hincrby(key, "total", 1)
+        pipe.expire(key, 86400)
+        pipe.execute()
+
+    def _record_miss(self, namespace: str):
+        key = self._make_metric_key(namespace)
+        pipe = self.redis.pipeline()
+        pipe.hincrby(key, "misses", 1)
+        pipe.hincrby(key, "total", 1)
+        pipe.expire(key, 86400)
+        pipe.execute()
+
+    def get_metrics(self, namespace: str) -> dict:
+        """Get cache performance metrics for a namespace."""
+        key = self._make_metric_key(namespace)
+        data = self.redis.hgetall(key)
+        if not data:
+            return {"namespace": namespace, "hits": 0, "misses": 0, "hit_rate": 0}
+        hits = int(data.get(b"hits", data.get("hits", 0)))
+        misses = int(data.get(b"misses", data.get("misses", 0)))
+        total = hits + misses
+        return {
+            "namespace": namespace,
+            "hits": hits,
+            "misses": misses,
+            "total": total,
+            "hit_rate": round(hits / max(total, 1), 4),
+        }
+
+
+# Singleton instance
+cache = SmartCache()
+
+
+def cached(namespace: str, ttl: str = "standard", tags: list[str] | None = None):
+    """Decorator for caching function results.
+
+    Usage:
+        @cached("dashboard", ttl="frequent", tags=["expenses", "user:{uid}"])
+        def get_dashboard_data(user_id):
+            ...
+    """
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            # Build cache key from function name + args
+            key_parts = [fn.__name__] + [str(a) for a in args[1:]] + [f"{k}={v}" for k, v in sorted(kwargs.items())]
+            cache_key = hashlib.md5(":".join(key_parts).encode()).hexdigest()
+
+            return cache.get_or_set(namespace, cache_key, lambda: fn(*args, **kwargs), ttl=ttl, tags=tags)
+        return wrapper
+    return decorator

--- a/packages/backend/tests/test_smart_cache.py
+++ b/packages/backend/tests/test_smart_cache.py
@@ -1,0 +1,96 @@
+"""
+Tests for smart caching service.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from app.services.smart_cache import SmartCache, cache, TTL_PRESETS
+
+
+class TestSmartCache:
+    def test_set_and_get(self):
+        c = SmartCache(redis=MagicMock())
+        # Mock redis get/set
+        c.redis.get.return_value = json.dumps({"amount": 100})
+        c.redis.pipeline.return_value.execute.return_value = [True]
+        c.redis.pipeline.return_value.setex.return_value = True
+        c.redis.pipeline.return_value.hincrby.return_value = True
+        c.redis.pipeline.return_value.expire.return_value = True
+
+        c.set("test", "key1", {"amount": 100}, ttl="standard")
+        result = c.get("test", "key1")
+        assert result == {"amount": 100}
+
+    def test_miss_returns_none(self):
+        c = SmartCache(redis=MagicMock())
+        c.redis.get.return_value = None
+        c.redis.pipeline.return_value.hincrby.return_value = True
+        c.redis.pipeline.return_value.expire.return_value = True
+        c.redis.pipeline.return_value.execute.return_value = []
+
+        result = c.get("test", "nonexistent")
+        assert result is None
+
+    def test_get_or_set_calls_factory_on_miss(self):
+        c = SmartCache(redis=MagicMock())
+        c.redis.get.return_value = None  # Cache miss
+        c.redis.pipeline.return_value.setex.return_value = True
+        c.redis.pipeline.return_value.execute.return_value = []
+        c.redis.pipeline.return_value.hincrby.return_value = True
+        c.redis.pipeline.return_value.expire.return_value = True
+
+        factory_called = False
+        def factory():
+            nonlocal factory_called
+            factory_called = True
+            return "computed_value"
+
+        result = c.get_or_set("test", "key1", factory, ttl="standard")
+        assert factory_called is True
+        assert result == "computed_value"
+
+    def test_get_or_set_returns_cached(self):
+        c = SmartCache(redis=MagicMock())
+        c.redis.get.return_value = json.dumps("cached_value")
+        c.redis.pipeline.return_value.hincrby.return_value = True
+        c.redis.pipeline.return_value.expire.return_value = True
+        c.redis.pipeline.return_value.execute.return_value = []
+
+        factory_called = False
+        def factory():
+            nonlocal factory_called
+            factory_called = True
+
+        result = c.get_or_set("test", "key1", factory, ttl="standard")
+        assert factory_called is False
+        assert result == "cached_value"
+
+    def test_invalidate_tag(self):
+        c = SmartCache(redis=MagicMock())
+        c.redis.smembers.return_value = {b"key1", b"key2"}
+        c.redis.delete.return_value = 2
+
+        count = c.invalidate_tag("expenses")
+        assert count == 2
+
+    def test_invalidate_empty_tag(self):
+        c = SmartCache(redis=MagicMock())
+        c.redis.smembers.return_value = set()
+
+        count = c.invalidate_tag("nonexistent")
+        assert count == 0
+
+    def test_ttl_presets(self):
+        assert TTL_PRESETS["realtime"] == 30
+        assert TTL_PRESETS["daily"] == 86400
+        assert TTL_PRESETS["standard"] == 900
+
+    def test_metrics(self):
+        c = SmartCache(redis=MagicMock())
+        c.redis.hgetall.return_value = {b"hits": 80, b"misses": 20}
+
+        metrics = c.get_metrics("test")
+        assert metrics["hits"] == 80
+        assert metrics["misses"] == 20
+        assert metrics["hit_rate"] == 0.8


### PR DESCRIPTION
## Summary
Implements **Smart Caching Strategy** as requested in #127.

### Changes
- **SmartCache Service** (`services/smart_cache.py`):
  - Cache-aside pattern with Redis backend
  - Tag-based invalidation for related data groups
  - Namespace-level bulk invalidation
  - TTL presets: realtime(30s), frequent(5m), standard(15m), daily(1d), weekly(7d)
  - Cache hit/miss metrics per namespace
  - `@cached` decorator for easy function result caching
  - `get_or_set()` for cache-aside pattern
- **Admin API** (`routes/cache_admin.py`):
  - `GET /cache/metrics?namespace=...` — performance metrics
  - `DELETE /cache/invalidate?tag=...` — invalidate by tag
  - `DELETE /cache/invalidate?namespace=...` — invalidate namespace
- **Tests** (`tests/test_smart_cache.py`):
  - Set/get, miss handling, get_or_set factory
  - Tag invalidation, TTL presets, metrics calculation

Closes #127