### PR TITLE
feat: goal-based savings tracking & milestones

### DIFF
--- a/app/src/api/savings.ts
+++ b/app/src/api/savings.ts
@@ -1,0 +1,47 @@
+import { api } from './client';
+
+export type SavingsGoal = {
+  id: number;
+  title: string;
+  target: number;
+  current: number;
+  currency: string;
+  deadline: string | null;
+  monthlyTarget: number;
+  status: 'on-track' | 'ahead' | 'behind' | 'completed';
+  created_at?: string;
+};
+
+export type SavingsGoalCreate = {
+  title: string;
+  target_amount: number;
+  current_amount?: number;
+  currency?: string;
+  deadline?: string | null;
+};
+
+export type SavingsGoalUpdate = Partial<SavingsGoalCreate>;
+
+export async function listSavingsGoals(): Promise<SavingsGoal[]> {
+  return api<SavingsGoal[]>('/savings');
+}
+
+export async function createSavingsGoal(payload: SavingsGoalCreate): Promise<SavingsGoal> {
+  return api<SavingsGoal>('/savings', { method: 'POST', body: payload });
+}
+
+export async function getSavingsGoal(id: number): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${id}`);
+}
+
+export async function updateSavingsGoal(id: number, payload: SavingsGoalUpdate): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${id}`, { method: 'PATCH', body: payload });
+}
+
+export async function contributeSavingsGoal(id: number, amount: number): Promise<SavingsGoal> {
+  return api<SavingsGoal>(`/savings/${id}/contribute`, { method: 'POST', body: { amount } });
+}
+
+export async function deleteSavingsGoal(id: number): Promise<{ message: string }> {
+  return api(`/savings/${id}`, { method: 'DELETE' });
+}

