### PR TITLE
implement smart reminder timing based on user behavior

### DIFF
--- a/packages/backend/app/routes/reminders.py
+++ b/packages/backend/app/routes/reminders.py
@@ -2,7 +2,7 @@ from datetime import datetime, time, timedelta
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..extensions import db
-from ..models import Bill, Reminder
+from ..models import Bill, Reminder, Expense
 from ..observability import track_reminder_event
 from ..services.reminders import send_reminder
 import logging
@@ -76,9 +76,10 @@ def schedule_bill_reminders(bill_id: int):
 
     channels = _bill_channels(bill)
     created = 0
+    optimal_time = _get_optimal_reminder_time(uid)
     for days_before in offsets:
         send_at = datetime.combine(
-            bill.next_due_date - timedelta(days=days_before), time(9, 0, 0)
+            bill.next_due_date - timedelta(days=days_before), optimal_time
         )
         message = (
             f"Upcoming bill reminder: {bill.name} due on "
@@ -97,7 +98,7 @@ def schedule_bill_reminders(bill_id: int):
 
     if bill.autopay_enabled:
         autopay_send_at = datetime.combine(
-            bill.next_due_date - timedelta(days=1), time(9, 0, 0)
+            bill.next_due_date - timedelta(days=1), optimal_time
         )
         autopay_message = (
             f"Autopay check: {bill.name} is due on {bill.next_due_date.isoformat()}. "
@@ -221,3 +222,28 @@ def _create_reminder_if_missing(
         )
     )
     return True
+
+
+def _get_optimal_reminder_time(user_id: int) -> time:
+    """Calculate optimal reminder time based on user's expense creation behavior."""
+    expenses = (
+        db.session.query(Expense.created_at)
+        .filter_by(user_id=user_id)
+        .order_by(Expense.created_at.desc())
+        .limit(100)
+        .all()
+    )
+    if not expenses:
+        return time(9, 0, 0)
+
+    hour_counts = {}
+    for (created_at,) in expenses:
+        if created_at:
+            h = created_at.hour
+            hour_counts[h] = hour_counts.get(h, 0) + 1
+
+    if not hour_counts:
+        return time(9, 0, 0)
+
+    best_hour = max(hour_counts.items(), key=lambda x: x[1])[0]
+    return time(best_hour, 0, 0)

--- a/packages/backend/tests/test_reminders.py
+++ b/packages/backend/tests/test_reminders.py
@@ -1,4 +1,6 @@
-from datetime import date
+from datetime import date, datetime
+from app.models import Expense
+from app.extensions import db
 
 
 def _create_bill(client, auth_header, *, due_date: str, autopay_enabled: bool = False):
@@ -80,3 +82,40 @@ def test_autopay_generates_precheck_and_result_followup_for_both_channels(
     followups = [x for x in reminders if "Autopay succeeded" in x["message"]]
     assert len(followups) == 2
     assert sorted([x["channel"] for x in followups]) == ["email", "whatsapp"]
+
+
+def test_smart_reminder_timing_based_on_user_behavior(client, auth_header, app_fixture):
+    # Create some expenses at a specific hour, e.g., 14:00
+    with app_fixture.app_context():
+        # Get user id 1
+        for _ in range(5):
+            e = Expense(
+                user_id=1,
+                amount=10.0,
+                created_at=datetime.utcnow().replace(hour=14, minute=30, second=0),
+            )
+            db.session.add(e)
+        db.session.commit()
+
+    bill_id = _create_bill(client, auth_header, due_date="2026-04-10")
+
+    r = client.post(f"/reminders/bills/{bill_id}/schedule", headers=auth_header)
+    assert r.status_code == 200
+
+    r = client.get("/reminders", headers=auth_header)
+    assert r.status_code == 200
+    reminders = r.get_json()
+
+    # Filter for the newly scheduled bill reminders
+    # (we might have old ones from previous tests)
+    bill_reminders = [
+        x
+        for x in reminders
+        if "Upcoming bill reminder" in x["message"]
+        and "2026-04-10" in x["message"]
+    ]
+    assert len(bill_reminders) > 0
+
+    for rem in bill_reminders:
+        dt = datetime.fromisoformat(rem["send_at"])
+        assert dt.hour == 14


### PR DESCRIPTION
hey! saw the bounty for this and decided to implement it. the reminder scheduling now analyzes the last 100 expenses from the user and calculates the most frequent hour they log expenses to set as the optimal reminder time. if they don't have enough data, it just defaults to 9 am. added tests and everything is passing locally. let me know if anything needs to be changed! fixes #111