### PR TITLE
feat: implement GDPR-ready PII Export & Delete Workflow (closes #76)

### DIFF
--- a/packages/backend/app/extensions.py
+++ b/packages/backend/app/extensions.py
@@ -1,6 +1,8 @@
 from flask_sqlalchemy import SQLAlchemy
 from flask_jwt_extended import JWTManager
 import redis
+import os
+import fakeredis
 from .config import Settings
 
 
@@ -8,4 +10,7 @@ db = SQLAlchemy()
 jwt = JWTManager()
 
 _settings = Settings()
-redis_client = redis.Redis.from_url(_settings.redis_url, decode_responses=True)
+if os.environ.get("FLASK_ENV") == "testing":
+    redis_client = fakeredis.FakeRedis(decode_responses=True)
+else:
+    redis_client = redis.Redis.from_url(_settings.redis_url, decode_responses=True)

--- a/packages/backend/app/routes/__init__.py
+++ b/packages/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .insights import bp as insights_bp
 from .categories import bp as categories_bp
 from .docs import bp as docs_bp
 from .dashboard import bp as dashboard_bp
+from .gdpr import bp as gdpr_bp
 
 
 def register_routes(app: Flask):
@@ -18,3 +19,4 @@ def register_routes(app: Flask):
     app.register_blueprint(categories_bp, url_prefix="/categories")
     app.register_blueprint(docs_bp, url_prefix="/docs")
     app.register_blueprint(dashboard_bp, url_prefix="/dashboard")
+    app.register_blueprint(gdpr_bp, url_prefix="/gdpr")

--- a/packages/backend/app/routes/gdpr.py
+++ b/packages/backend/app/routes/gdpr.py
@@ -1,0 +1,299 @@
+"""
+GDPR / Privacy routes
+
+GET  /gdpr/export       → JSON export of all user PII
+GET  /gdpr/export/csv   → CSV export of expenses
+POST /gdpr/delete       → Initiate deletion (30-day grace period)
+POST /gdpr/delete/confirm → Hard-delete (admin or after grace period; requires
+                             re-authentication via password confirmation)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta
+
+from flask import Blueprint, Response, jsonify, request
+from flask_jwt_extended import get_jwt_identity, jwt_required
+from werkzeug.security import check_password_hash
+
+from ..extensions import db
+from ..models import AuditLog, User
+from ..services.gdpr import (
+    DELETION_GRACE_DAYS,
+    GDPR_ACTION_DELETE_INITIATED,
+    execute_deletion,
+    export_user_data,
+    export_user_data_csv,
+    initiate_deletion,
+)
+
+bp = Blueprint("gdpr", __name__)
+logger = logging.getLogger("finmind.gdpr.routes")
+
+
+def _get_request_meta() -> tuple[str, str]:
+    ip = (
+        request.headers.get("X-Forwarded-For", request.remote_addr or "unknown")
+        .split(",")[0]
+        .strip()
+    )
+    ua = request.headers.get("User-Agent", "unknown")[:200]
+    return ip, ua
+
+
+# ── Export ─────────────────────────────────────────────────────────────────────
+
+
+@bp.get("/export")
+@jwt_required()
+def export_json():
+    """
+    Return a JSON file containing all PII for the authenticated user.
+
+    Writes a GDPR_EXPORT audit record.
+    """
+    user_id = int(get_jwt_identity())
+    ip, ua = _get_request_meta()
+
+    try:
+        payload = export_user_data(user_id, ip, ua)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 404
+
+    json_bytes = json.dumps(payload, indent=2, default=str).encode("utf-8")
+
+    return Response(
+        json_bytes,
+        status=200,
+        mimetype="application/json",
+        headers={
+            "Content-Disposition": (
+                f"attachment; filename=finmind-export-{user_id}.json"
+            ),
+            "Content-Length": str(len(json_bytes)),
+        },
+    )
+
+
+@bp.get("/export/csv")
+@jwt_required()
+def export_csv():
+    """
+    Return a CSV file containing the authenticated user's expenses.
+
+    Writes a GDPR_EXPORT audit record.
+    """
+    user_id = int(get_jwt_identity())
+    ip, ua = _get_request_meta()
+
+    try:
+        csv_bytes = export_user_data_csv(user_id, ip, ua)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 404
+
+    return Response(
+        csv_bytes,
+        status=200,
+        mimetype="text/csv",
+        headers={
+            "Content-Disposition": (
+                f"attachment; filename=finmind-expenses-{user_id}.csv"
+            ),
+            "Content-Length": str(len(csv_bytes)),
+        },
+    )
+
+
+# ── Delete ─────────────────────────────────────────────────────────────────────
+
+
+@bp.post("/delete")
+@jwt_required()
+def delete_initiate():
+    """
+    Initiate the GDPR deletion workflow.
+
+    Writes a GDPR_DELETE_INITIATED audit record and returns the scheduled
+    deletion date (now + 30-day grace period).
+
+    The user account is NOT deleted immediately; they have 30 days to cancel
+    by contacting support.
+    """
+    user_id = int(get_jwt_identity())
+    ip, ua = _get_request_meta()
+
+    # Require password re-confirmation as a safety gate.
+    data = request.get_json(silent=True) or {}
+    password = data.get("password", "")
+    if not password:
+        return jsonify(error="password required to confirm deletion request"), 400
+
+    user: User | None = db.session.get(User, user_id)
+    if user is None:
+        return jsonify(error="user not found"), 404
+
+    if not check_password_hash(user.password_hash, password):
+        logger.warning("GDPR delete initiation: wrong password for user_id=%s", user_id)
+        return jsonify(error="invalid password"), 401
+
+    # Check if a deletion has already been initiated.
+    existing = (
+        db.session.query(AuditLog)
+        .filter(
+            AuditLog.user_id == user_id,
+            AuditLog.action.like(f"{GDPR_ACTION_DELETE_INITIATED}%"),
+        )
+        .order_by(AuditLog.created_at.desc())
+        .first()
+    )
+    if existing:
+        scheduled_at = existing.created_at + timedelta(days=DELETION_GRACE_DAYS)
+        if scheduled_at > datetime.utcnow():
+            return (
+                jsonify(
+                    error="deletion already scheduled",
+                    scheduled_deletion_at=scheduled_at.isoformat() + "Z",
+                ),
+                409,
+            )
+
+    try:
+        result = initiate_deletion(user_id, ip, ua)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 404
+
+    return jsonify(result), 202
+
+
+@bp.post("/delete/confirm")
+@jwt_required()
+def delete_confirm():
+    """
+    Execute the hard-delete after the grace period.
+
+    Requires:
+    - Valid JWT (user must still be able to log in)
+    - password in body (re-authentication)
+    - confirm=true in body (explicit opt-in)
+
+    The grace period must have elapsed since the deletion was initiated, OR
+    the request must come from an admin (role=ADMIN) acting on behalf of
+    the user.
+
+    GDPR audit log entries are preserved (user_id set to NULL).
+    """
+    user_id = int(get_jwt_identity())
+    ip, ua = _get_request_meta()
+
+    data = request.get_json(silent=True) or {}
+    password = data.get("password", "")
+    confirmed = data.get("confirm", False)
+
+    if not password or not confirmed:
+        return (
+            jsonify(
+                error="password and confirm=true required to permanently delete account"
+            ),
+            400,
+        )
+
+    user: User | None = db.session.get(User, user_id)
+    if user is None:
+        return jsonify(error="user not found"), 404
+
+    if not check_password_hash(user.password_hash, password):
+        logger.warning("GDPR hard-delete: wrong password for user_id=%s", user_id)
+        return jsonify(error="invalid password"), 401
+
+    # Admins can force-delete immediately; regular users must wait for grace period.
+    is_admin = getattr(user, "role", "") == "ADMIN"
+
+    if not is_admin:
+        initiated = (
+            db.session.query(AuditLog)
+            .filter(
+                AuditLog.user_id == user_id,
+                AuditLog.action.like(f"{GDPR_ACTION_DELETE_INITIATED}%"),
+            )
+            .order_by(AuditLog.created_at.desc())
+            .first()
+        )
+        if initiated is None:
+            return (
+                jsonify(
+                    error="no deletion request found; call POST /gdpr/delete first"
+                ),
+                409,
+            )
+
+        scheduled_at = initiated.created_at + timedelta(days=DELETION_GRACE_DAYS)
+        if datetime.utcnow() < scheduled_at:
+            return (
+                jsonify(
+                    error="grace period has not elapsed yet",
+                    scheduled_deletion_at=scheduled_at.isoformat() + "Z",
+                    days_remaining=(scheduled_at - datetime.utcnow()).days,
+                ),
+                403,
+            )
+
+    try:
+        result = execute_deletion(user_id, ip, ua)
+    except ValueError as exc:
+        return jsonify(error=str(exc)), 404
+
+    return jsonify(result), 200
+
+
+# ── Audit trail (admin) ────────────────────────────────────────────────────────
+
+
+@bp.get("/audit")
+@jwt_required()
+def audit_trail():
+    """
+    Return the GDPR audit trail for the authenticated user.
+    Admins can pass ?user_id=<id> to view any user's trail.
+    """
+    requester_id = int(get_jwt_identity())
+    requester: User | None = db.session.get(User, requester_id)
+    if requester is None:
+        return jsonify(error="user not found"), 404
+
+    target_id = requester_id
+    if requester.role == "ADMIN":
+        qp = request.args.get("user_id")
+        if qp:
+            try:
+                target_id = int(qp)
+            except ValueError:
+                return jsonify(error="invalid user_id"), 400
+
+    logs = (
+        db.session.query(AuditLog)
+        .filter(
+            AuditLog.user_id == target_id,
+            AuditLog.action.like("GDPR_%"),
+        )
+        .order_by(AuditLog.created_at.desc())
+        .limit(100)
+        .all()
+    )
+
+    return (
+        jsonify(
+            [
+                {
+                    "id": log.id,
+                    "action": log.action,
+                    "created_at": (
+                        log.created_at.isoformat() if log.created_at else None
+                    ),
+                }
+                for log in logs
+            ]
+        ),
+        200,
+    )

--- a/packages/backend/app/services/gdpr.py
+++ b/packages/backend/app/services/gdpr.py
@@ -1,0 +1,264 @@
+"""
+GDPR PII Export & Delete Service
+
+Provides:
+- export_user_data: Collect all PII into a structured dict (JSON-serialisable)
+- initiate_deletion: Two-step soft-delete → hard-delete workflow
+- execute_deletion: Hard-delete user data, preserve GDPR audit trail
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+from ..extensions import db
+from ..models import (
+    AuditLog,
+    Bill,
+    Category,
+    Expense,
+    RecurringExpense,
+    Reminder,
+    User,
+    UserSubscription,
+    AdImpression,
+)
+
+logger = logging.getLogger("finmind.gdpr")
+
+# ── constants ──────────────────────────────────────────────────────────────────
+
+DELETION_GRACE_DAYS = 30  # days before hard delete executes after initiation
+GDPR_ACTION_EXPORT = "GDPR_EXPORT"
+GDPR_ACTION_DELETE_INITIATED = "GDPR_DELETE_INITIATED"
+GDPR_ACTION_DELETE_CANCELLED = "GDPR_DELETE_CANCELLED"
+GDPR_ACTION_DELETE_EXECUTED = "GDPR_DELETE_EXECUTED"
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+
+def _serialize(obj: Any) -> Any:
+    """Recursively convert non-serialisable types."""
+    if isinstance(obj, dict):
+        return {k: _serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_serialize(i) for i in obj]
+    if isinstance(obj, Decimal):
+        return str(obj)
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if hasattr(obj, "date") and callable(obj.date):
+        return obj.isoformat()
+    return obj
+
+
+def _row_to_dict(row: db.Model) -> dict:
+    return {col.name: getattr(row, col.name) for col in row.__table__.columns}
+
+
+# ── public API ─────────────────────────────────────────────────────────────────
+
+
+def export_user_data(user_id: int, request_ip: str, user_agent: str) -> dict:
+    """
+    Collect all PII associated with *user_id* into a structured dict.
+    Also writes a GDPR_EXPORT audit record.
+
+    Returns a dict with keys: profile, categories, expenses,
+    recurring_expenses, bills, reminders, subscriptions.
+    """
+    user: User | None = db.session.get(User, user_id)
+    if user is None:
+        raise ValueError(f"User {user_id} not found")
+
+    categories = db.session.query(Category).filter_by(user_id=user_id).all()
+    expenses = db.session.query(Expense).filter_by(user_id=user_id).all()
+    recurring = db.session.query(RecurringExpense).filter_by(user_id=user_id).all()
+    bills = db.session.query(Bill).filter_by(user_id=user_id).all()
+    reminders = db.session.query(Reminder).filter_by(user_id=user_id).all()
+    subscriptions = db.session.query(UserSubscription).filter_by(user_id=user_id).all()
+
+    payload = {
+        "exported_at": datetime.utcnow().isoformat() + "Z",
+        "profile": {
+            "id": user.id,
+            "email": user.email,
+            "preferred_currency": user.preferred_currency,
+            "role": user.role,
+            "created_at": user.created_at.isoformat() if user.created_at else None,
+        },
+        "categories": [_serialize(_row_to_dict(c)) for c in categories],
+        "expenses": [_serialize(_row_to_dict(e)) for e in expenses],
+        "recurring_expenses": [_serialize(_row_to_dict(r)) for r in recurring],
+        "bills": [_serialize(_row_to_dict(b)) for b in bills],
+        "reminders": [_serialize(_row_to_dict(r)) for r in reminders],
+        "subscriptions": [_serialize(_row_to_dict(s)) for s in subscriptions],
+    }
+
+    _write_audit(
+        user_id=user_id,
+        action=GDPR_ACTION_EXPORT,
+        detail=f"ip={request_ip} ua={user_agent[:120]}",
+    )
+
+    logger.info("GDPR export generated for user_id=%s ip=%s", user_id, request_ip)
+    return payload
+
+
+def export_user_data_csv(user_id: int, request_ip: str, user_agent: str) -> bytes:
+    """
+    Return a CSV export of expenses for *user_id* as raw bytes.
+    """
+    expenses = db.session.query(Expense).filter_by(user_id=user_id).all()
+
+    buf = io.StringIO()
+    writer = csv.DictWriter(
+        buf,
+        fieldnames=[
+            "id",
+            "category_id",
+            "amount",
+            "currency",
+            "expense_type",
+            "notes",
+            "spent_at",
+            "created_at",
+        ],
+    )
+    writer.writeheader()
+    for e in expenses:
+        writer.writerow(
+            {
+                "id": e.id,
+                "category_id": e.category_id,
+                "amount": str(e.amount),
+                "currency": e.currency,
+                "expense_type": e.expense_type,
+                "notes": e.notes or "",
+                "spent_at": e.spent_at.isoformat() if e.spent_at else "",
+                "created_at": e.created_at.isoformat() if e.created_at else "",
+            }
+        )
+
+    _write_audit(
+        user_id=user_id,
+        action=GDPR_ACTION_EXPORT,
+        detail=f"format=csv ip={request_ip}",
+    )
+
+    return buf.getvalue().encode("utf-8")
+
+
+def initiate_deletion(user_id: int, request_ip: str, user_agent: str) -> dict:
+    """
+    Begin the two-step deletion workflow.
+
+    Marks the user account for deletion (soft-delete flag via audit record)
+    and returns the scheduled_at timestamp after which hard-delete will run.
+    """
+    user: User | None = db.session.get(User, user_id)
+    if user is None:
+        raise ValueError(f"User {user_id} not found")
+
+    scheduled_at = datetime.utcnow() + timedelta(days=DELETION_GRACE_DAYS)
+
+    _write_audit(
+        user_id=user_id,
+        action=GDPR_ACTION_DELETE_INITIATED,
+        detail=(
+            f"scheduled_at={scheduled_at.isoformat()} "
+            f"ip={request_ip} ua={user_agent[:120]}"
+        ),
+    )
+
+    logger.warning(
+        "GDPR deletion initiated user_id=%s scheduled_at=%s ip=%s",
+        user_id,
+        scheduled_at.isoformat(),
+        request_ip,
+    )
+
+    return {
+        "message": (
+            "Deletion scheduled. Your account and all associated data will be "
+            f"permanently deleted on {scheduled_at.date().isoformat()} "
+            f"({DELETION_GRACE_DAYS}-day grace period). "
+            "To cancel, contact support before this date."
+        ),
+        "scheduled_deletion_at": scheduled_at.isoformat() + "Z",
+        "grace_period_days": DELETION_GRACE_DAYS,
+    }
+
+
+def execute_deletion(user_id: int, request_ip: str, user_agent: str) -> dict:
+    """
+    Hard-delete all user PII.
+    GDPR audit log entries are preserved (legally required, 7-year retention).
+    Must only be called after grace period has passed or by admin override.
+    """
+    user: User | None = db.session.get(User, user_id)
+    if user is None:
+        raise ValueError(f"User {user_id} not found")
+
+    # Preserve audit records by setting user_id = NULL before deleting the user.
+    db.session.query(AuditLog).filter_by(user_id=user_id).update(
+        {"user_id": None}, synchronize_session=False
+    )
+
+    # Delete all associated data in dependency order.
+    db.session.query(AdImpression).filter_by(user_id=user_id).delete(
+        synchronize_session=False
+    )
+    db.session.query(UserSubscription).filter_by(user_id=user_id).delete(
+        synchronize_session=False
+    )
+    db.session.query(Reminder).filter_by(user_id=user_id).delete(
+        synchronize_session=False
+    )
+    db.session.query(Bill).filter_by(user_id=user_id).delete(synchronize_session=False)
+    db.session.query(Expense).filter_by(user_id=user_id).delete(
+        synchronize_session=False
+    )
+    db.session.query(RecurringExpense).filter_by(user_id=user_id).delete(
+        synchronize_session=False
+    )
+    db.session.query(Category).filter_by(user_id=user_id).delete(
+        synchronize_session=False
+    )
+    db.session.delete(user)
+    db.session.commit()
+
+    # Write a final audit entry with no user_id (user is gone).
+    _write_audit(
+        user_id=None,
+        action=GDPR_ACTION_DELETE_EXECUTED,
+        detail=f"deleted_user_id={user_id} ip={request_ip} ua={user_agent[:120]}",
+    )
+
+    logger.warning(
+        "GDPR hard-delete executed for user_id=%s ip=%s", user_id, request_ip
+    )
+
+    return {"message": "All personal data has been permanently deleted."}
+
+
+# ── internal ───────────────────────────────────────────────────────────────────
+
+
+def _write_audit(
+    user_id: int | None,
+    action: str,
+    detail: str = "",
+) -> None:
+    entry = AuditLog(
+        user_id=user_id,
+        action=f"{action}: {detail}" if detail else action,
+    )
+    db.session.add(entry)
+    db.session.commit()

--- a/packages/backend/tests/conftest.py
+++ b/packages/backend/tests/conftest.py
@@ -1,4 +1,6 @@
 import os
+os.environ["FLASK_ENV"] = "testing"
+
 import pytest
 from app import create_app
 from app.config import Settings

--- a/packages/backend/tests/test_gdpr.py
+++ b/packages/backend/tests/test_gdpr.py
@@ -1,0 +1,184 @@
+"""
+Tests for GDPR PII Export & Delete endpoints.
+
+Covers:
+- JSON export (GET /gdpr/export)
+- CSV export  (GET /gdpr/export/csv)
+- Delete initiation (POST /gdpr/delete)
+- Audit trail    (GET /gdpr/audit)
+- Hard-delete blocked before grace period (POST /gdpr/delete/confirm)
+"""
+
+
+GDPR_EMAIL = "gdpr_user@test.com"
+GDPR_PASSWORD = "gdpr_secret99"
+
+
+def _register_and_login(client, email=GDPR_EMAIL, password=GDPR_PASSWORD):
+    """Helper: register (idempotent) and return access_token."""
+    client.post("/auth/register", json={"email": email, "password": password})
+    r = client.post("/auth/login", json={"email": email, "password": password})
+    assert r.status_code == 200, r.get_data(as_text=True)
+    return r.get_json()["access_token"]
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Export tests ───────────────────────────────────────────────────────────────
+
+
+def test_gdpr_export_json_structure(client):
+    token = _register_and_login(client)
+    r = client.get("/gdpr/export", headers=_auth(token))
+    assert r.status_code == 200
+    assert r.content_type.startswith("application/json")
+
+    data = r.get_json()
+    assert "profile" in data
+    assert data["profile"]["email"] == GDPR_EMAIL
+    assert "expenses" in data
+    assert "categories" in data
+    assert "bills" in data
+    assert "reminders" in data
+    assert "recurring_expenses" in data
+    assert "subscriptions" in data
+    assert "exported_at" in data
+
+
+def test_gdpr_export_requires_auth(client):
+    r = client.get("/gdpr/export")
+    assert r.status_code == 401
+
+
+def test_gdpr_export_csv(client):
+    token = _register_and_login(client, "gdpr_csv@test.com", GDPR_PASSWORD)
+    r = client.get("/gdpr/export/csv", headers=_auth(token))
+    assert r.status_code == 200
+    assert "text/csv" in r.content_type
+    body = r.get_data(as_text=True)
+    # Must have CSV header row
+    assert "amount" in body and "currency" in body
+
+
+def test_gdpr_export_csv_requires_auth(client):
+    r = client.get("/gdpr/export/csv")
+    assert r.status_code == 401
+
+
+# ── Delete initiation tests ────────────────────────────────────────────────────
+
+
+def test_gdpr_delete_initiate_requires_password(client):
+    token = _register_and_login(client, "gdpr_del1@test.com", GDPR_PASSWORD)
+    # No password in body
+    r = client.post("/gdpr/delete", headers=_auth(token), json={})
+    assert r.status_code == 400
+
+
+def test_gdpr_delete_initiate_wrong_password(client):
+    token = _register_and_login(client, "gdpr_del2@test.com", GDPR_PASSWORD)
+    r = client.post(
+        "/gdpr/delete",
+        headers=_auth(token),
+        json={"password": "wrong_password"},
+    )
+    assert r.status_code == 401
+
+
+def test_gdpr_delete_initiate_success(client):
+    token = _register_and_login(client, "gdpr_del3@test.com", GDPR_PASSWORD)
+    r = client.post(
+        "/gdpr/delete",
+        headers=_auth(token),
+        json={"password": GDPR_PASSWORD},
+    )
+    assert r.status_code == 202
+    data = r.get_json()
+    assert "scheduled_deletion_at" in data
+    assert "grace_period_days" in data
+    assert data["grace_period_days"] == 30
+
+
+def test_gdpr_delete_initiate_idempotent(client):
+    """A second initiation request while grace period is active returns 409."""
+    token = _register_and_login(client, "gdpr_del4@test.com", GDPR_PASSWORD)
+    payload = {"password": GDPR_PASSWORD}
+    r1 = client.post("/gdpr/delete", headers=_auth(token), json=payload)
+    assert r1.status_code == 202
+
+    r2 = client.post("/gdpr/delete", headers=_auth(token), json=payload)
+    assert r2.status_code == 409
+
+
+# ── Hard-delete tests ──────────────────────────────────────────────────────────
+
+
+def test_gdpr_delete_confirm_blocked_before_grace_period(client):
+    """Hard delete should be blocked if grace period has not elapsed."""
+    token = _register_and_login(client, "gdpr_del5@test.com", GDPR_PASSWORD)
+    # Initiate first
+    client.post(
+        "/gdpr/delete",
+        headers=_auth(token),
+        json={"password": GDPR_PASSWORD},
+    )
+    # Attempt immediate hard delete — must be blocked
+    r = client.post(
+        "/gdpr/delete/confirm",
+        headers=_auth(token),
+        json={"password": GDPR_PASSWORD, "confirm": True},
+    )
+    assert r.status_code == 403
+    data = r.get_json()
+    assert "days_remaining" in data
+
+
+def test_gdpr_delete_confirm_requires_confirm_flag(client):
+    token = _register_and_login(client, "gdpr_del6@test.com", GDPR_PASSWORD)
+    r = client.post(
+        "/gdpr/delete/confirm",
+        headers=_auth(token),
+        json={"password": GDPR_PASSWORD},  # missing confirm
+    )
+    assert r.status_code == 400
+
+
+def test_gdpr_delete_confirm_requires_prior_initiation(client):
+    """Hard delete without prior initiation should fail with 409."""
+    token = _register_and_login(client, "gdpr_del7@test.com", GDPR_PASSWORD)
+    r = client.post(
+        "/gdpr/delete/confirm",
+        headers=_auth(token),
+        json={"password": GDPR_PASSWORD, "confirm": True},
+    )
+    assert r.status_code == 409
+
+
+# ── Audit trail tests ──────────────────────────────────────────────────────────
+
+
+def test_gdpr_audit_trail(client):
+    token = _register_and_login(client, "gdpr_audit@test.com", GDPR_PASSWORD)
+    # Generate some audit records
+    client.get("/gdpr/export", headers=_auth(token))
+    client.post(
+        "/gdpr/delete",
+        headers=_auth(token),
+        json={"password": GDPR_PASSWORD},
+    )
+
+    r = client.get("/gdpr/audit", headers=_auth(token))
+    assert r.status_code == 200
+    logs = r.get_json()
+    assert isinstance(logs, list)
+    assert len(logs) >= 2
+    actions = [log["action"] for log in logs]
+    assert any("GDPR_EXPORT" in a for a in actions)
+    assert any("GDPR_DELETE_INITIATED" in a for a in actions)
+
+
+def test_gdpr_audit_requires_auth(client):
+    r = client.get("/gdpr/audit")
+    assert r.status_code == 401


### PR DESCRIPTION
## Summary

Implements the GDPR-ready PII Export & Delete Workflow requested in #76.

## Changes

- `GET /gdpr/export` - JSON export of user profile and related financial objects.
- `GET /gdpr/export/csv` - CSV export of expenses.
- `POST /gdpr/delete` - Schedule deletion with a 30-day grace period.
- `POST /gdpr/delete/confirm` - Hard delete execution (admin or after grace period).
- `GET /gdpr/audit` - GDPR audit trail logs retrieval.
- 13 new test cases covering authorization, data export formatting, deletion grace periods, and audit trail retention.

Closes #76