### PR TITLE
add lifestyle inflation endpoint

### DIFF
--- a/packages/backend/app/openapi.yaml
+++ b/packages/backend/app/openapi.yaml
@@ -481,6 +481,39 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/Error' }
 
+  /insights/lifestyle-inflation:
+    get:
+      summary: Detect lifestyle inflation
+      tags: [Insights]
+      security: [{ bearerAuth: [] }]
+      responses:
+        '200':
+          description: Lifestyle inflation report
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inflation_detected: { type: boolean }
+                  overall_increase_percentage: { type: number, format: float }
+                  recent_total: { type: number, format: float }
+                  past_total: { type: number, format: float }
+                  period_days: { type: integer }
+                  driving_categories:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        category: { type: string }
+                        past_amount: { type: number, format: float }
+                        recent_amount: { type: number, format: float }
+                        increase_percentage: { type: number, format: float }
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Error' }
+
 components:
   securitySchemes:
     bearerAuth:

--- a/packages/backend/app/routes/insights.py
+++ b/packages/backend/app/routes/insights.py
@@ -2,6 +2,7 @@ from datetime import date
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required, get_jwt_identity
 from ..services.ai import monthly_budget_suggestion
+from ..services.lifestyle import detect_lifestyle_inflation
 import logging
 
 bp = Blueprint("insights", __name__)
@@ -23,3 +24,12 @@ def budget_suggestion():
     )
     logger.info("Budget suggestion served user=%s month=%s", uid, ym)
     return jsonify(suggestion)
+
+
+@bp.get("/lifestyle-inflation")
+@jwt_required()
+def lifestyle_inflation():
+    uid = int(get_jwt_identity())
+    insights = detect_lifestyle_inflation(uid)
+    logger.info("Lifestyle inflation detection served user=%s", uid)
+    return jsonify(insights)

--- a/packages/backend/app/services/lifestyle.py
+++ b/packages/backend/app/services/lifestyle.py
@@ -1,0 +1,81 @@
+from datetime import date
+from dateutil.relativedelta import relativedelta
+from sqlalchemy import func
+from ..models import Expense, Category
+from ..extensions import db
+
+
+def detect_lifestyle_inflation(user_id: int):
+    """
+    Detect lifestyle inflation by comparing the last 90 days of spending
+    against the 90 days before that.
+    """
+    today = date.today()
+    # Define periods
+    period_1_end = today
+    period_1_start = today - relativedelta(days=90)
+    
+    period_2_end = period_1_start
+    period_2_start = period_2_end - relativedelta(days=90)
+
+    # Helper to get category spending for a period
+    def get_spending(start_d, end_d):
+        result = (
+            db.session.query(
+                Category.name,
+                func.sum(Expense.amount).label("total")
+            )
+            .join(Expense, Expense.category_id == Category.id)
+            .filter(
+                Expense.user_id == user_id,
+                Expense.spent_at >= start_d,
+                Expense.spent_at < end_d,
+                Expense.expense_type == "EXPENSE"
+            )
+            .group_by(Category.name)
+            .all()
+        )
+        return {row.name: float(row.total) for row in result}
+
+    recent_spending = get_spending(period_1_start, period_1_end)
+    past_spending = get_spending(period_2_start, period_2_end)
+
+    total_recent = sum(recent_spending.values())
+    total_past = sum(past_spending.values())
+
+    inflation_detected = False
+    overall_increase_pct = 0.0
+
+    if total_past > 0:
+        overall_increase_pct = ((total_recent - total_past) / total_past) * 100
+        # If overall spending increased by more than 10%, flag as potential inflation
+        if overall_increase_pct > 10.0:
+            inflation_detected = True
+
+    # Identify top categories driving the inflation
+    drivers = []
+    for cat, recent_amt in recent_spending.items():
+        past_amt = past_spending.get(cat, 0.0)
+        # Category must have meaningful amount
+        if recent_amt > past_amt and recent_amt > 50:
+            increase = recent_amt - past_amt
+            pct = ((increase) / past_amt * 100) if past_amt > 0 else 100.0
+            if pct > 15.0:
+                drivers.append({
+                    "category": cat,
+                    "past_amount": past_amt,
+                    "recent_amount": recent_amt,
+                    "increase_percentage": round(pct, 2)
+                })
+    
+    # Sort drivers by absolute increase
+    drivers.sort(key=lambda x: x["recent_amount"] - x["past_amount"], reverse=True)
+
+    return {
+        "inflation_detected": inflation_detected and len(drivers) > 0,
+        "overall_increase_percentage": round(overall_increase_pct, 2),
+        "recent_total": total_recent,
+        "past_total": total_past,
+        "period_days": 90,
+        "driving_categories": drivers[:5]  # Top 5 drivers
+    }

