### PR TITLE
Add weekly smart financial digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ OpenAPI: `backend/app/openapi.yaml`
 - Expenses: CRUD `/expenses`
 - Bills: CRUD `/bills`, pay/mark `/bills/{id}/pay`
 - Reminders: CRUD `/reminders`, trigger `/reminders/run`
-- Insights: `/insights/monthly`, `/insights/budget-suggestion`
+- Insights: `/insights/monthly`, `/insights/budget-suggestion`, `/insights/weekly-digest`
 
 ## MVP UI/UX Plan
 - Auth screens: register/login.
@@ -73,6 +73,7 @@ OpenAPI: `backend/app/openapi.yaml`
   - Monthly spend chart, category breakdown donut.
   - Upcoming bills list with due dates and pay status.
   - AI budget suggestion card.
+  - Weekly smart digest with spend trend, category drivers, upcoming bills, and recommendations.
 - Expenses page: add expense (amount, category, notes, date), list & filter.
 - Bills page: create bill (name, amount, cadence, due date, channel), toggle WhatsApp/email.
 - Settings: profile, categories, reminders default channel, export (premium).

--- a/app/src/api/insights.ts
+++ b/app/src/api/insights.ts
@@ -21,6 +21,46 @@ export type BudgetSuggestion = {
   net_flow?: number;
 };
 
