### PR TITLE
feat: add weekly financial summary digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`,
+  `/insights/weekly-summary?week_start=YYYY-MM-DD&currency=USD`
+
+### Weekly Financial Summary
+
+`GET /insights/weekly-summary` returns an authenticated smart digest for the
+selected ISO week. It normalizes any `week_start` date to Monday, compares
+expenses with the previous week, groups spending by category, returns seven
+daily buckets, highlights the largest expenses, includes bills due that week,
+and emits deterministic insights plus recommendations. Omit `week_start` for
+the current week and omit `currency` to include all currencies.
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.

--- a/app/src/__tests__/Analytics.integration.test.tsx
+++ b/app/src/__tests__/Analytics.integration.test.tsx
@@ -30,8 +30,10 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 
 const getBudgetSuggestionMock = jest.fn();
+const getWeeklySummaryMock = jest.fn();
 jest.mock('@/api/insights', () => ({
   getBudgetSuggestion: (...args: unknown[]) => getBudgetSuggestionMock(...args),
+  getWeeklySummary: (...args: unknown[]) => getWeeklySummaryMock(...args),
 }));
 
 describe('Analytics integration', () => {
@@ -52,13 +54,50 @@ describe('Analytics integration', () => {
       method: 'heuristic',
       warnings: [],
     });
+    getWeeklySummaryMock.mockResolvedValue({
+      period: {
+        week_start: '2026-05-25',
+        week_end: '2026-05-31',
+        previous_week_start: '2026-05-18',
+        previous_week_end: '2026-05-24',
+      },
+      currency: 'USD',
+      summary: {
+        income: 800,
+        expenses: 200,
+        net_flow: 600,
+        transaction_count: 3,
+        expense_count: 2,
+        income_count: 1,
+        average_daily_expense: 28.57,
+      },
+      comparison: {
+        previous_expenses: 50,
+        expense_delta: 150,
+        expense_delta_pct: 300,
+        expense_trend: 'up',
+      },
+      category_breakdown: [
+        { category_id: 1, category_name: 'Dining', amount: 120, share_pct: 60 },
+      ],
+      daily_breakdown: [
+        { date: '2026-05-25', income: 800, expenses: 0, net_flow: 800 },
+      ],
+      top_expenses: [],
+      upcoming_bills: [],
+      insights: ['Dining was the largest spending category.'],
+      recommendations: ['Set a temporary cap for Dining next week.'],
+      method: 'deterministic',
+    });
   });
 
   it('loads and renders insights data', async () => {
     render(<Analytics />);
     await waitFor(() => expect(getBudgetSuggestionMock).toHaveBeenCalled());
     expect(screen.getByText(/live spending analytics/i)).toBeInTheDocument();
-    expect(screen.getByText(/suggested budget/i)).toBeInTheDocument();
+    expect(await screen.findByText(/suggested budget/i)).toBeInTheDocument();
+    expect(screen.getByText(/weekly digest/i)).toBeInTheDocument();
+    expect(screen.getByText(/dining was the largest spending category/i)).toBeInTheDocument();
     expect(screen.getByText(/tip a/i)).toBeInTheDocument();
   });
 
@@ -68,6 +107,8 @@ describe('Analytics integration', () => {
 
     await userEvent.clear(screen.getByLabelText(/analytics month/i));
     await userEvent.type(screen.getByLabelText(/analytics month/i), '2026-01');
+    await userEvent.clear(screen.getByLabelText(/analytics week/i));
+    await userEvent.type(screen.getByLabelText(/analytics week/i), '2026-01-05');
     await userEvent.selectOptions(screen.getByLabelText(/analytics persona/i), 'Debt-focused planner');
     await userEvent.type(screen.getByLabelText(/gemini api key/i), 'abc123');
     await userEvent.click(screen.getByRole('button', { name: /refresh insights/i }));
@@ -81,5 +122,6 @@ describe('Analytics integration', () => {
         }),
       ),
     );
+    expect(getWeeklySummaryMock).toHaveBeenLastCalledWith({ weekStart: '2026-01-05' });
   });
 });

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,62 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklySummary = {
+  period: {
+    week_start: string;
+    week_end: string;
+    previous_week_start: string;
+    previous_week_end: string;
+  };
+  currency: string;
+  summary: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+    expense_count: number;
+    income_count: number;
+    average_daily_expense: number;
+  };
+  comparison: {
+    previous_expenses: number;
+    expense_delta: number;
+    expense_delta_pct: number | null;
+    expense_trend: 'up' | 'down' | 'flat' | string;
+  };
+  category_breakdown: Array<{
+    category_id: number | null;
+    category_name: string;
+    amount: number;
+    share_pct: number;
+  }>;
+  daily_breakdown: Array<{
+    date: string;
+    income: number;
+    expenses: number;
+    net_flow: number;
+  }>;
+  top_expenses: Array<{
+    id: number;
+    description: string;
+    amount: number;
+    currency: string;
+    date: string;
+    category_id: number | null;
+  }>;
+  upcoming_bills: Array<{
+    id: number;
+    name: string;
+    amount: number;
+    currency: string;
+    next_due_date: string;
+    cadence: string;
+  }>;
+  insights: string[];
+  recommendations: string[];
+  method: 'deterministic' | string;
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +87,15 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklySummary(params?: {
+  weekStart?: string;
+  currency?: string;
+}): Promise<WeeklySummary> {
+  const search = new URLSearchParams();
+  if (params?.weekStart) search.set('week_start', params.weekStart);
+  if (params?.currency) search.set('currency', params.currency);
+  const query = search.toString();
+  return api<WeeklySummary>(`/insights/weekly-summary${query ? `?${query}` : ''}`);
 }

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -10,7 +10,12 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
-import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
+import {
+  getBudgetSuggestion,
+  getWeeklySummary,
+  type BudgetSuggestion,
+  type WeeklySummary,
+} from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
 
 const PERSONAS = [
@@ -22,22 +27,28 @@ const PERSONAS = [
 export function Analytics() {
   const { toast } = useToast();
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [weekStart, setWeekStart] = useState(() => new Date().toISOString().slice(0, 10));
   const [persona, setPersona] = useState(PERSONAS[0]);
   const [geminiKey, setGeminiKey] = useState('');
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BudgetSuggestion | null>(null);
+  const [weeklyData, setWeeklyData] = useState<WeeklySummary | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
     setLoading(true);
     setError(null);
     try {
-      const payload = await getBudgetSuggestion({
-        month,
-        persona,
-        geminiApiKey: geminiKey.trim() || undefined,
-      });
-      setData(payload);
+      const [budgetPayload, weeklyPayload] = await Promise.all([
+        getBudgetSuggestion({
+          month,
+          persona,
+          geminiApiKey: geminiKey.trim() || undefined,
+        }),
+        getWeeklySummary({ weekStart }),
+      ]);
+      setData(budgetPayload);
+      setWeeklyData(weeklyPayload);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
@@ -61,6 +72,10 @@ export function Analytics() {
     ];
   }, [data]);
 
+  const trendLabel = weeklyData?.comparison.expense_delta_pct == null
+    ? 'New baseline'
+    : `${weeklyData.comparison.expense_delta_pct.toFixed(2)}%`;
+
   return (
     <div className="page-wrap space-y-6">
       <div className="page-header">
@@ -71,7 +86,7 @@ export function Analytics() {
               Live spending analytics with Gemini-powered budget coaching.
             </p>
           </div>
-          <div className="grid gap-2 md:grid-cols-4">
+          <div className="grid gap-2 md:grid-cols-5">
             <div>
               <Label htmlFor="analytics-month">Month</Label>
               <Input
@@ -80,6 +95,16 @@ export function Analytics() {
                 type="month"
                 value={month}
                 onChange={(e) => setMonth(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-week">Week</Label>
+              <Input
+                id="analytics-week"
+                aria-label="analytics week"
+                type="date"
+                value={weekStart}
+                onChange={(e) => setWeekStart(e.target.value)}
               />
             </div>
             <div>
@@ -169,6 +194,106 @@ export function Analytics() {
               </div>
             </FinancialCardContent>
           </FinancialCard>
+
+          {weeklyData ? (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Weekly Digest</FinancialCardTitle>
+                <FinancialCardDescription>
+                  {weeklyData.period.week_start} to {weeklyData.period.week_end}
+                </FinancialCardDescription>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid gap-3 md:grid-cols-4">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Income</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklyData.summary.income, weeklyData.currency)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expenses</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklyData.summary.expenses, weeklyData.currency)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Net Flow</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklyData.summary.net_flow, weeklyData.currency)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">WoW Change</div>
+                    <div className="font-semibold">{trendLabel}</div>
+                  </div>
+                </div>
+
+                <div className="mt-5 grid gap-5 lg:grid-cols-2">
+                  <div>
+                    <h4 className="mb-3 font-semibold">Top Categories</h4>
+                    {weeklyData.category_breakdown.length ? (
+                      <div className="space-y-3">
+                        {weeklyData.category_breakdown.slice(0, 5).map((category) => (
+                          <div key={category.category_id ?? category.category_name}>
+                            <div className="mb-1 flex items-center justify-between text-sm">
+                              <span>{category.category_name}</span>
+                              <span>
+                                {formatMoney(category.amount, weeklyData.currency)} -{' '}
+                                {category.share_pct.toFixed(1)}%
+                              </span>
+                            </div>
+                            <div className="h-2 rounded-full bg-muted">
+                              <div
+                                className="h-2 rounded-full bg-primary"
+                                style={{ width: `${Math.min(category.share_pct, 100)}%` }}
+                              />
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="text-sm text-muted-foreground">No category spend this week.</div>
+                    )}
+                  </div>
+
+                  <div>
+                    <h4 className="mb-3 font-semibold">Daily Flow</h4>
+                    <div className="space-y-2">
+                      {weeklyData.daily_breakdown.map((day) => (
+                        <div
+                          key={day.date}
+                          className="flex items-center justify-between rounded-lg border px-3 py-2 text-sm"
+                        >
+                          <span>{day.date}</span>
+                          <span>{formatMoney(day.net_flow, weeklyData.currency)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-5 grid gap-5 lg:grid-cols-2">
+                  <div>
+                    <h4 className="mb-3 font-semibold">Insights</h4>
+                    <ul className="list-disc pl-5 space-y-1 text-sm">
+                      {weeklyData.insights.map((insight) => (
+                        <li key={insight}>{insight}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <h4 className="mb-3 font-semibold">Recommendations</h4>
+                    <ul className="list-disc pl-5 space-y-1 text-sm">
+                      {weeklyData.recommendations.map((recommendation) => (
+                        <li key={recommendation}>{recommendation}</li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          ) : null}
 
           <FinancialCard variant="financial">
             <FinancialCardHeader>

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,89 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/weekly-summary:
+    get:
+      summary: Get smart weekly financial summary
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week_start
+          required: false
+          description: Any date in the target ISO week; normalized to Monday.
+          schema: { type: string, format: date }
+        - in: query
+          name: currency
+          required: false
+          description: Optional currency filter, for example USD or INR.
+          schema: { type: string }
+      responses:
+        '200':
+          description: Weekly digest with totals, trends, categories, bills and recommendations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeeklySummary'
+              example:
+                period:
+                  week_start: 2026-05-25
+                  week_end: 2026-05-31
+                  previous_week_start: 2026-05-18
+                  previous_week_end: 2026-05-24
+                currency: USD
+                summary:
+                  income: 800
+                  expenses: 200
+                  net_flow: 600
+                  transaction_count: 3
+                  expense_count: 2
+                  income_count: 1
+                  average_daily_expense: 28.57
+                comparison:
+                  previous_expenses: 50
+                  expense_delta: 150
+                  expense_delta_pct: 300
+                  expense_trend: up
+                category_breakdown:
+                  - category_id: 1
+                    category_name: Dining
+                    amount: 120
+                    share_pct: 60
+                daily_breakdown:
+                  - date: 2026-05-25
+                    income: 800
+                    expenses: 0
+                    net_flow: 800
+                top_expenses:
+                  - id: 11
+                    description: Team dinner
+                    amount: 120
+                    currency: USD
+                    date: 2026-05-26
+                    category_id: 1
+                upcoming_bills:
+                  - id: 5
+                    name: Internet
+                    amount: 40
+                    currency: USD
+                    next_due_date: 2026-05-29
+                    cadence: MONTHLY
+                insights:
+                  - Weekly expenses rose by 300.0% compared with the previous week.
+                recommendations:
+                  - Set a temporary cap for Dining next week.
+                method: deterministic
+        '400':
+          description: Invalid week_start
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:
@@ -572,6 +655,74 @@ components:
         autopay_enabled: { type: boolean, default: false }
         channel_email: { type: boolean, default: true }
         channel_whatsapp: { type: boolean, default: false }
+    WeeklySummary:
+      type: object
+      properties:
+        period:
+          type: object
+          properties:
+            week_start: { type: string, format: date }
+            week_end: { type: string, format: date }
+            previous_week_start: { type: string, format: date }
+            previous_week_end: { type: string, format: date }
+        currency: { type: string }
+        summary:
+          type: object
+          properties:
+            income: { type: number }
+            expenses: { type: number }
+            net_flow: { type: number }
+            transaction_count: { type: integer }
+            expense_count: { type: integer }
+            income_count: { type: integer }
+            average_daily_expense: { type: number }
+        comparison:
+          type: object
+          properties:
+            previous_expenses: { type: number }
+            expense_delta: { type: number }
+            expense_delta_pct: { type: number, nullable: true }
+            expense_trend: { type: string, enum: [up, down, flat] }
+        category_breakdown:
+          type: array
+          items:
+            type: object
+            properties:
+              category_id: { type: integer, nullable: true }
+              category_name: { type: string }
+              amount: { type: number }
+              share_pct: { type: number }
+        daily_breakdown:
+          type: array
+          items:
+            type: object
+            properties:
+              date: { type: string, format: date }
+              income: { type: number }
+              expenses: { type: number }
+              net_flow: { type: number }
+        top_expenses:
+          type: array
+          items:
+            type: object
+            properties:
+              id: { type: integer }
+              description: { type: string }
+              amount: { type: number }
+              currency: { type: string }
+              date: { type: string, format: date }
+              category_id: { type: integer, nullable: true }
+        upcoming_bills:
+          type: array
+          items:
+            $ref: '#/components/schemas/Bill'
+        insights:
+          type: array
+          items: { type: string }
+        recommendations:
+          type: array
+          items: { type: string }
+        method: { type: string }
     Reminder:
       type: object
       properties:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,7 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.weekly_summary import parse_week_start, weekly_financial_summary
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +24,22 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-summary")
+@jwt_required()
+def weekly_summary():
+    uid = int(get_jwt_identity())
+    try:
+        week_start = parse_week_start(request.args.get("week_start"))
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 400
+    currency = (request.args.get("currency") or "").strip().upper() or None
+    payload = weekly_financial_summary(uid, week_start=week_start, currency=currency)
+    logger.info(
+        "Weekly summary served user=%s week_start=%s currency=%s",
+        uid,
+        payload["period"]["week_start"],
+        currency or "all",
+    )
+    return jsonify(payload)

--- a/packages/backend/app/services/weekly_summary.py
+++ b/packages/backend/app/services/weekly_summary.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from ..extensions import db
+from ..models import Bill, Category, Expense, User
+
+
+def weekly_financial_summary(
+    user_id: int,
+    *,
+    week_start: date | None = None,
+    currency: str | None = None,
+) -> dict:
+    start = _week_start(week_start or date.today())
+    end = start + timedelta(days=6)
+    previous_start = start - timedelta(days=7)
+    previous_end = start - timedelta(days=1)
+
+    user = db.session.get(User, user_id)
+    response_currency = currency or (user.preferred_currency if user else "INR")
+
+    current_rows = _expense_rows(user_id, start, end, currency)
+    previous_rows = _expense_rows(user_id, previous_start, previous_end, currency)
+    bills = _upcoming_bills(user_id, start, end, currency)
+
+    summary = _summarize_rows(current_rows)
+    previous = _summarize_rows(previous_rows)
+    category_breakdown = _category_breakdown(current_rows)
+    daily_breakdown = _daily_breakdown(current_rows, start)
+    top_expenses = _top_expenses(current_rows)
+    comparison = _comparison(summary, previous)
+
+    return {
+        "period": {
+            "week_start": start.isoformat(),
+            "week_end": end.isoformat(),
+            "previous_week_start": previous_start.isoformat(),
+            "previous_week_end": previous_end.isoformat(),
+        },
+        "currency": response_currency,
+        "summary": summary,
+        "comparison": comparison,
+        "category_breakdown": category_breakdown,
+        "daily_breakdown": daily_breakdown,
+        "top_expenses": top_expenses,
+        "upcoming_bills": bills,
+        "insights": _insights(summary, comparison, category_breakdown, bills),
+        "recommendations": _recommendations(
+            summary, comparison, category_breakdown, bills
+        ),
+        "method": "deterministic",
+    }
+
+
+def parse_week_start(raw: str | None) -> date | None:
+    if not raw:
+        return None
+    try:
+        return _week_start(date.fromisoformat(raw.strip()))
+    except ValueError as exc:
+        raise ValueError("invalid week_start, expected YYYY-MM-DD") from exc
+
+
+def _week_start(value: date) -> date:
+    return value - timedelta(days=value.weekday())
+
+
+def _expense_rows(
+    user_id: int,
+    start: date,
+    end: date,
+    currency: str | None,
+) -> list[Expense]:
+    query = (
+        db.session.query(Expense)
+        .filter(
+            Expense.user_id == user_id,
+            Expense.spent_at >= start,
+            Expense.spent_at <= end,
+        )
+        .order_by(Expense.spent_at.asc(), Expense.id.asc())
+    )
+    if currency:
+        query = query.filter(Expense.currency == currency)
+    return query.all()
+
+
+def _upcoming_bills(
+    user_id: int,
+    start: date,
+    end: date,
+    currency: str | None,
+) -> list[dict]:
+    query = (
+        db.session.query(Bill)
+        .filter(
+            Bill.user_id == user_id,
+            Bill.active.is_(True),
+            Bill.next_due_date >= start,
+            Bill.next_due_date <= end,
+        )
+        .order_by(Bill.next_due_date.asc(), Bill.id.asc())
+    )
+    if currency:
+        query = query.filter(Bill.currency == currency)
+    return [
+        {
+            "id": bill.id,
+            "name": bill.name,
+            "amount": _money(bill.amount),
+            "currency": bill.currency,
+            "next_due_date": bill.next_due_date.isoformat(),
+            "cadence": bill.cadence.value,
+        }
+        for bill in query.all()
+    ]
+
+
+def _summarize_rows(rows: list[Expense]) -> dict:
+    income = sum(
+        _as_decimal(row.amount) for row in rows if row.expense_type == "INCOME"
+    )
+    expenses = sum(
+        _as_decimal(row.amount) for row in rows if row.expense_type != "INCOME"
+    )
+    return {
+        "income": _money(income),
+        "expenses": _money(expenses),
+        "net_flow": _money(income - expenses),
+        "transaction_count": len(rows),
+        "expense_count": sum(1 for row in rows if row.expense_type != "INCOME"),
+        "income_count": sum(1 for row in rows if row.expense_type == "INCOME"),
+        "average_daily_expense": _money(expenses / Decimal("7")),
+    }
+
+
+def _comparison(current: dict, previous: dict) -> dict:
+    current_expenses = Decimal(str(current["expenses"]))
+    previous_expenses = Decimal(str(previous["expenses"]))
+    expense_delta = current_expenses - previous_expenses
+    return {
+        "previous_expenses": _money(previous_expenses),
+        "expense_delta": _money(expense_delta),
+        "expense_delta_pct": _percent_change(current_expenses, previous_expenses),
+        "expense_trend": _trend(expense_delta),
+    }
+
+
+def _category_breakdown(rows: list[Expense]) -> list[dict]:
+    category_ids = {row.category_id for row in rows if row.category_id is not None}
+    category_names = {}
+    if category_ids:
+        for category in db.session.query(Category).filter(
+            Category.id.in_(category_ids)
+        ):
+            category_names[category.id] = category.name
+
+    totals: dict[int | None, Decimal] = {}
+    for row in rows:
+        if row.expense_type == "INCOME":
+            continue
+        totals[row.category_id] = totals.get(
+            row.category_id, Decimal("0")
+        ) + _as_decimal(row.amount)
+    grand_total = sum(totals.values(), Decimal("0"))
+    breakdown = []
+    for category_id, amount in sorted(
+        totals.items(), key=lambda item: item[1], reverse=True
+    ):
+        breakdown.append(
+            {
+                "category_id": category_id,
+                "category_name": category_names.get(category_id, "Uncategorized"),
+                "amount": _money(amount),
+                "share_pct": (
+                    round(float((amount / grand_total) * Decimal("100")), 2)
+                    if grand_total
+                    else 0.0
+                ),
+            }
+        )
+    return breakdown
+
+
+def _daily_breakdown(rows: list[Expense], start: date) -> list[dict]:
+    daily = {
+        start
+        + timedelta(days=offset): {"income": Decimal("0"), "expenses": Decimal("0")}
+        for offset in range(7)
+    }
+    for row in rows:
+        bucket = daily[row.spent_at]
+        if row.expense_type == "INCOME":
+            bucket["income"] += _as_decimal(row.amount)
+        else:
+            bucket["expenses"] += _as_decimal(row.amount)
+    return [
+        {
+            "date": day.isoformat(),
+            "income": _money(values["income"]),
+            "expenses": _money(values["expenses"]),
+            "net_flow": _money(values["income"] - values["expenses"]),
+        }
+        for day, values in daily.items()
+    ]
+
+
+def _top_expenses(rows: list[Expense]) -> list[dict]:
+    expenses = [row for row in rows if row.expense_type != "INCOME"]
+    expenses.sort(key=lambda row: _as_decimal(row.amount), reverse=True)
+    return [
+        {
+            "id": row.id,
+            "description": row.notes or "Expense",
+            "amount": _money(row.amount),
+            "currency": row.currency,
+            "date": row.spent_at.isoformat(),
+            "category_id": row.category_id,
+        }
+        for row in expenses[:5]
+    ]
+
+
+def _insights(
+    summary: dict,
+    comparison: dict,
+    category_breakdown: list[dict],
+    bills: list[dict],
+) -> list[str]:
+    insights = []
+    if summary["transaction_count"] == 0:
+        insights.append("No transactions were recorded for this week.")
+    elif comparison["expense_trend"] == "up":
+        insights.append(
+            "Weekly expenses rose by "
+            f"{comparison['expense_delta_pct']}% compared with the previous week."
+        )
+    elif comparison["expense_trend"] == "down":
+        insights.append("Weekly expenses decreased compared with the previous week.")
+    else:
+        insights.append("Weekly expenses were flat compared with the previous week.")
+
+    if category_breakdown:
+        top = category_breakdown[0]
+        insights.append(
+            f"{top['category_name']} was the largest spending category at "
+            f"{top['share_pct']}% of expenses."
+        )
+    if bills:
+        total_due = sum(Decimal(str(bill["amount"])) for bill in bills)
+        insights.append(
+            f"{len(bills)} bill(s) are due this week totaling {_money(total_due)}."
+        )
+    return insights
+
+
+def _recommendations(
+    summary: dict,
+    comparison: dict,
+    category_breakdown: list[dict],
+    bills: list[dict],
+) -> list[str]:
+    recommendations = []
+    if summary["net_flow"] < 0:
+        recommendations.append(
+            "Review discretionary spending before adding new recurring costs."
+        )
+    if comparison["expense_trend"] == "up" and category_breakdown:
+        recommendations.append(
+            "Set a temporary cap for "
+            f"{category_breakdown[0]['category_name']} next week."
+        )
+    if bills:
+        recommendations.append(
+            "Reserve cash for upcoming bills before allocating savings."
+        )
+    if not recommendations:
+        recommendations.append(
+            "Keep the current budget rhythm and revisit the digest next week."
+        )
+    return recommendations
+
+
+def _percent_change(current: Decimal, previous: Decimal) -> float | None:
+    if previous == 0:
+        return None if current == 0 else 100.0
+    return round(float(((current - previous) / previous) * Decimal("100")), 2)
+
+
+def _trend(delta: Decimal) -> str:
+    if delta > 0:
+        return "up"
+    if delta < 0:
+        return "down"
+    return "flat"
+
+
+def _as_decimal(value) -> Decimal:
+    return Decimal(str(value or "0"))
+
+
+def _money(value) -> float:
+    return round(float(_as_decimal(value)), 2)

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,10 +1,54 @@
 import os
+from fnmatch import fnmatch
+
 import pytest
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
+from app import extensions
+from app.routes import auth as auth_routes
+from app.services import cache as cache_service
+
+
+class FakeRedis:
+    def __init__(self):
+        self.store = {}
+
+    def set(self, key, value):
+        self.store[key] = value
+        return True
+
+    def setex(self, key, _ttl, value):
+        self.store[key] = value
+        return True
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def delete(self, *keys):
+        removed = 0
+        for key in keys:
+            if key in self.store:
+                removed += 1
+                del self.store[key]
+        return removed
+
+    def scan(self, cursor=0, match=None, count=100):
+        keys = list(self.store)
+        if match:
+            keys = [key for key in keys if fnmatch(key, match)]
+        return 0, keys[:count]
+
+    def flushdb(self):
+        self.store.clear()
+        return True
+
+
+fake_redis = FakeRedis()
+extensions.redis_client = fake_redis
+auth_routes.redis_client = fake_redis
+cache_service.redis_client = fake_redis
 
 
 class TestSettings(Settings):
@@ -31,18 +75,12 @@ def app_fixture():
     app = create_app(settings)
     app.config.update(TESTING=True)
     _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
     yield app
     with app.app_context():
         db.session.remove()
         db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_weekly_summary.py
+++ b/packages/backend/tests/test_weekly_summary.py
@@ -1,0 +1,116 @@
+from datetime import date, timedelta
+
+
+def _category(client, auth_header, name):
+    r = client.post("/categories", json={"name": name}, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()["id"]
+
+
+def _expense(client, auth_header, amount, description, spent_at, **extra):
+    payload = {
+        "amount": amount,
+        "description": description,
+        "date": spent_at.isoformat(),
+        **extra,
+    }
+    r = client.post("/expenses", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    return r.get_json()
+
+
+def test_weekly_summary_returns_trends_categories_and_bills(client, auth_header):
+    monday = date(2026, 5, 25)
+    dining = _category(client, auth_header, "Dining")
+    travel = _category(client, auth_header, "Travel")
+
+    _expense(
+        client,
+        auth_header,
+        800,
+        "Salary",
+        monday,
+        expense_type="INCOME",
+        currency="USD",
+    )
+    _expense(
+        client,
+        auth_header,
+        120,
+        "Team dinner",
+        monday + timedelta(days=1),
+        category_id=dining,
+        currency="USD",
+    )
+    _expense(
+        client,
+        auth_header,
+        80,
+        "Train tickets",
+        monday + timedelta(days=2),
+        category_id=travel,
+        currency="USD",
+    )
+    _expense(
+        client,
+        auth_header,
+        50,
+        "Previous week food",
+        monday - timedelta(days=3),
+        category_id=dining,
+        currency="USD",
+    )
+    r = client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 40,
+            "currency": "USD",
+            "next_due_date": (monday + timedelta(days=4)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get(
+        f"/insights/weekly-summary?week_start={monday.isoformat()}&currency=USD",
+        headers=auth_header,
+    )
+
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["period"]["week_start"] == monday.isoformat()
+    assert payload["summary"]["income"] == 800.0
+    assert payload["summary"]["expenses"] == 200.0
+    assert payload["summary"]["net_flow"] == 600.0
+    assert payload["comparison"]["previous_expenses"] == 50.0
+    assert payload["comparison"]["expense_delta"] == 150.0
+    assert payload["comparison"]["expense_delta_pct"] == 300.0
+    assert payload["category_breakdown"][0]["category_name"] == "Dining"
+    assert payload["category_breakdown"][0]["amount"] == 120.0
+    assert len(payload["daily_breakdown"]) == 7
+    assert payload["top_expenses"][0]["description"] == "Team dinner"
+    assert payload["upcoming_bills"][0]["name"] == "Internet"
+    assert payload["method"] == "deterministic"
+    assert payload["insights"]
+    assert payload["recommendations"]
+
+
+def test_weekly_summary_normalizes_any_week_date_to_monday(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=2026-05-28",
+        headers=auth_header,
+    )
+
+    assert r.status_code == 200
+    assert r.get_json()["period"]["week_start"] == "2026-05-25"
+
+
+def test_weekly_summary_rejects_invalid_week_start(client, auth_header):
+    r = client.get(
+        "/insights/weekly-summary?week_start=not-a-date", headers=auth_header
+    )
+
+    assert r.status_code == 400
+    assert "invalid week_start" in r.get_json()["error"]


### PR DESCRIPTION
/claim #121

## Summary
- Added authenticated `GET /insights/weekly-summary` for a smart weekly digest.
- Aggregates income, expenses, net flow, transaction counts, average daily expense, daily buckets, category shares, top expenses, and upcoming bills for the selected ISO week.
- Compares weekly expenses with the previous week and returns deterministic insights/recommendations without an LLM or scheduler dependency.
- Surfaced the weekly digest on the existing Analytics page with week selection, summary cards, category share bars, daily flow, insights, and recommendations.
- Updated README and OpenAPI docs.
- Added backend tests for weekly aggregation, week normalization, and invalid dates; updated Analytics integration coverage.
- Replaced test Redis dependency with a lightweight in-memory fake so auth/cache-backed tests can run without an external Redis server.

## Demo
https://github.com/Jorel97/bounty-demo-assets/raw/main/finmind/finmind-121-weekly-summary-demo.mp4

## Validation
- `python -m pytest packages/backend/tests/test_weekly_summary.py packages/backend/tests/test_insights.py -q` -> 6 passed
- `python -m black --check packages/backend/app/services/weekly_summary.py packages/backend/app/routes/insights.py packages/backend/tests/test_weekly_summary.py packages/backend/tests/conftest.py` -> passed
- `python -m flake8 packages/backend/app/services/weekly_summary.py packages/backend/app/routes/insights.py packages/backend/tests/test_weekly_summary.py packages/backend/tests/conftest.py` -> passed
- OpenAPI parse check -> passed
- `npm test -- Analytics.integration.test.tsx --runInBand` -> 2 passed
- `npm run build` -> passed