--- a/packages/backend/app/services/lifestyle.py
+++ b/packages/backend/app/services/lifestyle.py
@@ -1,5 +1,4 @@
-from datetime import date
-from dateutil.relativedelta import relativedelta
+from datetime import date, timedelta
 from sqlalchemy import func
 from ..models import Expense, Category
 from ..extensions import db
@@ -13,10 +12,10 @@ def detect_lifestyle_inflation(user_id: int):
     today = date.today()
     # Define periods
     period_1_end = today
-    period_1_start = today - relativedelta(days=90)
+    period_1_start = today - timedelta(days=90)
     
     period_2_end = period_1_start
-    period_2_start = period_2_end - relativedelta(days=90)
+    period_2_start = period_2_end - timedelta(days=90)
 
     # Helper to get category spending for a period
     def get_spending(start_d, end_d):

--- a/packages/backend/tests/test_lifestyle.py
+++ b/packages/backend/tests/test_lifestyle.py
@@ -1,5 +1,4 @@
 from datetime import date, timedelta
-from dateutil.relativedelta import relativedelta
 
 
 def test_lifestyle_inflation(client, auth_header):
@@ -7,7 +6,7 @@ def test_lifestyle_inflation(client, auth_header):
     # 30 days ago -> recent
     recent_date = today - timedelta(days=30)
     # 120 days ago -> past
-    past_date = today - relativedelta(days=120)
+    past_date = today - timedelta(days=120)
 
     # Past expenses (small)
     r = client.post(
@@ -53,7 +52,7 @@ def test_no_lifestyle_inflation(client, auth_header):
     # 30 days ago -> recent
     recent_date = today - timedelta(days=30)
     # 120 days ago -> past
-    past_date = today - relativedelta(days=120)
+    past_date = today - timedelta(days=120)
 
     # Past expenses
     r = client.post(

--- a/packages/backend/tests/test_lifestyle.py
+++ b/packages/backend/tests/test_lifestyle.py
@@ -1,0 +1,88 @@
+from datetime import date, timedelta
+from dateutil.relativedelta import relativedelta
+
+
+def test_lifestyle_inflation(client, auth_header):
+    today = date.today()
+    # 30 days ago -> recent
+    recent_date = today - timedelta(days=30)
+    # 120 days ago -> past
+    past_date = today - relativedelta(days=120)
+
+    # Past expenses (small)
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 100,
+            "description": "Dining Out Past",
+            "date": past_date.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_name": "Dining"
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    # Recent expenses (inflated)
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 300,
+            "description": "Dining Out Recent",
+            "date": recent_date.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_name": "Dining"
+        },
+        headers=auth_header,
+    )
+    assert r.status_code == 201
+
+    r = client.get("/insights/lifestyle-inflation", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["inflation_detected"] is True
+    assert payload["recent_total"] == 300
+    assert payload["past_total"] == 100
+    assert payload["overall_increase_percentage"] == 200.0
+    assert len(payload["driving_categories"]) == 1
+    assert payload["driving_categories"][0]["category"] == "Dining"
+    assert payload["driving_categories"][0]["increase_percentage"] == 200.0
+
+def test_no_lifestyle_inflation(client, auth_header):
+    today = date.today()
+    # 30 days ago -> recent
+    recent_date = today - timedelta(days=30)
+    # 120 days ago -> past
+    past_date = today - relativedelta(days=120)
+
+    # Past expenses
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 500,
+            "description": "Rent",
+            "date": past_date.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_name": "Housing"
+        },
+        headers=auth_header,
+    )
+
+    # Recent expenses
+    r = client.post(
+        "/expenses",
+        json={
+            "amount": 500,
+            "description": "Rent",
+            "date": recent_date.isoformat(),
+            "expense_type": "EXPENSE",
+            "category_name": "Housing"
+        },
+        headers=auth_header,
+    )
+
+    r = client.get("/insights/lifestyle-inflation", headers=auth_header)
+    assert r.status_code == 200
+    payload = r.get_json()
+    assert payload["inflation_detected"] is False
+    assert payload["overall_increase_percentage"] == 0.0


### PR DESCRIPTION
hey, i saw the bounty for issue #118 and put together this endpoint to calculate lifestyle inflation. it compares the trailing 90 days of discretionary spend to the previous 90 days. i added the tests and updated openapi.yaml. let me know if there's any changes needed!