+export type WeeklyDigest = {
+  week_start: string;
+  week_end: string;
+  currency?: string | null;
+  summary: {
+    income: number;
+    expenses: number;
+    net_flow: number;
+    transaction_count: number;
+    category_breakdown: Array<{ category: string; amount: number }>;
+    daily_breakdown: Array<{ date: string; amount: number }>;
+    top_expenses: Array<{
+      id: number;
+      date: string;
+      description: string;
+      amount: number;
+      category: string;
+    }>;
+  };
+  previous_week: {
+    week_start: string;
+    week_end: string;
+    income: number;
+    expenses: number;
+    net_flow: number;
+  };
+  week_over_week_change_pct: number;
+  upcoming_bills: Array<{
+    id: number;
+    name: string;
+    amount: number;
+    currency: string;
+    due_date: string;
+    autopay_enabled: boolean;
+  }>;
+  insights: string[];
+  recommendations: string[];
+  method: string;
+};
+
 export async function getBudgetSuggestion(params?: {
   month?: string;
   geminiApiKey?: string;
@@ -31,4 +71,15 @@ export async function getBudgetSuggestion(params?: {
   if (params?.geminiApiKey) headers['X-Gemini-Api-Key'] = params.geminiApiKey;
   if (params?.persona) headers['X-Insight-Persona'] = params.persona;
   return api<BudgetSuggestion>(`/insights/budget-suggestion${monthQuery}`, { headers });
+}
+
+export async function getWeeklyDigest(params?: {
+  week?: string;
+  currency?: string;
+}): Promise<WeeklyDigest> {
+  const query = new URLSearchParams();
+  if (params?.week) query.set('week', params.week);
+  if (params?.currency) query.set('currency', params.currency);
+  const suffix = query.toString() ? `?${query.toString()}` : '';
+  return api<WeeklyDigest>(`/insights/weekly-digest${suffix}`);
 }

--- a/app/src/pages/Analytics.tsx
+++ b/app/src/pages/Analytics.tsx
@@ -10,7 +10,7 @@ import {
   FinancialCardTitle,
 } from '@/components/ui/financial-card';
 import { useToast } from '@/hooks/use-toast';
-import { getBudgetSuggestion, type BudgetSuggestion } from '@/api/insights';
+import { getBudgetSuggestion, getWeeklyDigest, type BudgetSuggestion, type WeeklyDigest } from '@/api/insights';
 import { formatMoney } from '@/lib/currency';
 
 const PERSONAS = [
@@ -22,10 +22,13 @@ const PERSONAS = [
 export function Analytics() {
   const { toast } = useToast();
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [week, setWeek] = useState(() => new Date().toISOString().slice(0, 10));
+  const [currency, setCurrency] = useState('');
   const [persona, setPersona] = useState(PERSONAS[0]);
   const [geminiKey, setGeminiKey] = useState('');
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<BudgetSuggestion | null>(null);
+  const [weeklyDigest, setWeeklyDigest] = useState<WeeklyDigest | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   async function load() {
@@ -37,7 +40,12 @@ export function Analytics() {
         persona,
         geminiApiKey: geminiKey.trim() || undefined,
       });
+      const digest = await getWeeklyDigest({
+        week,
+        currency: currency.trim() || undefined,
+      });
       setData(payload);
+      setWeeklyDigest(digest);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'Failed to load insights';
       setError(message);
@@ -107,6 +115,27 @@ export function Analytics() {
                 value={geminiKey}
                 onChange={(e) => setGeminiKey(e.target.value)}
                 placeholder="AIza..."
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-week">Digest Week</Label>
+              <Input
+                id="analytics-week"
+                aria-label="digest week"
+                type="date"
+                value={week}
+                onChange={(e) => setWeek(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="analytics-currency">Currency Filter</Label>
+              <Input
+                id="analytics-currency"
+                aria-label="digest currency"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value.toUpperCase())}
+                placeholder="USD"
+                maxLength={10}
               />
             </div>
           </div>
@@ -191,6 +220,83 @@ export function Analytics() {
               ) : null}
             </FinancialCardContent>
           </FinancialCard>
+
+          {weeklyDigest ? (
+            <FinancialCard variant="financial">
+              <FinancialCardHeader>
+                <FinancialCardTitle>Weekly Smart Digest</FinancialCardTitle>
+                <FinancialCardDescription>
+                  {weeklyDigest.week_start} to {weeklyDigest.week_end}
+                </FinancialCardDescription>
+              </FinancialCardHeader>
+              <FinancialCardContent>
+                <div className="grid gap-3 md:grid-cols-4">
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Expenses</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklyDigest.summary.expenses)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Income</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklyDigest.summary.income)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">Net Flow</div>
+                    <div className="font-semibold">
+                      {formatMoney(weeklyDigest.summary.net_flow)}
+                    </div>
+                  </div>
+                  <div className="rounded-lg border p-3">
+                    <div className="text-sm text-muted-foreground">WoW Change</div>
+                    <div className="font-semibold">
+                      {weeklyDigest.week_over_week_change_pct.toFixed(2)}%
+                    </div>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 md:grid-cols-3">
+                  <div>
+                    <h3 className="font-semibold">Insights</h3>
+                    <ul className="mt-2 list-disc pl-5 text-sm space-y-1">
+                      {weeklyDigest.insights.map((insight) => (
+                        <li key={insight}>{insight}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <h3 className="font-semibold">Recommendations</h3>
+                    <ul className="mt-2 list-disc pl-5 text-sm space-y-1">
+                      {weeklyDigest.recommendations.map((recommendation) => (
+                        <li key={recommendation}>{recommendation}</li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div>
+                    <h3 className="font-semibold">Upcoming Bills</h3>
+                    {weeklyDigest.upcoming_bills.length ? (
+                      <ul className="mt-2 text-sm space-y-2">
+                        {weeklyDigest.upcoming_bills.map((bill) => (
+                          <li key={bill.id} className="rounded-md border p-2">
+                            <div className="font-medium">{bill.name}</div>
+                            <div className="text-muted-foreground">
+                              {formatMoney(bill.amount)} due {bill.due_date}
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <div className="mt-2 text-sm text-muted-foreground">
+                        No bills due during this week.
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </FinancialCardContent>
+            </FinancialCard>
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,65 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/weekly-digest:
+    get:
+      summary: Get weekly smart financial digest
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: week
+          required: false
+          schema: { type: string, format: date }
+          description: Any date in the requested week. The API normalizes it to Monday.
+        - in: query
+          name: currency
+          required: false
+          schema: { type: string }
+      responses:
+        '200':
+          description: Weekly digest
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+              example:
+                week_start: 2026-06-01
+                week_end: 2026-06-07
+                currency: USD
+                summary:
+                  income: 0
+                  expenses: 180
+                  net_flow: -180
+                  transaction_count: 2
+                  category_breakdown:
+                    - category: Groceries
+                      amount: 180
+                previous_week:
+                  week_start: 2026-05-25
+                  week_end: 2026-05-31
+                  expenses: 200
+                week_over_week_change_pct: -10
+                upcoming_bills:
+                  - name: Internet
+                    amount: 75
+                    currency: USD
+                    due_date: 2026-06-05
+                insights: ["Weekly expenses are broadly stable versus last week."]
+                recommendations: ["Keep monitoring category mix for one-off spikes."]
+                method: deterministic
+        '400':
+          description: Invalid week
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -1,7 +1,7 @@
 from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
-from ..services.ai import monthly_budget_suggestion
+from ..services.ai import monthly_budget_suggestion, weekly_financial_digest
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +23,21 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/weekly-digest")
+@jwt_required()
+def weekly_digest():
+    uid = int(get_jwt_identity())
+    week = (request.args.get("week") or "").strip() or None
+    currency = (request.args.get("currency") or "").strip() or None
+    try:
+        digest = weekly_financial_digest(uid, week=week, currency=currency)
+    except ValueError:
+        return jsonify(error="invalid week"), 400
+    logger.info(
+        "Weekly digest served user=%s week_start=%s",
+        uid,
+        digest["week_start"],
+    )
+    return jsonify(digest)

--- a/packages/backend/app/services/ai.py
+++ b/packages/backend/app/services/ai.py
@@ -1,11 +1,12 @@
 import json
+from datetime import date, timedelta
 from urllib import request
 
 from sqlalchemy import extract, func
 
 from ..config import Settings
 from ..extensions import db
-from ..models import Expense
+from ..models import Bill, Category, Expense
 
 _settings = Settings()
 DEFAULT_PERSONA = (
@@ -185,3 +186,217 @@ def monthly_budget_suggestion(
                 uid, ym, persona_text, warnings=["gemini_unavailable"]
             )
     return _heuristic_budget(uid, ym, persona_text)
+
+
+def _normalize_week_start(raw: str | None) -> date:
+    selected = date.fromisoformat(raw) if raw else date.today()
+    return selected - timedelta(days=selected.weekday())
+
+
+def _week_range(week_start: date) -> tuple[date, date]:
+    return week_start, week_start + timedelta(days=6)
+
+
+def _expenses_for_range(uid: int, start: date, end: date, currency: str | None = None):
+    q = db.session.query(Expense).filter(
+        Expense.user_id == uid,
+        Expense.spent_at >= start,
+        Expense.spent_at <= end,
+    )
+    if currency:
+        q = q.filter(Expense.currency == currency)
+    return q.order_by(Expense.spent_at.asc(), Expense.created_at.asc()).all()
+
+
+def _amount(expense: Expense) -> float:
+    return float(expense.amount or 0)
+
+
+def _category_names(uid: int) -> dict[int, str]:
+    rows = db.session.query(Category).filter(Category.user_id == uid).all()
+    return {row.id: row.name for row in rows}
+
+
+def _summarize_expenses(
+    expenses: list[Expense], category_names: dict[int, str]
+) -> dict:
+    income = 0.0
+    expenses_total = 0.0
+    category_totals: dict[str, float] = {}
+    daily_totals: dict[str, float] = {}
+
+    for item in expenses:
+        amount = _amount(item)
+        day_key = item.spent_at.isoformat()
+        if item.expense_type == "INCOME":
+            income += amount
+            continue
+        expenses_total += amount
+        daily_totals[day_key] = daily_totals.get(day_key, 0.0) + amount
+        category = category_names.get(item.category_id or 0, "Uncategorized")
+        category_totals[category] = category_totals.get(category, 0.0) + amount
+
+    sorted_categories = sorted(
+        category_totals.items(), key=lambda item: item[1], reverse=True
+    )
+    top_expenses = sorted(
+        [item for item in expenses if item.expense_type != "INCOME"],
+        key=lambda item: (_amount(item), item.spent_at),
+        reverse=True,
+    )[:5]
+
+    return {
+        "income": round(income, 2),
+        "expenses": round(expenses_total, 2),
+        "net_flow": round(income - expenses_total, 2),
+        "transaction_count": len(expenses),
+        "category_breakdown": [
+            {"category": category, "amount": round(amount, 2)}
+            for category, amount in sorted_categories
+        ],
+        "daily_breakdown": [
+            {"date": day, "amount": round(amount, 2)}
+            for day, amount in sorted(daily_totals.items())
+        ],
+        "top_expenses": [
+            {
+                "id": item.id,
+                "date": item.spent_at.isoformat(),
+                "description": item.notes,
+                "amount": round(_amount(item), 2),
+                "category": category_names.get(item.category_id or 0, "Uncategorized"),
+            }
+            for item in top_expenses
+        ],
+    }
+
+
+def _upcoming_bills(
+    uid: int, start: date, end: date, currency: str | None = None
+) -> list[dict]:
+    q = db.session.query(Bill).filter(
+        Bill.user_id == uid,
+        Bill.active.is_(True),
+        Bill.next_due_date >= start,
+        Bill.next_due_date <= end,
+    )
+    if currency:
+        q = q.filter(Bill.currency == currency)
+    bills = q.order_by(Bill.next_due_date.asc(), Bill.amount.desc()).all()
+    return [
+        {
+            "id": bill.id,
+            "name": bill.name,
+            "amount": round(float(bill.amount or 0), 2),
+            "currency": bill.currency,
+            "due_date": bill.next_due_date.isoformat(),
+            "autopay_enabled": bill.autopay_enabled,
+        }
+        for bill in bills
+    ]
+
+
+def _trend_label(current: float, previous: float) -> str:
+    if previous == 0 and current == 0:
+        return "flat"
+    if previous == 0:
+        return "new_activity"
+    delta_pct = ((current - previous) / previous) * 100
+    if delta_pct > 10:
+        return "up"
+    if delta_pct < -10:
+        return "down"
+    return "flat"
+
+
+def _weekly_insights(
+    current: dict, previous: dict, upcoming_bills: list[dict]
+) -> tuple[list[str], list[str]]:
+    insights: list[str] = []
+    recommendations: list[str] = []
+
+    trend = _trend_label(current["expenses"], previous["expenses"])
+    if trend == "up":
+        insights.append("Weekly expenses increased more than 10% versus last week.")
+        recommendations.append(
+            "Review the top expense and category drivers before the next spend cycle."
+        )
+    elif trend == "down":
+        insights.append("Weekly expenses decreased more than 10% versus last week.")
+        recommendations.append(
+            "Preserve the lower-spend pattern by setting a weekly category cap."
+        )
+    elif current["expenses"] == 0:
+        insights.append("No weekly expense activity was recorded.")
+        recommendations.append(
+            "Add transactions for this week to unlock a more useful digest."
+        )
+    else:
+        insights.append("Weekly expenses are broadly stable versus last week.")
+        recommendations.append("Keep monitoring category mix for one-off spikes.")
+
+    if current["category_breakdown"]:
+        top = current["category_breakdown"][0]
+        insights.append(f"{top['category']} is the largest spend category this week.")
+        recommendations.append(
+            f"Set a specific weekly limit for {top['category']} if it is discretionary."
+        )
+
+    if upcoming_bills:
+        due_total = round(sum(item["amount"] for item in upcoming_bills), 2)
+        insights.append(
+            f"{len(upcoming_bills)} bill(s) totaling {due_total} are due this week."
+        )
+        recommendations.append(
+            "Keep bill cash reserved separately from discretionary spend."
+        )
+
+    return insights[:5], recommendations[:5]
+
+
+def weekly_financial_digest(
+    uid: int, week: str | None = None, currency: str | None = None
+) -> dict:
+    week_start = _normalize_week_start(week)
+    week_end = week_start + timedelta(days=6)
+    previous_start = week_start - timedelta(days=7)
+    previous_end = week_start - timedelta(days=1)
+    currency_filter = (currency or "").strip() or None
+    category_names = _category_names(uid)
+
+    current = _summarize_expenses(
+        _expenses_for_range(uid, week_start, week_end, currency_filter),
+        category_names,
+    )
+    previous = _summarize_expenses(
+        _expenses_for_range(uid, previous_start, previous_end, currency_filter),
+        category_names,
+    )
+    bills = _upcoming_bills(uid, week_start, week_end, currency_filter)
+    insights, recommendations = _weekly_insights(current, previous, bills)
+
+    previous_expenses = previous["expenses"]
+    week_over_week_change_pct = (
+        round(((current["expenses"] - previous_expenses) / previous_expenses) * 100, 2)
+        if previous_expenses
+        else 0.0
+    )
+
+    return {
+        "week_start": week_start.isoformat(),
+        "week_end": week_end.isoformat(),
+        "currency": currency_filter,
+        "summary": current,
+        "previous_week": {
+            "week_start": previous_start.isoformat(),
+            "week_end": previous_end.isoformat(),
+            "expenses": previous["expenses"],
+            "income": previous["income"],
+            "net_flow": previous["net_flow"],
+        },
+        "week_over_week_change_pct": week_over_week_change_pct,
+        "upcoming_bills": bills,
+        "insights": insights,
+        "recommendations": recommendations,
+        "method": "deterministic",
+    }

--- a/packages/backend/tests/test_insights.py
+++ b/packages/backend/tests/test_insights.py
@@ -90,3 +90,78 @@ def test_budget_suggestion_falls_back_when_gemini_fails(
     assert payload["method"] == "heuristic"
     assert "warnings" in payload
     assert "gemini_unavailable" in payload["warnings"]
+
+
+def test_weekly_digest_returns_trends_bills_and_recommendations(client, auth_header):
+    week_start = date(2026, 6, 1)
+
+    category = client.post(
+        "/categories",
+        json={"name": "Groceries"},
+        headers=auth_header,
+    )
+    assert category.status_code == 201
+    category_id = category.get_json()["id"]
+
+    for amount, day, description in [
+        (120, week_start, "Weekly groceries"),
+        (60, week_start + timedelta(days=2), "Pantry restock"),
+        (200, week_start - timedelta(days=3), "Previous week groceries"),
+    ]:
+        response = client.post(
+            "/expenses",
+            json={
+                "amount": amount,
+                "description": description,
+                "date": day.isoformat(),
+                "expense_type": "EXPENSE",
+                "category_id": category_id,
+                "currency": "USD",
+            },
+            headers=auth_header,
+        )
+        assert response.status_code == 201
+
+    bill = client.post(
+        "/bills",
+        json={
+            "name": "Internet",
+            "amount": 75,
+            "currency": "USD",
+            "next_due_date": (week_start + timedelta(days=4)).isoformat(),
+            "cadence": "MONTHLY",
+        },
+        headers=auth_header,
+    )
+    assert bill.status_code == 201
+
+    response = client.get(
+        f"/insights/weekly-digest?week={week_start.isoformat()}&currency=USD",
+        headers=auth_header,
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload["week_start"] == week_start.isoformat()
+    assert payload["week_end"] == (week_start + timedelta(days=6)).isoformat()
+    assert payload["currency"] == "USD"
+    assert payload["summary"]["expenses"] == 180
+    assert payload["summary"]["net_flow"] == -180
+    assert payload["summary"]["category_breakdown"][0] == {
+        "category": "Groceries",
+        "amount": 180,
+    }
+    assert payload["previous_week"]["expenses"] == 200
+    assert payload["week_over_week_change_pct"] == -10
+    assert payload["upcoming_bills"][0]["name"] == "Internet"
+    assert payload["insights"]
+    assert payload["recommendations"]
+    assert payload["method"] == "deterministic"
+
+
+def test_weekly_digest_rejects_invalid_week(client, auth_header):
+    response = client.get(
+        "/insights/weekly-digest?week=not-a-date", headers=auth_header
+    )
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid week"


### PR DESCRIPTION
## Summary

Implements the weekly smart financial digest requested in #121.

/claim #121

## What changed

- Added authenticated `GET /insights/weekly-digest`.
- Normalizes any requested date to a Monday-Sunday week.
- Supports optional currency filtering.
- Returns weekly income, expenses, net flow, transaction count, daily breakdown, category breakdown, top expenses, and previous-week comparison.
- Adds upcoming bills due during the selected week.
- Generates deterministic insights and recommendations without requiring an LLM key or scheduler.
- Surfaces the digest in the existing Analytics page.
- Updates OpenAPI docs and README.
- Adds backend coverage for the digest response and invalid week handling.

## Verification

- `black --check packages/backend/app/services/ai.py packages/backend/app/routes/insights.py packages/backend/tests/test_insights.py`
- `npm run build`
- Backend service smoke check with in-memory SQLite covering:
  - weekly expenses
  - previous-week comparison
  - upcoming bill inclusion
  - deterministic insights

## Local test note

Focused pytest is blocked in my local environment before feature execution because the auth fixture/login path attempts to connect to Redis hostname `redis`, and there is no local Redis server/binary available. The new digest service was smoke-tested directly with the same models and in-memory SQLite.

Fixes #121