--- a/app/src/pages/Budgets.tsx
+++ b/app/src/pages/Budgets.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { FinancialCard, FinancialCardContent, FinancialCardDescription, FinancialCardFooter, FinancialCardHeader, FinancialCardTitle } from '@/components/ui/financial-card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, DollarSign, Plus, PieChart, TrendingDown, TrendingUp, Target, AlertCircle, Settings } from 'lucide-react';
+import { Calendar, DollarSign, Plus, PieChart, TrendingDown, TrendingUp, Target, AlertCircle, Settings, Loader2 } from 'lucide-react';
+import { listSavingsGoals, type SavingsGoal } from '@/api/savings';
 
 const budgetCategories = [
   {
@@ -67,42 +68,40 @@ const budgetCategories = [
   }
 ];
 
-const budgetGoals = [
-  {
-    id: 1,
-    title: 'Emergency Fund',
-    target: 10000,
-    current: 7250,
-    deadline: 'Dec 2025',
-    monthlyTarget: 458,
-    status: 'on-track'
-  },
-  {
-    id: 2,
-    title: 'Vacation Fund',
-    target: 3000,
-    current: 1850,
-    deadline: 'Jun 2025',
-    monthlyTarget: 383,
-    status: 'behind'
-  },
-  {
-    id: 3,
-    title: 'New Car',
-    target: 25000,
-    current: 15600,
-    deadline: 'Mar 2026',
-    monthlyTarget: 625,
-    status: 'ahead'
-  }
-];
-
 export function Budgets() {
   const [selectedPeriod] = useState('monthly');
-  
+  const [savingsGoals, setSavingsGoals] = useState<SavingsGoal[]>([]);
+  const [goalsLoading, setGoalsLoading] = useState(true);
+
+  useEffect(() => {
+    listSavingsGoals()
+      .then(setSavingsGoals)
+      .catch(() => setSavingsGoals([]))
+      .finally(() => setGoalsLoading(false));
+  }, []);
+
   const totalAllocated = budgetCategories.reduce((sum, cat) => sum + cat.allocated, 0);
   const totalSpent = budgetCategories.reduce((sum, cat) => sum + cat.spent, 0);
   const totalRemaining = totalAllocated - totalSpent;
+
+  const statusLabel = (status: SavingsGoal['status']) => {
+    if (status === 'on-track') return 'On Track';
+    if (status === 'ahead') return 'Ahead';
+    if (status === 'completed') return 'Completed';
+    return 'Behind';
+  };
+
+  const statusVariant = (status: SavingsGoal['status']): 'default' | 'secondary' | 'destructive' => {
+    if (status === 'on-track') return 'default';
+    if (status === 'ahead' || status === 'completed') return 'secondary';
+    return 'destructive';
+  };
+
+  const formatDeadline = (deadline: string | null) => {
+    if (!deadline) return '—';
+    const d = new Date(deadline);
+    return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+  };
 
   return (
     <div className="page-wrap">
@@ -211,7 +210,7 @@ export function Budgets() {
                   {budgetCategories.map((category) => {
                     const percentage = (category.spent / category.allocated) * 100;
                     const isOverBudget = category.remaining < 0;
-                    
+
                     return (
                       <div key={category.id} className="space-y-3 interactive-row">
                         <div className="flex items-center justify-between">
@@ -278,48 +277,58 @@ export function Budgets() {
                 </FinancialCardDescription>
               </FinancialCardHeader>
               <FinancialCardContent>
-                <div className="space-y-4">
-                  {budgetGoals.map((goal) => {
-                    const percentage = (goal.current / goal.target) * 100;
-                    
-                    return (
-                      <div key={goal.id} className="interactive-row p-3 rounded-lg border border-border">
-                        <div className="flex items-center justify-between mb-2">
-                          <div className="font-medium text-foreground text-sm">
-                            {goal.title}
+                {goalsLoading ? (
+                  <div className="flex justify-center py-6">
+                    <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+                  </div>
+                ) : savingsGoals.length === 0 ? (
+                  <div className="text-center py-6 text-muted-foreground text-sm">
+                    No savings goals yet. Add one to get started!
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    {savingsGoals.map((goal) => {
+                      const percentage = Math.min((goal.current / goal.target) * 100, 100);
+                      return (
+                        <div key={goal.id} className="interactive-row p-3 rounded-lg border border-border">
+                          <div className="flex items-center justify-between mb-2">
+                            <div className="font-medium text-foreground text-sm">
+                              {goal.title}
+                            </div>
+                            <Badge
+                              variant={statusVariant(goal.status)}
+                              className="text-xs"
+                            >
+                              {statusLabel(goal.status)}
+                            </Badge>
                           </div>
-                          <Badge 
-                            variant={
-                              goal.status === 'on-track' ? 'default' :
-                              goal.status === 'ahead' ? 'secondary' : 'destructive'
-                            }
-                            className="text-xs"
-                          >
-                            {goal.status === 'on-track' ? 'On Track' :
-                             goal.status === 'ahead' ? 'Ahead' : 'Behind'}
-                          </Badge>
+                          <div className="space-y-2">
+                            <div className="flex justify-between text-sm">
+                              <span className="text-muted-foreground">
+                                {goal.currency} {goal.current.toLocaleString()} / {goal.target.toLocaleString()}
+                              </span>
+                              <span className="text-foreground font-medium">
+                                {percentage.toFixed(0)}%
+                              </span>
+                            </div>
+                            <div className="chart-track">
+                              <div
+                                className="chart-fill-success"
+                                style={{ width: `${percentage}%` }}
+                              />
+                            </div>
+                            <div className="flex justify-between text-xs text-muted-foreground">
+                              <span>Target: {formatDeadline(goal.deadline)}</span>
+                              {goal.monthlyTarget > 0 && (
+                                <span>{goal.currency} {goal.monthlyTarget.toLocaleString()}/mo</span>
+                              )}
+                            </div>
+                          </div>
                         </div>
-                        <div className="space-y-2">
-                          <div className="flex justify-between text-sm">
-                            <span className="text-muted-foreground">
-                              ${goal.current.toLocaleString()} / ${goal.target.toLocaleString()}
-                            </span>
-                            <span className="text-foreground font-medium">
-                              {percentage.toFixed(0)}%
-                            </span>
-                          </div>
-                          <div className="chart-track">
-                            <div className="chart-fill-success" style={{ width: `${Math.min(percentage, 100)}%` }} />
-                          </div>
-                          <div className="flex justify-between text-xs text-muted-foreground">
-                            <span>Target: {goal.deadline}</span>
-                            <span>${goal.monthlyTarget}/mo</span>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+                      );
+                    })}
+                  </div>
+                )}
               </FinancialCardContent>
               <FinancialCardFooter>
                 <Button variant="financial" size="sm" className="w-full">

--- a/packages/backend/app/db/schema.sql
+++ b/packages/backend/app/db/schema.sql
@@ -123,3 +123,16 @@ CREATE TABLE IF NOT EXISTS audit_logs (
   action VARCHAR(100) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+CREATE TABLE IF NOT EXISTS savings_goals (
+  id SERIAL PRIMARY KEY,
+  user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  title VARCHAR(200) NOT NULL,
+  target_amount NUMERIC(12,2) NOT NULL,
+  current_amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+  deadline DATE,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_savings_goals_user ON savings_goals(user_id);

--- a/packages/backend/app/models.py
+++ b/packages/backend/app/models.py
@@ -127,6 +127,21 @@ class UserSubscription(db.Model):
     started_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
 
 
+class SavingsGoal(db.Model):
+    __tablename__ = "savings_goals"
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    target_amount = db.Column(db.Numeric(12, 2), nullable=False)
+    current_amount = db.Column(db.Numeric(12, 2), nullable=False, default=0)
+    currency = db.Column(db.String(10), default="INR", nullable=False)
+    deadline = db.Column(db.Date, nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+
 class AuditLog(db.Model):
     __tablename__ = "audit_logs"
     id = db.Column(db.Integer, primary_key=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .savings import bp as savings_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(savings_bp, url_prefix="/savings")

--- a/packages/backend/app/routes/savings.py
+++ b/packages/backend/app/routes/savings.py
@@ -1,0 +1,233 @@
+from datetime import date, datetime
+from math import ceil
+
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from ..extensions import db
+from ..models import SavingsGoal, User
+import logging
+
+bp = Blueprint("savings", __name__)
+logger = logging.getLogger("finmind.savings")
+
+
+def _compute_status(goal: SavingsGoal) -> str:
+    current = float(goal.current_amount)
+    target = float(goal.target_amount)
+
+    if current >= target:
+        return "completed"
+
+    if not goal.deadline:
+        return "on-track"
+
+    today = date.today()
+    if goal.deadline <= today:
+        return "behind"
+
+    created = goal.created_at.date() if goal.created_at else today
+    total_days = (goal.deadline - created).days
+    elapsed_days = (today - created).days
+
+    if total_days <= 0:
+        return "on-track"
+
+    expected = target * (elapsed_days / total_days)
+    if current >= expected * 1.05:
+        return "ahead"
+    if current < expected * 0.95:
+        return "behind"
+    return "on-track"
+
+
+def _monthly_target(goal: SavingsGoal) -> float:
+    if not goal.deadline:
+        return 0.0
+    remaining = float(goal.target_amount) - float(goal.current_amount)
+    if remaining <= 0:
+        return 0.0
+    today = date.today()
+    months_remaining = (
+        (goal.deadline.year - today.year) * 12
+        + (goal.deadline.month - today.month)
+    )
+    if months_remaining <= 0:
+        return remaining
+    return round(remaining / months_remaining, 2)
+
+
+def _goal_to_dict(goal: SavingsGoal) -> dict:
+    return {
+        "id": goal.id,
+        "title": goal.title,
+        "target": float(goal.target_amount),
+        "current": float(goal.current_amount),
+        "currency": goal.currency,
+        "deadline": goal.deadline.isoformat() if goal.deadline else None,
+        "monthlyTarget": _monthly_target(goal),
+        "status": _compute_status(goal),
+        "created_at": goal.created_at.isoformat() if goal.created_at else None,
+    }
+
+
+@bp.get("")
+@jwt_required()
+def list_goals():
+    uid = int(get_jwt_identity())
+    items = (
+        db.session.query(SavingsGoal)
+        .filter_by(user_id=uid)
+        .order_by(SavingsGoal.created_at.desc())
+        .all()
+    )
+    logger.info("List savings goals user=%s count=%s", uid, len(items))
+    return jsonify([_goal_to_dict(g) for g in items])
+
+
+@bp.post("")
+@jwt_required()
+def create_goal():
+    uid = int(get_jwt_identity())
+    user = db.session.get(User, uid)
+    data = request.get_json() or {}
+
+    title = (data.get("title") or "").strip()
+    if not title:
+        return jsonify(error="title is required"), 400
+
+    try:
+        target_amount = float(data["target_amount"])
+        if target_amount <= 0:
+            raise ValueError
+    except (KeyError, ValueError, TypeError):
+        return jsonify(error="target_amount must be a positive number"), 400
+
+    current_amount = 0.0
+    if "current_amount" in data:
+        try:
+            current_amount = max(0.0, float(data["current_amount"]))
+        except (ValueError, TypeError):
+            return jsonify(error="current_amount must be a number"), 400
+
+    deadline = None
+    if data.get("deadline"):
+        try:
+            deadline = date.fromisoformat(data["deadline"])
+        except ValueError:
+            return jsonify(error="deadline must be YYYY-MM-DD"), 400
+
+    currency = data.get("currency") or (
+        user.preferred_currency if user else "INR"
+    )
+
+    goal = SavingsGoal(
+        user_id=uid,
+        title=title,
+        target_amount=target_amount,
+        current_amount=current_amount,
+        currency=currency,
+        deadline=deadline,
+    )
+    db.session.add(goal)
+    db.session.commit()
+    logger.info("Created savings goal id=%s user=%s title=%s", goal.id, uid, title)
+    return jsonify(_goal_to_dict(goal)), 201
+
+
+@bp.get("/<int:goal_id>")
+@jwt_required()
+def get_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.patch("/<int:goal_id>")
+@jwt_required()
+def update_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+
+    if "title" in data:
+        title = (data["title"] or "").strip()
+        if not title:
+            return jsonify(error="title cannot be empty"), 400
+        goal.title = title
+
+    if "target_amount" in data:
+        try:
+            val = float(data["target_amount"])
+            if val <= 0:
+                raise ValueError
+            goal.target_amount = val
+        except (ValueError, TypeError):
+            return jsonify(error="target_amount must be a positive number"), 400
+
+    if "current_amount" in data:
+        try:
+            goal.current_amount = max(0.0, float(data["current_amount"]))
+        except (ValueError, TypeError):
+            return jsonify(error="current_amount must be a number"), 400
+
+    if "deadline" in data:
+        if data["deadline"] is None:
+            goal.deadline = None
+        else:
+            try:
+                goal.deadline = date.fromisoformat(data["deadline"])
+            except ValueError:
+                return jsonify(error="deadline must be YYYY-MM-DD"), 400
+
+    if "currency" in data:
+        goal.currency = data["currency"] or "INR"
+
+    goal.updated_at = datetime.utcnow()
+    db.session.commit()
+    logger.info("Updated savings goal id=%s user=%s", goal_id, uid)
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.post("/<int:goal_id>/contribute")
+@jwt_required()
+def contribute(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+
+    data = request.get_json() or {}
+    try:
+        amount = float(data["amount"])
+        if amount <= 0:
+            raise ValueError
+    except (KeyError, ValueError, TypeError):
+        return jsonify(error="amount must be a positive number"), 400
+
+    goal.current_amount = float(goal.current_amount) + amount
+    goal.updated_at = datetime.utcnow()
+    db.session.commit()
+    logger.info(
+        "Contributed %.2f to goal id=%s user=%s new_total=%.2f",
+        amount, goal_id, uid, float(goal.current_amount),
+    )
+    return jsonify(_goal_to_dict(goal))
+
+
+@bp.delete("/<int:goal_id>")
+@jwt_required()
+def delete_goal(goal_id: int):
+    uid = int(get_jwt_identity())
+    goal = db.session.get(SavingsGoal, goal_id)
+    if not goal or goal.user_id != uid:
+        return jsonify(error="not found"), 404
+    db.session.delete(goal)
+    db.session.commit()
+    logger.info("Deleted savings goal id=%s user=%s", goal_id, uid)
+    return jsonify(message="deleted")

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
 import pytest
+import fakeredis
+from unittest.mock import patch
 from app import create_app
 from app.config import Settings
 from app.extensions import db
-from app.extensions import redis_client
 from app import models  # noqa: F401 - ensure models are registered
 
 
@@ -20,7 +21,12 @@ def _setup_db(app):
 
 
 @pytest.fixture()
-def app_fixture():
+def fake_redis():
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture()
+def app_fixture(fake_redis):
     # Ensure a clean env for tests
     os.environ.setdefault("FLASK_ENV", "testing")
     settings = TestSettings(
@@ -28,21 +34,17 @@ def app_fixture():
         redis_url="redis://localhost:6379/15",
         jwt_secret="test-secret-with-32-plus-chars-1234567890",
     )
-    app = create_app(settings)
-    app.config.update(TESTING=True)
-    _setup_db(app)
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
-    yield app
-    with app.app_context():
-        db.session.remove()
-        db.drop_all()
-    try:
-        redis_client.flushdb()
-    except Exception:
-        pass
+    with patch("app.extensions.redis_client", fake_redis), \
+         patch("app.routes.auth.redis_client", fake_redis):
+        app = create_app(settings)
+        app.config.update(TESTING=True)
+        _setup_db(app)
+        fake_redis.flushdb()
+        yield app
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+        fake_redis.flushdb()
 
 
 @pytest.fixture()

--- a/packages/backend/tests/test_savings.py
+++ b/packages/backend/tests/test_savings.py
@@ -1,0 +1,236 @@
+from datetime import date, timedelta
+
+
+def test_savings_goals_empty_initially(client, auth_header):
+    r = client.get("/savings", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json() == []
+
+
+def test_create_savings_goal(client, auth_header):
+    payload = {
+        "title": "Emergency Fund",
+        "target_amount": 10000,
+        "current_amount": 2500,
+        "currency": "USD",
+        "deadline": (date.today() + timedelta(days=180)).isoformat(),
+    }
+    r = client.post("/savings", json=payload, headers=auth_header)
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["title"] == "Emergency Fund"
+    assert data["target"] == 10000.0
+    assert data["current"] == 2500.0
+    assert data["currency"] == "USD"
+    assert data["status"] in ("on-track", "ahead", "behind", "completed")
+    assert isinstance(data["monthlyTarget"], (int, float))
+    return data["id"]
+
+
+def test_list_savings_goals_after_create(client, auth_header):
+    client.post(
+        "/savings",
+        json={"title": "Vacation Fund", "target_amount": 3000},
+        headers=auth_header,
+    )
+    r = client.get("/savings", headers=auth_header)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert len(items) >= 1
+    assert any(g["title"] == "Vacation Fund" for g in items)
+
+
+def test_get_savings_goal(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "Car Fund", "target_amount": 20000},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    r = client.get(f"/savings/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["id"] == goal_id
+
+
+def test_get_savings_goal_not_found(client, auth_header):
+    r = client.get("/savings/9999", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_update_savings_goal(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "House Down Payment", "target_amount": 50000},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    r = client.patch(
+        f"/savings/{goal_id}",
+        json={"title": "House Deposit", "target_amount": 60000},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["title"] == "House Deposit"
+    assert data["target"] == 60000.0
+
+
+def test_update_savings_goal_not_found(client, auth_header):
+    r = client.patch(
+        "/savings/9999",
+        json={"title": "X"},
+        headers=auth_header,
+    )
+    assert r.status_code == 404
+
+
+def test_contribute_to_savings_goal(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "Laptop Fund", "target_amount": 1500, "current_amount": 0},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/savings/{goal_id}/contribute",
+        json={"amount": 500},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["current"] == 500.0
+
+    r = client.post(
+        f"/savings/{goal_id}/contribute",
+        json={"amount": 1000},
+        headers=auth_header,
+    )
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["current"] == 1500.0
+    assert data["status"] == "completed"
+
+
+def test_contribute_invalid_amount(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "Misc Fund", "target_amount": 500},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    r = client.post(
+        f"/savings/{goal_id}/contribute",
+        json={"amount": -100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+    r = client.post(
+        f"/savings/{goal_id}/contribute",
+        json={"amount": 0},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_delete_savings_goal(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "Temp Goal", "target_amount": 100},
+        headers=auth_header,
+    )
+    goal_id = r.get_json()["id"]
+
+    r = client.delete(f"/savings/{goal_id}", headers=auth_header)
+    assert r.status_code == 200
+    assert r.get_json()["message"] == "deleted"
+
+    r = client.get(f"/savings/{goal_id}", headers=auth_header)
+    assert r.status_code == 404
+
+
+def test_create_goal_missing_title(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"target_amount": 1000},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_create_goal_invalid_target(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "Bad Goal", "target_amount": -100},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_create_goal_invalid_deadline(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "Bad Deadline Goal", "target_amount": 1000, "deadline": "not-a-date"},
+        headers=auth_header,
+    )
+    assert r.status_code == 400
+
+
+def test_goal_status_behind(client, auth_header):
+    past_deadline = (date.today() - timedelta(days=30)).isoformat()
+    r = client.post(
+        "/savings",
+        json={"title": "Overdue Goal", "target_amount": 1000, "deadline": past_deadline},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["status"] == "behind"
+
+
+def test_goal_status_completed(client, auth_header):
+    r = client.post(
+        "/savings",
+        json={"title": "Completed Goal", "target_amount": 500, "current_amount": 500},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["status"] == "completed"
+
+
+def test_goal_defaults_to_user_currency(client, auth_header):
+    client.patch("/auth/me", json={"preferred_currency": "EUR"}, headers=auth_header)
+    r = client.post(
+        "/savings",
+        json={"title": "Euro Goal", "target_amount": 2000},
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["currency"] == "EUR"
+
+
+def test_goals_isolated_per_user(client):
+    # Register two different users
+    for email in ["user1@example.com", "user2@example.com"]:
+        client.post("/auth/register", json={"email": email, "password": "pw123456"})
+
+    def login(email):
+        r = client.post("/auth/login", json={"email": email, "password": "pw123456"})
+        token = r.get_json()["access_token"]
+        return {"Authorization": f"Bearer {token}"}
+
+    h1 = login("user1@example.com")
+    h2 = login("user2@example.com")
+
+    client.post("/savings", json={"title": "User1 Goal", "target_amount": 1000}, headers=h1)
+
+    r = client.get("/savings", headers=h2)
+    assert r.status_code == 200
+    items = r.get_json()
+    assert not any(g["title"] == "User1 Goal" for g in items)


### PR DESCRIPTION
Closes #133

## Summary

- Adds `SavingsGoal` SQLAlchemy model with `target_amount`, `current_amount`, `currency`, `deadline` fields
- REST API under `/savings`: list, create, get, update, delete goals; contribute amounts
- Status computation (`completed`/`on-track`/`ahead`/`behind`) based on progress relative to deadline
- Monthly target calculation based on remaining amount and months until deadline
- Goals default to the authenticated user's preferred currency
- React frontend: `Budgets.tsx` loads real savings goals from the API (with loading/empty states)
- Frontend API client at `app/src/api/savings.ts`
- 17 passing backend tests using `fakeredis` for Redis isolation

## Test plan

- [ ] `cd packages/backend && python -m pytest tests/test_savings.py -v` → 17 passed
- [ ] Create a savings goal via POST /savings and verify status field
- [ ] Contribute to a goal and verify `status` flips to `completed` when current >= target
- [ ] Verify goals are isolated between users
- [ ] Open Budgets page in browser — goals panel loads from API